### PR TITLE
fix(release): make nightly version deterministic, cap at minor, add dry-run gate

### DIFF
--- a/.github/workflows/nightly-dry-run.yml
+++ b/.github/workflows/nightly-dry-run.yml
@@ -1,0 +1,40 @@
+name: nightly-dry-run
+
+# Manual preview of the nightly version-computation plan (cross-test gate +
+# git-cliff oracle, capped at minor, with the not-major assertion). Calls the
+# same release-gate-plan reusable workflow the real nightly uses, so it
+# exercises identical logic. Has NO publish jobs — it structurally cannot
+# publish/tag anything. Use this to verify pipeline changes before they ship.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Ref to compute the nightly plan for"
+        required: false
+        type: string
+        default: main
+
+jobs:
+  plan:
+    uses: ./.github/workflows/release-gate-plan.yml
+    with:
+      ref: ${{ inputs.ref || github.ref_name }}
+    secrets: inherit
+  summary:
+    needs: [plan]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print plan result
+        run: |
+          {
+            echo "## Nightly dry-run plan"
+            echo ""
+            echo "- gate-skip: \`${{ needs.plan.outputs.gate-skip }}\`"
+            echo "- nothing-pending: \`${{ needs.plan.outputs.nothing-pending }}\`"
+            echo "- version: \`${{ needs.plan.outputs.version }}\`"
+            echo "- kind: \`${{ needs.plan.outputs.kind }}\`"
+            echo ""
+            echo "No publishes/tags occur in a dry-run."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-gate-plan.yml
+++ b/.github/workflows/release-gate-plan.yml
@@ -1,0 +1,151 @@
+name: release-gate-plan
+
+# Reusable: cross-test gate + version oracle (the nightly "plan"). Computes the
+# pending libxmtp {version,kind}, caps at minor, asserts not-major, prints the
+# plan. Does NO publishing. Called by release.yml (real nightly) and
+# nightly-dry-run.yml (manual preview) so both run identical logic.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+    outputs:
+      sha:
+        value: ${{ jobs.gate.outputs.sha }}
+      gate-skip:
+        value: ${{ jobs.gate.outputs.gate-skip }}
+      version:
+        value: ${{ jobs.pending.outputs.version }}
+      kind:
+        value: ${{ jobs.pending.outputs.kind }}
+      nothing-pending:
+        value: ${{ jobs.pending.outputs.nothing-pending }}
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
+      gate-skip: ${{ steps.gate.outputs.gate-skip }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+      - uses: ./.github/actions/setup-release-tools
+      - name: Resolve exact SHA
+        id: sha
+        run: |
+          set -euo pipefail
+          # Use the SHA of the commit actually checked out above (inputs.ref).
+          # This is correct for an arbitrary requested ref (e.g. a dry-run
+          # previewing a specific branch) AND avoids a TOCTOU race — it's the
+          # literal checked-out tree, not a second branch-HEAD lookup that a
+          # concurrent push could move. (Earlier this preferred github.sha,
+          # which ignored a dispatched inputs.ref and gated the wrong commit.)
+          SHA=$(git rev-parse HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+      - name: Evaluate cross-test gate
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${REPO}/actions/workflows/cross-test.yml/runs?head_sha=${SHA}&status=completed" > /tmp/cross-runs.json
+          RESULT=$(xmtp-release cross-test-gate --input=/tmp/cross-runs.json --sha "$SHA")
+          PASS=$(printf '%s' "$RESULT" | jq -r '.pass')
+          if [ "$PASS" = "true" ]; then
+            echo "gate-skip=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::cross-test green for ${SHA}; nightly may proceed."
+          else
+            REASON=$(printf '%s' "$RESULT" | jq -r '.reason')
+            echo "gate-skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Nightly skipped — ${REASON}"
+          fi
+
+  pending:
+    needs: [gate]
+    if: needs.gate.outputs.gate-skip != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pending.outputs.version }}
+      kind: ${{ steps.pending.outputs.kind }}
+      # 'true' when there are no conventional commits since the last tag — a
+      # legitimate "nothing to release" nightly that downstream jobs skip.
+      nothing-pending: ${{ steps.pending.outputs.nothing-pending }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-release-tools
+      - name: Install git-cliff
+        run: |
+          set -euo pipefail
+          # Pinned for reproducibility — an unpinned/floating git-cliff once
+          # computed a major bump in CI that didn't reproduce locally, which
+          # published a bogus version. Keep in sync with the devshell's nixpkgs
+          # git-cliff (nix/lib/shell-common.nix).
+          cargo binstall -y git-cliff --version 2.13.1 \
+            || cargo install git-cliff --version 2.13.1 --locked
+          git cliff --version
+      - name: Compute pending libxmtp release (git-cliff oracle)
+        id: pending
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LAST=$(gh api "repos/${REPO}/git/matching-refs/tags/v" \
+            --jq '[.[].ref | sub("refs/tags/v";"")]
+                  | map(select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$")))
+                  | sort_by(split(".")|map(tonumber)) | last // ""')
+          # Fail loudly if no stable libxmtp tag exists rather than silently
+          # diffing against a stale hardcoded baseline.
+          if [ -z "$LAST" ]; then
+            echo "::error::No stable v* libxmtp tag found to use as the bump baseline"
+            exit 1
+          fi
+          git cliff --config cliff.toml --bump --context > /tmp/cliff-context.json
+          # Default (no --require): emits {version:null,kind:null} on exit 0 when
+          # there are no conventional commits since the last tag — a legitimate
+          # no-op nightly we skip rather than fail.
+          # --max-bump minor: a nightly must NEVER auto-major. A real major is a
+          # deliberate, manual stable decision. capBumpKind recomputes the
+          # version from $LAST when it clamps.
+          PENDING=$(xmtp-release pending-version \
+            --input=/tmp/cliff-context.json --last-shipped "$LAST" --max-bump minor)
+          VERSION=$(printf '%s' "$PENDING" | jq -r '.version')
+          KIND=$(printf '%s' "$PENDING" | jq -r '.kind')
+          if [ "$VERSION" = "null" ] && [ "$KIND" = "null" ]; then
+            echo "nothing-pending=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No conventional commits since the last tag; skipping nightly (nothing to release)."
+            exit 0
+          fi
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ] || [ -z "$KIND" ] || [ "$KIND" = "null" ]; then
+            echo "::error::pending-version produced malformed version/kind: '$PENDING'"
+            exit 1
+          fi
+          # Defense-in-depth: the cap above should make this impossible. If a
+          # major still reaches here the cap regressed — fail BEFORE any publish.
+          # Failing this job fails the caller's `plan` job, and every
+          # release-*/hub job needs: [plan], so this blocks them all.
+          if [ "$KIND" = "major" ]; then
+            echo "::error::nightly computed a major bump ($VERSION) after cap — refusing to publish"
+            exit 1
+          fi
+          echo "nothing-pending=false" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+          # Human-readable release plan.
+          {
+            echo "## Nightly release plan"
+            echo ""
+            echo "- libxmtp: \`$VERSION\` (bump: $KIND, baseline: $LAST)"
+            echo ""
+            echo "Per-SDK versions are resolved in each release job from this pending bump."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,9 +211,12 @@ jobs:
       - name: Install git-cliff
         run: |
           set -euo pipefail
-          cargo binstall -y git-cliff || cargo install git-cliff
-          # Fail loudly if neither install path produced a working binary, so a
-          # broken install can't fall through to an empty pending version.
+          # Pinned for reproducibility — an unpinned/floating git-cliff once
+          # computed a major bump in CI that didn't reproduce locally, which
+          # published a bogus version. Keep in sync with the devshell's nixpkgs
+          # git-cliff (nix/lib/shell-common.nix).
+          cargo binstall -y git-cliff --version 2.13.1 \
+            || cargo install git-cliff --version 2.13.1 --locked
           git cliff --version
       - name: Compute pending libxmtp release (git-cliff oracle)
         id: pending
@@ -236,7 +239,11 @@ jobs:
           # Default (no --require): emits {version:null,kind:null} on exit 0 when
           # there are no conventional commits since the last tag — a legitimate
           # no-op nightly we skip rather than fail.
-          PENDING=$(xmtp-release pending-version --input=/tmp/cliff-context.json --last-shipped "$LAST")
+          # --max-bump minor: a nightly must NEVER auto-major. A real major is a
+          # deliberate, manual stable decision. capBumpKind recomputes the
+          # version from $LAST when it clamps.
+          PENDING=$(xmtp-release pending-version \
+            --input=/tmp/cliff-context.json --last-shipped "$LAST" --max-bump minor)
           VERSION=$(printf '%s' "$PENDING" | jq -r '.version')
           KIND=$(printf '%s' "$PENDING" | jq -r '.kind')
           if [ "$VERSION" = "null" ] && [ "$KIND" = "null" ]; then
@@ -244,14 +251,28 @@ jobs:
             echo "::notice::No conventional commits since the last tag; skipping nightly (nothing to release)."
             exit 0
           fi
-          # Anything else empty/null is unexpected corruption, not a clean no-op.
           if [ -z "$VERSION" ] || [ "$VERSION" = "null" ] || [ -z "$KIND" ] || [ "$KIND" = "null" ]; then
             echo "::error::pending-version produced malformed version/kind: '$PENDING'"
+            exit 1
+          fi
+          # Defense-in-depth: the cap above should make this impossible. If a
+          # major still reaches here the cap regressed — fail BEFORE any publish
+          # (every release-*/hub job needs: [pending], so this blocks them all).
+          if [ "$KIND" = "major" ]; then
+            echo "::error::nightly computed a major bump ($VERSION) after cap — refusing to publish"
             exit 1
           fi
           echo "nothing-pending=false" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+          # Human-readable release plan.
+          {
+            echo "## Nightly release plan"
+            echo ""
+            echo "- libxmtp: \`$VERSION\` (bump: $KIND, baseline: $LAST)"
+            echo ""
+            echo "Per-SDK versions are resolved in each release job from this pending bump."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   release-ios:
     needs: [validate, gate, pending]
@@ -412,7 +433,8 @@ jobs:
         if: steps.guard.outputs.should-release == 'true'
         run: |
           set -euo pipefail
-          cargo binstall -y git-cliff || cargo install git-cliff
+          cargo binstall -y git-cliff --version 2.13.1 \
+            || cargo install git-cliff --version 2.13.1 --locked
           git cliff --version
       # Per-nightly changelog: the delta since the PREVIOUS nightly tag (not
       # since the last stable). Computed BEFORE tagging this run, so the newest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: boolean
         default: false
+      dry-run:
+        description: "Compute + print the full release plan but skip ALL publishes/tags"
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Nightly: 06:00 UTC daily (~11pm PT / 02am ET). Schedule-only, never manual.
     - cron: "0 6 * * *"
@@ -58,6 +63,7 @@ jobs:
       android: ${{ steps.resolve.outputs.android }}
       node: ${{ steps.resolve.outputs.node }}
       wasm: ${{ steps.resolve.outputs.wasm }}
+      dry-run: ${{ steps.resolve.outputs.dry-run }}
       skip: ${{ steps.skip-check.outputs.skip }}
     steps:
       - name: Resolve release parameters
@@ -71,6 +77,7 @@ jobs:
           INPUT_ANDROID: ${{ inputs.android }}
           INPUT_NODE: ${{ inputs.node }}
           INPUT_WASM: ${{ inputs.wasm }}
+          INPUT_DRY_RUN: ${{ inputs.dry-run }}
         run: |
           if [ "$EVENT_NAME" = "schedule" ]; then
             echo "release-type=nightly" >> "$GITHUB_OUTPUT"
@@ -79,6 +86,7 @@ jobs:
             echo "android=true" >> "$GITHUB_OUTPUT"
             echo "node=true" >> "$GITHUB_OUTPUT"
             echo "wasm=true" >> "$GITHUB_OUTPUT"
+            echo "dry-run=false" >> "$GITHUB_OUTPUT"
           else
             echo "release-type=$INPUT_RELEASE_TYPE" >> "$GITHUB_OUTPUT"
             echo "ref=${INPUT_REF:-$GITHUB_REF}" >> "$GITHUB_OUTPUT"
@@ -86,6 +94,7 @@ jobs:
             echo "android=$INPUT_ANDROID" >> "$GITHUB_OUTPUT"
             echo "node=$INPUT_NODE" >> "$GITHUB_OUTPUT"
             echo "wasm=$INPUT_WASM" >> "$GITHUB_OUTPUT"
+            echo "dry-run=${INPUT_DRY_RUN:-false}" >> "$GITHUB_OUTPUT"
           fi
       - name: Validate dev release
         if: steps.resolve.outputs.release-type == 'dev'
@@ -279,6 +288,7 @@ jobs:
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.ios == 'true' && needs.validate.outputs.skip != 'true'
+      && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
           || (needs.gate.outputs.gate-skip != 'true' && needs.pending.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-ios.yml
@@ -295,6 +305,7 @@ jobs:
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.android == 'true' && needs.validate.outputs.skip != 'true'
+      && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
           || (needs.gate.outputs.gate-skip != 'true' && needs.pending.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-android.yml
@@ -311,6 +322,7 @@ jobs:
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.node == 'true' && needs.validate.outputs.skip != 'true'
+      && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
           || (needs.gate.outputs.gate-skip != 'true' && needs.pending.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-node.yml
@@ -327,6 +339,7 @@ jobs:
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.wasm == 'true' && needs.validate.outputs.skip != 'true'
+      && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
           || (needs.gate.outputs.gate-skip != 'true' && needs.pending.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-wasm.yml
@@ -381,6 +394,7 @@ jobs:
       needs.validate.outputs.release-type == 'nightly'
       && needs.gate.outputs.gate-skip != 'true'
       && needs.pending.outputs.nothing-pending != 'true'
+      && needs.validate.outputs.dry-run != 'true'
       && !cancelled() && !contains(needs.*.result, 'failure')
     # Serialize hub runs for the same pending version so two overlapping nightly
     # runs (e.g. cron + a manual dispatch) can't both create the same tag/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,211 +148,92 @@ jobs:
 
   # Nightly blocking relies on TWO mechanisms that must BOTH be preserved (see hub job below):
   #  1. gate-skip == 'true' (a legitimate "not green yet" skip; gate job succeeds), and
-  #  2. job-dependency skip on gate/pending FAILURE.
-  gate:
+  #  2. job-dependency skip on plan FAILURE.
+  # The cross-test gate + version oracle live in the reusable release-gate-plan
+  # workflow (one source of truth, shared with nightly-dry-run.yml). This `plan`
+  # job runs it for the real nightly. Outputs: sha, gate-skip, version, kind,
+  # nothing-pending.
+  plan:
     needs: [validate]
     if: needs.validate.outputs.release-type == 'nightly' && needs.validate.outputs.skip != 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.sha.outputs.sha }}
-      gate-skip: ${{ steps.gate.outputs.gate-skip }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.validate.outputs.ref }}
-          fetch-depth: 1
-      - uses: ./.github/actions/setup-release-tools
-      - name: Resolve exact SHA
-        id: sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          REF: ${{ needs.validate.outputs.ref }}
-          # github.sha is the exact commit this run was triggered on (and the one
-          # checked out above). For schedule/dispatch on main this is the nightly
-          # target — using it avoids a TOCTOU race where a concurrent push moves
-          # the branch HEAD between resolving the SHA and querying cross-test.
-          EVENT_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          if [ -n "${EVENT_SHA:-}" ]; then
-            SHA="$EVENT_SHA"
-          else
-            SHA=$(gh api "repos/${REPO}/commits/${REF}" --jq '.sha')
-          fi
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-      - name: Evaluate cross-test gate
-        id: gate
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ steps.sha.outputs.sha }}
-        run: |
-          set -euo pipefail
-          gh api "repos/${REPO}/actions/workflows/cross-test.yml/runs?head_sha=${SHA}&status=completed" > /tmp/cross-runs.json
-          RESULT=$(xmtp-release cross-test-gate --input=/tmp/cross-runs.json --sha "$SHA")
-          PASS=$(printf '%s' "$RESULT" | jq -r '.pass')
-          if [ "$PASS" = "true" ]; then
-            echo "gate-skip=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::cross-test green for ${SHA}; nightly may proceed."
-          else
-            REASON=$(printf '%s' "$RESULT" | jq -r '.reason')
-            echo "gate-skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Nightly skipped — ${REASON}"
-          fi
-
-  pending:
-    needs: [validate, gate]
-    if: needs.validate.outputs.release-type == 'nightly' && needs.gate.outputs.gate-skip != 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.pending.outputs.version }}
-      kind: ${{ steps.pending.outputs.kind }}
-      # 'true' when there are no conventional commits since the last tag — a
-      # legitimate "nothing to release" nightly that downstream jobs skip.
-      nothing-pending: ${{ steps.pending.outputs.nothing-pending }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.validate.outputs.ref }}
-          fetch-depth: 0
-      - uses: ./.github/actions/setup-release-tools
-      - name: Install git-cliff
-        run: |
-          set -euo pipefail
-          # Pinned for reproducibility — an unpinned/floating git-cliff once
-          # computed a major bump in CI that didn't reproduce locally, which
-          # published a bogus version. Keep in sync with the devshell's nixpkgs
-          # git-cliff (nix/lib/shell-common.nix).
-          cargo binstall -y git-cliff --version 2.13.1 \
-            || cargo install git-cliff --version 2.13.1 --locked
-          git cliff --version
-      - name: Compute pending libxmtp release (git-cliff oracle)
-        id: pending
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          LAST=$(gh api "repos/${REPO}/git/matching-refs/tags/v" \
-            --jq '[.[].ref | sub("refs/tags/v";"")]
-                  | map(select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$")))
-                  | sort_by(split(".")|map(tonumber)) | last // ""')
-          # Fail loudly if no stable libxmtp tag exists rather than silently
-          # diffing against a stale hardcoded baseline.
-          if [ -z "$LAST" ]; then
-            echo "::error::No stable v* libxmtp tag found to use as the bump baseline"
-            exit 1
-          fi
-          git cliff --config cliff.toml --bump --context > /tmp/cliff-context.json
-          # Default (no --require): emits {version:null,kind:null} on exit 0 when
-          # there are no conventional commits since the last tag — a legitimate
-          # no-op nightly we skip rather than fail.
-          # --max-bump minor: a nightly must NEVER auto-major. A real major is a
-          # deliberate, manual stable decision. capBumpKind recomputes the
-          # version from $LAST when it clamps.
-          PENDING=$(xmtp-release pending-version \
-            --input=/tmp/cliff-context.json --last-shipped "$LAST" --max-bump minor)
-          VERSION=$(printf '%s' "$PENDING" | jq -r '.version')
-          KIND=$(printf '%s' "$PENDING" | jq -r '.kind')
-          if [ "$VERSION" = "null" ] && [ "$KIND" = "null" ]; then
-            echo "nothing-pending=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::No conventional commits since the last tag; skipping nightly (nothing to release)."
-            exit 0
-          fi
-          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ] || [ -z "$KIND" ] || [ "$KIND" = "null" ]; then
-            echo "::error::pending-version produced malformed version/kind: '$PENDING'"
-            exit 1
-          fi
-          # Defense-in-depth: the cap above should make this impossible. If a
-          # major still reaches here the cap regressed — fail BEFORE any publish
-          # (every release-*/hub job needs: [pending], so this blocks them all).
-          if [ "$KIND" = "major" ]; then
-            echo "::error::nightly computed a major bump ($VERSION) after cap — refusing to publish"
-            exit 1
-          fi
-          echo "nothing-pending=false" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
-          # Human-readable release plan.
-          {
-            echo "## Nightly release plan"
-            echo ""
-            echo "- libxmtp: \`$VERSION\` (bump: $KIND, baseline: $LAST)"
-            echo ""
-            echo "Per-SDK versions are resolved in each release job from this pending bump."
-          } >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/release-gate-plan.yml
+    with:
+      ref: ${{ needs.validate.outputs.ref }}
+    secrets: inherit
 
   release-ios:
-    needs: [validate, gate, pending]
+    needs: [validate, plan]
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.ios == 'true' && needs.validate.outputs.skip != 'true'
       && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
-          || (needs.gate.outputs.gate-skip != 'true' && needs.pending.outputs.nothing-pending != 'true'))
+          || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-ios.yml
     with:
       release-type: ${{ needs.validate.outputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ needs.validate.outputs.ref }}
-      pending-version: ${{ needs.pending.outputs.version }}
-      pending-kind: ${{ needs.pending.outputs.kind }}
+      pending-version: ${{ needs.plan.outputs.version }}
+      pending-kind: ${{ needs.plan.outputs.kind }}
     secrets: inherit
 
   release-android:
-    needs: [validate, gate, pending]
+    needs: [validate, plan]
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.android == 'true' && needs.validate.outputs.skip != 'true'
       && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
-          || (needs.gate.outputs.gate-skip != 'true' && needs.pending.outputs.nothing-pending != 'true'))
+          || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-android.yml
     with:
       release-type: ${{ needs.validate.outputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ needs.validate.outputs.ref }}
