### PR TITLE
feat(xmtp_mls): per-worker-turn telemetry spans

### DIFF
--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -248,6 +248,7 @@ where
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, fields(worker = ?self.kind(), operation = "worker_turn"))]
     pub async fn tick(&mut self) -> Result<(), CommitLogError> {
         self.save_remote_commit_log().await?;
         self.update_forked_state().await?;

--- a/crates/xmtp_mls/src/worker/device_sync/worker.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/worker.rs
@@ -136,33 +136,37 @@ where
 
     async fn run_internal(&mut self) -> Result<(), DeviceSyncError> {
         while let Ok(event) = self.receiver.recv().await {
-            // Tick is the internal timer heartbeat (every 20s); only log real events.
-            if !matches!(event, SyncWorkerEvent::Tick) {
-                tracing::info!(
-                    installation_id = %self.client.context.installation_id(),
-                    "new sync worker event: {event:?}",
-                );
+            // Tick is the internal timer heartbeat (every 20s): no real work, so
+            // dispatch it directly without opening a worker_turn span.
+            if matches!(event, SyncWorkerEvent::Tick) {
+                self.evt_new_sync_group_msg(true).await?;
+                continue;
             }
 
-            match event {
-                SyncWorkerEvent::NewSyncGroupFromWelcome(_group_id) => {
-                    self.evt_new_sync_group_from_welcome().await?;
-                }
-                SyncWorkerEvent::NewSyncGroupMsg => {
-                    self.evt_new_sync_group_msg(false).await?;
-                }
-                SyncWorkerEvent::Tick => {
-                    self.evt_new_sync_group_msg(true).await?;
-                }
-                SyncWorkerEvent::SyncPreferences(preference_updates) => {
-                    self.evt_sync_preferences(preference_updates).await?;
-                }
-                SyncWorkerEvent::CycleHMAC => {
-                    self.evt_cycle_hmac().await?;
-                }
-            }
+            tracing::info!(
+                installation_id = %self.client.context.installation_id(),
+                "new sync worker event: {event:?}",
+            );
+            self.handle_event(event).await?;
         }
         Ok(())
+    }
+
+    #[tracing::instrument(skip_all, fields(worker = ?self.kind(), operation = "worker_turn", event = ?event))]
+    async fn handle_event(&mut self, event: SyncWorkerEvent) -> Result<(), DeviceSyncError> {
+        match event {
+            SyncWorkerEvent::NewSyncGroupFromWelcome(_group_id) => {
+                self.evt_new_sync_group_from_welcome().await
+            }
+            SyncWorkerEvent::NewSyncGroupMsg => self.evt_new_sync_group_msg(false).await,
+            SyncWorkerEvent::SyncPreferences(preference_updates) => {
+                self.evt_sync_preferences(preference_updates).await
+            }
+            SyncWorkerEvent::CycleHMAC => self.evt_cycle_hmac().await,
+            // Tick is intentionally filtered out in `run_internal` before reaching
+            // here, so it never opens a worker_turn span.
+            SyncWorkerEvent::Tick => unreachable!("Tick is handled before dispatch"),
+        }
     }
 
     async fn tick(ctx: Context) {

--- a/crates/xmtp_mls/src/worker/disappearing_messages.rs
+++ b/crates/xmtp_mls/src/worker/disappearing_messages.rs
@@ -103,6 +103,7 @@ where
     }
 
     /// Iterate on the list of groups and delete expired messages
+    #[tracing::instrument(skip_all, fields(worker = ?self.kind(), operation = "worker_turn"))]
     async fn delete_expired_messages(&mut self) -> Result<(), DisappearingMessagesCleanerError> {
         let db = self.context.db();
         // Propagated to the supervisor, which is the sole logger for worker errors.

--- a/crates/xmtp_mls/src/worker/key_package_cleaner.rs
+++ b/crates/xmtp_mls/src/worker/key_package_cleaner.rs
@@ -121,9 +121,15 @@ where
             .worker_interval(WorkerKind::KeyPackageCleaner, INTERVAL_DURATION);
         let mut intervals = xmtp_common::time::jittered_interval_stream(base, jitter);
         while (intervals.next().await).is_some() {
-            self.delete_expired_key_packages()?;
-            self.rotate_last_key_package_if_needed().await?;
+            self.tick().await?;
         }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all, fields(worker = ?self.kind(), operation = "worker_turn"))]
+    async fn tick(&mut self) -> Result<(), KeyPackagesCleanerError> {
+        self.delete_expired_key_packages()?;
+        self.rotate_last_key_package_if_needed().await?;
         Ok(())
     }
 

--- a/crates/xmtp_mls/src/worker/pending_self_remove.rs
+++ b/crates/xmtp_mls/src/worker/pending_self_remove.rs
@@ -128,6 +128,7 @@ where
     }
 
     /// Iterate on the list of groups and delete expired messages
