### PR TITLE
refactor(xmtp_db): migrate db.* query spans to #[db_span] macro

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -560,7 +560,7 @@ where
 
 impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     /// Return regular `Purpose::Conversation` groups with additional optional filters
-    #[tracing::instrument(err, skip_all, fields(operation = "db.find_groups"))]
+    #[xmtp_common::db_span]
     fn find_groups<A: AsRef<GroupQueryArgs>>(
         &self,
         args: A,
@@ -710,7 +710,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         Ok(groups)
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.find_groups_by_id_paged"))]
+    #[xmtp_common::db_span]
     fn find_groups_by_id_paged<A: AsRef<GroupQueryArgs>>(
         &self,
         args: A,
@@ -741,7 +741,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     /// Updates group membership state
-    #[tracing::instrument(err, skip_all, fields(operation = "db.update_group_membership"))]
+    #[xmtp_common::db_span]
     fn update_group_membership<Id: AsRef<[u8]>>(
         &self,
         group_id: Id,
@@ -756,7 +756,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         Ok(())
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.all_sync_groups"))]
+    #[xmtp_common::db_span]
     fn all_sync_groups(&self) -> Result<Vec<StoredGroup>, crate::ConnectionError> {
         let query = dsl::groups
             .order(dsl::created_at_ns.desc())
@@ -765,7 +765,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         self.raw_query(|conn| query.load(conn))
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.find_sync_group"))]
+    #[xmtp_common::db_span]
     fn find_sync_group(&self, id: &GroupId) -> Result<Option<StoredGroup>, crate::ConnectionError> {
         let query = dsl::groups
             .filter(dsl::conversation_type.eq(ConversationType::Sync))
@@ -774,7 +774,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         self.raw_query(|conn| query.first(conn).optional())
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.primary_sync_group"))]
+    #[xmtp_common::db_span]
     fn primary_sync_group(&self) -> Result<Option<StoredGroup>, crate::ConnectionError> {
         let query = dsl::groups
             .order(dsl::created_at_ns.desc())
@@ -784,7 +784,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     /// Return a single group that matches the given ID
-    #[tracing::instrument(err, skip_all, fields(operation = "db.find_group"))]
+    #[xmtp_common::db_span]
     fn find_group(&self, id: &GroupId) -> Result<Option<StoredGroup>, crate::ConnectionError> {
         let query = dsl::groups
             .order(dsl::created_at_ns.asc())
@@ -796,7 +796,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     /// Return a single group that matches the given welcome ID
-    #[tracing::instrument(err, skip_all, fields(operation = "db.find_group_by_sequence_id"))]
+    #[xmtp_common::db_span]
     fn find_group_by_sequence_id(
         &self,
         cursor: Cursor,
@@ -1017,11 +1017,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
 
     /// Get conversation IDs for all conversations that require a remote commit log publish
     /// (DMs and groups where user is super admin, excluding sync groups and rejected groups)
-    #[tracing::instrument(
-        err,
-        skip_all,
-        fields(operation = "db.get_conversation_ids_for_remote_log_publish")
-    )]
+    #[xmtp_common::db_span]
     fn get_conversation_ids_for_remote_log_publish(
         &self,
     ) -> Result<Vec<StoredGroupCommitLogPublicKey>, crate::ConnectionError> {
@@ -1046,11 +1042,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     // All dms and groups that are not sync groups and have consent state Allowed
-    #[tracing::instrument(
-        err,
-        skip_all,
-        fields(operation = "db.get_conversation_ids_for_remote_log_download")
-    )]
+    #[xmtp_common::db_span]
     fn get_conversation_ids_for_remote_log_download(
         &self,
     ) -> Result<Vec<StoredGroupCommitLogPublicKey>, crate::ConnectionError> {
@@ -1068,11 +1060,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     // Get conversation IDs for fork checking (excludes already forked conversations and sync groups)
-    #[tracing::instrument(
-        err,
-        skip_all,
-        fields(operation = "db.get_conversation_ids_for_fork_check")
-    )]
+    #[xmtp_common::db_span]
     fn get_conversation_ids_for_fork_check(&self) -> Result<Vec<Vec<u8>>, crate::ConnectionError> {
         let query = dsl::groups
             .filter(
@@ -1089,11 +1077,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         self.raw_query(|conn| query.load::<Vec<u8>>(conn))
     }
 
-    #[tracing::instrument(
-        err,
-        skip_all,
-        fields(operation = "db.get_conversation_ids_for_requesting_readds")
-    )]
+    #[xmtp_common::db_span]
     fn get_conversation_ids_for_requesting_readds(
         &self,
     ) -> Result<Vec<StoredGroupForReaddRequest>, crate::ConnectionError> {
@@ -1114,11 +1098,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         })
     }
 
-    #[tracing::instrument(
-        err,
-        skip_all,
-        fields(operation = "db.get_conversation_ids_for_responding_readds")
-    )]
+    #[xmtp_common::db_span]
     fn get_conversation_ids_for_responding_readds(
         &self,
     ) -> Result<Vec<StoredGroupForRespondingReadds>, crate::ConnectionError> {
@@ -1145,7 +1125,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         })
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.get_conversation_type"))]
+    #[xmtp_common::db_span]
     fn get_conversation_type(
         &self,
         group_id: &GroupId,
@@ -1223,11 +1203,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         Ok(())
     }
 
