### PR TITLE
feat(observability): instrument ApiClientWrapper RPC methods for per-endpoint telemetry

### DIFF
--- a/crates/xmtp_api/src/identity.rs
+++ b/crates/xmtp_api/src/identity.rs
@@ -44,7 +44,7 @@ impl<ApiClient> ApiClientWrapper<ApiClient>
 where
     ApiClient: XmtpIdentityClient,
 {
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[xmtp_common::rpc_span]
     pub async fn publish_identity_update<U: Into<IdentityUpdate>>(
         &self,
         update: U,
@@ -64,7 +64,7 @@ where
         Ok(cursor)
     }
 
-    #[tracing::instrument(level = "trace", skip_all, fields(len = filters.len()))]
+    #[xmtp_common::rpc_span]
     pub async fn get_identity_updates_v2<T>(
         &self,
         filters: Vec<GetIdentityUpdatesV2Filter>,
@@ -109,7 +109,7 @@ where
         Ok(res)
     }
 
-    #[tracing::instrument(level = "trace", skip_all, fields(len = account_identifiers.len()))]
+    #[xmtp_common::rpc_span]
     pub async fn get_inbox_ids(
         &self,
         account_identifiers: Vec<ApiIdentifier>,
@@ -157,7 +157,7 @@ where
             .collect())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[xmtp_common::rpc_span]
     pub async fn verify_smart_contract_wallet_signatures(
         &self,
         request: VerifySmartContractWalletSignaturesRequest,

--- a/crates/xmtp_api/src/mls.rs
+++ b/crates/xmtp_api/src/mls.rs
@@ -69,7 +69,7 @@ impl<ApiClient> ApiClientWrapper<ApiClient>
 where
     ApiClient: XmtpApi,
 {
-    #[tracing::instrument(level = "trace", skip_all, fields(group_id = %group_id))]
+    #[xmtp_common::rpc_span]
     pub async fn query_group_messages(&self, group_id: GroupId) -> Result<Vec<GroupMessage>> {
         self.api_client
             .query_group_messages(group_id)
@@ -78,7 +78,7 @@ where
     }
 
     /// Query for the latest message on a group
-    #[tracing::instrument(level = "trace", skip_all, fields(group_id = %group_id))]
+    #[xmtp_common::rpc_span]
     pub async fn query_latest_group_message(
         &self,
         group_id: GroupId,
@@ -94,7 +94,7 @@ where
             .map_err(crate::dyn_err)
     }
 
-    #[tracing::instrument(level = "trace", skip_all, fields(installation_id = hex::encode(installation_id)))]
+    #[xmtp_common::rpc_span]
     pub async fn query_welcome_messages<Id: AsRef<[u8]> + Copy>(
         &self,
         installation_id: Id,
@@ -114,7 +114,7 @@ where
     /// New InboxID clients should set `is_inbox_id_credential` to true.
     /// V3 clients should have `is_inbox_id_credential` to `false`.
     /// Not indicating your client version will result in validation failure.
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[xmtp_common::rpc_span]
     pub async fn upload_key_package(
         &self,
         key_package: Vec<u8>,
@@ -139,7 +139,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[xmtp_common::rpc_span]
     pub async fn fetch_key_packages(
         &self,
         installation_keys: Vec<Vec<u8>>,
@@ -186,7 +186,7 @@ where
         Ok(mapping)
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[xmtp_common::rpc_span]
     pub async fn send_welcome_messages(&self, messages: &[WelcomeMessageInput]) -> Result<()> {
         tracing::debug!(inbox_id = self.inbox_id, "send welcome messages");
         retry_async!(
@@ -204,7 +204,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[xmtp_common::rpc_span]
     pub async fn send_group_messages(&self, group_messages: Vec<GroupMessageInput>) -> Result<()> {
         tracing::debug!(
             inbox_id = self.inbox_id,
@@ -227,6 +227,7 @@ where
         Ok(())
     }
 
+    #[xmtp_common::rpc_span]
     pub async fn subscribe_group_messages(
         &self,
         group_ids: &[&GroupId],
@@ -241,6 +242,7 @@ where
             .map_err(crate::dyn_err)
     }
 
+    #[xmtp_common::rpc_span]
     pub async fn subscribe_group_messages_with_cursors(
         &self,
         groups_with_cursors: &TopicCursor,
@@ -258,6 +260,7 @@ where
             .map_err(crate::dyn_err)
     }
 
+    #[xmtp_common::rpc_span]
     pub async fn subscribe_welcome_messages(
         &self,
         installation_key: &InstallationId,
@@ -275,6 +278,7 @@ where
             .map_err(crate::dyn_err)
     }
 
+    #[xmtp_common::rpc_span]
     pub async fn publish_commit_log(&self, requests: Vec<PublishCommitLogRequest>) -> Result<()> {
         tracing::debug!(inbox_id = self.inbox_id, "publishing commit log");
 
@@ -293,6 +297,7 @@ where
         Ok(())
     }
 
+    #[xmtp_common::rpc_span]
     pub async fn query_commit_log(
         &self,
         query_log_requests: Vec<QueryCommitLogRequest>,
@@ -319,6 +324,7 @@ where
         Ok(all_responses)
     }
 
+    #[xmtp_common::rpc_span]
     pub async fn get_newest_message_metadata(
         &self,
         group_ids: &[GroupId],

--- a/crates/xmtp_common/src/lib.rs
+++ b/crates/xmtp_common/src/lib.rs
@@ -49,6 +49,10 @@ pub use event_logging::*;
 pub use xmtp_cryptography::hash::*;
 pub use xmtp_cryptography::rand::*;
 
+pub use xmtp_macro::db_span;
 pub use xmtp_macro::log_event;
+pub use xmtp_macro::mls_span;
 pub use xmtp_macro::parser;
+pub use xmtp_macro::rpc_span;
+pub use xmtp_macro::span;
 pub use xmtp_macro::timeout;

--- a/crates/xmtp_macro/src/lib.rs
+++ b/crates/xmtp_macro/src/lib.rs
@@ -7,6 +7,7 @@ mod error_code;
 mod log_macros;
 mod logging;
 mod parse_logs_macro;
+mod span_macro;
 mod test_macro;
 mod timeout_macro;
 
@@ -218,4 +219,69 @@ pub fn timeout(
     body: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     timeout_macro::timeout(attr, body)
+}
+
+/// Instrument an `ApiClientWrapper` RPC method as `operation = "rpc.<fn_name>"`
+/// in libxmtp's canonical, OTEL-safe span form (`err, skip_all`). Surfaces as
+/// `xmtp.api.*` Collector metrics. See [`span`] for the shared rationale.
+///
+/// ```ignore
+/// #[xmtp_macro::rpc_span]
+/// pub async fn upload_key_package(&self, ..) -> Result<()> { .. }
+/// // → #[tracing::instrument(err, skip_all, fields(operation = "rpc.upload_key_package"))]
+/// ```
+#[proc_macro_attribute]
+pub fn rpc_span(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    span_macro::rpc_span(attr, body)
+}
+
+/// Instrument an `xmtp_db` query method as `operation = "db.<fn_name>"` in
+/// libxmtp's canonical, OTEL-safe span form (`err, skip_all`). Surfaces as
+/// `xmtp.db.*` Collector metrics. See [`span`] for the shared rationale.
+#[proc_macro_attribute]
+pub fn db_span(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    span_macro::db_span(attr, body)
+}
+
+/// Instrument a high-level MLS operation as `operation = "mls.<fn_name>"` in
+/// libxmtp's canonical, OTEL-safe span form (`err, skip_all`). Surfaces as
+/// `xmtp.mls.*` Collector metrics. See [`span`] for the shared rationale.
+#[proc_macro_attribute]
+pub fn mls_span(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    span_macro::mls_span(attr, body)
+}
+
+/// Instrument a method as a telemetry operation span in libxmtp's single
+/// canonical, OTEL-safe form: `#[tracing::instrument(err, skip_all,
+/// fields(operation = "<prefix>.<fn_name>"))]`.
+///
+/// `err` records span status=error on an `Err` return; `skip_all` keeps every
+/// argument off the span so a per-call id can never leak in and explode
+/// trace-attribute cardinality. `operation` is the single dimension the
+/// Collector's `span_metrics` connector buckets on. Making this the only
+/// writable form guarantees those invariants at compile time — no runtime test.
+///
+/// This is the escape hatch for a namespace without a dedicated attribute;
+/// prefer [`rpc_span`] / [`db_span`] / [`mls_span`] where they apply.
+///
+/// ```ignore
+/// #[xmtp_macro::span(prefix = "stream")]
+/// pub async fn subscribe(&self, ..) -> Result<..> { .. }
+/// // → operation = "stream.subscribe"
+/// ```
+#[proc_macro_attribute]
+pub fn span(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    span_macro::span(attr, body)
 }

--- a/crates/xmtp_macro/src/span_macro.rs
+++ b/crates/xmtp_macro/src/span_macro.rs
@@ -1,0 +1,95 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    Meta, Token, parse::Parse, parse::ParseStream, parse_macro_input, punctuated::Punctuated,
+};
+
+/// Expand a span attribute into libxmtp's one canonical, OTEL-safe instrument
+/// form, deriving the operation as `"<prefix>.<fn_name>"`:
+///
+/// ```ignore
+/// #[tracing::instrument(err, skip_all, fields(operation = "<prefix>.<fn_name>"))]
+/// ```
+///
+/// `err` records span status=error on an `Err` return (feeding
+/// `<namespace>.calls{status.code}` in the Collector). `skip_all` keeps every
+/// argument OUT of the span, so a per-call id (group_id / inbox_id / cursor) can
+/// never leak in and explode trace-attribute cardinality on the OTEL export.
+/// `operation` is the single dimension the Collector's `span_metrics` connector
+/// buckets on. Making this the only writable form guarantees those invariants at
+/// compile time — no runtime test required.
+pub(crate) fn expand_with_prefix(prefix: &str, input_fn: syn::ItemFn) -> TokenStream {
+    let operation = format!("{}.{}", prefix, input_fn.sig.ident);
+    quote! {
+        #[tracing::instrument(err, skip_all, fields(operation = #operation))]
+        #input_fn
+    }
+}
+
+/// `#[rpc_span]` → `operation = "rpc.<fn_name>"`. For `ApiClientWrapper` RPC
+/// methods; surfaces as `xmtp.api.*` Collector metrics.
+pub fn rpc_span(
+    _attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let input_fn = parse_macro_input!(body as syn::ItemFn);
+    expand_with_prefix("rpc", input_fn).into()
+}
+
+/// `#[db_span]` → `operation = "db.<fn_name>"`. For `xmtp_db` query methods;
+/// surfaces as `xmtp.db.*` Collector metrics.
+pub fn db_span(
+    _attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let input_fn = parse_macro_input!(body as syn::ItemFn);
+    expand_with_prefix("db", input_fn).into()
+}
+
+/// `#[mls_span]` → `operation = "mls.<fn_name>"`. For high-level MLS operations
+/// (sync, intent, send); surfaces as `xmtp.mls.*` Collector metrics.
+pub fn mls_span(
+    _attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let input_fn = parse_macro_input!(body as syn::ItemFn);
+    expand_with_prefix("mls", input_fn).into()
+}
+
+/// `#[span(prefix = "...")]` → `operation = "<prefix>.<fn_name>"`. Escape hatch
+/// for a namespace without a dedicated attribute; prefer `#[rpc_span]` /
+/// `#[db_span]` / `#[mls_span]` where they apply.
+pub fn span(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = parse_macro_input!(attr as SpanArgs);
+    let input_fn = parse_macro_input!(body as syn::ItemFn);
+    expand_with_prefix(&args.prefix, input_fn).into()
+}
+
+/// Parses the `prefix = "..."` argument of `#[span(...)]`.
+struct SpanArgs {
+    prefix: String,
+}
+
+impl Parse for SpanArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let metas = Punctuated::<Meta, Token![,]>::parse_terminated(input)?;
+        for meta in &metas {
+            if let Meta::NameValue(nv) = meta
+                && nv.path.is_ident("prefix")
+                && let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(s),
+                    ..
+                }) = &nv.value
+            {
+                return Ok(SpanArgs { prefix: s.value() });
+            }
+        }
+        Err(syn::Error::new(
+            input.span(),
+            r#"#[span] requires a string prefix: #[span(prefix = "rpc")]"#,
+        ))
+    }
+}


### PR DESCRIPTION
## What

Adds operation spans to every `ApiClientWrapper` RPC method so the OTel Collector's `span_metrics` connector can derive a dedicated `xmtp.api.*` metric family — **exact per-endpoint call counts** (e.g. "N `get_inbox_ids` in the last hour") and **RPC latency p50/p95/p99** — for slow/flapping-endpoint detection.

Same trace→Collector pattern as the merged DB-query telemetry (#3723): libxmtp emits traces only; metrics are derived Collector-side. No new metrics SDK, no Rust feature flag.

## Two commits

1. **`xmtp_macro`: span proc-macros.** New `#[rpc_span]` / `#[db_span]` / `#[mls_span]` (and `#[span(prefix = "…")]`) attributes that expand to the one canonical, OTEL-safe form:
   ```rust
   #[tracing::instrument(err, skip_all, fields(operation = "<prefix>.<fn_name>"))]
   ```
   The prefix-named macros derive `operation` from the function name, so the method name can't be mistyped and `err` / `skip_all` can't be dropped or an id-field added — **the correct span form is the only writable form, verified at compile time** (no runtime capture-subscriber test needed). Re-exported from `xmtp_common`.

2. **`xmtp_api`: apply `#[rpc_span]`.** All 16 `ApiClientWrapper` MLS + identity RPC methods now carry `operation = "rpc.<method>"`. The previous per-call `group_id` / `installation_id` span fields are **dropped** — spans are uniform and operation-only, which is cardinality-safe on the OTEL export. The forwarding trait impls (`scw_verifier`, `xmtp_query`) are intentionally left uninstrumented to avoid double-counting.

## Why counts are exact

On the Collector, `span_metrics/api` sits on its own pre-sampler pipeline (parallel to the MLS/DB ones), so it sees 100% of `rpc.*` spans → `xmtp.api.calls{operation}` is an exact counter. `tail_sampling` only affects the separate raw-trace copy sent to APM. The Collector-side config plan lives in the `convos-uptime` repo (`docs/plans/2026-06-05-api-rpc-spanmetrics.md`).

## Test plan

- [x] `cargo check -p xmtp_api`
- [x] `cargo clippy -p xmtp_api` / `-p xmtp_macro` — clean
- [x] `cargo nextest run -p xmtp_api` — 13 pass
- [x] `cargo fmt --all --check`

The instrumentation is a static span field; `cargo check` + `clippy` (macro expands correctly across async, generics, and `where` clauses) are the meaningful guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `rpc_span`, `db_span`, and `mls_span` proc macros to instrument `ApiClientWrapper` RPC methods
> - Introduces a new `span_macro` module in [xmtp_macro](https://github.com/xmtp/libxmtp/pull/3729/files#diff-cea3c5a1b2dd8d137d886a09cca5e90c3835c5a0681ff6c7fed5c20bc4a446a5) that implements `rpc_span`, `db_span`, `mls_span`, and a generic `span` proc-macro attribute, each wrapping the target function with `#[tracing::instrument(err, skip_all, fields(operation = "<prefix>.<fn_name>"))]`.
> - Replaces manual `#[tracing::instrument(level = "trace", skip_all, fields(...))]` annotations across all `ApiClientWrapper` methods in [identity.rs](https://github.com/xmtp/libxmtp/pull/3729/files#diff-61e7c2314db0736152c7b16281cc013850917603a9f15891cede889e6fbde214) and [mls.rs](https://github.com/xmtp/libxmtp/pull/3729/files#diff-85c63ca17c26ee353960247a8a31b08598056b1f5f229c35cbaf0de0e0f800f8) with `#[xmtp_common::rpc_span]`.
> - Adds `rpc_span` instrumentation to previously uninstrumented methods: `subscribe_group_messages`, `subscribe_group_messages_with_cursors`, `subscribe_welcome_messages`, `publish_commit_log`, `query_commit_log`, and `get_newest_message_metadata`.
> - Behavioral Change: per-call custom fields (`group_id`, `installation_id`, `len`) are removed from spans; all spans now record an `operation` field and capture errors via `err` at the macro's default tracing level instead of `trace`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f56439c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->