-      pending-version: ${{ needs.pending.outputs.version }}
-      pending-kind: ${{ needs.pending.outputs.kind }}
+      pending-version: ${{ needs.plan.outputs.version }}
+      pending-kind: ${{ needs.plan.outputs.kind }}
     secrets: inherit
 
   release-node:
-    needs: [validate, gate, pending]
+    needs: [validate, plan]
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.node == 'true' && needs.validate.outputs.skip != 'true'
       && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
-          || (needs.gate.outputs.gate-skip != 'true' && needs.pending.outputs.nothing-pending != 'true'))
+          || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-node.yml
     with:
       release-type: ${{ needs.validate.outputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ needs.validate.outputs.ref }}
-      pending-version: ${{ needs.pending.outputs.version }}
-      pending-kind: ${{ needs.pending.outputs.kind }}
+      pending-version: ${{ needs.plan.outputs.version }}
+      pending-kind: ${{ needs.plan.outputs.kind }}
     secrets: inherit
 
   release-wasm:
-    needs: [validate, gate, pending]
+    needs: [validate, plan]
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.wasm == 'true' && needs.validate.outputs.skip != 'true'
       && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
-          || (needs.gate.outputs.gate-skip != 'true' && needs.pending.outputs.nothing-pending != 'true'))
+          || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-wasm.yml
     with:
       release-type: ${{ needs.validate.outputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ needs.validate.outputs.ref }}
