### PR TITLE
fix(xmtp_mls): forward db-disconnect signal through SyncSummary and sibling errors

### DIFF
--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -311,6 +311,14 @@ pub enum SqlKeyStoreError {
     Connection(#[from] crate::ConnectionError),
 }
 
+impl SqlKeyStoreError {
+    /// True when the pool can't currently hand out a connection. Mirrors
+    /// [`StorageError::db_needs_connection`](crate::StorageError::db_needs_connection).
+    pub fn db_needs_connection(&self) -> bool {
+        matches!(self, Self::Connection(c) if c.db_needs_connection())
+    }
+}
+
 impl RetryableError for SqlKeyStoreError {
     fn is_retryable(&self) -> bool {
         use SqlKeyStoreError::*;

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -147,16 +147,18 @@ impl NeedsDbReconnect for CommitLogError {
             // A readd send failure wraps an inner CommitLogError; forward.
             Self::FailedToSendReadd { source, .. } => source.needs_db_reconnect(),
             Self::FailedReadds { errors } => errors.iter().any(|e| e.needs_db_reconnect()),
+            // A dropped pool can be wrapped inside a SyncSummary; forward.
+            Self::SyncError(s) => s.needs_db_reconnect(),
+            // OpenMLS key-store ops surface a disconnect as a Connection error.
+            Self::KeystoreError(e) => e.db_needs_connection(),
             // Remaining variants can't carry a dropped-pool signal.
             Self::Diesel(_)
             | Self::Api(_)
             | Self::Prost(_)
-            | Self::KeystoreError(_)
             | Self::CryptoError(_)
             | Self::TryFromSliceError(_)
             | Self::Conversion(_)
             | Self::GroupReaddValidationError(_)
-            | Self::SyncError(_)
             | Self::MissingLatestCommitSequenceId { .. } => false,
         }
     }

--- a/crates/xmtp_mls/src/groups/error.rs
+++ b/crates/xmtp_mls/src/groups/error.rs
@@ -653,6 +653,11 @@ impl crate::worker::NeedsDbReconnect for GroupError {
             Self::MlsStore(s) => s.needs_db_reconnect(),
             Self::Identity(i) => i.needs_db_reconnect(),
             Self::DeviceSync(d) => d.needs_db_reconnect(),
+            // A dropped pool can be wrapped inside a SyncSummary's
+            // publish/post-commit/other/per-message errors; forward it.
+            Self::Sync(s) | Self::SyncFailedToWait(s) => s.needs_db_reconnect(),
+            // OpenMLS key-store ops surface a disconnect as a Connection error.
+            Self::SqlKeyStore(e) => e.db_needs_connection(),
             _ => false,
         }
     }

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -273,6 +273,33 @@ impl RetryableError for GroupMessageProcessingError {
     }
 }
 
