### PR TITLE
fix(release): point SDK npm-publish cache+install at Yarn workspace root

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,16 @@ on:
         description: 'Path to the npm package directory'
         required: true
         type: string
+      install-dir:
+        description: 'Directory to run `yarn` install from. For a Yarn workspace member this is the workspace root, not the package dir. Defaults to package-dir.'
+        required: false
+        type: string
+        default: ''
+      lockfile-path:
+        description: 'Path to the yarn.lock used for dependency caching. For a Yarn workspace member this is the workspace-root lockfile. Defaults to <package-dir>/yarn.lock.'
+        required: false
+        type: string
+        default: ''
       sdk:
         description: 'SDK name for release tools (e.g. node-bindings, wasm-bindings)'
         required: true
@@ -66,12 +76,12 @@ jobs:
       - name: Setup node
         uses: ./.github/actions/setup-node
         with:
-          cache-dependency-path: "${{ inputs.package-dir }}/yarn.lock"
+          cache-dependency-path: "${{ inputs.lockfile-path != '' && inputs.lockfile-path || format('{0}/yarn.lock', inputs.package-dir) }}"
 
       - uses: ./.github/actions/setup-release-tools
 
       - name: Install dependencies
-        working-directory: ${{ inputs.package-dir }}
+        working-directory: ${{ inputs.install-dir != '' && inputs.install-dir || inputs.package-dir }}
         run: yarn
 
       - name: Set version

--- a/.github/workflows/release-browser-sdk.yml
+++ b/.github/workflows/release-browser-sdk.yml
@@ -124,6 +124,8 @@ jobs:
     uses: ./.github/workflows/npm-publish.yml
     with:
       package-dir: sdks/js/browser-sdk
+      install-dir: sdks/js
+      lockfile-path: sdks/js/yarn.lock
       sdk: browser-sdk
       version: ${{ needs.setup.outputs.version }}
       artifact-pattern: browser_sdk_build

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -124,6 +124,8 @@ jobs:
     uses: ./.github/workflows/npm-publish.yml
     with:
       package-dir: sdks/js/node-sdk
+      install-dir: sdks/js
+      lockfile-path: sdks/js/yarn.lock
       sdk: node-sdk
       version: ${{ needs.setup.outputs.version }}
       artifact-pattern: node_sdk_build


### PR DESCRIPTION
## Problem

The first `release-node-sdk` publish from libxmtp [failed](https://github.com/xmtp/libxmtp/actions/runs/27026448256/job/79768640571) at the `Setup node` step in the publish job:

```
##[warning]No existing directories found containing cache-dependency-path="sdks/js/node-sdk/yarn.lock"
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

The reusable `npm-publish.yml` cached deps at `<package-dir>/yarn.lock` and ran `yarn` in `<package-dir>`. That works for the standalone bindings (`bindings/node`, `bindings/wasm` each have their own `yarn.lock`), but **node-sdk and browser-sdk are Yarn Berry workspace members** — there is no per-package lockfile. The lockfile lives at the workspace root `sdks/js/yarn.lock`, so `setup-node` couldn't resolve the cache path and hard-failed.

## Fix

- `npm-publish.yml`: add optional `install-dir` and `lockfile-path` inputs. They default to `package-dir` / `<package-dir>/yarn.lock`, so the bindings publishers are **unchanged**.
- `release-node-sdk.yml` / `release-browser-sdk.yml`: pass `install-dir: sdks/js` + `lockfile-path: sdks/js/yarn.lock` so the cache path resolves and `yarn` installs from the workspace root (matching the build job, which already does `cd sdks/js && yarn install`).

The `npm publish` step itself still runs from `package-dir` and packs only `dist/` (per `files`), so the published tarball is unaffected.

## Validation

- `yarn install` at `sdks/js` root succeeds (exit 0).
- `cache-dependency-path` now resolves to the existing `sdks/js/yarn.lock`.
- `just lint-config` clean.

Unblocks the first browser/node-sdk publish from libxmtp, which is the prerequisite for the xmtp-js teardown (Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix npm-publish workflow to use Yarn workspace root for cache and install
> The reusable [npm-publish.yml](https://github.com/xmtp/libxmtp/pull/3732/files#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240) workflow was caching and installing dependencies from the individual package directory rather than the Yarn workspace root, breaking monorepo installs.
>
> - Adds `install-dir` and `lockfile-path` inputs to `npm-publish.yml`; when provided, dependency caching uses the given lockfile and `yarn install` runs in the given directory instead of the package directory.
> - Updates [release-browser-sdk.yml](https://github.com/xmtp/libxmtp/pull/3732/files#diff-11a3d30f7e1ac2a2c555d982152b6755b2874e6f048b15293675bba5a5cc48e8) and [release-node-sdk.yml](https://github.com/xmtp/libxmtp/pull/3732/files#diff-fe2273dcab1b20a9a2143a75d02c4919170535996960d961c0bcc83358a577c2) to pass `install-dir: sdks/js` and `lockfile-path: sdks/js/yarn.lock` to the reusable workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be990ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->