-      pending-version: ${{ needs.pending.outputs.version }}
-      pending-kind: ${{ needs.pending.outputs.kind }}
+      pending-version: ${{ needs.plan.outputs.version }}
+      pending-kind: ${{ needs.plan.outputs.kind }}
     secrets: inherit
 
   merge-pr:
-    if: needs.validate.outputs.release-type == 'final' && !inputs.no-merge && !cancelled() && !contains(needs.*.result, 'failure')
+    # dry-run must not mutate the repo: a final + dry-run would otherwise merge
+    # and delete the release branch even though the release-* jobs were skipped
+    # (skipped ≠ failure, so the !contains(failure) check alone lets it through).
+    if: needs.validate.outputs.release-type == 'final' && !inputs.no-merge && !cancelled() && !contains(needs.*.result, 'failure') && needs.validate.outputs.dry-run != 'true'
     needs: [validate, release-ios, release-android, release-node, release-wasm]
     runs-on: ubuntu-latest
     permissions:
@@ -389,20 +270,20 @@ jobs:
   # Do NOT drop any of the three; they jointly make non-nightly run and nightly
   # block-on-not-green / block-on-error.
   hub:
-    needs: [validate, gate, pending, release-ios, release-android, release-node, release-wasm]
+    needs: [validate, plan, release-ios, release-android, release-node, release-wasm]
     if: >-
       needs.validate.outputs.release-type == 'nightly'
