### PR TITLE
feat: per-worker jitter for WorkerConfig (replace global jitter_ns)

### DIFF
--- a/bindings/mobile/src/worker_config.rs
+++ b/bindings/mobile/src/worker_config.rs
@@ -8,6 +8,13 @@ pub struct FfiWorkerIntervalOverride {
     pub interval_ns: u64,
 }
 
+/// A single per-worker jitter override (nanoseconds).
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct FfiWorkerJitterOverride {
+    pub kind: FfiWorkerKind,
+    pub jitter_ns: u64,
+}
+
 /// Tuning for the background worker scheduler. All fields optional; the empty
 /// record preserves default behavior (all workers enabled, const intervals,
 /// no jitter).
@@ -15,10 +22,10 @@ pub struct FfiWorkerIntervalOverride {
 pub struct FfiWorkerConfig {
     /// Global default interval for all workers, in nanoseconds.
     pub default_interval_ns: Option<u64>,
-    /// Jitter added to de-synchronize fleets, in nanoseconds. 0/absent = none.
-    pub jitter_ns: Option<u64>,
     /// Per-worker interval overrides (nanoseconds).
     pub worker_intervals_ns: Vec<FfiWorkerIntervalOverride>,
+    /// Per-worker jitter overrides (nanoseconds).
+    pub worker_jitters_ns: Vec<FfiWorkerJitterOverride>,
     /// Workers to disable. Anything not listed stays enabled.
     pub disabled_workers: Vec<FfiWorkerKind>,
 }
@@ -27,12 +34,14 @@ impl From<FfiWorkerConfig> for WorkerConfig {
     fn from(o: FfiWorkerConfig) -> Self {
         let mut cfg = WorkerConfig {
             default_interval_ns: o.default_interval_ns,
-            jitter_ns: o.jitter_ns,
             ..Default::default()
         };
         for ov in o.worker_intervals_ns {
             cfg.interval_overrides
                 .insert(ov.kind.into(), ov.interval_ns);
+        }
+        for ov in o.worker_jitters_ns {
+            cfg.jitter_overrides.insert(ov.kind.into(), ov.jitter_ns);
         }
         for k in o.disabled_workers {
             cfg.enabled.insert(k.into(), false);

--- a/bindings/node/src/client/options.rs
+++ b/bindings/node/src/client/options.rs
@@ -70,6 +70,13 @@ pub struct WorkerIntervalOverride {
   pub interval_ns: BigInt,
 }
 
+/// A single per-worker jitter override (nanoseconds).
+#[napi(object)]
+pub struct WorkerJitterOverride {
+  pub kind: WorkerKind,
+  pub jitter_ns: BigInt,
+}
+
 /// Tuning for the background worker scheduler. All fields optional; omitting
 /// the whole object preserves default behavior.
 #[napi(object)]
@@ -77,10 +84,10 @@ pub struct WorkerIntervalOverride {
 pub struct WorkerConfigOptions {
   /// Global default interval for all workers, in nanoseconds.
   pub default_interval_ns: Option<BigInt>,
-  /// Jitter added to de-synchronize fleets, in nanoseconds. 0/absent = none.
-  pub jitter_ns: Option<BigInt>,
   /// Per-worker interval overrides (nanoseconds).
   pub worker_intervals_ns: Option<Vec<WorkerIntervalOverride>>,
+  /// Per-worker jitter overrides (nanoseconds).
+  pub worker_jitters_ns: Option<Vec<WorkerJitterOverride>>,
   /// Workers to disable. Anything not listed stays enabled.
   pub disabled_workers: Option<Vec<WorkerKind>>,
 }
@@ -90,7 +97,6 @@ impl From<WorkerConfigOptions> for XmtpWorkerConfig {
     let to_u64 = |b: BigInt| -> u64 { b.get_u64().1 };
     let mut cfg = XmtpWorkerConfig {
       default_interval_ns: o.default_interval_ns.map(to_u64),
-      jitter_ns: o.jitter_ns.map(to_u64),
       ..Default::default()
     };
     if let Some(overrides) = o.worker_intervals_ns {
@@ -98,6 +104,13 @@ impl From<WorkerConfigOptions> for XmtpWorkerConfig {
         cfg
           .interval_overrides
           .insert(ov.kind.into(), to_u64(ov.interval_ns));
+      }
+    }
+    if let Some(jitters) = o.worker_jitters_ns {
+      for ov in jitters {
+        cfg
+          .jitter_overrides
+          .insert(ov.kind.into(), to_u64(ov.jitter_ns));
       }
     }
     if let Some(disabled) = o.disabled_workers {

--- a/bindings/wasm/src/client.rs
+++ b/bindings/wasm/src/client.rs
@@ -117,6 +117,15 @@ pub struct WorkerIntervalOverride {
   pub interval_ns: u64,
 }
 
+/// A single per-worker jitter override (nanoseconds).
+#[derive(Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerJitterOverride {
+  pub kind: WorkerKind,
+  pub jitter_ns: u64,
+}
+
 /// Tuning for the background worker scheduler. All fields optional.
 #[derive(Clone, Default, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
@@ -126,14 +135,14 @@ pub struct WorkerConfigOptions {
   #[tsify(optional)]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub default_interval_ns: Option<u64>,
-  /// Jitter in nanoseconds. 0/absent = none.
-  #[tsify(optional)]
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub jitter_ns: Option<u64>,
   /// Per-worker interval overrides (nanoseconds).
   #[tsify(optional)]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub worker_intervals_ns: Option<Vec<WorkerIntervalOverride>>,
+  /// Per-worker jitter overrides (nanoseconds).
+  #[tsify(optional)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub worker_jitters_ns: Option<Vec<WorkerJitterOverride>>,
   /// Workers to disable.
   #[tsify(optional)]
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -144,7 +153,6 @@ impl From<WorkerConfigOptions> for xmtp_mls::worker::WorkerConfig {
   fn from(o: WorkerConfigOptions) -> Self {
     let mut cfg = xmtp_mls::worker::WorkerConfig {
       default_interval_ns: o.default_interval_ns,
-      jitter_ns: o.jitter_ns,
       ..Default::default()
     };
     if let Some(overrides) = o.worker_intervals_ns {
@@ -152,6 +160,11 @@ impl From<WorkerConfigOptions> for xmtp_mls::worker::WorkerConfig {
         cfg
           .interval_overrides
           .insert(ov.kind.into(), ov.interval_ns);
+      }
+    }
+    if let Some(jitters) = o.worker_jitters_ns {
+      for ov in jitters {
+        cfg.jitter_overrides.insert(ov.kind.into(), ov.jitter_ns);
       }
     }
     if let Some(disabled) = o.disabled_workers {

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -48,10 +48,13 @@ pub struct WorkerConfig {
     /// Global fallback interval (ns) for any worker without a per-kind
     /// override. `None` => each worker uses its own const default.
     pub default_interval_ns: Option<u64>,
-    /// Optional jitter (ns). `None` or `0` => deterministic intervals.
-    pub jitter_ns: Option<u64>,
     /// Per-worker interval override (ns). Wins over `default_interval_ns`.
     pub interval_overrides: HashMap<WorkerKind, u64>,
+    /// Per-worker jitter (ns). An absent entry means `0` (deterministic).
+    /// Jitter de-synchronizes a fleet of clients; scoping it per-worker
+    /// avoids blanketing fast workers with a large jitter meant for a slow
+    /// one (e.g. the daily CommitLog worker).
+    pub jitter_overrides: HashMap<WorkerKind, u64>,
     /// Per-worker enable flag. An absent entry means enabled.
     pub enabled: HashMap<WorkerKind, bool>,
 }
@@ -61,7 +64,8 @@ impl WorkerConfig {
     ///
     /// Base precedence: per-kind override > global default > `const_default`.
     /// A resolved base of `0` is clamped to `const_default` to avoid a
-    /// pathological busy-loop. Jitter is the global `jitter_ns` (0 if unset).
+    /// pathological busy-loop. Jitter is the per-kind `jitter_overrides` entry
+    /// (0 if absent).
     pub fn interval(&self, kind: WorkerKind, const_default: Duration) -> (Duration, Duration) {
         let base_ns = self
             .interval_overrides
@@ -73,7 +77,9 @@ impl WorkerConfig {
             Some(ns) => Duration::from_nanos(ns),
         };
         let jitter = self
-            .jitter_ns
+            .jitter_overrides
+            .get(&kind)
+            .copied()
             .map(Duration::from_nanos)
             .unwrap_or(Duration::ZERO);
         (base, jitter)
@@ -535,13 +541,30 @@ mod worker_config_tests {
     }
 
     #[xmtp_common::test]
-    fn jitter_is_carried() {
-        let cfg = WorkerConfig {
-            jitter_ns: Some(Duration::from_secs(2).as_nanos() as u64),
-            ..Default::default()
-        };
+    fn per_kind_jitter_is_carried() {
+        let mut cfg = WorkerConfig::default();
+        cfg.jitter_overrides.insert(
+            WorkerKind::TaskRunner,
+            Duration::from_secs(2).as_nanos() as u64,
+        );
         let (_, jitter) = cfg.interval(WorkerKind::TaskRunner, Duration::from_secs(1));
         assert_eq!(jitter, Duration::from_secs(2));
+    }
+
+    #[xmtp_common::test]
+    fn jitter_is_scoped_per_worker() {
+        let mut cfg = WorkerConfig::default();
+        cfg.jitter_overrides.insert(
+            WorkerKind::CommitLog,
+            Duration::from_secs(6 * 3600).as_nanos() as u64,
+        );
+        // The jittered worker gets its jitter...
+        let (_, commit_log_jitter) = cfg.interval(WorkerKind::CommitLog, Duration::from_secs(300));
+        assert_eq!(commit_log_jitter, Duration::from_secs(6 * 3600));
+        // ...while an un-listed worker stays deterministic.
+        let (_, disappearing_jitter) =
+            cfg.interval(WorkerKind::DisappearingMessages, Duration::from_secs(1));
+        assert_eq!(disappearing_jitter, Duration::ZERO);
     }
 
     #[xmtp_common::test]

--- a/docs/superpowers/specs/2026-06-03-per-worker-jitter-design.md
+++ b/docs/superpowers/specs/2026-06-03-per-worker-jitter-design.md
@@ -1,0 +1,169 @@
+# Per-Worker Jitter for WorkerConfig
+
+**Date:** 2026-06-03
+**Status:** Approved design, ready for implementation plan
+
+## Problem
+
+`WorkerConfig` (shipped in libxmtp #3706) carries a single **global** `jitter_ns`
+that applies to *every* background worker. Consumers who only want to jitter one
+worker — e.g. herald-lite scheduling the CommitLog fork-recovery worker daily
+with 6h jitter to avoid a fleet stampede — end up jittering the fast workers too.
+A 1s-interval worker (DisappearingMessages) inheriting up to 6h of jitter is
+effectively broken.
+
+We want jitter to be configurable **per worker**, the same way interval already
+is via `interval_overrides`.
+
+## Decision summary
+
+- **Replace** the global `jitter_ns: Option<u64>` with a per-worker
+  `jitter_overrides: HashMap<WorkerKind, u64>`. (Breaking change — acceptable;
+  the only consumers are nightly bindings, where breakage is expected.)
+- **No global default jitter.** Absent entry => 0 jitter (deterministic) for that
+  worker. This is deliberate: a global default is the exact foot-gun we are
+  removing.
+- Mirror the existing `interval_overrides` shape and resolution exactly.
+
+## Non-goals
+
+- No `default_jitter_ns` fallback (rejected — reintroduces the foot-gun).
+- No change to interval resolution, enable/disable, or the `default_interval_ns`
+  fallback (those stay as-is).
+- No change to `jittered_interval_stream` in `xmtp_common` — it already takes
+  `(base, jitter)` per worker; only the *source* of `jitter` changes.
+- No DB or protocol change.
+
+## Core change (`crates/xmtp_mls/src/worker.rs`)
+
+### `WorkerConfig`
+
+```rust
+#[derive(Clone, Debug, Default)]
+pub struct WorkerConfig {
+    pub default_interval_ns: Option<u64>,
+    pub interval_overrides: HashMap<WorkerKind, u64>,
+    /// Per-worker jitter (ns). Absent => 0 (deterministic). Replaces the
+    /// former global `jitter_ns`.
+    pub jitter_overrides: HashMap<WorkerKind, u64>,
+    pub enabled: HashMap<WorkerKind, bool>,
+}
+```
+
+`jitter_ns` field is **removed**.
+
+### `interval()` resolution
+
+Base-interval logic is unchanged. Jitter changes from the global field to a
+per-kind lookup:
+
+```rust
+let jitter = self
+    .jitter_overrides
+    .get(&kind)
+    .copied()
+    .map(Duration::from_nanos)
+    .unwrap_or(Duration::ZERO);
+```
+
+`Default` (empty maps) still reproduces historical behavior: every worker
+deterministic, each on its const default interval.
+
+### Tests (`worker.rs`)
+
+- The existing `jitter_is_carried` unit test constructs `WorkerConfig { jitter_ns:
+  Some(..), .. }` — update it to use `jitter_overrides.insert(kind, ns)` and
+  assert the jitter is returned for that kind.
+- Add a test asserting per-kind scoping: jitter set for worker A, absent for
+  worker B → `interval(A)` returns nonzero jitter, `interval(B)` returns
+  `Duration::ZERO`.
+- Other `WorkerConfig` tests (interval precedence, zero-clamp, enable) are
+  unaffected.
+
+## Bindings (all three, symmetric)
+
+Each binding currently exposes a scalar `jitterNs` on its `WorkerConfigOptions`
+analogue. Replace it with a per-worker array mirroring `workerIntervalsNs`. Use a
+distinct override type per binding (do not overload the interval-override type)
+so the generated surface is self-documenting.
+
+### Generated TS/Swift/Kotlin surface
+
+```ts
+workerConfig.workerJittersNs?: Array<{ kind: WorkerKind; jitterNs: bigint }>
+```
+
+`jitterNs` (scalar) is removed from each `WorkerConfigOptions`.
+
+### Node (`bindings/node/src/client/options.rs`)
+
+- Add `WorkerJitterOverride { kind: WorkerKind, jitter_ns: BigInt }`
+  (`#[napi(object)]`), parallel to the existing `WorkerIntervalOverride`.
+- In `WorkerConfigOptions`: remove `jitter_ns`, add
+  `worker_jitters_ns: Option<Vec<WorkerJitterOverride>>`.
+- In the `From<WorkerConfigOptions> for XmtpWorkerConfig` impl: drop the
+  `jitter_ns: o.jitter_ns.map(to_u64)` line; instead, after building `cfg`,
+  populate `cfg.jitter_overrides` from `worker_jitters_ns` exactly as
+  `interval_overrides` is populated from `worker_intervals_ns`.
+
+### WASM (`bindings/wasm/src/client.rs`)
+
+- Add `WorkerJitterOverride { kind: WorkerKind, jitter_ns: u64 }` with the same
+  `Serialize, Deserialize, Tsify` derives + `#[serde(rename_all = "camelCase")]`
+  as `WorkerIntervalOverride`.
+- In `WorkerConfigOptions`: remove the `jitter_ns: Option<u64>` field (and its
+  tsify/serde attrs), add `worker_jitters_ns:
+  Option<Vec<WorkerJitterOverride>>`.
+- In the `From` impl: drop `jitter_ns: o.jitter_ns`; populate
+  `cfg.jitter_overrides` from `worker_jitters_ns`.
+
+### Mobile (`bindings/mobile/src/worker_config.rs`)
+
+- Add `FfiWorkerJitterOverride { kind: FfiWorkerKind, jitter_ns: u64 }`
+  (`#[derive(uniffi::Record, ...)]`), parallel to `FfiWorkerIntervalOverride`.
+- In `FfiWorkerConfig`: remove `jitter_ns: Option<u64>`, add
+  `worker_jitters_ns: Vec<FfiWorkerJitterOverride>` (Vec, matching the
+  interval-override field style for uniffi).
+- In the `From` impl: drop `jitter_ns: o.jitter_ns`; populate
+  `cfg.jitter_overrides` from `worker_jitters_ns`.
+
+## Caller / FFI-signature impact
+
+This change is confined to the **inside** of the `WorkerConfigOptions` /
+`FfiWorkerConfig` types. The `create_client` / `createClient` function
+signatures do **not** change (still one `worker_config` param), so the large
+test/bench caller sweep from #3706 is **not** needed. Verify anyway:
+
+- `cargo check -p xmtpv3 --all-targets` and `cargo check -p bindings_wasm
+  --target wasm32-unknown-unknown --tests` compile.
+- No SDK wrapper changes (`Client.kt`, `Client.swift`) — they pass
+  `workerConfig`/`worker_config` through opaquely and don't reference the
+  removed field.
+
+## Downstream: herald-lite PR #81
+
+herald-lite currently sets `jitterNs: <6h>` (global). After this lands and a new
+node-sdk nightly is published, that PR must change to:
+
+```ts
+workerJittersNs: [{ kind: "CommitLog", jitterNs: BigInt(jitterSeconds) * 1_000_000_000n }]
+```
+
+dropping the top-level `jitterNs`. The `buildWorkerConfig` helper and its tests
+update accordingly. This is tracked separately (the herald-lite review), not part
+of this libxmtp change.
+
+## Testing
+
+- Core: `cargo nextest run -p xmtp_mls worker` — updated + new jitter tests pass;
+  existing interval/enable tests unchanged.
+- Lint: `just lint-rust` (clippy `-Dwarnings`, fmt, hakari).
+- Bindings compile: `cargo check -p bindings_node`, `just wasm check`,
+  `cargo check -p xmtpv3`.
+- Node lint (per CLAUDE.md, bindings_node changed): `just node lint`.
+
+## Backward compatibility
+
+- `WorkerConfig::default()` unchanged in behavior (empty maps, deterministic).
+- Breaking only at the binding `WorkerConfigOptions.jitterNs` field, which is
+  nightly-only. No stable consumers. No DB/protocol change.


### PR DESCRIPTION
## Summary

Follow-up to #3706. `WorkerConfig` shipped with a single **global** `jitter_ns` that applied to *every* background worker. Consumers who only want to jitter one worker — e.g. scheduling the daily CommitLog fork-recovery worker with 6h jitter to avoid a fleet stampede — end up jittering the fast workers too. A 1s-interval worker (DisappearingMessages) inheriting up to 6h of jitter is effectively broken.

This makes jitter **per-worker**, mirroring how interval already works via `interval_overrides`.

## Changes

- **Core** (`crates/xmtp_mls/src/worker.rs`): remove `WorkerConfig.jitter_ns: Option<u64>`, add `jitter_overrides: HashMap<WorkerKind, u64>`. `interval()` resolves jitter per-kind; absent entry => `0` (deterministic). No global default jitter — that's the foot-gun being removed.
- **Bindings** (node / wasm / mobile): drop the scalar `jitterNs` from `WorkerConfigOptions`, add a `workerJittersNs` array of `{ kind, jitterNs }` mirroring `workerIntervalsNs`.

Generated TS surface:
```ts
workerConfig.workerJittersNs?: Array<{ kind: WorkerKind; jitterNs: bigint }>
```

## Breaking change

Breaks the nightly-only `WorkerConfigOptions.jitterNs` field. No stable consumers; nightly breakage is expected. Downstream consumers set per-worker jitter instead, e.g.:
```ts
workerJittersNs: [{ kind: "CommitLog", jitterNs: 21600n * 1_000_000_000n }]
```

## Notes

- `create_client` FFI signatures unchanged (still one `worker_config` param) — only the inside of `WorkerConfigOptions` changes, so no SDK-wrapper or caller churn.
- `WorkerConfig::default()` behavior unchanged (empty maps, deterministic). No DB/protocol change.

## Testing

- Core: per-kind jitter carried; jitter scoped per worker (jittered worker gets it, un-listed worker stays `0`).
- `just lint-rust` ✓ · `just node lint` ✓ · all three bindings compile (`bindings_node`, `bindings_wasm` wasm32, `xmtpv3`) ✓ · `xmtp_mls worker_config` tests ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace global `jitter_ns` with per-worker `jitter_overrides` in `WorkerConfig`
> - Removes the global `jitter_ns: Option<u64>` field from `WorkerConfig` and replaces it with `jitter_overrides: HashMap<WorkerKind, u64>`, so jitter is scoped per worker kind with a default of zero.
> - Updates `WorkerConfig.interval()` to resolve jitter from the per-kind map instead of a single global value.
> - Mirrors the change across all three binding layers: [worker_config.rs](https://github.com/xmtp/libxmtp/pull/3709/files#diff-3b21fab5bc1e30d4eb92b2d0e14461f1c2fd991164b484046e665363bb3fd48d) (mobile/FFI), [options.rs](https://github.com/xmtp/libxmtp/pull/3709/files#diff-5306d98c5fe6413b641310877f4657e782cd87bc1e7497e28c0478154fb062d7) (Node), and [client.rs](https://github.com/xmtp/libxmtp/pull/3709/files#diff-6fa64ca0f35092cf055d31985b6e071f8dda1fcac5f9f3216f813422411af7c8) (WASM), each replacing a single `jitter_ns` field with a `worker_jitters_ns` array of per-worker override objects.
> - Behavioral Change: workers with no explicit jitter entry now receive `Duration::ZERO` instead of any previously configured global jitter; callers must migrate to per-worker overrides.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 187d245.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->