### PR TITLE
feat(node-sdk): DB pool config + shared-backend multi-client test

### DIFF
--- a/sdks/js/node-sdk/src/Client.ts
+++ b/sdks/js/node-sdk/src/Client.ts
@@ -24,7 +24,12 @@ import { HistorySyncUrls } from "@/constants";
 import { Conversations } from "@/Conversations";
 import { DebugInformation } from "@/DebugInformation";
 import { Preferences } from "@/Preferences";
-import type { ClientOptions, ExtractCodecContentTypes, XmtpEnv } from "@/types";
+import type {
+  ClientOptions,
+  DistributiveOmit,
+  ExtractCodecContentTypes,
+  XmtpEnv,
+} from "@/types";
 import { createBackend } from "@/utils/createBackend";
 import { createClient } from "@/utils/createClient";
 import {
@@ -131,7 +136,7 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    */
   static async create<ContentCodecs extends ContentCodec[] = []>(
     signer: Signer,
-    options?: Omit<ClientOptions, "codecs"> & {
+    options?: DistributiveOmit<ClientOptions, "codecs"> & {
       codecs?: ContentCodecs;
     },
   ) {
@@ -159,7 +164,7 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    */
   static async build<ContentCodecs extends ContentCodec[] = []>(
     identifier: Identifier,
-    options?: Omit<ClientOptions, "codecs"> & {
+    options?: DistributiveOmit<ClientOptions, "codecs"> & {
       codecs?: ContentCodecs;
     },
   ) {

--- a/sdks/js/node-sdk/src/types.ts
+++ b/sdks/js/node-sdk/src/types.ts
@@ -111,6 +111,26 @@ export type StorageOptions = {
    * @see https://docs.xmtp.org/chat-apps/core-messaging/create-a-client#view-an-encrypted-database
    */
   dbEncryptionKey?: Uint8Array | HexString;
+  /**
+   * Maximum number of connections in the local DB connection pool.
+   *
+   * Defaults to 25 when unset. Ignored when `useSingleConnection` is `true`.
+   */
+  maxDbPoolSize?: number;
+  /**
+   * Minimum number of connections kept warm in the local DB connection pool.
+   *
+   * Defaults to 5 when unset. Ignored when `useSingleConnection` is `true`.
+   */
+  minDbPoolSize?: number;
+  /**
+   * When `true`, the native DB uses a single connection (one file descriptor)
+   * instead of a pool. The pool-size options above are ignored. Intended for
+   * services running many clients in one process.
+   *
+   * Defaults to `false` (pooled).
+   */
+  useSingleConnection?: boolean;
 };
 
 export type ContentOptions = {
@@ -175,6 +195,16 @@ export type ClientOptions = (NetworkOptions | { backend: Backend }) &
   StorageOptions &
   ContentOptions &
   OtherOptions;
+
+/**
+ * `Omit` that distributes over unions. The built-in `Omit` collapses a union
+ * (e.g. `ClientOptions`' `NetworkOptions | { backend }` arm) because
+ * `keyof (A | B)` only yields shared keys. This preserves each arm, so options
+ * like `{ backend }` survive `Omit<ClientOptions, "codecs">`.
+ */
+export type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
 
 export type EnrichedReply<T = unknown, U = unknown> = {
   referenceId: string;

--- a/sdks/js/node-sdk/src/utils/createClient.ts
+++ b/sdks/js/node-sdk/src/utils/createClient.ts
@@ -93,6 +93,9 @@ export const createClient = async (
     {
       dbPath: dbPath ?? undefined,
       encryptionKey: dbEncryptionKey,
+      maxDbPoolSize: options?.maxDbPoolSize,
+      minDbPoolSize: options?.minDbPoolSize,
+      useSingleConnection: options?.useSingleConnection,
     },
     inboxId,
     identifier,

--- a/sdks/js/node-sdk/test/Client.test.ts
+++ b/sdks/js/node-sdk/test/Client.test.ts
@@ -49,6 +49,38 @@ describe("Client", () => {
     expect(client3.inboxId).not.toEqual(client.inboxId);
   });
 
+  it("should create multiple clients from a single shared backend", async () => {
+    // Build one backend (connection) and reuse it to create several clients,
+    // the way a service hosting many inboxes in one process would.
+    const backend = await createBackend({ env: "local" });
+
+    const { signer: signer1, address: address1 } = createSigner();
+    const { signer: signer2, address: address2 } = createSigner();
+
+    const client1 = await Client.create(signer1, { backend, dbPath: null });
+    const client2 = await Client.create(signer2, { backend, dbPath: null });
+
+    // Both clients came up and are distinct.
+    expect(client1.inboxId).toBeDefined();
+    expect(client2.inboxId).toBeDefined();
+    expect(client1.inboxId).not.toEqual(client2.inboxId);
+    expect(client1.accountIdentifier?.identifier).toBe(address1);
+    expect(client2.accountIdentifier?.identifier).toBe(address2);
+
+    // Each shares the same backend instance.
+    const backendOf = (options: typeof client1.options) =>
+      options && "backend" in options ? options.backend : undefined;
+    expect(backendOf(client1.options)).toBe(backend);
+    expect(backendOf(client2.options)).toBe(backend);
+
+    // The shared backend is usable for backend-only calls too.
+    const canMessage = await Client.canMessage(
+      [await signer1.getIdentifier(), await signer2.getIdentifier()],
+      backend,
+    );
+    expect(canMessage.size).toBe(2);
+  });
+
   it("should create a client with worker config and logging options", async () => {
     const { signer } = createSigner();
     const workerConfig = {
@@ -77,6 +109,26 @@ describe("Client", () => {
     expect(() => {
       flushTelemetry();
     }).not.toThrow();
+  });
+
+  it("should create a client with DB connection pool options", async () => {
+    const { signer } = createSigner();
+    const client = await createClient(signer, {
+      maxDbPoolSize: 10,
+      minDbPoolSize: 2,
+    });
+    expect(client.inboxId).toBeDefined();
+    expect(client.options?.maxDbPoolSize).toBe(10);
+    expect(client.options?.minDbPoolSize).toBe(2);
+  });
+
+  it("should create a client with a single DB connection", async () => {
+    const { signer } = createSigner();
+    const client = await createClient(signer, {
+      useSingleConnection: true,
+    });
+    expect(client.inboxId).toBeDefined();
+    expect(client.options?.useSingleConnection).toBe(true);
   });
 
   it("should create a client without a signer", async () => {


### PR DESCRIPTION
## Summary

The node binding's `DbOptions` already accepts `maxDbPoolSize`, `minDbPoolSize`, and `useSingleConnection`, and the mobile SDKs surface them — but `node-sdk` never plumbed them through. `createClient` only forwarded `dbPath` + `encryptionKey`, so these pool settings were unreachable from the node SDK.

## Changes

- Add `maxDbPoolSize`, `minDbPoolSize`, and `useSingleConnection` to `StorageOptions` (documented).
- Forward them to the binding's `DbOptions` in `createClient`.
- Defaults are unchanged when unset (the native defaults: pool of 25 max / 5 min).
- Add two tests creating a client with pool options and with `useSingleConnection: true`.

`useSingleConnection` is intended for services running many clients in one process (single file descriptor instead of a pool); the pool-size options are ignored when it's set.

## Verification

- `typecheck` passes — the three field names/types match the binding's `DbOptions` exactly.
- New tests pass against a live binding: a client creates with `maxDbPoolSize: 10` / `minDbPoolSize: 2`, and with `useSingleConnection: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DB connection pool config options to node-sdk `Client`
> - Adds `maxDbPoolSize`, `minDbPoolSize`, and `useSingleConnection` optional fields to `StorageOptions` in [types.ts](https://github.com/xmtp/libxmtp/pull/3727/files#diff-5bf94a3cfdcc804e11b38049d2057987796553a279e6d40c4127f115dfeae3f8), with defaults documented in comments.
> - Propagates these fields through `createClient` to the native backend in [createClient.ts](https://github.com/xmtp/libxmtp/pull/3727/files#diff-f2f3a7f8037979bdd09b86959f380879ce06e2d349f6058112cde1a570521109).
> - Switches `Client.create` and `Client.build` parameter types to use `DistributiveOmit` (also added to `types.ts`) to correctly handle union types in `ClientOptions`.
> - Adds tests covering shared-backend multi-client creation, pool config options, and single-connection mode in [Client.test.ts](https://github.com/xmtp/libxmtp/pull/3727/files#diff-cad4eb3139a655d81bef737f413be110b11f4443c7306e5d3a99d5ff5867c3c2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 720abf2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->