### PR TITLE
fix(release): dev builds bump off last-released + correct npm dist-tags

### DIFF
--- a/.github/workflows/nightly-dry-run.yml
+++ b/.github/workflows/nightly-dry-run.yml
@@ -1,26 +1,91 @@
 name: nightly-dry-run
 
-# Manual preview of the nightly version-computation plan (cross-test gate +
+# Manual preview of the release version-computation plan (cross-test gate +
 # git-cliff oracle, capped at minor, with the not-major assertion). Calls the
-# same release-gate-plan reusable workflow the real nightly uses, so it
+# same release-gate-plan reusable workflow the real release uses, so it
 # exercises identical logic. Has NO publish jobs — it structurally cannot
 # publish/tag anything. Use this to verify pipeline changes before they ship.
+#
+# release-type:
+#   nightly — preview the gated nightly plan (cross-test must be green).
+#   dev     — preview the GATELESS dev plan AND the per-SDK resolved dev
+#             versions (e.g. node-sdk 6.1.0-dev.<sha>). This is the dry-run for
+#             the dev path: it runs the exact oracle + resolve-sdk-version the
+#             real dev release uses, minus every publish/tag step.
 
 on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Ref to compute the nightly plan for"
+        description: "Ref to compute the release plan for"
         required: false
         type: string
         default: main
+      release-type:
+        description: "Which plan to preview"
+        required: false
+        type: choice
+        options:
+          - nightly
+          - dev
+        default: nightly
 
 jobs:
   plan:
     uses: ./.github/workflows/release-gate-plan.yml
     with:
       ref: ${{ inputs.ref || github.ref_name }}
+      # dev previews the gateless path (no cross-test gate), exactly like the
+      # real dev release. nightly keeps the gate.
+      gate: ${{ inputs.release-type != 'dev' }}
     secrets: inherit
