### PR TITLE
refactor: collapse the two gRPC connections into one

### DIFF
--- a/apps/cli/cli-client.rs
+++ b/apps/cli/cli-client.rs
@@ -468,7 +468,7 @@ async fn create_client<C: XmtpApi + Clone + XmtpQuery + 'static>(
 > {
     let msg_store = get_encrypted_store(&cli.db).await?;
     let builder = xmtp_mls::Client::builder(account).store(msg_store);
-    let builder = builder.api_clients(grpc.clone(), grpc);
+    let builder = builder.api_client(grpc);
 
     let client = builder
         .with_remote_verifier()?

--- a/apps/xmtp_debug/src/app/clients.rs
+++ b/apps/xmtp_debug/src/app/clients.rs
@@ -92,7 +92,6 @@ async fn new_client_inner(
     network: &crate::args::BackendOpts,
 ) -> Result<crate::DbgClient> {
     let api = network.client_bundle()?;
-    let sync_api = network.client_bundle()?;
     let ident = wallet.get_identifier()?;
     let inbox_id = ident.inbox_id(XDBG_ID_NONCE)?;
 
@@ -117,8 +116,7 @@ async fn new_client_inner(
     let cursor_store = Arc::new(SqliteCursorStore::new(db.db()));
     let mut backend = MessageBackendBuilder::default();
     backend.cursor_store(cursor_store);
-    let api = backend.clone().from_bundle(api)?;
-    let sync_api = backend.from_bundle(sync_api)?;
+    let api = backend.from_bundle(api)?;
 
     let client = xmtp_mls::Client::builder(IdentityStrategy::new(
         inbox_id,
@@ -126,7 +124,7 @@ async fn new_client_inner(
         XDBG_ID_NONCE,
         None,
     ))
-    .api_clients(api, sync_api)
+    .api_client(api)
     .store(db)
     .default_mls_store()?
     .with_remote_verifier()?
@@ -171,7 +169,6 @@ fn existing_client_inner_for(
     network: &crate::args::BackendOpts,
 ) -> Result<crate::DbgClient> {
     let api = network.client_bundle()?;
-    let sync_api = network.client_bundle()?;
     let path = db_path.clone().into_os_string().into_string().unwrap();
 
     let db = NativeDb::builder()
@@ -192,11 +189,10 @@ fn existing_client_inner_for(
     let cursor_store = Arc::new(SqliteCursorStore::new(store.db()));
     let mut backend = MessageBackendBuilder::default();
     backend.cursor_store(cursor_store);
-    let api = backend.clone().from_bundle(api)?;
-    let sync_api = backend.from_bundle(sync_api)?;
+    let api = backend.from_bundle(api)?;
 
     let client = xmtp_mls::Client::builder(IdentityStrategy::CachedOnly)
-        .api_clients(api, sync_api)
+        .api_client(api)
         .with_remote_verifier()?
         .store(store)
         .default_mls_store()?

--- a/bindings/mobile/benches/create_client.rs
+++ b/bindings/mobile/benches/create_client.rs
@@ -45,10 +45,8 @@ fn create_ffi_client(c: &mut Criterion) {
                     let inbox_id = ident.inbox_id(nonce).unwrap();
                     let path = tmp_path();
                     let api = xmtpv3::test_utils::connect_to_backend_test().await;
-                    let sync_api = xmtpv3::test_utils::connect_to_backend_test().await;
                     (
                         api,
-                        sync_api,
                         inbox_id,
                         wallet.identifier(),
                         nonce,
@@ -57,11 +55,10 @@ fn create_ffi_client(c: &mut Criterion) {
                     )
                 })
             },
-            |(api, sync_api, inbox_id, ident, nonce, path, span)| async move {
+            |(api, inbox_id, ident, nonce, path, span)| async move {
                 let ffi_ident: FfiIdentifier = ident.into();
                 xmtpv3::mls::create_client(
                     api,
-                    sync_api,
                     DbOptions::new(
                         Some(path),
                         Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
@@ -106,7 +103,6 @@ fn cached_create_ffi_client(c: &mut Criterion) {
         let api = xmtpv3::test_utils::connect_to_backend_test().await;
         xmtpv3::mls::create_client(
             api.clone(),
-            api.clone(),
             DbOptions::new(
                 Some(tmp_path()),
                 Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
@@ -145,7 +141,6 @@ fn cached_create_ffi_client(c: &mut Criterion) {
                 let ffi_ident: FfiIdentifier = ident.into();
                 xmtpv3::mls::create_client(
                     api.clone(),
-                    api,
                     DbOptions::new(
                         Some(path),
                         Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -351,7 +351,6 @@ impl DbOptions {
 #[tracing::instrument(level = "debug", skip_all)]
 pub async fn create_client(
     api: Arc<XmtpApiClient>,
-    sync_api: Arc<XmtpApiClient>,
     db: DbOptions,
     inbox_id: &InboxId,
     account_identifier: FfiIdentifier,
@@ -416,15 +415,13 @@ pub async fn create_client(
     );
 
     let api_client: xmtp_mls::XmtpClientBundle = Arc::unwrap_or_clone(api).client_bundle;
-    let sync_api_client: xmtp_mls::XmtpClientBundle = Arc::unwrap_or_clone(sync_api).client_bundle;
     let cursor_store = Arc::new(SqliteCursorStore::new(store.db()));
     let mut backend = MessageBackendBuilder::default();
     backend.cursor_store(cursor_store);
-    let api_client = backend.clone().from_bundle(api_client)?;
-    let sync_api_client = backend.from_bundle(sync_api_client)?;
+    let api_client = backend.from_bundle(api_client)?;
 
     let mut builder = xmtp_mls::Client::builder(identity_strategy)
-        .api_clients(api_client, sync_api_client)
+        .api_client(api_client)
         .enable_api_stats()?
         .with_remote_verifier()?
         .with_allow_offline(allow_offline)

--- a/bindings/mobile/src/mls/test_utils.rs
+++ b/bindings/mobile/src/mls/test_utils.rs
@@ -152,7 +152,6 @@ where
 
     let client = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),

--- a/bindings/mobile/src/mls/tests/client.rs
+++ b/bindings/mobile/src/mls/tests/client.rs
@@ -15,7 +15,6 @@ async fn test_create_client_with_storage() {
 
     let client_a = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(Some(path.clone()), None, None, None),
         &inbox_id,
         ffi_inbox_owner.identifier(),
@@ -34,7 +33,6 @@ async fn test_create_client_with_storage() {
     drop(client_a);
 
     let client_b = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(Some(path.clone()), None, None, None),
         &inbox_id,
@@ -71,7 +69,6 @@ async fn test_create_client_with_key() {
 
     let client_a = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(Some(path.clone()), Some(key), None, None),
         &inbox_id,
         ffi_inbox_owner.identifier(),
@@ -91,7 +88,6 @@ async fn test_create_client_with_key() {
     other_key[31] = 1;
 
     let result_errored = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(Some(path.clone()), Some(other_key.to_vec()), None, None),
         &inbox_id,
@@ -122,7 +118,6 @@ async fn test_can_message() {
     let path = tmp_path();
 
     let client_amal = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(Some(path.clone()), None, None, None),
         &amal_inbox_id,
@@ -163,7 +158,6 @@ async fn test_can_message() {
     );
 
     let client_bola = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(Some(path.clone()), None, None, None),
         &bola_inbox_id,

--- a/bindings/mobile/src/mls/tests/identity.rs
+++ b/bindings/mobile/src/mls/tests/identity.rs
@@ -25,7 +25,6 @@ async fn test_can_add_wallet_to_inbox() {
 
     let client = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
             Some(static_enc_key().to_vec()),
@@ -124,7 +123,6 @@ async fn test_can_revoke_wallet() {
 
     let client = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
             Some(static_enc_key().to_vec()),
@@ -220,7 +218,6 @@ async fn test_invalid_external_signature() {
     let inbox_id = ident.inbox_id(nonce).unwrap();
 
     let client = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
@@ -420,7 +417,6 @@ async fn test_can_not_create_new_inbox_id_with_already_associated_wallet() {
     let ffi_ident: FfiIdentifier = wallet_a.identifier().into();
     let client_a = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
@@ -464,7 +460,6 @@ async fn test_can_not_create_new_inbox_id_with_already_associated_wallet() {
 
     let ffi_ident: FfiIdentifier = wallet_b.identifier().into();
     let client_b = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
@@ -554,7 +549,6 @@ async fn test_can_not_create_new_inbox_id_with_already_associated_wallet() {
     let ffi_ident: FfiIdentifier = wallet_b.identifier().into();
     let client_b_new_result = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
@@ -594,7 +588,6 @@ async fn test_wallet_b_cannot_create_new_client_for_inbox_b_after_association() 
     let ffi_ident: FfiIdentifier = wallet_a.identifier().into();
     let client_a = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
@@ -622,7 +615,6 @@ async fn test_wallet_b_cannot_create_new_client_for_inbox_b_after_association() 
     let ffi_ident: FfiIdentifier = wallet_b.identifier().into();
     let client_b1 = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
@@ -646,7 +638,6 @@ async fn test_wallet_b_cannot_create_new_client_for_inbox_b_after_association() 
     // Step 3: Wallet B creates a second client for inbox_id B
     let ffi_ident: FfiIdentifier = wallet_b.identifier().into();
     let _client_b2 = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
@@ -682,7 +673,6 @@ async fn test_wallet_b_cannot_create_new_client_for_inbox_b_after_association() 
     // Step 5: Wallet B tries to create another new client for inbox_id B, but it fails
     let ffi_ident: FfiIdentifier = wallet_b.identifier().into();
     let client_b3 = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
@@ -794,7 +784,6 @@ async fn test_sorts_members_by_created_at_using_ffi_identifiers() {
     let inbox_id = ident.inbox_id(nonce).unwrap();
 
     let client = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),

--- a/bindings/mobile/src/mls/tests/mod.rs
+++ b/bindings/mobile/src/mls/tests/mod.rs
@@ -335,7 +335,6 @@ pub(crate) async fn new_test_client_with_wallet_and_history_sync_url(
 
     let client = create_client(
         connect_to_backend_test().await,
-        connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
@@ -371,7 +370,6 @@ pub(crate) async fn new_test_client_no_panic(
     let inbox_id = ident.inbox_id(nonce).unwrap();
 
     let client = create_client(
-        connect_to_backend_test().await,
         connect_to_backend_test().await,
         DbOptions::new(
             Some(tmp_path()),

--- a/bindings/mobile/src/mls/tests/networking.rs
+++ b/bindings/mobile/src/mls/tests/networking.rs
@@ -66,7 +66,6 @@ async fn create_client_does_not_hit_network() {
     let connection = connect_to_backend_test().await;
     let client = create_client(
         connection.clone(),
-        connect_to_backend_test().await,
         DbOptions::new(Some(path.clone()), Some(key.clone()), None, None),
         &inbox_id,
         ffi_inbox_owner.identifier(),
@@ -98,7 +97,11 @@ async fn create_client_does_not_hit_network() {
 
     let identity_stats = client.api_identity_statistics();
     assert_eq!(identity_stats.publish_identity_update, 1);
-    assert_eq!(identity_stats.get_identity_updates_v2, 2);
+    // Was 2 before collapsing the two gRPC connections into one. With a single
+    // client, identity-update reads that previously landed on the separate
+    // (never-inspected) sync client's counter now all count on the one api
+    // client — so the observable total is 3. Same network calls, one bucket.
+    assert_eq!(identity_stats.get_identity_updates_v2, 3);
     assert_eq!(identity_stats.get_inbox_ids, 1);
     assert_eq!(identity_stats.verify_smart_contract_wallet_signature, 0);
 
@@ -106,7 +109,6 @@ async fn create_client_does_not_hit_network() {
 
     let build = create_client(
         connection.clone(),
-        connect_to_backend_test().await,
         DbOptions::new(Some(path.clone()), Some(key.clone()), None, None),
         &inbox_id,
         ffi_inbox_owner.identifier(),

--- a/bindings/node/src/client/create_client.rs
+++ b/bindings/node/src/client/create_client.rs
@@ -173,7 +173,6 @@ fn parse_nonce(nonce: Option<BigInt>) -> Result<u64> {
 #[allow(clippy::too_many_arguments)]
 async fn create_client_inner(
   api_client: XmtpApiClient,
-  sync_api_client: XmtpApiClient,
   store: EncryptedMessageStore<NativeDb>,
   inbox_id: String,
   account_identifier: Identifier,
@@ -188,7 +187,7 @@ async fn create_client_inner(
   let identity_strategy = IdentityStrategy::new(inbox_id, internal_account_identifier, nonce, None);
 
   let mut builder = xmtp_mls::Client::builder(identity_strategy)
-    .api_clients(api_client, sync_api_client)
+    .api_client(api_client)
     .enable_api_stats()
     .map_err(ErrorWrapper::from)?
     .with_remote_verifier()
@@ -260,18 +259,10 @@ pub async fn create_client(
 
   let cursor_store = SqliteCursorStore::new(store.db());
   backend.cursor_store(cursor_store);
-  let api_client = backend
-    .clone()
-    .build_optional_d14n()
-    .map_err(ErrorWrapper::from)?;
-  let sync_api_client = backend
-    .clone()
-    .build_optional_d14n()
-    .map_err(ErrorWrapper::from)?;
+  let api_client = backend.build_optional_d14n().map_err(ErrorWrapper::from)?;
 
   create_client_inner(
     api_client,
-    sync_api_client,
     store,
     inbox_id,
     account_identifier,
@@ -310,16 +301,11 @@ pub async fn create_client_with_backend(
   let mut mbb = MessageBackendBuilder::default();
   mbb.cursor_store(cursor_store);
   let api_client = mbb
-    .clone()
-    .from_bundle(backend.bundle.clone())
-    .map_err(ErrorWrapper::from)?;
-  let sync_api_client = mbb
     .from_bundle(backend.bundle.clone())
     .map_err(ErrorWrapper::from)?;
 
   create_client_inner(
     api_client,
-    sync_api_client,
     store,
     inbox_id,
     account_identifier,

--- a/bindings/wasm/src/client.rs
+++ b/bindings/wasm/src/client.rs
@@ -377,7 +377,6 @@ pub(crate) async fn build_store(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn create_client_inner(
   api_client: xmtp_mls::XmtpApiClient,
-  sync_api_client: xmtp_mls::XmtpApiClient,
   store: EncryptedMessageStore<WasmDb>,
   inbox_id: String,
   account_identifier: Identifier,
@@ -395,7 +394,7 @@ pub(crate) async fn create_client_inner(
   );
 
   let mut builder = xmtp_mls::Client::builder(identity_strategy)
-    .api_clients(api_client, sync_api_client)
+    .api_client(api_client)
     .enable_api_stats()?
     .with_remote_verifier()?
     .with_allow_offline(allow_offline)
@@ -460,18 +459,10 @@ pub async fn create_client(
 
   let cursor_store = SqliteCursorStore::new(store.db());
   backend.cursor_store(cursor_store);
-  let api_client = backend
-    .clone()
-    .build_optional_d14n()
-    .map_err(ErrorWrapper::js)?;
-  let sync_api_client = backend
-    .clone()
-    .build_optional_d14n()
-    .map_err(ErrorWrapper::js)?;
+  let api_client = backend.build_optional_d14n().map_err(ErrorWrapper::js)?;
 
   create_client_inner(
     api_client,
-    sync_api_client,
     store,
     inbox_id,
     account_identifier,

--- a/bindings/wasm/src/client/backend.rs
+++ b/bindings/wasm/src/client/backend.rs
@@ -127,16 +127,11 @@ pub async fn create_client_with_backend(
   let mut mbb = xmtp_api_d14n::MessageBackendBuilder::default();
   mbb.cursor_store(cursor_store);
   let api_client = mbb
-    .clone()
-    .from_bundle(backend.bundle.clone())
-    .map_err(|e| JsError::new(&e.to_string()))?;
-  let sync_api_client = mbb
     .from_bundle(backend.bundle.clone())
     .map_err(|e| JsError::new(&e.to_string()))?;
 
   super::create_client_inner(
     api_client,
-    sync_api_client,
     store,
     inbox_id,
     account_identifier,

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -105,7 +105,6 @@ pub struct ClientBuilder<ApiClient, S, Db = xmtp_db::DefaultStore> {
     pub(crate) allow_offline: bool,
     pub(crate) disable_commit_log_worker: bool,
     pub(crate) mls_storage: Option<S>,
-    pub(crate) sync_api_client: Option<ApiClient>,
     pub(crate) cursor_store: Option<Arc<dyn CursorStore>>,
     pub(crate) disable_workers: bool,
     pub(crate) worker_config: crate::worker::WorkerConfig,
@@ -165,7 +164,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: false,
             disable_commit_log_worker: false,
             mls_storage: None,
-            sync_api_client: None,
             cursor_store: None,
             disable_workers: false,
             worker_config: crate::worker::WorkerConfig::default(),
@@ -184,7 +182,6 @@ where
         client: Client<ContextParts<ApiClient, S, Db>>,
     ) -> ClientBuilder<ApiClient, S, Db> {
         let cloned_api: ApiClient = client.context.api_client.clone().api_client;
-        let cloned_sync_api: ApiClient = client.context.sync_api_client.clone().api_client;
         ClientBuilder {
             api_client: Some(cloned_api),
             identity: Some(client.context.identity.clone()),
@@ -197,7 +194,6 @@ where
             allow_offline: false,
             disable_commit_log_worker: false,
             mls_storage: Some(client.context.mls_storage.clone()),
-            sync_api_client: Some(cloned_sync_api),
             cursor_store: None,
             disable_workers: false,
             worker_config: client.context.worker_config.clone(),
@@ -241,7 +237,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline,
             disable_commit_log_worker,
             mut mls_storage,
-            mut sync_api_client,
             // cursor_store,
             disable_workers,
             worker_config,
@@ -253,13 +248,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             .ok_or(ClientBuilderError::MissingParameter {
                 parameter: "api_client",
             })?;
-
-        let sync_api_client =
-            sync_api_client
-                .take()
-                .ok_or(ClientBuilderError::MissingParameter {
-                    parameter: "sync_api_client",
-                })?;
 
         let scw_verifier = scw_verifier
             .take()
@@ -278,7 +266,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             })?;
 
         let api_client = ApiClientWrapper::new(api_client, Retry::default());
-        let sync_api_client = ApiClientWrapper::new(sync_api_client, Retry::default());
         let conn = store.db();
         let identity = if let Some(identity) = identity {
             identity
@@ -341,7 +328,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             fork_recovery_opts: fork_recovery_opts.unwrap_or_default(),
             worker_config,
 
-            sync_api_client,
             worker_metrics: workers.metrics().clone(),
             task_channels: workers.task_channels().clone(),
             cancellation_token: CancellationToken::new(),
@@ -452,7 +438,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
             mls_storage: self.mls_storage,
-            sync_api_client: self.sync_api_client,
             cursor_store: self.cursor_store,
             disable_workers: self.disable_workers,
             worker_config: self.worker_config,
@@ -488,7 +473,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                     .db(),
             )),
             store: self.store,
-            sync_api_client: self.sync_api_client,
             cursor_store: self.cursor_store,
             disable_workers: self.disable_workers,
             worker_config: self.worker_config,
@@ -508,7 +492,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
             mls_storage: Some(mls_storage),
-            sync_api_client: self.sync_api_client,
             cursor_store: self.cursor_store,
             disable_workers: self.disable_workers,
             worker_config: self.worker_config,
@@ -548,10 +531,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
         self
     }
 
-    pub fn api_clients<A>(self, api_client: A, sync_api_client: A) -> ClientBuilder<A, S, Db> {
-        // let api_retry = Retry::builder().build();
-        // let api_client = ApiClientWrapper::new(api_client, api_retry.clone());
-        // let sync_api_client = ApiClientWrapper::new(sync_api_client, api_retry.clone());
+    pub fn api_client<A>(self, api_client: A) -> ClientBuilder<A, S, Db> {
         ClientBuilder {
             api_client: Some(api_client),
             identity: self.identity,
@@ -564,7 +544,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
             mls_storage: self.mls_storage,
-            sync_api_client: Some(sync_api_client),
             cursor_store: self.cursor_store,
             disable_workers: self.disable_workers,
             worker_config: self.worker_config,
@@ -634,7 +613,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
     pub fn enable_api_stats(
         self,
     ) -> Result<ClientBuilder<TrackedStatsClient<ApiClient>, S, Db>, ClientBuilderError> {
-        if self.api_client.is_none() || self.sync_api_client.is_none() {
+        if self.api_client.is_none() {
             return Err(ClientBuilderError::MissingParameter {
                 parameter: "api_client",
             });
@@ -655,9 +634,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
             mls_storage: self.mls_storage,
-            sync_api_client: Some(TrackedStatsClient::new(
-                self.sync_api_client.expect("checked for none"),
-            )),
             cursor_store: self.cursor_store,
             disable_workers: self.disable_workers,
             worker_config: self.worker_config,
@@ -681,7 +657,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
             mls_storage: self.mls_storage,
-            sync_api_client: self.sync_api_client,
             cursor_store: self.cursor_store,
             disable_workers: self.disable_workers,
             worker_config: self.worker_config,
@@ -714,7 +689,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
             mls_storage: self.mls_storage,
-            sync_api_client: self.sync_api_client,
             cursor_store: self.cursor_store,
             disable_workers: self.disable_workers,
             worker_config: self.worker_config,

--- a/crates/xmtp_mls/src/context.rs
+++ b/crates/xmtp_mls/src/context.rs
@@ -38,7 +38,6 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     pub(crate) identity: Identity,
     /// The XMTP Api Client
     pub(crate) api_client: ApiClientWrapper<ApiClient>,
-    pub(crate) sync_api_client: ApiClientWrapper<ApiClient>, // sync-only channel
     /// XMTP Local Storage
     pub(crate) store: Db,
     pub(crate) mls_storage: S,
@@ -114,7 +113,6 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
         XmtpMlsLocalContext::<ApiClient, Db, S2> {
             identity: self.identity,
             api_client: self.api_client,
-            sync_api_client: self.sync_api_client,
             store: self.store,
             mls_storage: mls_store,
             mutexes: self.mutexes,
@@ -199,7 +197,6 @@ where
     fn context_ref(&self) -> &Self::ContextReference;
     fn db(&self) -> <Self::Db as XmtpDb>::DbQuery;
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient>;
-    fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient>;
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>>;
 
     fn device_sync(&self) -> &DeviceSync;
@@ -286,10 +283,6 @@ where
 
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         &self.api_client
-    }
-
-    fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
-        &self.sync_api_client
     }
 
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>> {
@@ -381,10 +374,6 @@ where
 
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         <T as XmtpSharedContext>::api(self)
-    }
-
-    fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
-        <T as XmtpSharedContext>::sync_api(self)
     }
 
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>> {

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -3865,7 +3865,7 @@ where
             inbox_ids.extend_from_slice(inbox_ids_to_add);
             let conn = self.context.db();
             // Load any missing updates from the network
-            load_identity_updates(self.context.sync_api(), &conn, &inbox_ids).await?;
+            load_identity_updates(self.context.api(), &conn, &inbox_ids).await?;
 
             let latest_sequence_id_map = conn.get_latest_sequence_id(&inbox_ids as &[&str])?;
 

--- a/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -150,7 +150,6 @@ async fn test_spoofed_inbox_id() {
     let malicious_context = Arc::new(XmtpMlsLocalContext {
         identity: malicious_identity,
         api_client: alix.context.api_client.clone(),
-        sync_api_client: alix.context.sync_api_client.clone(),
         store: alix.context.store.clone(),
         mls_storage: alix.context.mls_storage.clone(),
         mutexes: alix.context.mutexes.clone(),

--- a/crates/xmtp_mls/src/mls_store.rs
+++ b/crates/xmtp_mls/src/mls_store.rs
@@ -89,11 +89,7 @@ where
         &self,
         group_id: GroupId,
     ) -> Result<Vec<GroupMessage>, MlsStoreError> {
-        let messages = self
-            .context
-            .sync_api()
-            .query_group_messages(group_id)
-            .await?;
+        let messages = self.context.api().query_group_messages(group_id).await?;
 
         Ok(messages)
     }

--- a/crates/xmtp_mls/src/test/builder.rs
+++ b/crates/xmtp_mls/src/test/builder.rs
@@ -209,10 +209,7 @@ async fn test_client_creation() {
         let result = Client::builder(test_case.strategy)
             .temp_store()
             .await
-            .api_clients(
-                DefaultTestClientCreator::create().build().unwrap(),
-                DefaultTestClientCreator::create().build().unwrap(),
-            )
+            .api_client(DefaultTestClientCreator::create().build().unwrap())
             .default_mls_store()
             .unwrap()
             .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
@@ -254,10 +251,7 @@ async fn test_2nd_time_client_creation() {
 
     let client1 = Client::builder(identity_strategy.clone())
         .store(store.clone())
-        .api_clients(
-            DefaultTestClientCreator::create().build().unwrap(),
-            DefaultTestClientCreator::create().build().unwrap(),
-        )
+        .api_client(DefaultTestClientCreator::create().build().unwrap())
         .default_mls_store()
         .unwrap()
         .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
@@ -268,10 +262,7 @@ async fn test_2nd_time_client_creation() {
 
     let client2 = Client::builder(IdentityStrategy::CachedOnly)
         .store(store.clone())
-        .api_clients(
-            DefaultTestClientCreator::create().build().unwrap(),
-            DefaultTestClientCreator::create().build().unwrap(),
-        )
+        .api_client(DefaultTestClientCreator::create().build().unwrap())
         .default_mls_store()
         .unwrap()
         .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
@@ -289,10 +280,7 @@ async fn test_2nd_time_client_creation() {
         None,
     ))
     .store(store.clone())
-    .api_clients(
-        DefaultTestClientCreator::create().build().unwrap(),
-        DefaultTestClientCreator::create().build().unwrap(),
-    )
+    .api_client(DefaultTestClientCreator::create().build().unwrap())
     .default_mls_store()
     .unwrap()
     .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
@@ -306,10 +294,7 @@ async fn test_2nd_time_client_creation() {
     let client4 = Client::builder(identity_strategy)
         .temp_store()
         .await
-        .api_clients(
-            DefaultTestClientCreator::create().build().unwrap(),
-            DefaultTestClientCreator::create().build().unwrap(),
-        )
+        .api_client(DefaultTestClientCreator::create().build().unwrap())
         .default_mls_store()
         .unwrap()
         .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
@@ -542,10 +527,7 @@ async fn identity_persistence_test() {
         nonce,
         None,
     ))
-    .api_clients(
-        DefaultTestClientCreator::create().build().unwrap(),
-        DefaultTestClientCreator::create().build().unwrap(),
-    )
+    .api_client(DefaultTestClientCreator::create().build().unwrap())
     .store(store_a)
     .default_mls_store()
     .unwrap()
@@ -567,10 +549,7 @@ async fn identity_persistence_test() {
         nonce,
         None,
     ))
-    .api_clients(
-        DefaultTestClientCreator::create().build().unwrap(),
-        DefaultTestClientCreator::create().build().unwrap(),
-    )
+    .api_client(DefaultTestClientCreator::create().build().unwrap())
     .store(store_b)
     .default_mls_store()
     .unwrap()
@@ -603,10 +582,7 @@ async fn identity_persistence_test() {
     // Use cached only strategy
     let store_d = xmtp_db::TestDb::create_persistent_store(Some(tmpdb.clone())).await;
     let client_d = Client::builder(IdentityStrategy::CachedOnly)
-        .api_clients(
-            DefaultTestClientCreator::create().build().unwrap(),
-            DefaultTestClientCreator::create().build().unwrap(),
-        )
+        .api_client(DefaultTestClientCreator::create().build().unwrap())
         .store(store_d)
         .default_mls_store()
         .unwrap()

--- a/crates/xmtp_mls/src/test/mock.rs
+++ b/crates/xmtp_mls/src/test/mock.rs
@@ -79,7 +79,6 @@ impl Clone for NewMockContext {
         Self {
             identity: self.identity.clone(),
             api_client: self.api_client.clone(),
-            sync_api_client: self.sync_api_client.clone(),
             store: self.store.clone(),
             mls_storage: self.mls_storage.clone(),
             mutexes: self.mutexes.clone(),
@@ -172,10 +171,6 @@ impl XmtpSharedContext for NewMockContext {
             .lock()
             .get(&WorkerKind::DeviceSync)?
             .as_sync_metrics()
-    }
-
-    fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
-        &self.sync_api_client
     }
 
     fn cancellation_token(&self) -> &CancellationToken {

--- a/crates/xmtp_mls/src/test/mock/generate.rs
+++ b/crates/xmtp_mls/src/test/mock/generate.rs
@@ -37,7 +37,6 @@ pub fn context() -> NewMockContext {
         fork_recovery_opts: Default::default(),
         worker_config: Default::default(),
         mls_storage: SqlKeyStore::new(MemoryStorage::new()),
-        sync_api_client: ApiClientWrapper::new(MockApiClient::new(), Default::default()),
         task_channels: TaskWorkerChannels::default(),
         worker_metrics: Arc::default(),
         cancellation_token: tokio_util::sync::CancellationToken::new(),

--- a/crates/xmtp_mls/src/utils/bench/clients.rs
+++ b/crates/xmtp_mls/src/utils/bench/clients.rs
@@ -30,14 +30,6 @@ pub async fn new_unregistered_client() -> (BenchClient, PrivateKeySigner) {
         LocalOnlyTestClientCreator::create().build().unwrap()
     };
 
-    let sync_api_client = if is_dev_network {
-        tracing::info!("Using Dev GRPC");
-        DevOnlyTestClientCreator::create().build().unwrap()
-    } else {
-        tracing::info!("Using Local GRPC");
-        LocalOnlyTestClientCreator::create().build().unwrap()
-    };
-
     let client = crate::Client::builder(IdentityStrategy::new(
         inbox_id,
         wallet.identifier(),
@@ -48,7 +40,7 @@ pub async fn new_unregistered_client() -> (BenchClient, PrivateKeySigner) {
     let client = client
         .temp_store()
         .await
-        .api_clients(api_client, sync_api_client)
+        .api_client(api_client)
         .with_remote_verifier()
         .unwrap()
         .default_mls_store()
@@ -98,14 +90,6 @@ pub async fn create_client_from_identity(
         DefaultTestClientCreator::create().build().unwrap()
     };
 
-    let sync_api_client = if is_dev_network {
-        tracing::info!("Using Dev GRPC");
-        DefaultTestClientCreator::create().build().unwrap()
-    } else {
-        tracing::info!("Using Local GRPC");
-        DefaultTestClientCreator::create().build().unwrap()
-    };
-
     let client = crate::Client::builder(IdentityStrategy::new(
         inbox_id,
         identity.identifier.clone(),
@@ -116,7 +100,7 @@ pub async fn create_client_from_identity(
     client
         .temp_store()
         .await
-        .api_clients(api_client, sync_api_client)
+        .api_client(api_client)
         .with_remote_verifier()
         .unwrap()
         .default_mls_store()

--- a/crates/xmtp_mls/src/utils/test/mod.rs
+++ b/crates/xmtp_mls/src/utils/test/mod.rs
@@ -42,20 +42,16 @@ impl<A, S> ClientBuilder<A, S> {
 
     pub fn dev(self) -> ClientBuilder<TestClient, S> {
         let s = Arc::new(SqliteCursorStore::new(self.store.as_ref().unwrap().db()));
-        let a = DevOnlyTestClientCreator::with_cursor_store(s.clone());
-        let s = DevOnlyTestClientCreator::with_cursor_store(s);
+        let a = DevOnlyTestClientCreator::with_cursor_store(s);
         let api_client = a.build().unwrap();
-        let sync_api_client = s.build().unwrap();
-        self.api_clients(api_client, sync_api_client)
+        self.api_client(api_client)
     }
 
     pub fn local(self) -> ClientBuilder<TestClient, S> {
         let s = Arc::new(SqliteCursorStore::new(self.store.as_ref().unwrap().db()));
-        let a = LocalOnlyTestClientCreator::with_cursor_store(s.clone());
-        let s = LocalOnlyTestClientCreator::with_cursor_store(s);
+        let a = LocalOnlyTestClientCreator::with_cursor_store(s);
         let api_client = a.build().unwrap();
-        let sync_api_client = s.build().unwrap();
-        self.api_clients(api_client, sync_api_client)
+        self.api_client(api_client)
     }
 }
 

--- a/crates/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/crates/xmtp_mls/src/utils/test/tester_utils.rs
@@ -205,30 +205,22 @@ where
 
         let mut proxy = None;
         let store = Arc::new(SqliteCursorStore::new(client.store.as_ref().unwrap().db()));
-        let (local_client, sync_api_client) = match (&self.api_endpoint, self.proxy) {
-            (ApiEndpoint::Local, false) => (
-                LocalOnlyTestClientCreator::with_cursor_store(store.clone()),
-                LocalOnlyTestClientCreator::with_cursor_store(store.clone()),
-            ),
-            (ApiEndpoint::Dev, false) => (
-                DevOnlyTestClientCreator::with_cursor_store(store.clone()),
-                DevOnlyTestClientCreator::with_cursor_store(store.clone()),
-            ),
+        let local_client = match (&self.api_endpoint, self.proxy) {
+            (ApiEndpoint::Local, false) => {
+                LocalOnlyTestClientCreator::with_cursor_store(store.clone())
+            }
+            (ApiEndpoint::Dev, false) => DevOnlyTestClientCreator::with_cursor_store(store.clone()),
             (ApiEndpoint::Local, true) => {
                 proxy = Some(ToxicOnlyTestClientCreator::proxies().await);
-                (
-                    ToxicOnlyTestClientCreator::with_cursor_store(store.clone()),
-                    ToxicOnlyTestClientCreator::with_cursor_store(store.clone()),
-                )
+                ToxicOnlyTestClientCreator::with_cursor_store(store.clone())
             }
             (ApiEndpoint::Dev, true) => (unimplemented!("toxiproxy not supported on dev")),
         };
 
         let api_client = local_client.build().unwrap();
-        let sync_api_client = sync_api_client.build().unwrap();
 
         let mut client = client
-            .api_clients(api_client, sync_api_client)
+            .api_client(api_client)
             .with_disable_workers(self.disable_workers)
             .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
             .with_device_sync_worker_mode(Some(self.sync_mode))

--- a/crates/xmtp_mls/tests/chaos.rs
+++ b/crates/xmtp_mls/tests/chaos.rs
@@ -27,10 +27,7 @@ async fn chaos_demo() {
     let (chaos, store) = ChaosDb::builder(store).error_frequency(0.0).build();
     let alix = Client::builder(new_identity(&owner))
         .store(store)
-        .api_clients(
-            DefaultTestClientCreator::create().build().unwrap(),
-            DefaultTestClientCreator::create().build().unwrap(),
-        )
+        .api_client(DefaultTestClientCreator::create().build().unwrap())
         .default_mls_store()
         .unwrap()
         .with_remote_verifier()

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -170,9 +170,6 @@ class Client(
         private val apiClientCache = mutableMapOf<String, XmtpApiClient>()
         private val cacheLock = Mutex()
 
-        private val syncApiClientCache = mutableMapOf<String, XmtpApiClient>()
-        private val syncCacheLock = Mutex()
-
         fun activatePersistentLibXMTPLogWriter(
             appContext: Context,
             logLevel: FfiLogLevel,
@@ -265,30 +262,6 @@ class Client(
             }
         }
 
-        suspend fun connectToSyncApiBackend(api: ClientOptions.Api): XmtpApiClient {
-            val cacheKey = api.toCacheKey()
-            return syncCacheLock.withLock {
-                val cached = syncApiClientCache[cacheKey]
-
-                if (cached != null && isConnected(cached)) {
-                    return cached
-                }
-
-                // If not cached or not connected, create a fresh client
-                val newClient =
-                    connectToBackend(
-                        api.env.getUrl(),
-                        api.gatewayHost,
-                        FfiClientMode.DEFAULT,
-                        api.appVersion,
-                        null,
-                        null,
-                    )
-                syncApiClientCache[cacheKey] = newClient
-                return@withLock newClient
-            }
-        }
-
         suspend fun getOrCreateInboxId(
             api: ClientOptions.Api,
             publicIdentity: PublicIdentity,
@@ -367,7 +340,6 @@ class Client(
                 val ffiClient =
                     createClient(
                         api = connectToApiBackend(api),
-                        syncApi = connectToApiBackend(api),
                         db =
                             DbOptions(
                                 db = null,
@@ -579,7 +551,6 @@ class Client(
                     val ffiClient =
                         createClient(
                             api = connectToApiBackend(options.api),
-                            syncApi = connectToSyncApiBackend(options.api),
                             db =
                                 DbOptions(
                                     db = null,
@@ -625,7 +596,6 @@ class Client(
                 val ffiClient =
                     createClient(
                         api = connectToApiBackend(options.api),
-                        syncApi = connectToSyncApiBackend(options.api),
                         db =
                             DbOptions(
                                 db = dbPath,

--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -182,7 +182,6 @@ struct ApiCacheKey {
 /// To be removed in a future release
 actor ApiClientCache {
 	private var apiClientCache: [String: XmtpApiClient] = [:]
-	private var syncApiClientCache: [String: XmtpApiClient] = [:]
 
 	func getClient(forKey key: String) -> XmtpApiClient? {
 		apiClientCache[key]
@@ -190,14 +189,6 @@ actor ApiClientCache {
 
 	func setClient(_ client: XmtpApiClient, forKey key: String) {
 		apiClientCache[key] = client
-	}
-
-	func getSyncClient(forKey key: String) -> XmtpApiClient? {
-		syncApiClientCache[key]
-	}
-
-	func setSyncClient(_ client: XmtpApiClient, forKey key: String) {
-		syncApiClientCache[key] = client
 	}
 }
 
@@ -436,7 +427,6 @@ public final class Client {
 
 			let ffiClient = try await createClient(
 				api: connectToApiBackend(api: options.api),
-				syncApi: connectToSyncApiBackend(api: options.api),
 				db: DbOptions(
 					db: nil,
 					encryptionKey: nil,
@@ -503,7 +493,6 @@ public final class Client {
 
 		let ffiClient = try await createClient(
 			api: connectToApiBackend(api: options.api),
-			syncApi: connectToSyncApiBackend(api: options.api),
 			db: DbOptions(
 				db: dbURL,
 				encryptionKey: options.dbEncryptionKey,
@@ -573,32 +562,6 @@ public final class Client {
 			authHandle: nil
 		)
 		await apiCache.setClient(newClient, forKey: cacheKey)
-		return newClient
-	}
-
-	public static func connectToSyncApiBackend(api: ClientOptions.Api)
-		async throws
-		-> XmtpApiClient
-	{
-		let cacheKey = ApiCacheKey(api: api).stringValue
-
-		// Check for an existing connected client
-		if let cached = await apiCache.getSyncClient(forKey: cacheKey),
-		   try await isConnected(api: cached)
-		{
-			return cached
-		}
-
-		// Either not cached or not connected; create new client
-		let newClient = try await connectToBackend(
-			v3Host: api.env.url,
-			gatewayHost: api.gatewayHost,
-			clientMode: FfiClientMode.default,
-			appVersion: api.appVersion,
-			authCallback: nil,
-			authHandle: nil
-		)
-		await apiCache.setSyncClient(newClient, forKey: cacheKey)
 		return newClient
 	}
 
@@ -728,7 +691,6 @@ public final class Client {
 		)
 		return try await createClient(
 			api: connectToApiBackend(api: api),
-			syncApi: connectToApiBackend(api: api),
 			db: DbOptions(db: nil, encryptionKey: nil, maxDbPoolSize: nil, minDbPoolSize: nil),
 			inboxId: inboxId,
 			accountIdentifier: identity.ffiPrivate,

--- a/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -5261,6 +5261,21 @@ public protocol FfiXmtpClientProtocol: AnyObject, Sendable {
     func setConsentStates(records: [FfiConsent]) async throws 
     
     /**
+     * Cleanly shut down this client: cancel in-flight workers and detached
+     * streams, then release the DB connection. Idempotent — a second call
+     * resolves to `Ok`.
+     *
+     * `await` this before deleting the SQLite file or dropping the client
+     * reference to avoid late log spew from detached workers/streams firing
+     * against a dead DB.
+     *
+     * Named `shutdown` rather than `close` because uniffi reserves `close`
+     * on every exported object for the Kotlin `Disposable` handle-disposal
+     * method, which would conflict with this one.
+     */
+    func shutdown() async throws 
+    
+    /**
      * A utility function to sign a piece of text with this installation's private key.
      */
     func signWithInstallationKey(text: String) throws  -> Data
@@ -5819,6 +5834,36 @@ open func setConsentStates(records: [FfiConsent])async throws   {
                 uniffi_xmtpv3_fn_method_ffixmtpclient_set_consent_states(
                     self.uniffiCloneHandle(),
                     FfiConverterSequenceTypeFfiConsent.lower(records)
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_void,
+            completeFunc: ffi_xmtpv3_rust_future_complete_void,
+            freeFunc: ffi_xmtpv3_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeFfiError_lift
+        )
+}
+    
+    /**
+     * Cleanly shut down this client: cancel in-flight workers and detached
+     * streams, then release the DB connection. Idempotent — a second call
+     * resolves to `Ok`.
+     *
+     * `await` this before deleting the SQLite file or dropping the client
+     * reference to avoid late log spew from detached workers/streams firing
+     * against a dead DB.
+     *
+     * Named `shutdown` rather than `close` because uniffi reserves `close`
+     * on every exported object for the Kotlin `Disposable` handle-disposal
+     * method, which would conflict with this one.
+     */
+open func shutdown()async throws   {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_method_ffixmtpclient_shutdown(
+                    self.uniffiCloneHandle()
+                    
                 )
             },
             pollFunc: ffi_xmtpv3_rust_future_poll_void,
@@ -9933,6 +9978,211 @@ public func FfiConverterTypeFfiWalletSendCalls_lower(_ value: FfiWalletSendCalls
     return FfiConverterTypeFfiWalletSendCalls.lower(value)
 }
 
+
+/**
+ * Tuning for the background worker scheduler. All fields optional; the empty
+ * record preserves default behavior (all workers enabled, const intervals,
+ * no jitter).
+ */
+public struct FfiWorkerConfig: Equatable, Hashable {
+    /**
+     * Global default interval for all workers, in nanoseconds.
+     */
+    public var defaultIntervalNs: UInt64?
+    /**
+     * Per-worker interval overrides (nanoseconds).
+     */
+    public var workerIntervalsNs: [FfiWorkerIntervalOverride]
+    /**
+     * Per-worker jitter overrides (nanoseconds).
+     */
+    public var workerJittersNs: [FfiWorkerJitterOverride]
+    /**
+     * Workers to disable. Anything not listed stays enabled.
+     */
+    public var disabledWorkers: [FfiWorkerKind]
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Global default interval for all workers, in nanoseconds.
+         */defaultIntervalNs: UInt64?, 
+        /**
+         * Per-worker interval overrides (nanoseconds).
+         */workerIntervalsNs: [FfiWorkerIntervalOverride], 
+        /**
+         * Per-worker jitter overrides (nanoseconds).
+         */workerJittersNs: [FfiWorkerJitterOverride], 
+        /**
+         * Workers to disable. Anything not listed stays enabled.
+         */disabledWorkers: [FfiWorkerKind]) {
+        self.defaultIntervalNs = defaultIntervalNs
+        self.workerIntervalsNs = workerIntervalsNs
+        self.workerJittersNs = workerJittersNs
+        self.disabledWorkers = disabledWorkers
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension FfiWorkerConfig: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiWorkerConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiWorkerConfig {
+        return
+            try FfiWorkerConfig(
+                defaultIntervalNs: FfiConverterOptionUInt64.read(from: &buf), 
+                workerIntervalsNs: FfiConverterSequenceTypeFfiWorkerIntervalOverride.read(from: &buf), 
+                workerJittersNs: FfiConverterSequenceTypeFfiWorkerJitterOverride.read(from: &buf), 
+                disabledWorkers: FfiConverterSequenceTypeFfiWorkerKind.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiWorkerConfig, into buf: inout [UInt8]) {
+        FfiConverterOptionUInt64.write(value.defaultIntervalNs, into: &buf)
+        FfiConverterSequenceTypeFfiWorkerIntervalOverride.write(value.workerIntervalsNs, into: &buf)
+        FfiConverterSequenceTypeFfiWorkerJitterOverride.write(value.workerJittersNs, into: &buf)
+        FfiConverterSequenceTypeFfiWorkerKind.write(value.disabledWorkers, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiWorkerConfig_lift(_ buf: RustBuffer) throws -> FfiWorkerConfig {
+    return try FfiConverterTypeFfiWorkerConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiWorkerConfig_lower(_ value: FfiWorkerConfig) -> RustBuffer {
+    return FfiConverterTypeFfiWorkerConfig.lower(value)
+}
+
+
+/**
+ * A single per-worker interval override.
+ */
+public struct FfiWorkerIntervalOverride: Equatable, Hashable {
+    public var kind: FfiWorkerKind
+    public var intervalNs: UInt64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(kind: FfiWorkerKind, intervalNs: UInt64) {
+        self.kind = kind
+        self.intervalNs = intervalNs
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension FfiWorkerIntervalOverride: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiWorkerIntervalOverride: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiWorkerIntervalOverride {
+        return
+            try FfiWorkerIntervalOverride(
+                kind: FfiConverterTypeFfiWorkerKind.read(from: &buf), 
+                intervalNs: FfiConverterUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiWorkerIntervalOverride, into buf: inout [UInt8]) {
+        FfiConverterTypeFfiWorkerKind.write(value.kind, into: &buf)
+        FfiConverterUInt64.write(value.intervalNs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiWorkerIntervalOverride_lift(_ buf: RustBuffer) throws -> FfiWorkerIntervalOverride {
+    return try FfiConverterTypeFfiWorkerIntervalOverride.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiWorkerIntervalOverride_lower(_ value: FfiWorkerIntervalOverride) -> RustBuffer {
+    return FfiConverterTypeFfiWorkerIntervalOverride.lower(value)
+}
+
+
+/**
+ * A single per-worker jitter override (nanoseconds).
+ */
+public struct FfiWorkerJitterOverride: Equatable, Hashable {
+    public var kind: FfiWorkerKind
+    public var jitterNs: UInt64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(kind: FfiWorkerKind, jitterNs: UInt64) {
+        self.kind = kind
+        self.jitterNs = jitterNs
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension FfiWorkerJitterOverride: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiWorkerJitterOverride: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiWorkerJitterOverride {
+        return
+            try FfiWorkerJitterOverride(
+                kind: FfiConverterTypeFfiWorkerKind.read(from: &buf), 
+                jitterNs: FfiConverterUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiWorkerJitterOverride, into buf: inout [UInt8]) {
+        FfiConverterTypeFfiWorkerKind.write(value.kind, into: &buf)
+        FfiConverterUInt64.write(value.jitterNs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiWorkerJitterOverride_lift(_ buf: RustBuffer) throws -> FfiWorkerJitterOverride {
+    return try FfiConverterTypeFfiWorkerJitterOverride.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiWorkerJitterOverride_lower(_ value: FfiWorkerJitterOverride) -> RustBuffer {
+    return FfiConverterTypeFfiWorkerJitterOverride.lower(value)
+}
+
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
@@ -13023,6 +13273,101 @@ public func FfiConverterTypeFfiSyncMetric_lower(_ value: FfiSyncMetric) -> RustB
 }
 
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum FfiWorkerKind: Equatable, Hashable {
+    
+    case deviceSync
+    case disappearingMessages
+    case keyPackageCleaner
+    case commitLog
+    case taskRunner
+    case pendingSelfRemove
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension FfiWorkerKind: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiWorkerKind: FfiConverterRustBuffer {
+    typealias SwiftType = FfiWorkerKind
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiWorkerKind {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .deviceSync
+        
+        case 2: return .disappearingMessages
+        
+        case 3: return .keyPackageCleaner
+        
+        case 4: return .commitLog
+        
+        case 5: return .taskRunner
+        
+        case 6: return .pendingSelfRemove
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: FfiWorkerKind, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .deviceSync:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .disappearingMessages:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .keyPackageCleaner:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .commitLog:
+            writeInt(&buf, Int32(4))
+        
+        
+        case .taskRunner:
+            writeInt(&buf, Int32(5))
+        
+        
+        case .pendingSelfRemove:
+            writeInt(&buf, Int32(6))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiWorkerKind_lift(_ buf: RustBuffer) throws -> FfiWorkerKind {
+    return try FfiConverterTypeFfiWorkerKind.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiWorkerKind_lower(_ value: FfiWorkerKind) -> RustBuffer {
+    return FfiConverterTypeFfiWorkerKind.lower(value)
+}
+
+
 
 public enum IdentityValidationError: Swift.Error, Equatable, Hashable, Foundation.LocalizedError {
 
@@ -13714,6 +14059,30 @@ fileprivate struct FfiConverterOptionTypeFfiWalletCallMetadata: FfiConverterRust
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeFfiWalletCallMetadata.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeFfiWorkerConfig: FfiConverterRustBuffer {
+    typealias SwiftType = FfiWorkerConfig?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeFfiWorkerConfig.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeFfiWorkerConfig.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -14606,6 +14975,56 @@ fileprivate struct FfiConverterSequenceTypeFfiWalletCall: FfiConverterRustBuffer
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeFfiWorkerIntervalOverride: FfiConverterRustBuffer {
+    typealias SwiftType = [FfiWorkerIntervalOverride]
+
+    public static func write(_ value: [FfiWorkerIntervalOverride], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeFfiWorkerIntervalOverride.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [FfiWorkerIntervalOverride] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [FfiWorkerIntervalOverride]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeFfiWorkerIntervalOverride.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeFfiWorkerJitterOverride: FfiConverterRustBuffer {
+    typealias SwiftType = [FfiWorkerJitterOverride]
+
+    public static func write(_ value: [FfiWorkerJitterOverride], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeFfiWorkerJitterOverride.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [FfiWorkerJitterOverride] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [FfiWorkerJitterOverride]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeFfiWorkerJitterOverride.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeFfiBackupElementSelection: FfiConverterRustBuffer {
     typealias SwiftType = [FfiBackupElementSelection]
 
@@ -14698,6 +15117,31 @@ fileprivate struct FfiConverterSequenceTypeFfiPreferenceUpdate: FfiConverterRust
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypeFfiPreferenceUpdate.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeFfiWorkerKind: FfiConverterRustBuffer {
+    typealias SwiftType = [FfiWorkerKind]
+
+    public static func write(_ value: [FfiWorkerKind], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeFfiWorkerKind.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [FfiWorkerKind] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [FfiWorkerKind]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeFfiWorkerKind.read(from: &buf))
         }
         return seq
     }
@@ -15223,11 +15667,11 @@ public func connectToBackend(v3Host: String, gatewayHost: String?, clientMode: F
  * xmtp.create_client(account_identifier, nonce, inbox_id, Option<legacy_signed_private_key_proto>)
  * ```
  */
-public func createClient(api: XmtpApiClient, syncApi: XmtpApiClient, db: DbOptions, inboxId: String, accountIdentifier: FfiIdentifier, nonce: UInt64, legacySignedPrivateKeyProto: Data?, deviceSyncMode: FfiDeviceSyncMode?, allowOffline: Bool?, forkRecoveryOpts: FfiForkRecoveryOpts?)async throws  -> FfiXmtpClient  {
+public func createClient(api: XmtpApiClient, db: DbOptions, inboxId: String, accountIdentifier: FfiIdentifier, nonce: UInt64, legacySignedPrivateKeyProto: Data?, deviceSyncMode: FfiDeviceSyncMode?, allowOffline: Bool?, forkRecoveryOpts: FfiForkRecoveryOpts?, workerConfig: FfiWorkerConfig?)async throws  -> FfiXmtpClient  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
-                uniffi_xmtpv3_fn_func_create_client(FfiConverterTypeXmtpApiClient_lower(api),FfiConverterTypeXmtpApiClient_lower(syncApi),FfiConverterTypeDbOptions_lower(db),FfiConverterString.lower(inboxId),FfiConverterTypeFfiIdentifier_lower(accountIdentifier),FfiConverterUInt64.lower(nonce),FfiConverterOptionData.lower(legacySignedPrivateKeyProto),FfiConverterOptionTypeFfiDeviceSyncMode.lower(deviceSyncMode),FfiConverterOptionBool.lower(allowOffline),FfiConverterOptionTypeFfiForkRecoveryOpts.lower(forkRecoveryOpts)
+                uniffi_xmtpv3_fn_func_create_client(FfiConverterTypeXmtpApiClient_lower(api),FfiConverterTypeDbOptions_lower(db),FfiConverterString.lower(inboxId),FfiConverterTypeFfiIdentifier_lower(accountIdentifier),FfiConverterUInt64.lower(nonce),FfiConverterOptionData.lower(legacySignedPrivateKeyProto),FfiConverterOptionTypeFfiDeviceSyncMode.lower(deviceSyncMode),FfiConverterOptionBool.lower(allowOffline),FfiConverterOptionTypeFfiForkRecoveryOpts.lower(forkRecoveryOpts),FfiConverterOptionTypeFfiWorkerConfig.lower(workerConfig)
                 )
             },
             pollFunc: ffi_xmtpv3_rust_future_poll_u64,
@@ -15565,7 +16009,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_func_connect_to_backend() != 18361) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_func_create_client() != 20159) {
+    if (uniffi_xmtpv3_checksum_func_create_client() != 52109) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_decode_actions() != 20603) {
@@ -16145,6 +16589,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_set_consent_states() != 26184) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_method_ffixmtpclient_shutdown() != 44429) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_sign_with_installation_key() != 9313) {

--- a/sdks/ios/dev/.setup
+++ b/sdks/ios/dev/.setup
@@ -4,5 +4,14 @@
 
 set -eou pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
+# Resolve repo root. Prefer git, fall back to jj for non-colocated jj
+# workspaces (e.g. workspaces created via `jj workspace add`).
+if ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+elif ROOT="$(jj root 2>/dev/null)"; then
+    :
+else
+    echo "error: not in a git or jj working tree" >&2
+    exit 1
+fi
 IOS_SDK_DIR="${ROOT}/sdks/ios"


### PR DESCRIPTION
## Why

Creating an XMTP client required **two gRPC connections**. They were not a message/payer or primary/secondary split — they were two `tonic::Channel`s to the **same host**, wrapping the **same** client type, built from the **same** backend config. The second ("sync") connection was introduced on the assumption that a dedicated sync channel buys isolation; that isolation was never realized (same endpoint, no stream/concurrency separation), and the second client was used by exactly two unary reads.

The redundancy cost every client an extra TCP connection + file descriptor (the iOS SDK even kept a whole second client cache and dialed the backend twice), with no measured benefit.

This collapses the design to a single connection.

> Note: the d14n payer/message split (`xmtp_api_d14n`) is a separate internal concern and is **not** touched here.

## What changed

Commit-by-commit (each compiles + is self-contained):

1. **core** — remove `sync_api_client` field + `sync_api()` accessor from `XmtpMlsLocalContext`/`XmtpSharedContext`; collapse `ClientBuilder::api_clients(api, sync_api)` → `api_client(api)`; the two `.sync_api()` readers (`query_group_messages`, `load_identity_updates`) now use `.api()`.
2. **tests/benches** — every `.api_clients(a, b)` call site reduced to `.api_client(a)`.
3. **apps** — cli + xmtp_debug build one client.
4. **node + wasm** — `create_client_inner` drops its second client param; bindings build the backend once.
5. **mobile FFI** — **breaking**: `create_client` drops its second `sync_api: Arc<XmtpApiClient>` argument (plus its tests/bench call sites).
6. **sdks** — iOS + Android connect once, cache once, pass once. Android `xmtpv3.kt` regenerated.

## Verification

- `just check`, `just wasm check`, `just lint` (rust), `just node lint` — all green locally.
- `just android check` — green (bindings regenerated).
- Pre-existing markdown-lint failures in untouched repo docs (`sdks/ios/README.md`, `VALIDATION.md`, `TEST_SCENARIOS.md`) were left alone — not part of this change.

## ⚠️ Follow-up required before merge

- **iOS `xmtpv3.swift` must be regenerated on macOS.** The mobile FFI signature changed, but the iOS xcframework + Swift glue can only be regenerated on macOS/Xcode (`ios-xcframeworks-fast` has no Linux build), so the generated `xmtpv3.swift` in this branch still shows the old 2-arg signature. The hand-written `Client.swift` already targets the new 1-arg signature. Run `./sdks/ios/dev/bindings` on a Mac then `just ios check`.
- Minor: `sdks/ios/dev/.setup` resolves the repo root via `git rev-parse` with no jj fallback (Android's already has one), which breaks iOS regen from a jj workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse two gRPC connections into one across all client bindings
> - Removes the dedicated sync API client from `ClientBuilder`, `XmtpMlsLocalContext`, and the `XmtpSharedContext` trait in [builder.rs](https://github.com/xmtp/libxmtp/pull/3721/files#diff-112b6dd965ad29739b36ccfb7f1283b1dbc20ec772591a4487a0898c6c5650f6) and [context.rs](https://github.com/xmtp/libxmtp/pull/3721/files#diff-ca0115cb0e326f7fa5c9bc660a4a1c1aff68c42a4c048eb79529bba4575aa909); all network calls now route through a single API client.
> - Replaces the `.api_clients(api, sync_api)` builder method with `.api_client(api)` across all call sites: mobile FFI, Node, WASM, Android, iOS, and test utilities.
> - Operations previously routed through the sync client (group message queries, identity update fetches) now use the primary API client.
> - Behavioral Change: the `create_client_does_not_hit_network` test expectation for `get_identity_updates_v2` increases from 2 to 3 because all identity-update reads are now counted on the single client.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #3721 opened
>
> - Modified `FfiXmtpClient` to support graceful shutdown and worker configuration [6f64938]
> - Updated root resolution logic in setup script to support multiple version control systems [6f64938]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ab010b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->