-      && needs.gate.outputs.gate-skip != 'true'
-      && needs.pending.outputs.nothing-pending != 'true'
+      && needs.plan.outputs.gate-skip != 'true'
+      && needs.plan.outputs.nothing-pending != 'true'
       && needs.validate.outputs.dry-run != 'true'
       && !cancelled() && !contains(needs.*.result, 'failure')
     # Serialize hub runs for the same pending version so two overlapping nightly
     # runs (e.g. cron + a manual dispatch) can't both create the same tag/release
     # and race on `gh release create`. Scoped to the pending version (resolved by
-    # the `pending` job); cancel-in-progress: false so a second run waits rather
+    # the `plan` job); cancel-in-progress: false so a second run waits rather
     # than clobbering an in-flight tag/release.
     concurrency:
-      group: hub-release-${{ needs.pending.outputs.version }}
+      group: hub-release-${{ needs.plan.outputs.version }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
@@ -440,8 +321,8 @@ jobs:
           set -euo pipefail
           VERSION=$(xmtp-release resolve-sdk-version \
             --sdk libxmtp --release-type nightly \
-            --pending-version "${{ needs.pending.outputs.version }}" \
-            --pending-kind "${{ needs.pending.outputs.kind }}")
+            --pending-version "${{ needs.plan.outputs.version }}" \
+            --pending-kind "${{ needs.plan.outputs.kind }}")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Install git-cliff
         if: steps.guard.outputs.should-release == 'true'
