### PR TITLE
feat(keepalive-probe): XMTP gRPC connection-health probe + sidecar

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -37,6 +37,7 @@ workspace-members = [
   "error_glossary",
   "xnet-cli",
   "xnet-lib",
+  "keepalive-probe",
 ]
 third-party = [
   { name = "tonic" },
@@ -59,6 +60,7 @@ workspace-members = [
   "error_glossary",
   "xnet-cli",
   "xnet-lib",
+  "keepalive-probe",
 ]
 third-party = [
   { name = "tonic" },

--- a/.github/workflows/push-keepalive-probe.yml
+++ b/.github/workflows/push-keepalive-probe.yml
@@ -1,0 +1,68 @@
+name: Push keepalive-probe Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/keepalive-probe/**'
+      - 'crates/xmtp_proto/**'
+      - 'crates/xmtp_common/**'
+      - 'crates/xmtp_configuration/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: xmtp/keepalive-probe
+
+jobs:
+  build:
+    name: Build and push keepalive-probe image
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Capture commit metadata
+        id: vars
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.vars.outputs.short_sha }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/keepalive-probe/docker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test-keepalive-probe.yml
+++ b/.github/workflows/test-keepalive-probe.yml
@@ -1,0 +1,19 @@
+name: Test keepalive-probe
+on:
+  workflow_call:
+jobs:
+  check:
+    name: Check (keepalive-probe)
+    runs-on: warp-ubuntu-latest-x64-16x
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-nix
+        with:
+          github-token: ${{ github.token }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          sccache: "false"
+          with-warpbuild-cache: "false"
+      - name: Check keepalive-probe compiles
+        run: nix-fast-build --no-nom --flake .#cargo-clippy.x86_64-linux.keepalive-probe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       bindings-check: ${{ steps.filter.outputs.bindings-check }}
       devcontainer: ${{ steps.filter.outputs.devcontainer }}
       xdbg: ${{ steps.filter.outputs.xdbg }}
+      keepalive-probe: ${{ steps.filter.outputs.keepalive-probe }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -137,6 +138,17 @@ jobs:
               - 'flake.lock'
               - '.github/workflows/test.yml'
               - '.github/workflows/test-xdbg.yml'
+            keepalive-probe:
+              - 'apps/keepalive-probe/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.cargo/**'
+              - 'rust-toolchain.toml'
+              - 'nix/**'
+              - 'flake.lock'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/test-keepalive-probe.yml'
 
   test-workspace:
     needs: detect-changes
@@ -148,6 +160,12 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.xdbg == 'true'
     uses: ./.github/workflows/test-xdbg.yml
+    secrets: inherit
+
+  test-keepalive-probe:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.keepalive-probe == 'true'
+    uses: ./.github/workflows/test-keepalive-probe.yml
     secrets: inherit
 
   test-node:
@@ -227,6 +245,7 @@ jobs:
     needs:
       - test-workspace
       - test-xdbg
+      - test-keepalive-probe
       - test-node
       - test-wasm
       - test-node-sdk

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ docs/plans
 
 # Claude Code
 .claude/scheduled_tasks.lock
+/target-linux-amd64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6766,6 +6766,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "keepalive-probe"
+version = "1.11.0-dev"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "clap",
+ "hex",
+ "http-body-util",
+ "humantime",
+ "hyper 1.9.0",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tonic",
+ "tonic-prost",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "webpki-roots 0.26.11",
+ "xmtp_proto",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11940,7 +11964,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -13282,6 +13306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/apps/keepalive-probe/Cargo.toml
+++ b/apps/keepalive-probe/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "keepalive-probe"
+description = "Throwaway diagnostic: hold N idle HTTP/2 connections to an XMTP gRPC endpoint and measure how long each survives under configurable keepalive (herald-lite #70)"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+bytes.workspace = true
+clap.workspace = true
+http-body-util.workspace = true
+hyper = { workspace = true, features = ["client", "http2"] }
+hyper-util = { workspace = true, features = ["tokio"] }
+rustls = { workspace = true, features = ["ring"] }
+tokio = { workspace = true, features = [
+  "rt-multi-thread",
+  "macros",
+  "net",
+  "time",
+  "signal",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "ring",
+  "tls12",
+] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
+url.workspace = true
+webpki-roots = "0.26"
+humantime = "2"

--- a/apps/keepalive-probe/Cargo.toml
+++ b/apps/keepalive-probe/Cargo.toml
@@ -34,3 +34,8 @@ tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 url.workspace = true
 webpki-roots = "0.26"
 humantime = "2"
+hex = "0.4"
+# Subscribe mode (real V3 streams): tonic gRPC client + the MLS proto types.
+tonic = { workspace = true, features = ["default", "tls-webpki-roots", "tls-ring"] }
+tonic-prost = "0.14"
+xmtp_proto.workspace = true

--- a/apps/keepalive-probe/Cargo.toml
+++ b/apps/keepalive-probe/Cargo.toml
@@ -14,7 +14,9 @@ workspace = true
 anyhow.workspace = true
 bytes.workspace = true
 clap.workspace = true
+hex = "0.4"
 http-body-util.workspace = true
+humantime = "2"
 hyper = { workspace = true, features = ["client", "http2"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 rustls = { workspace = true, features = ["ring"] }
@@ -33,9 +35,11 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 url.workspace = true
 webpki-roots = "0.26"
-humantime = "2"
-hex = "0.4"
 # Subscribe mode (real V3 streams): tonic gRPC client + the MLS proto types.
-tonic = { workspace = true, features = ["default", "tls-webpki-roots", "tls-ring"] }
+tonic = { workspace = true, features = [
+  "default",
+  "tls-webpki-roots",
+  "tls-ring",
+] }
 tonic-prost = "0.14"
 xmtp_proto.workspace = true

--- a/apps/keepalive-probe/Cargo.toml
+++ b/apps/keepalive-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keepalive-probe"
-description = "Throwaway diagnostic: hold N idle HTTP/2 connections to an XMTP gRPC endpoint and measure how long each survives under configurable keepalive (herald-lite #70)"
+description = "Probe for XMTP gRPC connection health: hold N idle or subscribe streams to an endpoint and measure how long each survives under configurable keepalive (herald-lite #70)"
 license.workspace = true
 version.workspace = true
 rust-version.workspace = true

--- a/apps/keepalive-probe/README.md
+++ b/apps/keepalive-probe/README.md
@@ -1,0 +1,54 @@
+# keepalive-probe
+
+Throwaway diagnostic for [`herald-lite#70`](https://github.com/xmtplabs/herald-lite/issues/70) — "UNAVAILABLE status GRPC errors."
+
+herald instances regularly log `hyper::Error(Http2, KeepAliveTimedOut)` → gRPC `UNAVAILABLE` against the dev backend, then retry. We ruled out the NLB, server, CPU, and memory as causes. This binary isolates the **transport keepalive** in the simplest possible form: open *N* idle HTTP/2 connections to the gRPC endpoint, hold them doing nothing, and measure how long each survives — and whether tweaking the keepalive config changes that.
+
+## What it does
+
+For each of `--count` connections, one task: TCP → TLS (rustls, ALPN `h2`) → `hyper` HTTP/2 handshake with the configured keepalive, then it **holds the `SendRequest` handle and sends nothing**, awaiting the connection driver. The driver future resolves only when the connection actually dies, so we get an exact lifetime and reason, pinned to that one connection (no tonic-style reconnect masking). Setup failures are recorded as outcomes, never panics — one bad connection can't kill the run.
+
+## Why these defaults
+
+The defaults mirror libxmtp's real channel config in
+[`crates/xmtp_api_grpc/src/grpc_client/native.rs`](../../crates/xmtp_api_grpc/src/grpc_client/native.rs)
+(`apply_channel_options`), so a bare run reproduces herald's transport behavior:
+
+| flag | default | libxmtp source |
+|------|---------|----------------|
+| `--ka-interval` | `16s` | `http2_keep_alive_interval` |
+| `--ka-timeout` | `10s` | `keep_alive_timeout` ← the #70 knob |
+| `--ka-while-idle` | `true` | `keep_alive_while_idle` |
+| `--connect-timeout` | `10s` | `connect_timeout` |
+| `--endpoint` | `https://grpc.dev.xmtp.network:443` | node-sdk `ApiUrls.dev` |
+
+## Usage
+
+```sh
+# single connection, default (libxmtp) config — smoke test
+cargo run -p keepalive-probe -- --count 1 --duration 120s
+
+# the experiment: 1000 idle connections for 30 min
+cargo run -p keepalive-probe -- --count 1000 --duration 1800s --stagger 5ms
+
+# sweep the #70 knob: does a longer keepalive timeout stop the deaths?
+cargo run -p keepalive-probe -- --count 200 --duration 1800s --ka-timeout 30s
+
+# control: no idle pings at all
+cargo run -p keepalive-probe -- --count 200 --duration 1800s --ka-while-idle false
+```
+
+Stops at `--duration` or on Ctrl-C; either way it prints a summary. `RUST_LOG=debug` for more detail.
+
+## Output
+
+Per-connection lines as they die, then a summary: established / died / closed / survived / setup-errors, the lifetime distribution (min/p50/p95/max) of the connections that **died**, and a death-reason histogram (keepalive timeout / GOAWAY / reset / …).
+
+## Reading the result
+
+- **Idle connections die on default config** → keepalive-on-an-idle-path is the mechanism; confirm `--ka-timeout 30s` (or `--ka-while-idle false`) makes them survive, and that's the fix to push into libxmtp.
+- **Idle connections survive but herald's don't** → the death is stream/activity-specific, not pure transport; escalate to holding a real `Subscribe` stream.
+
+## Scope
+
+Throwaway. No XMTP protos, no auth (the gRPC layer has none), no real RPCs, no reconnect logic, no metrics export. Not in `default-members`, so it never builds in normal CI; `cargo run -p keepalive-probe` only.

--- a/apps/keepalive-probe/README.md
+++ b/apps/keepalive-probe/README.md
@@ -40,6 +40,26 @@ cargo run -p keepalive-probe -- --count 200 --duration 1800s --ka-while-idle fal
 
 Stops at `--duration` or on Ctrl-C; either way it prints a summary. `RUST_LOG=debug` for more detail.
 
+## Subscribe mode (real V3 streams) — `--subscribe-group`
+
+Instead of an idle connection, hold a real `MlsApi/SubscribeGroupMessages` stream per connection and log every payload + every disconnect. This is the herald-shaped test (herald holds subscribe streams), and it discriminates a *one-directional black hole* (return path drops → stream disconnects, client-side, no server error) from an idle-transport issue. Subscribe is unauthenticated — the V3 backend doesn't gate it.
+
+**Local first** (point at a local node-go, make a group with `xdbg`):
+```sh
+# 1. run node-go locally (V3 gRPC on http://localhost:5556)
+# 2. make a group + grab its id (hex)
+cargo run -p xmtp_debug -- --backend local generate group   # then `inspect` to get the group id
+# 3. hold a few streams to it and watch for disconnects
+cargo run -p keepalive-probe -- \
+  --endpoint http://localhost:5556 --subscribe-group <hex-group-id> --count 4 --duration 1h
+# 4. send a message to the group with xdbg → probe logs "payload received"
+# 5. kill / pause the local node → probe logs "DISCONNECTED: ..." with the reason + lifetime
+```
+
+Against dev: `--endpoint https://grpc.dev.xmtp.network:443 --subscribe-group <id>`. `http://` = plaintext h2 (local), `https://` = TLS. The keepalive flags apply to the stream's channel just like idle mode.
+
+A `DISCONNECTED` line is the disconnect notice; `payloads received` in the summary confirms the streams were live.
+
 ## Output
 
 Per-connection lines as they die, then a summary: established / died / closed / survived / setup-errors, the lifetime distribution (min/p50/p95/max) of the connections that **died**, and a death-reason histogram (keepalive timeout / GOAWAY / reset / …).

--- a/apps/keepalive-probe/README.md
+++ b/apps/keepalive-probe/README.md
@@ -51,13 +51,16 @@ Instead of an idle connection, hold a real `MlsApi/SubscribeGroupMessages` strea
 **Local first** (point at a local node-go, make a group with `xdbg`):
 ```sh
 # 1. run node-go locally (V3 gRPC on http://localhost:5556)
-# 2. make a group + grab its id (hex)
-cargo run -p xdbg -- --backend local generate group   # then `inspect` to get the group id
-# 3. hold a few streams to it and watch for disconnects
+# 2. seed identities, then a group (group creation needs members)
+cargo run -p xdbg -- --backend local generate --entity identity --amount 10
+cargo run -p xdbg -- --backend local generate --entity group --amount 1
+# 3. grab a group id (hex) — export prints/writes the local groups
+cargo run -p xdbg -- --backend local export --entity group --out /tmp/groups.json
+# 4. hold a few streams to it and watch for disconnects
 cargo run -p keepalive-probe -- \
   --endpoint http://localhost:5556 --subscribe-group <hex-group-id> --count 4 --duration 1h
-# 4. send a message to the group with xdbg → probe logs "payload received"
-# 5. kill / pause the local node → probe logs "DISCONNECTED: ..." with the reason + lifetime
+# 5. send a message to the group with xdbg → probe logs "payload received"
+# 6. kill / pause the local node → probe logs "DISCONNECTED: ..." with the reason + lifetime
 ```
 
 Against dev: `--endpoint https://grpc.dev.xmtp.network:443 --subscribe-group <id>`. `http://` = plaintext h2 (local), `https://` = TLS. The keepalive flags apply to the stream's channel just like idle mode.

--- a/apps/keepalive-probe/README.md
+++ b/apps/keepalive-probe/README.md
@@ -52,7 +52,7 @@ Instead of an idle connection, hold a real `MlsApi/SubscribeGroupMessages` strea
 ```sh
 # 1. run node-go locally (V3 gRPC on http://localhost:5556)
 # 2. make a group + grab its id (hex)
-cargo run -p xmtp_debug -- --backend local generate group   # then `inspect` to get the group id
+cargo run -p xdbg -- --backend local generate group   # then `inspect` to get the group id
 # 3. hold a few streams to it and watch for disconnects
 cargo run -p keepalive-probe -- \
   --endpoint http://localhost:5556 --subscribe-group <hex-group-id> --count 4 --duration 1h
@@ -61,6 +61,8 @@ cargo run -p keepalive-probe -- \
 ```
 
 Against dev: `--endpoint https://grpc.dev.xmtp.network:443 --subscribe-group <id>`. `http://` = plaintext h2 (local), `https://` = TLS. The keepalive flags apply to the stream's channel just like idle mode.
+
+> **Safety:** subscribe is unauthenticated — anyone who knows a group id can stream its (encrypted, but metadata-bearing) message envelopes. Probe your own throwaway groups; don't point it at someone else's group id. Separately, when `SSLKEYLOGFILE` is set the probe writes TLS session keys to that path so a capture can be decrypted in Wireshark — only do this against test endpoints, and treat the keylog file as a secret.
 
 A `DISCONNECTED` line is the disconnect notice; `payloads received` in the summary confirms the streams were live.
 

--- a/apps/keepalive-probe/README.md
+++ b/apps/keepalive-probe/README.md
@@ -1,8 +1,12 @@
 # keepalive-probe
 
-Throwaway diagnostic for [`herald-lite#70`](https://github.com/xmtplabs/herald-lite/issues/70) — "UNAVAILABLE status GRPC errors."
+A standalone probe for XMTP gRPC **connection health** — it holds connections to an XMTP gRPC endpoint with a configurable keepalive and reports how long each survives and why it dropped. Built to diagnose [`herald-lite#70`](https://github.com/xmtplabs/herald-lite/issues/70) (`hyper::Error(Http2, KeepAliveTimedOut)` → gRPC `UNAVAILABLE`), it doubles as a long-lived **sidecar** that continuously traps disconnects so you can tell a client/host problem apart from a backend/path one.
 
-herald instances regularly log `hyper::Error(Http2, KeepAliveTimedOut)` → gRPC `UNAVAILABLE` against the dev backend, then retry. We ruled out the NLB, server, CPU, and memory as causes. This binary isolates the **transport keepalive** in the simplest possible form: open *N* idle HTTP/2 connections to the gRPC endpoint, hold them doing nothing, and measure how long each survives — and whether tweaking the keepalive config changes that.
+Two modes:
+- **idle** (default): open *N* bare HTTP/2 connections and measure how long each survives — isolates pure transport keepalive behavior.
+- **subscribe** (`--subscribe-group <hex>`): hold *N* real `MlsApi/SubscribeGroupMessages` streams, logging every payload and every disconnect — the herald-shaped test.
+
+Run with `--continual` to make it a never-exiting daemon (retries through everything, drains on SIGINT/SIGTERM) suitable for running as a non-essential sidecar next to a real client.
 
 ## What it does
 
@@ -69,6 +73,10 @@ Per-connection lines as they die, then a summary: established / died / closed / 
 - **Idle connections die on default config** → keepalive-on-an-idle-path is the mechanism; confirm `--ka-timeout 30s` (or `--ka-while-idle false`) makes them survive, and that's the fix to push into libxmtp.
 - **Idle connections survive but herald's don't** → the death is stream/activity-specific, not pure transport; escalate to holding a real `Subscribe` stream.
 
-## Scope
+## Build & CI
 
-Throwaway. No XMTP protos, no auth (the gRPC layer has none), no real RPCs, no reconnect logic, no metrics export. Not in `default-members`, so it never builds in normal CI; `cargo run -p keepalive-probe` only.
+Excluded from `default-members` (like `xdbg`), so it doesn't build in the default workspace CI. Instead:
+- **clippy gate:** `nix/package/keepalive-probe-check.nix`, run by `.github/workflows/test-keepalive-probe.yml` on changes to the crate or its deps.
+- **image:** `apps/keepalive-probe/docker/Dockerfile`, built + pushed to `ghcr.io/xmtp/keepalive-probe` by `.github/workflows/push-keepalive-probe.yml` (sha + `latest` tags).
+
+Run locally with `cargo run -p keepalive-probe -- …`.

--- a/apps/keepalive-probe/docker/Dockerfile
+++ b/apps/keepalive-probe/docker/Dockerfile
@@ -1,0 +1,33 @@
+# Multi-stage image for the keepalive-probe binary.
+# Build context is the repo root (so the cargo build can see the workspace):
+#   docker build -f apps/keepalive-probe/docker/Dockerfile .
+FROM rust:1-bookworm AS builder
+WORKDIR /src
+
+COPY . .
+
+ARG FORCE_REBUILD=0
+RUN echo "FORCE_REBUILD=$FORCE_REBUILD"
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release --package keepalive-probe
+
+FROM debian:trixie-slim
+WORKDIR /work
+
+# tini = PID 1 so SIGTERM reaches the probe (it drains on SIGINT/SIGTERM);
+# procps for the pgrep healthcheck; ca-certificates is belt-and-suspenders
+# (the probe compiles in webpki-roots and doesn't use the system trust store).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends tini ca-certificates procps \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/target/release/keepalive-probe /usr/local/bin/keepalive-probe
+
+ENV RUST_LOG=info
+
+HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
+  CMD pgrep -x keepalive-probe >/dev/null || exit 1
+
+# Args (e.g. --continual --subscribe-group <id> ...) are supplied at deploy time.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/keepalive-probe"]

--- a/apps/keepalive-probe/src/main.rs
+++ b/apps/keepalive-probe/src/main.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use bytes::Bytes;
 use clap::Parser;
 use http_body_util::Empty;
@@ -61,6 +61,18 @@ struct Args {
     /// Delay between starting successive connections (avoid a boot thundering-herd).
     #[arg(long, default_value = "0ms", value_parser = humantime::parse_duration)]
     stagger: Duration,
+
+    /// Pin the TCP connection to this IP (TLS SNI still uses --endpoint's host).
+    /// Use to force all connections at one NLB IP for a clean packet capture.
+    #[arg(long)]
+    connect_ip: Option<String>,
+
+    /// SUBSCRIBE MODE: hex group id to open a real `MlsApi/SubscribeGroupMessages`
+    /// stream against (xdbg-style). When set, each connection holds one live
+    /// stream and logs received payloads + disconnects, instead of an idle conn.
+    /// (No auth — the V3 backend doesn't gate subscribe.)
+    #[arg(long)]
+    subscribe_group: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -80,6 +92,8 @@ struct ConnResult {
     /// Connection lifetime (from handshake to death/cutoff); setup time on SetupError.
     lifetime: Duration,
     outcome: Outcome,
+    /// Payloads received (subscribe mode only).
+    received: u64,
 }
 
 #[tokio::main]
@@ -93,9 +107,9 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .map_err(|_| anyhow!("failed to install rustls ring crypto provider"))?;
+    // Best-effort: ensure a process-default rustls provider exists. Errs only if
+    // one is already installed (e.g. by tonic's TLS), which is the state we want.
+    let _ = rustls::crypto::ring::default_provider().install_default();
 
     let url = Url::parse(&args.endpoint).context("parsing --endpoint")?;
     let host = url
@@ -110,6 +124,9 @@ async fn main() -> Result<()> {
         .with_root_certificates(roots)
         .with_no_client_auth();
     tls.alpn_protocols = vec![b"h2".to_vec()];
+    // Dump TLS session keys when SSLKEYLOGFILE is set, so a packet capture can
+    // be decrypted in Wireshark (no-op when the env var is unset).
+    tls.key_log = Arc::new(rustls::KeyLogFile::new());
     let tls = Arc::new(tls);
 
     tracing::info!(
@@ -173,18 +190,105 @@ async fn run_connection(
     tls: Arc<ClientConfig>,
 ) -> ConnResult {
     let start = Instant::now();
-    match establish_and_hold(args, host, port, tls).await {
-        Ok((outcome, lifetime)) => ConnResult {
+    // Subscribe mode (real V3 stream) vs idle mode (raw held connection).
+    let result = match &args.subscribe_group {
+        Some(group_hex) => run_subscribe(id, args, group_hex).await,
+        None => establish_and_hold(args, host, port, tls)
+            .await
+            .map(|(o, life)| (o, life, 0u64)),
+    };
+    match result {
+        Ok((outcome, lifetime, received)) => ConnResult {
             id,
             lifetime,
             outcome,
+            received,
         },
         Err(e) => ConnResult {
             id,
             lifetime: start.elapsed(),
             outcome: Outcome::SetupError(format!("{e:#}")),
+            received: 0,
         },
     }
+}
+
+/// SUBSCRIBE MODE: open one `MlsApi/SubscribeGroupMessages` stream to `group_hex`
+/// using a tonic channel with the same configurable keepalive, hold it, log every
+/// payload (then drop it), and report when/why the stream disconnects.
+async fn run_subscribe(
+    id: usize,
+    args: &Args,
+    group_hex: &str,
+) -> Result<(Outcome, Duration, u64)> {
+    use tonic::codegen::http::uri::PathAndQuery;
+    use tonic::transport::{ClientTlsConfig, Endpoint};
+    use tonic_prost::ProstCodec;
+    use xmtp_proto::mls_v1::{
+        GroupMessage, SubscribeGroupMessagesRequest, subscribe_group_messages_request::Filter,
+    };
+
+    let group_id = hex::decode(group_hex.trim_start_matches("0x")).context("group id not hex")?;
+
+    let mut ep = Endpoint::from_shared(args.endpoint.clone())
+        .context("bad --endpoint")?
+        .keep_alive_while_idle(args.ka_while_idle)
+        .http2_keep_alive_interval(args.ka_interval)
+        .keep_alive_timeout(args.ka_timeout)
+        .tcp_keepalive(Some(args.ka_interval))
+        .connect_timeout(args.connect_timeout);
+    if args.endpoint.starts_with("https://") {
+        ep = ep
+            .tls_config(ClientTlsConfig::new().with_enabled_roots())
+            .context("tls config")?;
+    }
+    let channel = ep.connect().await.context("connect")?;
+
+    let mut grpc = tonic::client::Grpc::new(channel);
+    grpc.ready().await.context("grpc not ready")?;
+    let codec: ProstCodec<SubscribeGroupMessagesRequest, GroupMessage> = ProstCodec::default();
+    let path = PathAndQuery::from_static("/xmtp.mls.api.v1.MlsApi/SubscribeGroupMessages");
+    let req = SubscribeGroupMessagesRequest {
+        filters: vec![Filter {
+            group_id,
+            id_cursor: 0,
+        }],
+    };
+    let resp = grpc
+        .server_streaming(tonic::Request::new(req), path, codec)
+        .await
+        .context("subscribe call")?;
+    let mut stream = resp.into_inner();
+    tracing::info!(id, "subscribed; holding stream");
+
+    let connected = Instant::now();
+    let mut received = 0u64;
+    let recv_loop = async {
+        loop {
+            match stream.message().await {
+                Ok(Some(msg)) => {
+                    received += 1;
+                    let mid = match msg.version {
+                        Some(xmtp_proto::mls_v1::group_message::Version::V1(v)) => v.id,
+                        None => 0,
+                    };
+                    tracing::info!(
+                        id,
+                        msg_id = mid,
+                        total = received,
+                        "payload received (dropped)"
+                    );
+                }
+                Ok(None) => return Outcome::Closed, // server ended the stream
+                Err(status) => return Outcome::Died(status.to_string()),
+            }
+        }
+    };
+    let outcome = match tokio::time::timeout(args.duration, recv_loop).await {
+        Err(_) => Outcome::Survived,
+        Ok(o) => o,
+    };
+    Ok((outcome, connected.elapsed(), received))
 }
 
 /// Establish one TLS+H2 connection, hold it idle, and await its death (or the
@@ -195,7 +299,9 @@ async fn establish_and_hold(
     port: u16,
     tls: Arc<ClientConfig>,
 ) -> Result<(Outcome, Duration)> {
-    let tcp = tokio::time::timeout(args.connect_timeout, TcpStream::connect((host, port)))
+    // Connect to --connect-ip if pinned, else resolve the endpoint host.
+    let dst = args.connect_ip.as_deref().unwrap_or(host);
+    let tcp = tokio::time::timeout(args.connect_timeout, TcpStream::connect((dst, port)))
         .await
         .context("tcp connect timed out")?
         .context("tcp connect")?;
@@ -238,10 +344,11 @@ async fn establish_and_hold(
 
 fn log_result(r: &ConnResult) {
     let life = humantime::format_duration(round_secs(r.lifetime));
+    let rx = r.received;
     match &r.outcome {
-        Outcome::Died(e) => tracing::warn!(id = r.id, %life, "DIED: {e}"),
-        Outcome::Closed => tracing::info!(id = r.id, %life, "closed (graceful)"),
-        Outcome::Survived => tracing::info!(id = r.id, %life, "alive at cutoff"),
+        Outcome::Died(e) => tracing::warn!(id = r.id, %life, rx, "DISCONNECTED: {e}"),
+        Outcome::Closed => tracing::info!(id = r.id, %life, rx, "closed (graceful)"),
+        Outcome::Survived => tracing::info!(id = r.id, %life, rx, "alive at cutoff"),
         Outcome::SetupError(e) => tracing::error!(id = r.id, %life, "setup error: {e}"),
     }
 }
@@ -271,6 +378,10 @@ fn summarize(results: &[ConnResult], requested: usize) {
     println!("  closed:    {closed}");
     println!("  survived:  {survived}");
     println!("setup errors:{setup_err}");
+    let total_rx: u64 = results.iter().map(|r| r.received).sum();
+    if total_rx > 0 {
+        println!("payloads received (subscribe mode): {total_rx}");
+    }
 
     if !died.is_empty() {
         let mut lifetimes: Vec<Duration> = died.iter().map(|r| r.lifetime).collect();

--- a/apps/keepalive-probe/src/main.rs
+++ b/apps/keepalive-probe/src/main.rs
@@ -1,0 +1,374 @@
+//! keepalive-probe — throwaway diagnostic for herald-lite #70.
+//!
+//! Opens `--count` idle HTTP/2 connections to an XMTP gRPC endpoint with a
+//! configurable keepalive, holds each one doing nothing, and reports how long
+//! each survives. Defaults mirror libxmtp's `apply_channel_options`
+//! (`crates/xmtp_api_grpc/src/grpc_client/native.rs`), so a bare run reproduces
+//! herald's transport behavior. Override the keepalive flags to sweep config.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use bytes::Bytes;
+use clap::Parser;
+use http_body_util::Empty;
+use hyper::client::conn::http2;
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
+use rustls::pki_types::ServerName;
+use rustls::{ClientConfig, RootCertStore};
+use tokio::net::TcpStream;
+use tokio::task::JoinSet;
+use tokio::time::Instant;
+use tokio_rustls::TlsConnector;
+use url::Url;
+
+#[derive(Parser, Debug, Clone)]
+#[command(
+    name = "keepalive-probe",
+    about = "Hold N idle HTTP/2 connections to an XMTP gRPC endpoint and measure their survival under a configurable keepalive (herald-lite #70)."
+)]
+struct Args {
+    /// gRPC endpoint to dial.
+    #[arg(long, default_value = "https://grpc.dev.xmtp.network:443")]
+    endpoint: String,
+
+    /// Number of concurrent idle connections to hold.
+    #[arg(long, default_value_t = 1)]
+    count: usize,
+
+    /// HTTP/2 keepalive PING interval (libxmtp default: 16s).
+    #[arg(long, default_value = "16s", value_parser = humantime::parse_duration)]
+    ka_interval: Duration,
+
+    /// Close the connection if no PONG arrives within this (libxmtp default: 10s).
+    /// This is the #70 knob — raise it to give a slow path more slack.
+    #[arg(long, default_value = "10s", value_parser = humantime::parse_duration)]
+    ka_timeout: Duration,
+
+    /// Send keepalive PINGs even with no active streams (libxmtp default: true).
+    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
+    ka_while_idle: bool,
+
+    /// TCP + TLS connect timeout (libxmtp default: 10s).
+    #[arg(long, default_value = "10s", value_parser = humantime::parse_duration)]
+    connect_timeout: Duration,
+
+    /// Stop the run after this long; survivors are reported as "alive >= duration".
+    #[arg(long, default_value = "600s", value_parser = humantime::parse_duration)]
+    duration: Duration,
+
+    /// Delay between starting successive connections (avoid a boot thundering-herd).
+    #[arg(long, default_value = "0ms", value_parser = humantime::parse_duration)]
+    stagger: Duration,
+}
+
+#[derive(Debug, Clone)]
+enum Outcome {
+    /// Connection driver returned an error (keepalive timeout, GOAWAY, reset, ...).
+    Died(String),
+    /// Connection closed cleanly (server GOAWAY / EOF without error).
+    Closed,
+    /// Still alive when the run duration elapsed.
+    Survived,
+    /// Failed to establish (DNS / TCP / TLS / HTTP-2 handshake).
+    SetupError(String),
+}
+
+struct ConnResult {
+    id: usize,
+    /// Connection lifetime (from handshake to death/cutoff); setup time on SetupError.
+    lifetime: Duration,
+    outcome: Outcome,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|_| anyhow!("failed to install rustls ring crypto provider"))?;
+
+    let url = Url::parse(&args.endpoint).context("parsing --endpoint")?;
+    let host = url
+        .host_str()
+        .context("--endpoint has no host")?
+        .to_string();
+    let port = url.port().unwrap_or(443);
+
+    let mut roots = RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let mut tls = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    tls.alpn_protocols = vec![b"h2".to_vec()];
+    let tls = Arc::new(tls);
+
+    tracing::info!(
+        endpoint = %args.endpoint,
+        count = args.count,
+        ka_interval = ?args.ka_interval,
+        ka_timeout = ?args.ka_timeout,
+        ka_while_idle = args.ka_while_idle,
+        duration = ?args.duration,
+        "starting keepalive probe"
+    );
+
+    let mut set: JoinSet<ConnResult> = JoinSet::new();
+    for id in 0..args.count {
+        let args = args.clone();
+        let host = host.clone();
+        let tls = tls.clone();
+        let stagger = args
+            .stagger
+            .checked_mul(id as u32)
+            .unwrap_or(Duration::ZERO);
+        set.spawn(async move {
+            if !stagger.is_zero() {
+                tokio::time::sleep(stagger).await;
+            }
+            run_connection(id, &args, &host, port, tls).await
+        });
+    }
+
+    let mut results: Vec<ConnResult> = Vec::with_capacity(args.count);
+    loop {
+        tokio::select! {
+            joined = set.join_next() => match joined {
+                Some(Ok(r)) => { log_result(&r); results.push(r); }
+                Some(Err(e)) => tracing::error!("worker task failed to join: {e}"),
+                None => break,
+            },
+            _ = tokio::signal::ctrl_c() => {
+                tracing::warn!(remaining = set.len(), "interrupted — aborting remaining connections");
+                set.abort_all();
+                while let Some(joined) = set.join_next().await {
+                    if let Ok(r) = joined {
+                        log_result(&r);
+                        results.push(r);
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    summarize(&results, args.count);
+    Ok(())
+}
+
+async fn run_connection(
+    id: usize,
+    args: &Args,
+    host: &str,
+    port: u16,
+    tls: Arc<ClientConfig>,
+) -> ConnResult {
+    let start = Instant::now();
+    match establish_and_hold(args, host, port, tls).await {
+        Ok((outcome, lifetime)) => ConnResult {
+            id,
+            lifetime,
+            outcome,
+        },
+        Err(e) => ConnResult {
+            id,
+            lifetime: start.elapsed(),
+            outcome: Outcome::SetupError(format!("{e:#}")),
+        },
+    }
+}
+
+/// Establish one TLS+H2 connection, hold it idle, and await its death (or the
+/// run cutoff). Returns the outcome and the connection's lifetime.
+async fn establish_and_hold(
+    args: &Args,
+    host: &str,
+    port: u16,
+    tls: Arc<ClientConfig>,
+) -> Result<(Outcome, Duration)> {
+    let tcp = tokio::time::timeout(args.connect_timeout, TcpStream::connect((host, port)))
+        .await
+        .context("tcp connect timed out")?
+        .context("tcp connect")?;
+    tcp.set_nodelay(true).ok();
+
+    let server_name = ServerName::try_from(host.to_string()).context("invalid TLS server name")?;
+    let tls_stream = tokio::time::timeout(
+        args.connect_timeout,
+        TlsConnector::from(tls).connect(server_name, tcp),
+    )
+    .await
+    .context("tls handshake timed out")?
+    .context("tls handshake")?;
+
+    let mut builder = http2::Builder::new(TokioExecutor::new());
+    builder
+        // hyper 1.x ships no timer; keepalive needs one.
+        .timer(TokioTimer::new())
+        .keep_alive_interval(args.ka_interval)
+        .keep_alive_timeout(args.ka_timeout)
+        .keep_alive_while_idle(args.ka_while_idle);
+
+    let (sender, conn) = builder
+        .handshake::<_, Empty<Bytes>>(TokioIo::new(tls_stream))
+        .await
+        .context("http2 handshake")?;
+
+    // "Do nothing": keep the SendRequest handle alive so hyper holds the
+    // connection open, send no requests, and drive the connection by awaiting
+    // it. It resolves only when the connection actually dies.
+    let _hold = sender;
+    let connected = Instant::now();
+    let outcome = match tokio::time::timeout(args.duration, conn).await {
+        Err(_) => Outcome::Survived,
+        Ok(Ok(())) => Outcome::Closed,
+        Ok(Err(e)) => Outcome::Died(e.to_string()),
+    };
+    Ok((outcome, connected.elapsed()))
+}
+
+fn log_result(r: &ConnResult) {
+    let life = humantime::format_duration(round_secs(r.lifetime));
+    match &r.outcome {
+        Outcome::Died(e) => tracing::warn!(id = r.id, %life, "DIED: {e}"),
+        Outcome::Closed => tracing::info!(id = r.id, %life, "closed (graceful)"),
+        Outcome::Survived => tracing::info!(id = r.id, %life, "alive at cutoff"),
+        Outcome::SetupError(e) => tracing::error!(id = r.id, %life, "setup error: {e}"),
+    }
+}
+
+fn summarize(results: &[ConnResult], requested: usize) {
+    let died: Vec<&ConnResult> = results
+        .iter()
+        .filter(|r| matches!(r.outcome, Outcome::Died(_)))
+        .collect();
+    let closed = results
+        .iter()
+        .filter(|r| matches!(r.outcome, Outcome::Closed))
+        .count();
+    let survived = results
+        .iter()
+        .filter(|r| matches!(r.outcome, Outcome::Survived))
+        .count();
+    let setup_err = results
+        .iter()
+        .filter(|r| matches!(r.outcome, Outcome::SetupError(_)))
+        .count();
+
+    println!("\n===== keepalive-probe summary =====");
+    println!("requested:   {requested}");
+    println!("established: {}", requested - setup_err);
+    println!("  died:      {}", died.len());
+    println!("  closed:    {closed}");
+    println!("  survived:  {survived}");
+    println!("setup errors:{setup_err}");
+
+    if !died.is_empty() {
+        let mut lifetimes: Vec<Duration> = died.iter().map(|r| r.lifetime).collect();
+        lifetimes.sort();
+        println!("\nlifetime of DIED connections:");
+        println!("  min  {}", fmt(percentile(&lifetimes, 0.0)));
+        println!("  p50  {}", fmt(percentile(&lifetimes, 0.50)));
+        println!("  p95  {}", fmt(percentile(&lifetimes, 0.95)));
+        println!("  max  {}", fmt(percentile(&lifetimes, 1.0)));
+
+        println!("\ndeath reasons:");
+        for (reason, n) in reason_histogram(&died) {
+            println!("  {n:>5}  {reason}");
+        }
+    }
+    println!("===================================");
+}
+
+/// Nearest-rank-ish percentile over a pre-sorted slice. `p` in [0.0, 1.0].
+fn percentile(sorted: &[Duration], p: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
+    let rank = (p * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted[rank.min(sorted.len() - 1)]
+}
+
+/// Collapse raw error strings into a few coarse buckets, counted desc.
+fn reason_histogram(died: &[&ConnResult]) -> Vec<(String, usize)> {
+    use std::collections::HashMap;
+    let mut counts: HashMap<&'static str, usize> = HashMap::new();
+    for r in died {
+        if let Outcome::Died(e) = &r.outcome {
+            *counts.entry(classify(e)).or_default() += 1;
+        }
+    }
+    let mut v: Vec<(String, usize)> = counts
+        .into_iter()
+        .map(|(k, n)| (k.to_string(), n))
+        .collect();
+    v.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+    v
+}
+
+fn classify(err: &str) -> &'static str {
+    let e = err.to_ascii_lowercase();
+    if e.contains("keepalive") {
+        "keepalive timeout"
+    } else if e.contains("goaway") {
+        "server GOAWAY"
+    } else if e.contains("reset") || e.contains("rst") {
+        "connection reset"
+    } else if e.contains("broken pipe") {
+        "broken pipe"
+    } else if e.contains("timed out") || e.contains("timeout") {
+        "timeout"
+    } else {
+        "other transport error"
+    }
+}
+
+fn round_secs(d: Duration) -> Duration {
+    Duration::from_secs(d.as_secs())
+}
+
+fn fmt(d: Duration) -> String {
+    humantime::format_duration(round_secs(d)).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secs(v: &[u64]) -> Vec<Duration> {
+        v.iter().map(|s| Duration::from_secs(*s)).collect()
+    }
+
+    #[test]
+    fn percentile_basics() {
+        let s = secs(&[1, 2, 3, 4, 5]);
+        assert_eq!(percentile(&s, 0.0), Duration::from_secs(1));
+        assert_eq!(percentile(&s, 0.50), Duration::from_secs(3));
+        assert_eq!(percentile(&s, 0.95), Duration::from_secs(5));
+        assert_eq!(percentile(&s, 1.0), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn percentile_empty_is_zero() {
+        assert_eq!(percentile(&[], 0.5), Duration::ZERO);
+    }
+
+    #[test]
+    fn classify_buckets() {
+        assert_eq!(
+            classify("connection error: keepalive timed out"),
+            "keepalive timeout"
+        );
+        assert_eq!(classify("http2 error: GOAWAY"), "server GOAWAY");
+        assert_eq!(classify("connection reset by peer"), "connection reset");
+    }
+}

--- a/apps/keepalive-probe/src/main.rs
+++ b/apps/keepalive-probe/src/main.rs
@@ -73,6 +73,12 @@ struct Args {
     /// (No auth — the V3 backend doesn't gate subscribe.)
     #[arg(long)]
     subscribe_group: Option<String>,
+
+    /// SUBSCRIBE MODE: on disconnect, re-subscribe and keep going (logging every
+    /// disconnect with timestamp + reason). Turns a one-shot into a multi-day
+    /// trap that catches every black-hole event, not just the first per stream.
+    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
+    reconnect: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -94,6 +100,8 @@ struct ConnResult {
     outcome: Outcome,
     /// Payloads received (subscribe mode only).
     received: u64,
+    /// Disconnect events survived via reconnect (subscribe mode only).
+    disconnects: u64,
 }
 
 #[tokio::main]
@@ -195,40 +203,48 @@ async fn run_connection(
         Some(group_hex) => run_subscribe(id, args, group_hex).await,
         None => establish_and_hold(args, host, port, tls)
             .await
-            .map(|(o, life)| (o, life, 0u64)),
+            .map(|(o, life)| (o, life, 0u64, 0u64)),
     };
     match result {
-        Ok((outcome, lifetime, received)) => ConnResult {
+        Ok((outcome, lifetime, received, disconnects)) => ConnResult {
             id,
             lifetime,
             outcome,
             received,
+            disconnects,
         },
         Err(e) => ConnResult {
             id,
             lifetime: start.elapsed(),
             outcome: Outcome::SetupError(format!("{e:#}")),
             received: 0,
+            disconnects: 0,
         },
     }
 }
 
-/// SUBSCRIBE MODE: open one `MlsApi/SubscribeGroupMessages` stream to `group_hex`
-/// using a tonic channel with the same configurable keepalive, hold it, log every
-/// payload (then drop it), and report when/why the stream disconnects.
-async fn run_subscribe(
+/// How one subscribe incarnation ended.
+enum SubEnd {
+    /// Run duration elapsed while the stream was healthy.
+    Cutoff,
+    /// Stream ended (server EOF or transport error) — reason for the log.
+    Ended(String),
+}
+
+/// One `MlsApi/SubscribeGroupMessages` incarnation: subscribe, hold up to
+/// `budget`, return how it ended + payloads received + how long it lived.
+async fn subscribe_once(
     id: usize,
     args: &Args,
-    group_hex: &str,
-) -> Result<(Outcome, Duration, u64)> {
+    group_id: Vec<u8>,
+    budget: Duration,
+) -> Result<(SubEnd, u64, Duration)> {
     use tonic::codegen::http::uri::PathAndQuery;
     use tonic::transport::{ClientTlsConfig, Endpoint};
     use tonic_prost::ProstCodec;
     use xmtp_proto::mls_v1::{
         GroupMessage, SubscribeGroupMessagesRequest, subscribe_group_messages_request::Filter,
     };
-
-    let group_id = hex::decode(group_hex.trim_start_matches("0x")).context("group id not hex")?;
 
     let mut ep = Endpoint::from_shared(args.endpoint.clone())
         .context("bad --endpoint")?
@@ -259,7 +275,7 @@ async fn run_subscribe(
         .await
         .context("subscribe call")?;
     let mut stream = resp.into_inner();
-    tracing::info!(id, "subscribed; holding stream");
+    tracing::debug!(id, "subscribed; holding stream");
 
     let connected = Instant::now();
     let mut received = 0u64;
@@ -279,16 +295,89 @@ async fn run_subscribe(
                         "payload received (dropped)"
                     );
                 }
-                Ok(None) => return Outcome::Closed, // server ended the stream
-                Err(status) => return Outcome::Died(status.to_string()),
+                Ok(None) => return SubEnd::Ended("server closed stream".into()),
+                Err(status) => return SubEnd::Ended(status.to_string()),
             }
         }
     };
-    let outcome = match tokio::time::timeout(args.duration, recv_loop).await {
-        Err(_) => Outcome::Survived,
-        Ok(o) => o,
+    let end = match tokio::time::timeout(budget, recv_loop).await {
+        Err(_) => SubEnd::Cutoff,
+        Ok(e) => e,
     };
-    Ok((outcome, connected.elapsed(), received))
+    Ok((end, received, connected.elapsed()))
+}
+
+/// SUBSCRIBE MODE: hold a stream to `group_hex` for the run duration. With
+/// `--reconnect` (default), every disconnect is logged with timestamp + reason
+/// and the stream is re-established — so a long run traps every black-hole event.
+/// Returns (final outcome, total runtime, payloads received, disconnect count).
+async fn run_subscribe(
+    id: usize,
+    args: &Args,
+    group_hex: &str,
+) -> Result<(Outcome, Duration, u64, u64)> {
+    let group_id = hex::decode(group_hex.trim_start_matches("0x")).context("group id not hex")?;
+    let overall = Instant::now();
+    let mut received_total = 0u64;
+    let mut disconnects = 0u64;
+    const BACKOFF: Duration = Duration::from_secs(1);
+
+    loop {
+        let budget = args.duration.saturating_sub(overall.elapsed());
+        if budget < Duration::from_secs(1) {
+            return Ok((
+                Outcome::Survived,
+                overall.elapsed(),
+                received_total,
+                disconnects,
+            ));
+        }
+        match subscribe_once(id, args, group_id.clone(), budget).await {
+            Ok((SubEnd::Cutoff, rx, _)) => {
+                received_total += rx;
+                return Ok((
+                    Outcome::Survived,
+                    overall.elapsed(),
+                    received_total,
+                    disconnects,
+                ));
+            }
+            Ok((SubEnd::Ended(reason), rx, life)) => {
+                received_total += rx;
+                disconnects += 1;
+                let lived = humantime::format_duration(round_secs(life));
+                tracing::warn!(id, %lived, n = disconnects, "DISCONNECTED: {reason}");
+                if !args.reconnect {
+                    return Ok((
+                        Outcome::Died(reason),
+                        overall.elapsed(),
+                        received_total,
+                        disconnects,
+                    ));
+                }
+                tokio::time::sleep(BACKOFF).await;
+            }
+            Err(e) => {
+                // First attempt failing is a genuine setup error — surface it.
+                if disconnects == 0 && received_total == 0 {
+                    return Err(e);
+                }
+                // A re-subscribe failed (server briefly unreachable): count it as a
+                // disconnect, back off, and keep trapping until the run ends.
+                disconnects += 1;
+                tracing::warn!(id, n = disconnects, "RECONNECT FAILED: {e:#}");
+                if !args.reconnect {
+                    return Ok((
+                        Outcome::Died(format!("{e:#}")),
+                        overall.elapsed(),
+                        received_total,
+                        disconnects,
+                    ));
+                }
+                tokio::time::sleep(BACKOFF).await;
+            }
+        }
+    }
 }
 
 /// Establish one TLS+H2 connection, hold it idle, and await its death (or the
@@ -345,10 +434,11 @@ async fn establish_and_hold(
 fn log_result(r: &ConnResult) {
     let life = humantime::format_duration(round_secs(r.lifetime));
     let rx = r.received;
+    let dc = r.disconnects;
     match &r.outcome {
-        Outcome::Died(e) => tracing::warn!(id = r.id, %life, rx, "DISCONNECTED: {e}"),
-        Outcome::Closed => tracing::info!(id = r.id, %life, rx, "closed (graceful)"),
-        Outcome::Survived => tracing::info!(id = r.id, %life, rx, "alive at cutoff"),
+        Outcome::Died(e) => tracing::warn!(id = r.id, %life, rx, dc, "DISCONNECTED: {e}"),
+        Outcome::Closed => tracing::info!(id = r.id, %life, rx, dc, "closed (graceful)"),
+        Outcome::Survived => tracing::info!(id = r.id, %life, rx, dc, "alive at cutoff"),
         Outcome::SetupError(e) => tracing::error!(id = r.id, %life, "setup error: {e}"),
     }
 }
@@ -379,8 +469,10 @@ fn summarize(results: &[ConnResult], requested: usize) {
     println!("  survived:  {survived}");
     println!("setup errors:{setup_err}");
     let total_rx: u64 = results.iter().map(|r| r.received).sum();
-    if total_rx > 0 {
+    let total_dc: u64 = results.iter().map(|r| r.disconnects).sum();
+    if total_rx > 0 || total_dc > 0 {
         println!("payloads received (subscribe mode): {total_rx}");
+        println!("disconnect events (reconnected):    {total_dc}");
     }
 
     if !died.is_empty() {

--- a/apps/keepalive-probe/src/main.rs
+++ b/apps/keepalive-probe/src/main.rs
@@ -123,6 +123,11 @@ async fn main() -> Result<()> {
         .init();
 
     let mut args = Args::parse();
+    if args.count == 0 {
+        // With 0 there are no workers, so the run loop (and --continual's
+        // run-forever contract) would exit immediately. Fail loudly instead.
+        anyhow::bail!("--count must be > 0");
+    }
     if args.continual {
         // Run forever, retrying everything; never exit on its own.
         args.duration = Duration::from_secs(100 * 365 * 24 * 3600);
@@ -496,13 +501,23 @@ fn summarize(results: &[ConnResult], requested: usize) {
         .filter(|r| matches!(r.outcome, Outcome::SetupError(_)))
         .count();
 
+    // `established` is derived from connections that actually produced a result
+    // (handshake completed), NOT `requested - setup_err`: on a mid-run shutdown
+    // some workers are aborted and never report, and counting those as
+    // established would inflate the number.
+    let established = results.len() - setup_err;
+    let interrupted = requested - results.len();
+
     println!("\n===== keepalive-probe summary =====");
     println!("requested:   {requested}");
-    println!("established: {}", requested - setup_err);
+    println!("established: {established}");
     println!("  died:      {}", died.len());
     println!("  closed:    {closed}");
     println!("  survived:  {survived}");
     println!("setup errors:{setup_err}");
+    if interrupted > 0 {
+        println!("interrupted: {interrupted}  (aborted on shutdown before reporting)");
+    }
     let total_rx: u64 = results.iter().map(|r| r.received).sum();
     let total_dc: u64 = results.iter().map(|r| r.disconnects).sum();
     if total_rx > 0 || total_dc > 0 {
@@ -571,7 +586,10 @@ fn classify(err: &str) -> &'static str {
 }
 
 fn round_secs(d: Duration) -> Duration {
-    Duration::from_secs(d.as_secs())
+    // Round to nearest second — truncating would under-report sub-second
+    // lifetimes (1.9s -> 1s, 0.4s -> 0s), which is exactly the timing this
+    // probe exists to measure.
+    Duration::from_secs(d.as_secs_f64().round() as u64)
 }
 
 fn fmt(d: Duration) -> String {
@@ -598,6 +616,23 @@ mod tests {
     #[test]
     fn percentile_empty_is_zero() {
         assert_eq!(percentile(&[], 0.5), Duration::ZERO);
+    }
+
+    #[test]
+    fn round_secs_rounds_to_nearest() {
+        // truncation would report these as 0s and 1s respectively
+        assert_eq!(
+            round_secs(Duration::from_millis(400)),
+            Duration::from_secs(0)
+        );
+        assert_eq!(
+            round_secs(Duration::from_millis(500)),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            round_secs(Duration::from_millis(1900)),
+            Duration::from_secs(2)
+        );
     }
 
     #[test]

--- a/apps/keepalive-probe/src/main.rs
+++ b/apps/keepalive-probe/src/main.rs
@@ -1,10 +1,13 @@
-//! keepalive-probe — throwaway diagnostic for herald-lite #70.
+//! keepalive-probe — XMTP gRPC connection-health probe.
 //!
-//! Opens `--count` idle HTTP/2 connections to an XMTP gRPC endpoint with a
-//! configurable keepalive, holds each one doing nothing, and reports how long
-//! each survives. Defaults mirror libxmtp's `apply_channel_options`
-//! (`crates/xmtp_api_grpc/src/grpc_client/native.rs`), so a bare run reproduces
-//! herald's transport behavior. Override the keepalive flags to sweep config.
+//! Holds `--count` connections to an XMTP gRPC endpoint with a configurable
+//! keepalive and reports how long each survives — either as bare idle HTTP/2
+//! connections, or (with `--subscribe-group`) as real `MlsApi/SubscribeGroupMessages`
+//! streams that log every payload and disconnect. Keepalive defaults mirror
+//! libxmtp's `apply_channel_options` (`crates/xmtp_api_grpc/src/grpc_client/native.rs`),
+//! so a bare run reproduces a client's transport behavior; override the flags to
+//! sweep config. Run with `--continual` as a long-lived sidecar that traps
+//! disconnects indefinitely and never exits on its own.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -79,6 +82,12 @@ struct Args {
     /// trap that catches every black-hole event, not just the first per stream.
     #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
     reconnect: bool,
+
+    /// Daemon mode: run forever (ignore --duration), retry through every error
+    /// including the first connect, and never exit on its own. For running as a
+    /// long-lived sidecar. Implies --reconnect. Stops only on SIGINT/SIGTERM.
+    #[arg(long, default_value_t = false)]
+    continual: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -113,7 +122,12 @@ async fn main() -> Result<()> {
         )
         .init();
 
-    let args = Args::parse();
+    let mut args = Args::parse();
+    if args.continual {
+        // Run forever, retrying everything; never exit on its own.
+        args.duration = Duration::from_secs(100 * 365 * 24 * 3600);
+        args.reconnect = true;
+    }
 
     // Best-effort: ensure a process-default rustls provider exists. Errs only if
     // one is already installed (e.g. by tonic's TLS), which is the state we want.
@@ -172,8 +186,8 @@ async fn main() -> Result<()> {
                 Some(Err(e)) => tracing::error!("worker task failed to join: {e}"),
                 None => break,
             },
-            _ = tokio::signal::ctrl_c() => {
-                tracing::warn!(remaining = set.len(), "interrupted — aborting remaining connections");
+            _ = shutdown_signal() => {
+                tracing::warn!(remaining = set.len(), "shutdown signal — aborting remaining connections");
                 set.abort_all();
                 while let Some(joined) = set.join_next().await {
                     if let Ok(r) = joined {
@@ -188,6 +202,26 @@ async fn main() -> Result<()> {
 
     summarize(&results, args.count);
     Ok(())
+}
+
+/// Resolve on SIGINT (Ctrl-C) or, on unix, SIGTERM — so a container stop drains cleanly.
+async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+    #[cfg(unix)]
+    let term = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut s) => {
+                s.recv().await;
+            }
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let term = std::future::pending::<()>();
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = term => {}
+    }
 }
 
 async fn run_connection(
@@ -358,8 +392,9 @@ async fn run_subscribe(
                 tokio::time::sleep(BACKOFF).await;
             }
             Err(e) => {
-                // First attempt failing is a genuine setup error — surface it.
-                if disconnects == 0 && received_total == 0 {
+                // First attempt failing is a genuine setup error — surface it, UNLESS
+                // we're a continual daemon (then keep retrying forever, never exit).
+                if !args.continual && disconnects == 0 && received_total == 0 {
                     return Err(e);
                 }
                 // A re-subscribe failed (server briefly unreachable): count it as a

--- a/nix/ci-checks.nix
+++ b/nix/ci-checks.nix
@@ -37,6 +37,7 @@ in
       { pkgs, ... }:
       {
         xdbg = pkgs.callPackage ./package/xdbg-check.nix { };
+        keepalive-probe = pkgs.callPackage ./package/keepalive-probe-check.nix { };
       }
     )
   );

--- a/nix/package/keepalive-probe-check.nix
+++ b/nix/package/keepalive-probe-check.nix
@@ -1,0 +1,39 @@
+# Derivation that runs `cargo clippy -p keepalive-probe`.
+#
+# keepalive-probe is excluded from default-members in the root Cargo.toml, so
+# the default per-PR Rust CI (clippy, nextest) skips it. This derivation is
+# the per-PR gate that catches workspace changes which break keepalive-probe's
+# build before they land on main.
+{
+  xmtp,
+  lib,
+  stdenv,
+}:
+let
+  inherit (xmtp) craneLib base;
+  root = ./../..;
+
+  rust-toolchain =
+    p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ "clippy-preview" ];
+  rust = craneLib.overrideToolchain rust-toolchain;
+
+  # `workspace` covers every member so cargo --locked can resolve all manifests and targets.
+  src = lib.fileset.toSource {
+    inherit root;
+    fileset = xmtp.filesets.workspace;
+  };
+
+  cargoArtifacts = base.mkCargoArtifacts rust false null;
+in
+rust.cargoClippy (
+  base.commonArgs
+  // {
+    inherit src cargoArtifacts;
+    pname = "keepalive-probe";
+    version = xmtp.mkVersion rust;
+    cargoExtraArgs = "--locked --all-targets -p keepalive-probe";
+    cargoClippyExtraArgs = "--no-deps -- -Dwarnings";
+    doCheck = false;
+    doInstallCargoArtifacts = false;
+  }
+)


### PR DESCRIPTION
## What

A new `apps/keepalive-probe` binary: a probe for XMTP gRPC **connection health**. It holds connections to an XMTP gRPC endpoint with a configurable keepalive (defaults mirror libxmtp's `apply_channel_options`) and reports how long each survives and why it dropped.

Two modes:
- **idle** — *N* bare HTTP/2 connections, to isolate pure transport keepalive behavior.
- **subscribe** (`--subscribe-group <hex>`) — *N* real `MlsApi/SubscribeGroupMessages` streams, logging every payload and disconnect (the herald-shaped test; the V3 backend doesn't gate subscribe).

With `--continual` it becomes a never-exiting daemon (retries through everything, drains on SIGINT/SIGTERM) for running as a long-lived, **non-essential sidecar** next to a real client.

## Why

Built to diagnose [`herald-lite#70`](https://github.com/xmtplabs/convos-assistants/issues/2388) — herald regularly logs `hyper::Error(Http2, KeepAliveTimedOut)` → gRPC `UNAVAILABLE`, retried. Running this probe (raw tonic, no libxmtp) against the same backend from a different host already isolated the failure as **client/host-side, not the V3 backend**: 500 streams held for days with zero disconnects while herald bursted. Productizing it (image + CI) so it can run as a durable sidecar that survives client redeploys.

## CI / build (mirrors `xdbg`, which is also an `apps/` binary excluded from `default-members`)

- `apps/keepalive-probe/docker/Dockerfile` — multi-stage (`rust:1-bookworm` → `debian:trixie-slim` + `tini` for clean SIGTERM).
- `push-keepalive-probe.yml` — builds + pushes `ghcr.io/xmtp/keepalive-probe` (sha + `latest`).
- per-PR clippy gate: `nix/package/keepalive-probe-check.nix` + `ci-checks.nix` + `test-keepalive-probe.yml`, wired into `test.yml` path-detection.
- excluded from hakari (`workspace-hack`) like the other apps.

Passes `clippy -Dwarnings`, `fmt`, `taplo`, `hakari`, and `cargo test` locally. No changes to any existing crate.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `keepalive-probe` binary and sidecar for monitoring XMTP gRPC connection health
> - Introduces a new `keepalive-probe` Rust binary crate under [apps/keepalive-probe/](https://github.com/xmtp/libxmtp/pull/3728/files#diff-2ef1e92100a8ad08a977468548118f827a1ef384532a4dbfbd134c169047248f) that spawns N concurrent connections (idle HTTP/2 or subscribe via gRPC streaming) and monitors their lifetimes under configurable keepalive settings.
> - Idle mode establishes a raw TLS+HTTP/2 connection via hyper/rustls and holds it open; subscribe mode uses tonic to stream `SubscribeGroupMessages` from an XMTP node endpoint.
> - On completion or shutdown (SIGINT/SIGTERM), the tool prints a summary with lifetime percentiles, error classification buckets, and subscribe counters.
> - Adds a multi-stage [Dockerfile](https://github.com/xmtp/libxmtp/pull/3728/files#diff-bb3f0d03e50364bb8290474119b27ce2eee13596da42eb68fb99c94ed23fe722), a GitHub Actions push workflow to publish `ghcr.io/xmtp/keepalive-probe`, and Nix/CI clippy checks for the new crate.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #3728 opened
>
> - Replaced single-step group creation and inspection instructions with a three-step sequence for seeding identities, generating groups, and exporting groups to obtain hex group IDs [fcd4b38]
> - Renumbered subsequent setup steps to accommodate the expanded group setup sequence [fcd4b38]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cfc2b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->