+
+  # Preview the per-SDK versions a dev release would publish, using the same
+  # `resolve-sdk-version --release-type dev` the real release jobs call. Prints
+  # only — no manifest writes, no npm publish, no tags.
+  preview-dev-versions:
+    needs: [plan]
+    if: inputs.release-type == 'dev' && needs.plan.outputs.nothing-pending != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Check out the exact SHA the plan oracle resolved against (not the
+          # branch HEAD), so the previewed short-sha + manifest match what a
+          # real dev run on this commit would compute — no drift if commits
+          # land between the plan job and this one.
+          ref: ${{ needs.plan.outputs.sha }}
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-release-tools
+      - name: Resolve dev versions per SDK
+        env:
+          PENDING_VERSION: ${{ needs.plan.outputs.version }}
+          PENDING_KIND: ${{ needs.plan.outputs.kind }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PENDING_VERSION" ] || [ -z "$PENDING_KIND" ]; then
+            echo "::error::plan produced empty pending version/kind; cannot preview dev versions"
+            exit 1
+          fi
+          {
+            echo "## Dev dry-run — resolved versions"
+            echo ""
+            echo "Pending libxmtp bump: \`$PENDING_VERSION\` (kind: $PENDING_KIND)"
+            echo ""
+            echo "| SDK | dev version |"
+            echo "| --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          for SDK in node-sdk browser-sdk node-bindings wasm-bindings ios android libxmtp; do
+            V=$(xmtp-release resolve-sdk-version \
+              --sdk "$SDK" --release-type dev \
+              --pending-version "$PENDING_VERSION" \
+              --pending-kind "$PENDING_KIND")
+            echo "| $SDK | \`$V\` |" >> "$GITHUB_STEP_SUMMARY"
+            echo "::notice::dev $SDK -> $V"
+          done
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No publishes/tags occur in a dry-run." >> "$GITHUB_STEP_SUMMARY"
+
   summary:
     needs: [plan]
     if: always()
@@ -29,7 +94,7 @@ jobs:
       - name: Print plan result
         run: |
           {
-            echo "## Nightly dry-run plan"
+            echo "## Release dry-run plan (${{ inputs.release-type || 'nightly' }})"
             echo ""
             echo "- gate-skip: \`${{ needs.plan.outputs.gate-skip }}\`"
             echo "- nothing-pending: \`${{ needs.plan.outputs.nothing-pending }}\`"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -98,13 +98,21 @@ jobs:
 
       - name: Determine NPM tag
         id: npm-tag
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if [[ "${{ inputs.version }}" == *"nightly"* ]]; then
-            echo "tag=nightly" >> $GITHUB_OUTPUT
-          elif [[ "${{ inputs.version }}" == *"dev"* || "${{ inputs.version }}" == *"rc"* ]]; then
-            echo "tag=prerelease" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          # Each prerelease channel gets its own dist-tag so consumers can pin
+          # @nightly / @dev / @rc independently. Check nightly first (a nightly
+          # string contains neither "dev" nor "rc"). A plain release -> latest.
+          if [[ "$VERSION" == *"nightly"* ]]; then
+            echo "tag=nightly" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" == *"-dev"* ]]; then
+            echo "tag=dev" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" == *"-rc"* ]]; then
+            echo "tag=rc" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=latest" >> $GITHUB_OUTPUT
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update npm to latest

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -47,7 +47,14 @@ jobs:
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk android --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk android --release-type dev)
+            if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
+              echo "::error::dev resolve called with empty pending version/kind"
+              exit 1
+            fi
+            VERSION=$(xmtp-release resolve-sdk-version \
+              --sdk android --release-type dev \
+              --pending-version "${{ inputs.pending-version }}" \
+              --pending-kind "${{ inputs.pending-kind }}")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             # Belt-and-suspenders: release.yml already skips this whole job when
             # the gate isn't green or there are no conventional commits

--- a/.github/workflows/release-browser-sdk.yml
+++ b/.github/workflows/release-browser-sdk.yml
@@ -53,7 +53,14 @@ jobs:
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk browser-sdk --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk browser-sdk --release-type dev)
+            if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
+              echo "::error::dev resolve called with empty pending version/kind"
+              exit 1
+            fi
+            VERSION=$(xmtp-release resolve-sdk-version \
+              --sdk browser-sdk --release-type dev \
+              --pending-version "${{ inputs.pending-version }}" \
+              --pending-kind "${{ inputs.pending-kind }}")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
               echo "::error::nightly resolve called with empty pending version/kind"

--- a/.github/workflows/release-gate-plan.yml
+++ b/.github/workflows/release-gate-plan.yml
@@ -1,9 +1,12 @@
 name: release-gate-plan
 
-# Reusable: cross-test gate + version oracle (the nightly "plan"). Computes the
+# Reusable: cross-test gate + version oracle (the release "plan"). Computes the
 # pending libxmtp {version,kind}, caps at minor, asserts not-major, prints the
-# plan. Does NO publishing. Called by release.yml (real nightly) and
-# nightly-dry-run.yml (manual preview) so both run identical logic.
+# plan. Does NO publishing. Used for BOTH nightly and dev: nightly runs the
+# cross-test gate (gate: true, the default); dev runs it gateless (gate: false)
+# since the cross-test gate is a nightly-only correctness gate. Called by
+# release.yml (real nightly + dev) and nightly-dry-run.yml (manual preview) so
+# all paths run identical version-computation logic.
 
 on:
   workflow_call:
@@ -11,6 +14,11 @@ on:
       ref:
         required: true
         type: string
+      gate:
+        required: false
+        type: boolean
+        default: true
+        description: "Run the nightly cross-test gate. dev builds pass false to skip it."
     outputs:
       sha:
         value: ${{ jobs.gate.outputs.sha }}
@@ -53,8 +61,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           SHA: ${{ steps.sha.outputs.sha }}
+          GATE_ENABLED: ${{ inputs.gate }}
         run: |
           set -euo pipefail
+          if [ "$GATE_ENABLED" != "true" ]; then
+            echo "gate-skip=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Cross-test gate disabled for this run (e.g. dev build); proceeding."
+            exit 0
+          fi
           gh api "repos/${REPO}/actions/workflows/cross-test.yml/runs?head_sha=${SHA}&status=completed" > /tmp/cross-runs.json
           RESULT=$(xmtp-release cross-test-gate --input=/tmp/cross-runs.json --sha "$SHA")
           PASS=$(printf '%s' "$RESULT" | jq -r '.pass')
@@ -143,7 +157,7 @@ jobs:
           echo "kind=$KIND" >> "$GITHUB_OUTPUT"
           # Human-readable release plan.
           {
-            echo "## Nightly release plan"
+            echo "## Release plan"
             echo ""
             echo "- libxmtp: \`$VERSION\` (bump: $KIND, baseline: $LAST)"
             echo ""

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -55,7 +55,14 @@ jobs:
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk ios --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk ios --release-type dev)
+            if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
+              echo "::error::dev resolve called with empty pending version/kind"
+              exit 1
+            fi
+            VERSION=$(xmtp-release resolve-sdk-version \
+              --sdk ios --release-type dev \
+              --pending-version "${{ inputs.pending-version }}" \
+              --pending-kind "${{ inputs.pending-kind }}")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             # Belt-and-suspenders: release.yml already skips this whole job when
             # the gate isn't green or there are no conventional commits

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -53,7 +53,14 @@ jobs:
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk node-sdk --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk node-sdk --release-type dev)
+            if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
+              echo "::error::dev resolve called with empty pending version/kind"
+              exit 1
+            fi
+            VERSION=$(xmtp-release resolve-sdk-version \
+              --sdk node-sdk --release-type dev \
+              --pending-version "${{ inputs.pending-version }}" \
+              --pending-kind "${{ inputs.pending-kind }}")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
               echo "::error::nightly resolve called with empty pending version/kind"

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -47,7 +47,14 @@ jobs:
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk node-bindings --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk node-bindings --release-type dev)
+            if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
+              echo "::error::dev resolve called with empty pending version/kind"
+              exit 1
+            fi
+            VERSION=$(xmtp-release resolve-sdk-version \
+              --sdk node-bindings --release-type dev \
+              --pending-version "${{ inputs.pending-version }}" \
+              --pending-kind "${{ inputs.pending-kind }}")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             # Belt-and-suspenders: release.yml already skips this whole job when
             # the gate isn't green or there are no conventional commits

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -50,7 +50,14 @@ jobs:
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk wasm-bindings --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk wasm-bindings --release-type dev)
+            if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
+              echo "::error::dev resolve called with empty pending version/kind"
+              exit 1
+            fi
+            VERSION=$(xmtp-release resolve-sdk-version \
+              --sdk wasm-bindings --release-type dev \
+              --pending-version "${{ inputs.pending-version }}" \
+              --pending-kind "${{ inputs.pending-kind }}")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             # Belt-and-suspenders: release.yml already skips this whole job when
             # the gate isn't green or there are no conventional commits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,10 +155,15 @@ jobs:
   # nothing-pending.
   plan:
     needs: [validate]