@@ -522,7 +403,7 @@ jobs:
           fi
 
   notify:
-    needs: [validate, gate, pending, hub, release-ios, release-android, release-node, release-wasm, merge-pr]
+    needs: [validate, plan, hub, release-ios, release-android, release-node, release-wasm, merge-pr]
     if: always() && needs.validate.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:

--- a/dev/release-tools/src/commands/pending-version.ts
+++ b/dev/release-tools/src/commands/pending-version.ts
@@ -1,6 +1,7 @@
 import type { ArgumentsCamelCase, Argv } from "yargs";
-import type { GlobalArgs } from "../types";
+import type { BumpType, GlobalArgs } from "../types";
 import { parsePendingFromContext } from "../lib/git-cliff";
+import { capBumpKind } from "../lib/sdk-version";
 import { readInput } from "../lib/io";
 
 export const command = "pending-version";
@@ -25,19 +26,27 @@ export function builder(yargs: Argv<GlobalArgs>) {
       default: false,
       describe:
         "Exit non-zero when nothing is pending. Default emits {version:null,kind:null} (exit 0), letting the caller skip a no-op nightly cleanly.",
+    })
+    .option("maxBump", {
+      type: "string",
+      choices: ["major", "minor", "patch"] as const,
+      describe:
+        "Cap the computed bump at this kind (e.g. 'minor' so nightlies never auto-major). Recomputes the version from --last-shipped when clamping.",
     });
 }
 
 export function handler(
   argv: ArgumentsCamelCase<
-    GlobalArgs & { input: string; lastShipped: string; require: boolean }
+    GlobalArgs & {
+      input: string;
+      lastShipped: string;
+      require: boolean;
+      maxBump?: BumpType;
+    }
   >,
 ) {
-  const pending = parsePendingFromContext(
-    readInput(argv.input),
-    argv.lastShipped,
-  );
-  if (!pending) {
+  const raw = parsePendingFromContext(readInput(argv.input), argv.lastShipped);
+  if (!raw) {
     // "Nothing to release" is a legitimate state (no conventional commits since
     // the last tag). By default emit a null sentinel so a nightly can skip
     // gracefully rather than failing the job; --require forces a hard error.
@@ -49,5 +58,8 @@ export function handler(
     console.log(JSON.stringify({ version: null, kind: null }));
     return;
   }
+  const pending = argv.maxBump
+    ? capBumpKind(raw, argv.lastShipped, argv.maxBump)
+    : raw;
   console.log(JSON.stringify(pending));
 }

--- a/dev/release-tools/src/lib/sdk-version.ts
+++ b/dev/release-tools/src/lib/sdk-version.ts
@@ -32,6 +32,26 @@ export function applyBumpKind(base: string, kind: BumpType): string {
   return bumped;
 }
 
+/** Bump kinds ordered by magnitude (lowest first) for clamping. */
+const BUMP_ORDER: BumpType[] = ["patch", "minor", "major"];
+
+/**
+ * Clamp a pending release's bump kind to a maximum. If `pending.kind` exceeds
+ * `maxKind`, recompute the version by applying `maxKind` to `lastShipped` and
+ * return the clamped {version, kind}. Otherwise return `pending` unchanged.
+ * Never raises a bump — only lowers it. Used to enforce "nightly never majors".
+ */
+export function capBumpKind(
+  pending: PendingRelease,
+  lastShipped: string,
+  maxKind: BumpType,
+): PendingRelease {
+  if (BUMP_ORDER.indexOf(pending.kind) <= BUMP_ORDER.indexOf(maxKind)) {
+    return pending;
+  }
+  return { version: applyBumpKind(lastShipped, maxKind), kind: maxKind };
+}
+
 export interface ResolveSdkVersionArgs {
   track: VersionTrack;
   /** The SDK's own current base version (from its manifest). */

--- a/dev/release-tools/tests/sdk-version.test.ts
+++ b/dev/release-tools/tests/sdk-version.test.ts
@@ -3,6 +3,7 @@ import {
   diffBumpKind,
   applyBumpKind,
   resolveSdkVersion,
+  capBumpKind,
 } from "../src/lib/sdk-version";
 
 describe("diffBumpKind", () => {
@@ -89,5 +90,34 @@ describe("resolveSdkVersion", () => {
         releaseType: "nightly",
       }),
     ).toThrow();
+  });
+});
+
+describe("capBumpKind", () => {
+  it("clamps a major bump down to the max kind and recomputes the version", () => {
+    expect(
+      capBumpKind({ version: "2.0.0", kind: "major" }, "1.10.0", "minor"),
+    ).toEqual({ version: "1.11.0", kind: "minor" });
+  });
+
+  it("leaves a bump at or below the cap unchanged", () => {
+    expect(
+      capBumpKind({ version: "1.11.0", kind: "minor" }, "1.10.0", "minor"),
+    ).toEqual({ version: "1.11.0", kind: "minor" });
+    expect(
+      capBumpKind({ version: "1.10.1", kind: "patch" }, "1.10.0", "minor"),
+    ).toEqual({ version: "1.10.1", kind: "patch" });
+  });
+
+  it("a cap above the computed kind is a no-op (never raises a bump)", () => {
+    expect(
+      capBumpKind({ version: "1.10.1", kind: "patch" }, "1.10.0", "major"),
+    ).toEqual({ version: "1.10.1", kind: "patch" });
+  });
+
+  it("clamps major down to patch when capped at patch", () => {
+    expect(
+      capBumpKind({ version: "2.0.0", kind: "major" }, "1.10.0", "patch"),
+    ).toEqual({ version: "1.10.1", kind: "patch" });
   });
 });


