### PR TITLE
fix(release): tidy changelog + per-nightly changelog in hub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,6 +408,33 @@ jobs:
             --pending-version "${{ needs.pending.outputs.version }}" \
             --pending-kind "${{ needs.pending.outputs.kind }}")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Install git-cliff
+        if: steps.guard.outputs.should-release == 'true'
+        run: |
+          set -euo pipefail
+          cargo binstall -y git-cliff || cargo install git-cliff
+          git cliff --version
+      # Per-nightly changelog: the delta since the PREVIOUS nightly tag (not
+      # since the last stable). Computed BEFORE tagging this run, so the newest
+      # existing v*-nightly.* tag is genuinely the prior nightly. First-ever
+      # nightly (no prior nightly tag) falls back to since-last-stable.
+      - name: Compute per-nightly changelog
+        id: nightly_changelog
+        if: steps.guard.outputs.should-release == 'true'
+        run: |
+          set -euo pipefail
+          PREV_NIGHTLY=$(git tag -l 'v*-nightly.*' --sort=-creatordate | head -1 || true)
+          if [ -n "$PREV_NIGHTLY" ]; then
+            echo "::notice::Changelog range ${PREV_NIGHTLY}..HEAD"
+            git cliff --config cliff.toml "${PREV_NIGHTLY}..HEAD" --strip header > /tmp/nightly-changelog.md 2>/dev/null || true
+          else
+            echo "::notice::No prior nightly tag; changelog falls back to since-last-stable."
+            git cliff --config cliff.toml --unreleased --strip header > /tmp/nightly-changelog.md 2>/dev/null || true
+          fi
+          # Collapse to empty if git-cliff produced only whitespace/heading noise.
+          if ! grep -qE '^- ' /tmp/nightly-changelog.md; then
+            : > /tmp/nightly-changelog.md
+          fi
       - name: Tag libxmtp hub
         if: steps.guard.outputs.should-release == 'true'
         run: xmtp-release tag-release --sdk libxmtp --version "${{ steps.hubver.outputs.version }}" --ignore-if-exists
@@ -437,6 +464,15 @@ jobs:
           See per-SDK release notes under \`docs/release-notes/\`.
           EOF
           )
+          # Append the per-nightly changelog (delta since the previous nightly),
+          # if git-cliff produced any entries.
+          if [ -s /tmp/nightly-changelog.md ]; then
+            BODY="${BODY}
+
+          ## Changes since the last nightly
+
+          $(cat /tmp/nightly-changelog.md)"
+          fi
           if gh release view "v${HUB_VERSION}" >/dev/null 2>&1; then
             gh release edit "v${HUB_VERSION}" \
               --title "libxmtp ${HUB_VERSION}" \

--- a/cliff.toml
+++ b/cliff.toml
@@ -19,7 +19,7 @@ body = """
 ### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
 - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
-{{ commit.message | upper_first }}\
+{{ commit.message | split(pat="\n") | first | trim | upper_first }}\
 {% endfor %}
 {% endfor %}\n
 """
@@ -56,4 +56,9 @@ commit_parsers = [
   { message = "^chore\\(release\\)", skip = true },
   { message = "^chore|^ci|^build", group = "<!-- 6 -->Miscellaneous" },
   { body = ".*security", group = "<!-- 7 -->Security" },
+  # Catch-all: non-conventional commits (no recognized type) go into one "Other"
+  # bucket instead of git-cliff inventing a fake per-scope group from a leading
+  # `word:`/`word/word:` prefix (which produced sections like "Xmtp_proto",
+  # "Bindings/mobile"). Sorts last via the high <!-- 8 --> prefix.
+  { message = ".*", group = "<!-- 8 -->Other" },
 ]


### PR DESCRIPTION
Two changelog improvements, both stemming from the scruffy first generated Release PR (#3712).

## 1. Tidy the generated changelog (`cliff.toml`)

**Body-dump scruff** — the template rendered `commit.message` (full message = subject + body). GitHub squash-merges fill the commit body with the PR description, so each merge dumped its whole PR body into the changelog: Macroscope HTML-comment summary blocks, `Co-authored-by:` trailers, even a pasted Nix build-error log (~316 of #3712's 461 lines).
```diff
-{{ commit.message | upper_first }}
+{{ commit.message | split(pat="\n") | first | trim | upper_first }}
```

**Fake per-scope groups** — non-conventional commits (e.g. `xmtp_proto: …`, `bindings/mobile: …`) made git-cliff invent junk section headers like `Xmtp_proto` / `Bindings/mobile`. A catch-all collects them into one `Other` group:
```diff
+  { message = ".*", group = "<!-- 8 -->Other" },
```

Result (regenerated from `main`): group headers are exactly **Features · Bug Fixes · Performance · Documentation · Other**, every entry a clean subject line, zero scruff.

## 2. Per-nightly changelog in the hub release (`release.yml`)

Each nightly hub GitHub Release now appends a **"Changes since the last nightly"** section — the git-cliff delta over `<previous-nightly-tag>..HEAD` (`--strip header`), computed before this run is tagged so the newest existing `v*-nightly.*` tag is genuinely the prior one. First-ever nightly (no prior nightly tag) falls back to since-last-stable. Empty output is dropped. Adds git-cliff to the hub job.

> Uses an explicit `<tag>..HEAD` range rather than the config's stable-anchored `tag_pattern`, so it diffs against the last *nightly*, not the last stable. Relies on the §1 fixes for clean output.

## Verification

- Regenerated changelog from `main`: clean, 5 well-formed groups, no scruff.
- Simulated the per-nightly delta (`<tag>..HEAD --strip header`): clean grouped output, 22 bullets, no header.
- All workflow YAML validated.

Once merged, the open Release PR (#3712) regenerates clean on the next push to main, and the next real nightly carries a proper since-last-nightly changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tidy generated changelog to show subject-only commits and group non-conventional commits into 'Other'
> - Updates [cliff.toml](https://github.com/xmtp/libxmtp/pull/3713/files#diff-e1372c8b03c40942b5d828a90975054cb8aaed3b38189f434396f922ec41a584) to trim commit messages to their first line only and capitalise the first character, removing multi-line noise from changelogs.
> - Adds a catch-all parser rule in [cliff.toml](https://github.com/xmtp/libxmtp/pull/3713/files#diff-e1372c8b03c40942b5d828a90975054cb8aaed3b38189f434396f922ec41a584) that places non-conventional commits into an 'Other' group instead of creating per-scope groups.
> - Updates [release.yml](https://github.com/xmtp/libxmtp/pull/3713/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) to install `git-cliff`, compute a delta changelog from the previous nightly tag to `HEAD`, and append a
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eecd171.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->