-    if: needs.validate.outputs.release-type == 'nightly' && needs.validate.outputs.skip != 'true'
+    if: >-
+      (needs.validate.outputs.release-type == 'nightly' || needs.validate.outputs.release-type == 'dev')
+      && needs.validate.outputs.skip != 'true'
     uses: ./.github/workflows/release-gate-plan.yml
     with:
       ref: ${{ needs.validate.outputs.ref }}
+      # dev builds preview the next version off main but must NOT be gated on
+      # cross-test (that's a nightly correctness gate). nightly keeps the gate.
+      gate: ${{ needs.validate.outputs.release-type == 'nightly' }}
     secrets: inherit
 
   release-ios:
@@ -167,7 +172,7 @@ jobs:
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.ios == 'true' && needs.validate.outputs.skip != 'true'
       && needs.validate.outputs.dry-run != 'true'
-      && (needs.validate.outputs.release-type != 'nightly'
+      && ((needs.validate.outputs.release-type != 'nightly' && needs.validate.outputs.release-type != 'dev')
           || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-ios.yml
     with:
@@ -184,7 +189,7 @@ jobs:
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.android == 'true' && needs.validate.outputs.skip != 'true'
       && needs.validate.outputs.dry-run != 'true'
-      && (needs.validate.outputs.release-type != 'nightly'
+      && ((needs.validate.outputs.release-type != 'nightly' && needs.validate.outputs.release-type != 'dev')
           || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-android.yml
     with:
@@ -200,7 +205,7 @@ jobs:
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.node-sdk == 'true' && needs.validate.outputs.skip != 'true'
-      && (needs.validate.outputs.release-type != 'nightly'
+      && ((needs.validate.outputs.release-type != 'nightly' && needs.validate.outputs.release-type != 'dev')
           || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-node-sdk.yml
     with:
@@ -217,7 +222,7 @@ jobs:
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.browser-sdk == 'true' && needs.validate.outputs.skip != 'true'
-      && (needs.validate.outputs.release-type != 'nightly'
+      && ((needs.validate.outputs.release-type != 'nightly' && needs.validate.outputs.release-type != 'dev')
           || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-browser-sdk.yml
     with:


### PR DESCRIPTION
## Problem

A `workflow_dispatch` **dev** release published the **already-shipped** version under the **wrong npm dist-tag** — e.g. [`@xmtp/node-sdk 6.0.0-dev.<sha>`](https://github.com/xmtp/libxmtp/actions/runs/27027357187/job/79771083402) tagged `prerelease`, when it should be `6.1.0-dev.<sha>` tagged `dev`.

### Bug 1 — dev didn't bump

After xmtp-js merged into the monorepo, the **independent**-track SDK manifests on `main` now hold the **last-released** version (node-sdk=6.0.0, browser-sdk=7.0.0, ios/android=4.10.0), not the old "next-target in manifest" convention. The dev path called `xmtp-release compute-version --release-type dev`, which only appends `-dev.<sha>` to the manifest base (no bump) → it previews the already-shipped version.

The **nightly** path already solves this: run the git-cliff "plan" oracle to compute the pending `{version, kind}`, then `resolve-sdk-version` (applies the pending bump *kind* to an independent SDK's own base; uses the pending libxmtp version for follows-libxmtp). This PR routes dev through the same path:

- Add a `gate` input to `release-gate-plan.yml` (default `true`); dev runs it **gateless** — the cross-test gate is a nightly-only correctness gate and must not block dev.
- Run the `plan` job for `dev` too; widen the six `release-*` `if:` clauses so dev runs when the plan succeeded and there is something pending (`nothing-pending != 'true'`).
- Change the `dev` branch of all 6 `release-*.yml` "Compute version" steps from `compute-version` to `resolve-sdk-version` (mirrors the existing nightly branch, including the empty-pending guard).

rc/final are unaffected — they run from `release/*` branches where `create-release-branch` pre-bumps the manifests, so `compute-version` is already correct there. Bindings (node/wasm + Cargo, still `1.11.0-dev` in-manifest) are unchanged.

### Bug 2 — wrong npm dist-tag

`npm-publish.yml` bucketed both `*dev*` and `*rc*` into `prerelease`. Now each prerelease channel gets its own dist-tag: nightly→`nightly`, `-dev`→`dev`, `-rc`→`rc`, else→`latest` (matches the old xmtp-js `dev` dist-tag).

## Scope

**YAML only** — no TypeScript change. The lib (`resolveSdkVersion`) already handled `releaseType: "dev"` correctly.

## Verification

`nightly-dry-run.yml` gains a `release-type` input (`nightly|dev`); the dev path previews the gateless oracle + `resolve-sdk-version` per SDK and prints the versions — **no publish/tag jobs exist**, so it structurally cannot mutate any registry.

Ran it [end-to-end on a fork](https://github.com/insipx/libxmtp/actions/runs/27029429714). Oracle returned `1.11.0`/`minor`; resolved dev versions:

| SDK | dev version |
| --- | --- |
| node-sdk | `6.1.0-dev.<sha>` (was `6.0.0-dev`) |
| browser-sdk | `7.1.0-dev.<sha>` |
| ios / android | `4.11.0-dev.<sha>` |
| node/wasm bindings + libxmtp | `1.11.0-dev.<sha>` (unchanged — no regression) |

Plus: `release-tools` 172 tests pass, typecheck clean, all 10 workflow YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dev release builds to bump off last-released version and use correct npm dist-tags
> - Dev release workflows now use `xmtp-release resolve-sdk-version` (instead of `compute-version`) across all SDK platforms (Android, iOS, Node, WASM, Browser), deriving the dev version from the pending libxmtp version/kind; each job fails early if those inputs are absent.
> - NPM publish now assigns separate dist-tags: `dev` for `-dev` versions and `rc` for `-rc` versions, replacing the shared `prerelease` tag used previously.
> - The release gate workflow gains an optional `gate` boolean input (default `true`); dev releases pass `gate=false` to skip cross-test evaluation.
> - The nightly dry-run workflow gains a `release-type` input (`nightly`|`dev`) and a `preview-dev-versions` job that resolves and displays per-SDK dev versions in the job summary.
> - Behavioral Change: `-dev` and `-rc` npm packages that previously shared the `prerelease` dist-tag are now tagged separately as `dev` and `rc`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d9d746.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->