### PR DESCRIPTION
## Why

On 2026-06-04 the nightly pipeline published a bogus **libxmtp `2.0.0`** and **iOS/Android `5.0.0`**, and the Android `5.0.0-nightly` is now **permanently on Maven Central** (immutable). Root causes:

1. **Non-deterministic git-cliff.** The oracle installed git-cliff via `cargo binstall git-cliff || cargo install git-cliff` — floating latest. At the same commit, CI computed a **major** bump while local computed minor.
2. **Nightly auto-majored.** A `BREAKING CHANGE:` footer drove a major bump; a nightly should never auto-major.
3. **No dry-run / preview gate.** Nothing sat between "compute version" and the irreversible publishes.

## What (three layers of protection)

- **COMPUTE** — new pure `capBumpKind` in `xmtp-release` clamps a nightly `major` → `minor` (recomputing the version from the last stable tag). Exposed via `pending-version --max-bump minor`. Unit-tested.
- **ASSERT** — the plan job fails if the bump is still `major` after the cap (defense-in-depth; every release-*/hub job `needs:` the plan, so a failure blocks all publishes). Plus a human-readable release plan printed to the step summary.
- **PREVIEW** — git-cliff is pinned to **2.13.1**; a `dry-run` dispatch input runs the full plan but skips every publish/tag; and `gate`+`pending` are extracted into a reusable `release-gate-plan.yml` so a new **`nightly-dry-run.yml`** can preview the real nightly version logic on demand (no publish jobs exist in it — structurally cannot publish).