-    #[tracing::instrument(
-        err,
-        skip_all,
-        fields(operation = "db.get_groups_have_pending_leave_request")
-    )]
+    #[xmtp_common::db_span]
     fn get_groups_have_pending_leave_request(
         &self,
     ) -> Result<Vec<Vec<u8>>, crate::ConnectionError> {
@@ -2020,7 +1996,7 @@ pub(crate) mod tests {
 
     /// Regression guard for the `find_group` query-span instrumentation.
     ///
-    /// `find_group` is annotated with
+    /// `find_group` is annotated with `#[xmtp_common::db_span]`, which expands to
     /// `#[tracing::instrument(err, skip_all, fields(operation = "db.find_group"))]`.
     /// Two contracts must hold for the DB telemetry to be useful and safe:
     ///   1. the span carries `operation = "db.find_group"` (the metric dimension

--- a/crates/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_intent.rs
@@ -352,7 +352,7 @@ where
 }
 
 impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
-    #[tracing::instrument(err, skip_all, fields(operation = "db.insert_group_intent"))]
+    #[xmtp_common::db_span]
     fn insert_group_intent(
         &self,
         to_save: NewGroupIntent,
@@ -365,7 +365,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
     }
 
     // Query for group_intents by group_id, optionally filtering by state and kind
-    #[tracing::instrument(err, skip_all, fields(operation = "db.find_group_intents"))]
+    #[xmtp_common::db_span]
     fn find_group_intents<Id: AsRef<[u8]>>(
         &self,
         group_id: Id,
@@ -526,11 +526,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
 
     // Simple lookup of intents by payload hash, meant to be used when processing messages off the
     // network
-    #[tracing::instrument(
-        err,
-        skip_all,
-        fields(operation = "db.find_group_intent_by_payload_hash")
-    )]
+    #[xmtp_common::db_span]
     fn find_group_intent_by_payload_hash(
         &self,
         payload_hash: &[u8],
@@ -547,7 +543,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
 
     /// Find the commit message refresh state for each intent by payload hash.
     /// Returns a map from payload hash to a vector of dependencies (one per originator).
-    #[tracing::instrument(err, skip_all, fields(operation = "db.find_dependant_commits"))]
+    #[xmtp_common::db_span]
     fn find_dependant_commits<P: AsRef<[u8]>>(
         &self,
         payload_hashes: &[P],

--- a/crates/xmtp_db/src/encrypted_store/group_message.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message.rs
@@ -850,7 +850,7 @@ macro_rules! apply_message_filters {
 
 impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
     /// Query for group messages
-    #[tracing::instrument(err, skip_all, fields(operation = "db.get_group_messages"))]
+    #[xmtp_common::db_span]
     fn get_group_messages(
         &self,
         group_id: &GroupId,
@@ -896,7 +896,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
     }
 
     /// Count group messages matching the given criteria
-    #[tracing::instrument(err, skip_all, fields(operation = "db.count_group_messages"))]
+    #[xmtp_common::db_span]
     fn count_group_messages(
         &self,
         group_id: &GroupId,
@@ -942,7 +942,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         Ok(count)
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.missing_messages"))]
+    #[xmtp_common::db_span]
     fn missing_messages(
         &self,
         group_id: &GroupId,
@@ -962,7 +962,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         self.raw_query(|conn| query.load(conn))
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.group_messages_paged"))]
+    #[xmtp_common::db_span]
     fn group_messages_paged(
         &self,
         args: &MsgQueryArgs,
@@ -1011,11 +1011,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
     }
 
     /// Query for group messages with their reactions
-    #[tracing::instrument(
-        err,
-        skip_all,
-        fields(operation = "db.get_group_messages_with_reactions")
-    )]
+    #[xmtp_common::db_span]
     fn get_group_messages_with_reactions(
         &self,
         group_id: &GroupId,
@@ -1093,7 +1089,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         Ok(messages_with_reactions)
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.get_inbound_relations"))]
+    #[xmtp_common::db_span]
     fn get_inbound_relations(
         &self,
         group_id: &GroupId,
@@ -1138,7 +1134,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         Ok(inbound_relations)
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.get_outbound_relations"))]
+    #[xmtp_common::db_span]
     fn get_outbound_relations(
         &self,
         group_id: &GroupId,
@@ -1158,7 +1154,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             .collect())
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.get_inbound_relation_counts"))]
+    #[xmtp_common::db_span]
     fn get_inbound_relation_counts(
         &self,
         group_id: &GroupId,
@@ -1186,11 +1182,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             .collect())
     }
 
-    #[tracing::instrument(
-        err,
-        skip_all,
-        fields(operation = "db.get_latest_message_times_by_sender")
-    )]
+    #[xmtp_common::db_span]
     fn get_latest_message_times_by_sender<Id: AsRef<[u8]>>(
         &self,
         group_id: Id,
@@ -1306,7 +1298,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         })
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.delete_expired_messages"))]
+    #[xmtp_common::db_span]
     fn delete_expired_messages(&self) -> Result<Vec<StoredGroupMessage>, crate::ConnectionError> {
         self.raw_query(|conn| {
             use diesel::prelude::*;
@@ -1335,7 +1327,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         })
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.messages_newer_than"))]
+    #[xmtp_common::db_span]
     fn messages_newer_than(
         &self,
         cursors_by_group: &HashMap<Vec<u8>, xmtp_proto::types::GlobalCursor>,
@@ -1418,7 +1410,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         Ok(all_cursors)
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.clear_messages"))]
+    #[xmtp_common::db_span]
     fn clear_messages(
         &self,
         group_ids: Option<&[GroupId]>,

--- a/crates/xmtp_db/src/sql_key_store/transactions.rs
+++ b/crates/xmtp_db/src/sql_key_store/transactions.rs
@@ -54,7 +54,7 @@ impl<C: ConnectionExt> XmtpMlsStorageProvider for SqlKeyStore<C> {
         DbConnection::new(&self.conn)
     }
 
-    #[tracing::instrument(err, skip_all, fields(operation = "db.transaction"))]
+    #[xmtp_common::db_span]
     fn transaction<T, E, F>(&self, f: F) -> Result<T, E>
     where
         F: FnOnce(&mut Self::TxQuery) -> Result<T, E>,


### PR DESCRIPTION
**Stacked on #3729** (which adds the `#[db_span]`/`#[rpc_span]`/`#[mls_span]` proc-macros). Review/merge #3729 first.

## What

Replaces all 32 verbose `#[tracing::instrument(err, skip_all, fields(operation = "db.<method>"))]` attributes across `xmtp_db` (`group.rs`, `group_message.rs`, `group_intent.rs`, `sql_key_store/transactions.rs`) with `#[xmtp_common::db_span]`, which derives the identical `operation = "db.<fn_name>"` form from the function name.

## Why

- **Uniform with the `rpc.*` work** in #3729 — one canonical, compile-time-enforced span form.
- **Net −36 lines** — the multi-line attrs (`get_conversation_ids_for_*`, etc.) collapse to a single `#[db_span]`.
- The macro makes `err` + `skip_all` + the `db.` prefix non-optional, so a future edit can't silently drop `skip_all` (cardinality leak) or mistype the operation name.

## Behavior-preserving

Every operation value already equalled its function name, so `#[db_span]` expands byte-identically. Verified:

- [x] `cargo clippy -p xmtp_db` — clean
- [x] `cargo fmt -p xmtp_db --check`
- [x] **`test_find_group_span_emits_operation_and_skips_group_id` passes** — the existing contract test still confirms `find_group` emits `operation = "db.find_group"` as the sole span field (no `skip_all` regression).

## Not included

The MLS spans are intentionally **not** migrated here — they re-namespace bare `operation` values (`sync`/`worker_turn`/`intent`/…) to `mls.*` and several carry a load-bearing `worker` dimension or custom levels the macro doesn't preserve, so they need coordination with the convos-uptime Collector/dashboards (separate plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `db.*` query span annotations to `#[db_span]` macro in `xmtp_db`
> Replaces verbose `#[tracing::instrument(err, skip_all, fields(operation = "db.*"))]` attributes across `group.rs`, `group_intent.rs`, `group_message.rs`, and `transactions.rs` with the concise `#[xmtp_common::db_span]` macro. The macro expands to the same tracing instrumentation, so runtime behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b568b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->