+impl crate::worker::NeedsDbReconnect for GroupMessageProcessingError {
+    /// Forwards a dropped-pool signal from storage-bearing variants so a
+    /// per-message disconnect (landing in `SyncSummary::process.errored`) isn't lost.
+    fn needs_db_reconnect(&self) -> bool {
+        use super::app_data::ProcessMessageWithAppDataError;
+        match self {
+            Self::Storage(s) => s.db_needs_connection(),
+            Self::Db(c) => c.db_needs_connection(),
+            Self::Identity(i) => i.needs_db_reconnect(),
+            Self::Client(c) => c.db_needs_connection(),
+            // OpenMLS state-I/O carries a pool drop as
+            // `StorageError(SqlKeyStoreError::Connection(_))`; forward it.
+            Self::ClearPendingCommit(e) => e.db_needs_connection(),
+            Self::OpenMlsProcessMessage(ProcessMessageError::StorageError(e)) => {
+                e.db_needs_connection()
+            }
+            Self::OpenMlsProcessMessageWithAppData(ProcessMessageWithAppDataError::OpenMls(
+                ProcessMessageError::StorageError(e),
+            )) => e.db_needs_connection(),
+            Self::MergeStagedCommit(openmls::group::MergeCommitError::StorageError(e)) => {
+                e.db_needs_connection()
+            }
+            _ => false,
+        }
+    }
+}
+
 impl GroupMessageProcessingError {
     pub(crate) fn commit_result(&self) -> CommitResult {
         use super::app_data::ProcessMessageWithAppDataError;

--- a/crates/xmtp_mls/src/groups/summary.rs
+++ b/crates/xmtp_mls/src/groups/summary.rs
@@ -30,6 +30,24 @@ impl RetryableError for SyncSummary {
     }
 }
 
+impl crate::worker::NeedsDbReconnect for SyncSummary {
+    /// Scans every error source (incl. per-message `process.errored`, which
+    /// `is_retryable` skips) so a dropped pool wrapped in a summary still surfaces.
+    fn needs_db_reconnect(&self) -> bool {
+        self.publish_errors.iter().any(|e| e.needs_db_reconnect())
+            || self
+                .post_commit_errors
+                .iter()
+                .any(|e| e.needs_db_reconnect())
+            || self.other.as_ref().is_some_and(|e| e.needs_db_reconnect())
+            || self
+                .process
+                .errored
+                .iter()
+                .any(|(_, e)| e.needs_db_reconnect())
+    }
+}
+
 impl SyncSummary {
     /// synced a single message successfully
     pub fn single(msg: MessageIdentifier) -> Self {

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -446,6 +446,10 @@ mod disconnect_propagation_tests {
             !CommitLogError::Connection(ConnectionError::DisconnectInTransaction)
                 .needs_db_reconnect()
         );
+        // A dropped pool wrapped in a SyncSummary (was `SyncError(_) => false`).
+        let mut summary = crate::groups::summary::SyncSummary::default();
+        summary.add_other(GroupError::Db(disconnect_connection()));
+        assert!(CommitLogError::SyncError(summary).needs_db_reconnect());
     }
 
     #[xmtp_common::test]
@@ -463,6 +467,10 @@ mod disconnect_propagation_tests {
             DeviceSyncError::Subscribe(SubscribeError::Db(disconnect_connection()))
                 .needs_db_reconnect()
         );
+        // A dropped pool wrapped in a SyncSummary (was caught by `_ => false`).
+        let mut summary = crate::groups::summary::SyncSummary::default();
+        summary.add_other(GroupError::Db(disconnect_connection()));
+        assert!(DeviceSyncError::Sync(Box::new(summary)).needs_db_reconnect());
         assert!(!DeviceSyncError::Storage(benign_storage()).needs_db_reconnect());
         assert!(!DeviceSyncError::InvalidPayload.needs_db_reconnect());
     }
@@ -482,6 +490,128 @@ mod disconnect_propagation_tests {
                 .needs_db_reconnect()
         );
         assert!(!KeyPackagesCleanerError::Storage(benign_storage()).needs_db_reconnect());
+    }
+
+    // SyncSummary previously had no NeedsDbReconnect impl, so a dropped pool in
+    // any of its four error sources hot-looped the worker via `_ => false`.
+    #[xmtp_common::test]
+    fn sync_summary_forwards_disconnect() {
+        use crate::groups::mls_sync::GroupMessageProcessingError;
+        use crate::groups::summary::{ProcessSummary, SyncSummary};
+        use xmtp_proto::types::Cursor;
+
+        // 1. disconnect in publish_errors
+        let mut s = SyncSummary::default();
+        s.add_publish_err(GroupError::Storage(disconnect_storage()));
+        assert!(s.needs_db_reconnect(), "publish_errors disconnect");
+
+        // 2. disconnect in post_commit_errors
+        let mut s = SyncSummary::default();
+        s.add_post_commit_err(GroupError::Db(disconnect_connection()));
+        assert!(s.needs_db_reconnect(), "post_commit_errors disconnect");
+
+        // 3. disconnect in `other`
+        let mut s = SyncSummary::default();
+        s.add_other(GroupError::Storage(disconnect_storage()));
+        assert!(s.needs_db_reconnect(), "other disconnect");
+
+        // 4. disconnect in a per-message processing error (process.errored) —
+        //    the source is_retryable() deliberately skips.
+        let mut process = ProcessSummary::default();
+        process.errored.push((
+            Cursor::new(1, 1u32),
+            GroupMessageProcessingError::Db(disconnect_connection()),
+        ));
+        let mut s = SyncSummary::default();
+        s.add_process(process);
+        assert!(s.needs_db_reconnect(), "process.errored disconnect");
+
+        // A benign sync error must NOT trip the contract (else the worker tears
+        // down the pool needlessly on an ordinary per-message failure).
+        let mut s = SyncSummary::default();
+        s.add_publish_err(GroupError::Storage(benign_storage()));
+        assert!(!s.needs_db_reconnect(), "benign publish error");
+
+        // And the forwarding must survive the GroupError wrappers the worker
+        // actually inspects.
+        let mut s = SyncSummary::default();
+        s.add_publish_err(GroupError::Db(disconnect_connection()));
+        assert!(
+            GroupError::Sync(Box::new(s)).needs_db_reconnect(),
+            "GroupError::Sync"
+        );
+
+        let mut s = SyncSummary::default();
+        s.add_other(GroupError::Storage(disconnect_storage()));
+        assert!(
+            GroupError::SyncFailedToWait(Box::new(s)).needs_db_reconnect(),
+            "GroupError::SyncFailedToWait"
+        );
+    }
+
+    // OpenMLS state-I/O wrappers carry a pool drop as
+    // `StorageError(SqlKeyStoreError::Connection(_))`; previously `_ => false`.
+    #[xmtp_common::test]
+    fn group_message_processing_error_forwards_openmls_disconnect() {
+        use crate::groups::mls_sync::GroupMessageProcessingError;
+        use openmls::group::MergeCommitError;
+        use openmls::prelude::ProcessMessageError;
+        use xmtp_db::sql_key_store::SqlKeyStoreError;
+
+        let disconnect_sql = || SqlKeyStoreError::Connection(disconnect_connection());
+        let benign_sql = || SqlKeyStoreError::Connection(ConnectionError::DisconnectInTransaction);
+
+        // OpenMlsProcessMessage(StorageError(Connection(PoolNeedsConnection)))
+        assert!(
+            GroupMessageProcessingError::OpenMlsProcessMessage(ProcessMessageError::StorageError(
+                disconnect_sql()
+            ))
+            .needs_db_reconnect()
+        );
+        // MergeStagedCommit(StorageError(Connection(PoolNeedsConnection)))
+        assert!(
+            GroupMessageProcessingError::MergeStagedCommit(MergeCommitError::StorageError(
+                disconnect_sql()
+            ))
+            .needs_db_reconnect()
+        );
+        // A non-pool-drop connection error inside the same wrapper must NOT trip it.
+        assert!(
+            !GroupMessageProcessingError::OpenMlsProcessMessage(ProcessMessageError::StorageError(
+                benign_sql()
+            ))
+            .needs_db_reconnect()
+        );
+        // The directly-wrapped paths still work.
+        assert!(GroupMessageProcessingError::Db(disconnect_connection()).needs_db_reconnect());
+        assert!(!GroupMessageProcessingError::Storage(benign_storage()).needs_db_reconnect());
+    }
+
+    // A disconnect can reach the task worker as Group(Db)/DeviceSync(Db), not
+    // only as the structurally-matched ::Storage; previously those were `false`.
+    #[xmtp_common::test]
+    fn task_worker_error_forwards_disconnect() {
+        use crate::worker::tasks::TaskWorkerError;
+        assert!(
+            TaskWorkerError::Group(GroupError::Db(disconnect_connection())).needs_db_reconnect(),
+            "Group(Db) disconnect"
+        );
+        assert!(
+            TaskWorkerError::Group(GroupError::MlsStore(MlsStoreError::Connection(
+                disconnect_connection()
+            )))
+            .needs_db_reconnect(),
+            "Group(MlsStore) disconnect"
+        );
+        assert!(
+            TaskWorkerError::DeviceSync(DeviceSyncError::Db(disconnect_connection()))
+                .needs_db_reconnect(),
+            "DeviceSync(Db) disconnect"
+        );
+        assert!(
+            !TaskWorkerError::Group(GroupError::InvalidGroupMembership).needs_db_reconnect(),
+            "benign group error"
+        );
     }
 }
 

