### PR TITLE
fix(xmtp_mls): log already-processed welcomes at warn, not error

### DIFF
--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -104,6 +104,20 @@ where
                     return Err(GroupError::ProcessIntent(
                         ProcessIntentError::WelcomeAlreadyProcessed(welcome.cursor),
                     ));
+                } else if matches!(
+                    err,
+                    GroupError::ProcessIntent(ProcessIntentError::WelcomeAlreadyProcessed(_))
+                ) {
+                    // Expected, non-retryable condition: the welcome was already
+                    // processed (e.g. duplicate delivery for a group we are already
+                    // in). It is handled gracefully upstream (cursor incremented,
+                    // welcome skipped), so log at warn rather than error to avoid
+                    // marking the span as status:error and inflating the error rate.
+                    tracing::warn!(
+                        welcome_cursor = %welcome.cursor,
+                        "welcome already processed, skipping: {}",
+                        err
+                    );
                 } else {
                     tracing::error!(
                         "failed to create group from welcome={} created at {}: {}",

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -307,7 +307,12 @@ where
         let requires_processing =
             welcome.resuming() || welcome.sequence_id() > self.last_sequence_id(&db)? as u64;
         if !requires_processing {
-            tracing::error!("Skipping already processed welcome {}", welcome.cursor);
+            // Expected, non-retryable condition: a welcome we've already processed
+            // (duplicate delivery / resume past our cursor). Logging at error! here
+            // marks the enclosing worker span status:error and inflates the error
+            // rate, even though it's handled gracefully. warn! keeps it visible
+            // without poisoning the span.
+            tracing::warn!("Skipping already processed welcome {}", welcome.cursor);
             return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.cursor).into());
         }
         if *cursor_increment {


### PR DESCRIPTION
## Summary

An already-processed welcome (duplicate delivery, or a resume past our cursor for a group we're already in) is an **expected, gracefully-handled** condition — the error is returned, the cursor is handled, the welcome is skipped. But it was logged at `tracing::error!`.

The otel tracing layer (`tracing_opentelemetry`, default config) sets a span's status to `Error` for any `error!` event fired while that span is active — it's event-driven, not return-value-driven. So this benign condition marked the enclosing worker/sync span `status:error` and **inflated the telemetry error rate** even though nothing actually failed.

## Fix

Downgrade both emitters of this condition from `error!` to `warn!`:

- **`groups/welcomes/xmtp_welcome.rs`** — the upstream `"Skipping already processed welcome"` log inside `.process()`. This is the one that actually fires inside the worker span and poisons its status; it's the dominant source for the duplicate-delivery case.
- **`groups/welcome_sync.rs`** — the downstream catch-all `Err(err)` arm, which would otherwise log the returned `WelcomeAlreadyProcessed` at `error!` for the already-in-group path.

This mirrors the existing storage-duplicate handling a few lines up, which already logs at `warn!`.

**Behavior is otherwise unchanged:** the error is still returned, cursor handling is untouched. This is a telemetry/log-level-only change.

## Test Plan

- [x] `just check crate xmtp_mls` — compiles clean
- [x] `just lint-rust` — clippy / fmt / hakari clean
- [x] `just test v3 welcome` — 60/60 welcome tests pass
- [x] Confirmed no `error!` remains for this condition (both sites now `warn!`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log already-processed welcomes at warn instead of error in `process_new_welcome`
> Encountering an already-processed welcome is an expected, non-retryable condition, so logging it at `error` level produced noise. Both [`welcome_sync.rs`](https://github.com/xmtp/libxmtp/pull/3714/files#diff-5ad5d6ca4506c4960727c32b22b9168a128f14af4d61497cd168ba5c80fb43f5) and [`xmtp_welcome.rs`](https://github.com/xmtp/libxmtp/pull/3714/files#diff-7ad79af03cc69f17888ed323b42554f52c5c706674e76a981c4fd4663464bb4e) now use `warn` for this case. Error return semantics are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43d7550.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->