+    #[tracing::instrument(skip_all, fields(worker = ?self.kind(), operation = "worker_turn"))]
     async fn remove_pending_remove_users(&mut self) -> Result<(), PendingSelfRemoveWorkerError> {
         let db = self.context.db();
         // Errors propagate to the supervisor (the sole logger); the worker restarts and

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -167,6 +167,7 @@ where
             }
         }
     }
+    #[tracing::instrument(skip_all, fields(worker = "TaskRunner", operation = "worker_turn"))]
     async fn run_and_reschedule_task(
         task: DbTask,
         context: &Context,


### PR DESCRIPTION
## Summary

Adds a `worker_turn` tracing span to each background worker's per-turn unit of work, so telemetry/otel can report **per-worker turn latency and counts, sliced by worker kind**.

**Why:** each worker's `run_tasks()`/`run()` is an internal infinite loop (`while intervals.next().await { ... }`), so the existing `worker_run` span is lifetime-long and idle-inclusive — useless for per-turn metrics. The fix attaches `#[tracing::instrument]` to each worker's actual per-turn method (the loop body), not the looping function.

## What changed

A `worker_turn` span on all 6 workers' turn methods, all carrying the byte-identical `operation = "worker_turn"` (the spanmetrics aggregation key) and a `worker` dimension:

| Worker | turn span site |
|---|---|
| CommitLog | `tick()` |
| DisappearingMessages | `delete_expired_messages()` |
| PendingSelfRemove | `remove_pending_remove_users()` |
| KeyPackageCleaner | extracted `tick()` |
| TaskRunner | `run_and_reschedule_task()` |
| DeviceSync | extracted `handle_event()` |

- `worker = ?self.kind()` (Debug) on the 5 method sites; `TaskRunner` uses the literal `"TaskRunner"` (its turn method is an associated fn with no `self`). Both formats equal the existing `worker_run` span's value, so the two span series correlate cleanly.
- `skip_all` everywhere (workers hold a `Context` with DB/API handles).
- Two behavior-preserving extractions to host the macro: `KeyPackageCleaner::tick()` and `DeviceSync::handle_event()`. The DeviceSync 20s `Tick` heartbeat is deliberately bypassed before dispatch so idle heartbeats open no span (and emit no log).

## Deliberately out of scope

- Existing `worker_run` / `libxmtp_worker` spans left untouched (don't break existing dashboards).
- Deep spans in `mls_sync.rs` (`sync`, `post_commit`, `publish_intents`, ...) not touched — they're shared by foreground user calls too, so there's no static worker to stamp. otel traces already carry the worker→deep-span lineage; deep-span dashboard slicing is a telemetry-repo concern.

Design + plan included under `docs/superpowers/`.

## Test Plan

- [x] `just check crate xmtp_mls` — compiles clean
- [x] `just lint-rust` — clippy / fmt / hakari clean
- [x] `just test v3 worker` — 29/29 worker tests pass (incl. all device_sync + disconnect-propagation)
- [x] Invariant check: exactly 6 `operation = "worker_turn"` sites, byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-worker-turn tracing spans across MLS background workers
> Adds `#[tracing::instrument]` spans with `worker` and `operation="worker_turn"` fields to each background worker's main processing method, enabling per-turn telemetry in distributed traces.
>
> - [`commit_log.rs`](https://github.com/xmtp/libxmtp/pull/3711/files#diff-523943065ed63a511a3a552e44cb0ba0a05fecab9163088d5588cb5c949e6a5d), [`disappearing_messages.rs`](https://github.com/xmtp/libxmtp/pull/3711/files#diff-93ae9a4a70ee163ee3ce898babe5119780fa34ca9d91b823ee0135fda32f1160), [`pending_self_remove.rs`](https://github.com/xmtp/libxmtp/pull/3711/files#diff-2c915110e23b0ac1caa8ae0026e6cf76cff97c528ff81f91eef1a26a5d421f81), and [`tasks.rs`](https://github.com/xmtp/libxmtp/pull/3711/files#diff-b3d01dc512a077cf4b625f516f8c36ea61978f070bcce720ed8d522065a268b6) each get a span on their primary tick/run method with no logic changes.
> - [`key_package_cleaner.rs`](https://github.com/xmtp/libxmtp/pull/3711/files#diff-f474b9d0bca387a8ef826d7b34e811f8644323a8ac5584efc6eef034cfaeeb8d) extracts a new `tick` method to serve as the span boundary.
> - [`device_sync/worker.rs`](https://github.com/xmtp/libxmtp/pull/3711/files#diff-3d1d107a7d85b7aaf674a2365c789f51bda6243c3a37caab478baa8672ec737e) introduces a `handle_event` method that wraps non-`Tick` events in a span with an additional `event` field; `Tick` events bypass the span to avoid noise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d32c55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->