## Verification (against the exact v5 failure mode)

Reproduced locally with the pinned git-cliff 2.13.1 against real upstream `main`:

| case | result |
| --- | --- |
| real current main, capped | `1.11.0` / minor ✓ |
| v5 mode (git-cliff says major), **no cap** | `2.0.0` / major — reproduces the bug |
| v5 mode **with `--max-bump minor`** | **`1.11.0` / minor** — clamped ✓ |
| assertion if a major slipped through | fires `::error:: refusing to publish`, exit 1 ✓ |

167 unit tests pass; typecheck clean; all 3 workflow YAMLs valid. The refactor was verified to NOT break non-nightly (dev/rc/final) releases (a skipped `plan` dependency doesn't block them — `!cancelled()` + `release-type != 'nightly'` short-circuit).

> **Post-merge step:** `workflow_dispatch` requires the workflow on the default branch, so the `nightly-dry-run.yml` GH-Actions wiring gets its full end-to-end check by dispatching it on `main` after merge (safe — no publish jobs) before the next cron nightly.

## Out of scope
- Recovering the already-published `5.0.0-nightly` (impossible — Maven Central is immutable) and the resulting Android-v5 / iOS-sync decision (team call).
- The larger release-process simplification (unify version lines / libsignal model / SPM-only) — tracked separately, needs team buy-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make nightly release version deterministic, cap bump at minor, and add dry-run gate
> - Extracts release gating and version computation into a reusable [release-gate-plan.yml](.github/workflows/release-gate-plan.yml) workflow that resolves the exact SHA, checks cross-test status, and computes a pending version capped at minor bump.
> - Adds `--max-bump` to the `pending-version` CLI command via a new `capBumpKind` utility in [sdk-version.ts](dev/release-tools/src/lib/sdk-version.ts) that clamps the bump kind and recomputes the version from the last-shipped baseline.
> - Replaces separate `gate` and `pending` jobs in [release.yml](.github/workflows/release.yml) with a single `plan` job; all release jobs now read `pending-version` and `pending-kind` from plan outputs and pin git-cliff to 2.13.1.
> - Adds a new manual-only [nightly-dry-run.yml](.github/workflows/nightly-dry-run.yml) workflow and an optional `dry-run` input to `release.yml` that prints the computed plan without publishing, tagging, or merging.
> - Risk: the workflow now fails hard if a major bump slips through after capping, which will block nightly releases until the bump is addressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c775131.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->