--- a/crates/xmtp_mls/src/worker/device_sync/mod.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/mod.rs
@@ -212,6 +212,8 @@ impl NeedsDbReconnect for DeviceSyncError {
             Self::Group(e) => e.needs_db_reconnect(),
             Self::MlsStore(e) => e.needs_db_reconnect(),
             Self::Subscribe(e) => e.needs_db_reconnect(),
+            // A dropped pool can be wrapped inside a SyncSummary; forward.
+            Self::Sync(s) => s.needs_db_reconnect(),
             _ => false,
         }
     }

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -45,14 +45,12 @@ pub enum TaskWorkerError {
 impl NeedsDbReconnect for TaskWorkerError {
     fn needs_db_reconnect(&self) -> bool {
         match self {
-            TaskWorkerError::Storage(s)
-            | TaskWorkerError::DeviceSync(DeviceSyncError::Storage(s)) => s.db_needs_connection(),
+            TaskWorkerError::Storage(s) => s.db_needs_connection(),
+            // Forward the full classification: a dropped pool can reach these as
+            // `Db`/`MlsStore`/`Sync`/... too, not only as `Storage`.
             TaskWorkerError::LoadGroup(e) => e.needs_db_reconnect(),
-            // Forward through GroupError's own classifier so a dropped pool hiding
-            // in a `Db`/`MlsStore` (not just `Storage`) variant still restarts the
-            // worker instead of being retried on a dead connection.
             TaskWorkerError::Group(e) => e.needs_db_reconnect(),
-            TaskWorkerError::DeviceSync(_) => false,
+            TaskWorkerError::DeviceSync(e) => e.needs_db_reconnect(),
             TaskWorkerError::InvalidTaskData { .. } => false,
             TaskWorkerError::InvalidHash { .. } => false,
             TaskWorkerError::ReceiverLocked => false,


### PR DESCRIPTION
## Summary

A dropped DB pool (`PoolNeedsConnection`) that surfaced **during a sync** was being misclassified as not-a-disconnect, so the worker supervisor never dropped the pool to reconnect — it **retried forever on a dead pool**. The worst path (`GroupError::SyncFailedToWait`) is also `is_retryable == true`, making it a true hot-loop.

Root cause: `SyncSummary` — the aggregate sync error — had **no `NeedsDbReconnect` impl at all**. Any `PoolNeedsConnection` landing in its `publish_errors` / `post_commit_errors` / `other` / per-message `process.errored` got wrapped into `GroupError::Sync` / `SyncFailedToWait` / `DeviceSyncError::Sync` / `CommitLogError::SyncError`, all of which hit `_ => false` in `needs_db_reconnect`. The disconnect signal was permanently buried.

This is the same bug class the existing `disconnect_propagation_tests` were written to prevent — the SyncSummary path just wasn't covered.

## Fix — forward the disconnect signal everywhere it was being dropped

- **`SqlKeyStoreError::db_needs_connection()`** (new, in `xmtp_db`) — mirrors `StorageError`/`ConnectionError`, so the OpenMLS key-store disconnect check lives in one place instead of three nested-variant matches.
- **`SyncSummary: NeedsDbReconnect`** (new) — scans all four error sources, including the per-message `process.errored` failures (which `is_retryable` deliberately skips, but which can still carry a pool drop).
- **`GroupMessageProcessingError: NeedsDbReconnect`** (new) — forwards the directly-wrapped DB variants (`Storage`/`Db`/`Identity`/`Client`/`ClearPendingCommit`) **and** the OpenMLS state-I/O wrappers (`OpenMlsProcessMessage`, `OpenMlsProcessMessageWithAppData`, `MergeStagedCommit`), which carry a drop as `StorageError(SqlKeyStoreError::Connection(_))` — the *most likely* per-message disconnect carriers.
- **`GroupError::needs_db_reconnect`** — `Sync` / `SyncFailedToWait` now forward to `SyncSummary`; `SqlKeyStore` forwarded.
- **`TaskWorkerError::needs_db_reconnect`** — `Group` / `LoadGroup` / `DeviceSync` forward the full classification instead of structurally matching only the inner `Storage` variant.
- **`CommitLogError`** — `SyncError` / `KeystoreError` forwarded.
- **`DeviceSyncError`** — `Sync` forwarded.

### Safety: no false positives
Every new arm bottoms out at `db_needs_connection()`, which matches **only** `PoolNeedsConnection` (and the pre-existing `Pool(_)`). A non-pool-drop connection error like `DisconnectInTransaction` stays classified `false`, so a healthy pool is never torn down needlessly. Each new test includes a benign-error negative case to pin this.

### Rebase
Rebased onto latest `main` (post-#3744 TaskRunner rework); `TaskWorkerError` merge keeps the new `LoadGroup` variant forwarding.

## Test Plan

- [x] `cargo check -p xmtp_mls --tests` — compiles clean
- [x] `just lint-rust` — clippy / fmt / hakari clean
- [x] `cargo nextest run -p xmtp_mls disconnect_propagation_tests` — 10/10 pass (3 new: `sync_summary_forwards_disconnect`, `group_message_processing_error_forwards_openmls_disconnect`, `task_worker_error_forwards_disconnect`)
- [x] `cargo nextest run -p xmtp_mls -E 'test(worker)'` — 33/33 pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward db-disconnect signals through `SyncSummary` and sibling error types in `xmtp_mls`
> Several `NeedsDbReconnect` trait implementations previously dropped pool-disconnect signals when errors were wrapped in `SyncSummary`, `SyncError`, `KeystoreError`, or OpenMLS storage error paths, causing reconnect logic to silently miss these conditions.
>
> - [`SyncSummary`](https://github.com/xmtp/libxmtp/pull/3716/files#diff-cc6e0f2ec334b2a161a0e24bf0a280e37287801dcc7c6e40c46b7d5153580240) gets a new `NeedsDbReconnect` impl that checks all contained error collections (`publish_errors`, `post_commit_errors`, `other`, `process.errored`).
> - [`GroupError`](https://github.com/xmtp/libxmtp/pull/3716/files#diff-3092c03be9a98f95252ffd3a9b58177bc1f8597a79a2505a0aac3bfc2689338d), [`CommitLogError`](https://github.com/xmtp/libxmtp/pull/3716/files#diff-523943065ed63a511a3a552e44cb0ba0a05fecab9163088d5588cb5c949e6a5d), and [`DeviceSyncError`](https://github.com/xmtp/libxmtp/pull/3716/files#diff-3551b5963cf2c5a05aeb3cd6d1105e82fedae4160d4258bec732cdbb5f382f15) now delegate to inner `SyncSummary::needs_db_reconnect()` instead of returning `false`.
> - [`GroupMessageProcessingError`](https://github.com/xmtp/libxmtp/pull/3716/files#diff-160aadcd7de477c1116260a79601a0548842f3bd91bf16bd8443debb66ce6684) gets a new `NeedsDbReconnect` impl covering OpenMLS `StorageError` and `MergeCommitError` paths.
> - [`TaskWorkerError`](https://github.com/xmtp/libxmtp/pull/3716/files#diff-b3d01dc512a077cf4b625f516f8c36ea61978f070bcce720ed8d522065a268b6) now fully delegates `DeviceSync(e)` to `e.needs_db_reconnect()` rather than only forwarding the `Storage` sub-variant.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0f3d67a. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->