### PR TITLE
ci(release): publish native binding inside the SDK release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,6 +48,11 @@ on:
         required: false
         type: string
         default: ''
+      dry-run:
+        description: 'When true, run all steps EXCEPT the npm publish and tag (no side effects)'
+        required: false
+        type: boolean
+        default: false
     outputs:
       version:
         description: "The published version"
@@ -106,8 +111,10 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish to NPM
+        if: ${{ inputs.dry-run != true }}
         working-directory: ${{ inputs.package-dir }}
         run: npm publish --provenance ${{ inputs.ignore-scripts && '--ignore-scripts' || '' }} --tag ${{ steps.npm-tag.outputs.tag }}
 
       - name: Tag release
+        if: ${{ inputs.dry-run != true }}
         run: xmtp-release tag-release --sdk "${{ inputs.sdk }}" --version "${{ inputs.version }}" --ignore-if-exists

--- a/.github/workflows/release-browser-sdk.yml
+++ b/.github/workflows/release-browser-sdk.yml
@@ -21,10 +21,17 @@ on:
       pending-kind:
         required: false
         type: string
+      dry-run:
+        required: false
+        type: boolean
+        default: false
     outputs:
       version:
         description: "The published version string"
         value: ${{ jobs.publish.outputs.version }}
+      binding-version:
+        description: "The @xmtp/wasm-bindings version published in this run and pinned by the SDK"
+        value: ${{ jobs.bindings.outputs.version }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,7 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      binding-version: ${{ steps.binding-version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -63,30 +69,20 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed version: $VERSION"
 
-      - name: Compute binding version
-        id: binding-version
-        run: |
-          if [ "${{ inputs.release-type }}" = "rc" ]; then
-            VERSION=$(xmtp-release compute-version --sdk wasm-bindings --release-type rc --rc-number ${{ inputs.rc-number }})
-          elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk wasm-bindings --release-type dev)
-          elif [ "${{ inputs.release-type }}" = "nightly" ]; then
-            if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
-              echo "::error::nightly resolve called with empty pending version/kind"
-              exit 1
-            fi
-            VERSION=$(xmtp-release resolve-sdk-version \
-              --sdk wasm-bindings --release-type nightly \
-              --pending-version "${{ inputs.pending-version }}" \
-              --pending-kind "${{ inputs.pending-kind }}")
-          else
-            VERSION=$(xmtp-release compute-version --sdk wasm-bindings --release-type final)
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Computed binding version: $VERSION"
+  bindings:
+    needs: setup
+    uses: ./.github/workflows/release-wasm.yml
+    with:
+      release-type: ${{ inputs.release-type }}
+      rc-number: ${{ inputs.rc-number }}
+      ref: ${{ inputs.ref }}
+      pending-version: ${{ inputs.pending-version }}
+      pending-kind: ${{ inputs.pending-kind }}
+      dry-run: ${{ inputs.dry-run }}
+    secrets: inherit
 
   build:
-    needs: setup
+    needs: [setup, bindings]
     runs-on: warp-ubuntu-latest-x64-16x
     env:
       NIX_DEVSHELL: js
@@ -120,7 +116,7 @@ jobs:
           retention-days: 1
 
   publish:
-    needs: [setup, build]
+    needs: [setup, build, bindings]
     uses: ./.github/workflows/npm-publish.yml
     with:
       package-dir: sdks/js/browser-sdk
@@ -132,5 +128,6 @@ jobs:
       artifact-path: sdks/js/browser-sdk/dist
       ignore-scripts: true
       dep-name: "@xmtp/wasm-bindings"
-      dep-version: ${{ needs.setup.outputs.binding-version }}
+      dep-version: ${{ needs.bindings.outputs.version }}
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -21,10 +21,17 @@ on:
       pending-kind:
         required: false
         type: string
+      dry-run:
+        required: false
+        type: boolean
+        default: false
     outputs:
       version:
         description: "The published version string"
         value: ${{ jobs.publish.outputs.version }}
+      binding-version:
+        description: "The @xmtp/node-bindings version published in this run and pinned by the SDK"
+        value: ${{ jobs.bindings.outputs.version }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,7 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      binding-version: ${{ steps.binding-version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -63,30 +69,20 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed version: $VERSION"
 
-      - name: Compute binding version
-        id: binding-version
-        run: |
-          if [ "${{ inputs.release-type }}" = "rc" ]; then
-            VERSION=$(xmtp-release compute-version --sdk node-bindings --release-type rc --rc-number ${{ inputs.rc-number }})
-          elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk node-bindings --release-type dev)
-          elif [ "${{ inputs.release-type }}" = "nightly" ]; then
-            if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
-              echo "::error::nightly resolve called with empty pending version/kind"
-              exit 1
-            fi
-            VERSION=$(xmtp-release resolve-sdk-version \
-              --sdk node-bindings --release-type nightly \
-              --pending-version "${{ inputs.pending-version }}" \
-              --pending-kind "${{ inputs.pending-kind }}")
-          else
-            VERSION=$(xmtp-release compute-version --sdk node-bindings --release-type final)
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Computed binding version: $VERSION"
+  bindings:
+    needs: setup
+    uses: ./.github/workflows/release-node.yml
+    with:
+      release-type: ${{ inputs.release-type }}
+      rc-number: ${{ inputs.rc-number }}
+      ref: ${{ inputs.ref }}
+      pending-version: ${{ inputs.pending-version }}
+      pending-kind: ${{ inputs.pending-kind }}
+      dry-run: ${{ inputs.dry-run }}
+    secrets: inherit
 
   build:
-    needs: setup
+    needs: [setup, bindings]
     runs-on: warp-ubuntu-latest-x64-16x
     env:
       NIX_DEVSHELL: js
@@ -120,7 +116,7 @@ jobs:
           retention-days: 1
 
   publish:
-    needs: [setup, build]
+    needs: [setup, build, bindings]
     uses: ./.github/workflows/npm-publish.yml
     with:
       package-dir: sdks/js/node-sdk
@@ -132,5 +128,6 @@ jobs:
       artifact-path: sdks/js/node-sdk/dist
       ignore-scripts: true
       dep-name: "@xmtp/node-bindings"
-      dep-version: ${{ needs.setup.outputs.binding-version }}
+      dep-version: ${{ needs.bindings.outputs.version }}
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -21,6 +21,10 @@ on:
       pending-kind:
         required: false
         type: string
+      dry-run:
+        required: false
+        type: boolean
+        default: false
     outputs:
       version:
         description: "The published version string"
@@ -269,4 +273,5 @@ jobs:
       version: ${{ needs.setup.outputs.version }}
       artifact-pattern: bindings_node_*
       artifact-path: bindings/node/dist
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -21,6 +21,10 @@ on:
       pending-kind:
         required: false
         type: string
+      dry-run:
+        required: false
+        type: boolean
+        default: false
     outputs:
       version:
         description: "The published version string"
@@ -100,4 +104,5 @@ jobs:
       artifact-pattern: wasm_build
       artifact-path: bindings/wasm/dist
       ignore-scripts: true
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,7 @@ jobs:
     # and delete the release branch even though the release-* jobs were skipped
     # (skipped ≠ failure, so the !contains(failure) check alone lets it through).
     if: needs.validate.outputs.release-type == 'final' && !inputs.no-merge && !cancelled() && !contains(needs.*.result, 'failure') && needs.validate.outputs.dry-run != 'true'
-    needs: [validate, release-ios, release-android, release-node, release-wasm, release-node-sdk, release-browser-sdk]
+    needs: [validate, release-ios, release-android, release-node-sdk, release-browser-sdk]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -270,7 +270,7 @@ jobs:
   # Do NOT drop any of the three; they jointly make non-nightly run and nightly
   # block-on-not-green / block-on-error.
   hub:
-    needs: [validate, plan, release-ios, release-android, release-node, release-wasm, release-node-sdk, release-browser-sdk]
+    needs: [validate, plan, release-ios, release-android, release-node-sdk, release-browser-sdk]
     if: >-
       needs.validate.outputs.release-type == 'nightly'
       && needs.plan.outputs.gate-skip != 'true'
@@ -304,8 +304,8 @@ jobs:
         env:
           IOS_VERSION: ${{ needs.release-ios.outputs.version }}
           ANDROID_VERSION: ${{ needs.release-android.outputs.version }}
-          NODE_VERSION: ${{ needs.release-node.outputs.version }}
-          WASM_VERSION: ${{ needs.release-wasm.outputs.version }}
+          NODE_VERSION: ${{ needs.release-node-sdk.outputs.binding-version }}
+          WASM_VERSION: ${{ needs.release-browser-sdk.outputs.binding-version }}
         run: |
           set -euo pipefail
           if [ -z "${IOS_VERSION}${ANDROID_VERSION}${NODE_VERSION}${WASM_VERSION}" ]; then
@@ -362,8 +362,8 @@ jobs:
           HUB_VERSION: ${{ steps.hubver.outputs.version }}
           IOS_VERSION: ${{ needs.release-ios.outputs.version }}
           ANDROID_VERSION: ${{ needs.release-android.outputs.version }}
-          NODE_VERSION: ${{ needs.release-node.outputs.version }}
-          WASM_VERSION: ${{ needs.release-wasm.outputs.version }}
+          NODE_VERSION: ${{ needs.release-node-sdk.outputs.binding-version }}
+          WASM_VERSION: ${{ needs.release-browser-sdk.outputs.binding-version }}
         run: |
           set -euo pipefail
           BODY=$(cat <<EOF
@@ -403,7 +403,7 @@ jobs:
           fi
 
   notify:
-    needs: [validate, plan, hub, release-ios, release-android, release-node, release-wasm, release-node-sdk, release-browser-sdk, merge-pr]
+    needs: [validate, plan, hub, release-ios, release-android, release-node-sdk, release-browser-sdk, merge-pr]
     if: always() && needs.validate.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
@@ -414,10 +414,10 @@ jobs:
           IOS_VERSION: ${{ needs.release-ios.outputs.version }}
           ANDROID_RESULT: ${{ needs.release-android.result }}
           ANDROID_VERSION: ${{ needs.release-android.outputs.version }}
-          NODE_RESULT: ${{ needs.release-node.result }}
-          NODE_VERSION: ${{ needs.release-node.outputs.version }}
-          WASM_RESULT: ${{ needs.release-wasm.result }}
-          WASM_VERSION: ${{ needs.release-wasm.outputs.version }}
+          NODE_RESULT: ${{ needs.release-node-sdk.result }}
+          NODE_VERSION: ${{ needs.release-node-sdk.outputs.binding-version }}
+          WASM_RESULT: ${{ needs.release-browser-sdk.result }}
+          WASM_VERSION: ${{ needs.release-browser-sdk.outputs.binding-version }}
           RELEASE_TYPE: ${{ needs.validate.outputs.release-type }}
         run: |
           MSG="${RELEASE_TYPE^} Release:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
       ref: ${{ needs.validate.outputs.ref }}
       pending-version: ${{ needs.plan.outputs.version }}
       pending-kind: ${{ needs.plan.outputs.kind }}
-      dry-run: ${{ needs.validate.outputs.dry-run }}
+      dry-run: ${{ needs.validate.outputs.dry-run == 'true' }}
     secrets: inherit
 
   release-browser-sdk:
@@ -226,7 +226,7 @@ jobs:
       ref: ${{ needs.validate.outputs.ref }}
       pending-version: ${{ needs.plan.outputs.version }}
       pending-kind: ${{ needs.plan.outputs.kind }}
-      dry-run: ${{ needs.validate.outputs.dry-run }}
+      dry-run: ${{ needs.validate.outputs.dry-run == 'true' }}
     secrets: inherit
 
   merge-pr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,40 +195,6 @@ jobs:
       pending-kind: ${{ needs.plan.outputs.kind }}
     secrets: inherit
 
-  release-node:
-    needs: [validate, plan]
-    if: >-
-      !cancelled() && !contains(needs.*.result, 'failure')
-      && needs.validate.outputs.node == 'true' && needs.validate.outputs.skip != 'true'
-      && needs.validate.outputs.dry-run != 'true'
-      && (needs.validate.outputs.release-type != 'nightly'
-          || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
-    uses: ./.github/workflows/release-node.yml
-    with:
-      release-type: ${{ needs.validate.outputs.release-type }}
-      rc-number: ${{ inputs.rc-number }}
-      ref: ${{ needs.validate.outputs.ref }}
-      pending-version: ${{ needs.plan.outputs.version }}
-      pending-kind: ${{ needs.plan.outputs.kind }}
-    secrets: inherit
-
-  release-wasm:
-    needs: [validate, plan]
-    if: >-
-      !cancelled() && !contains(needs.*.result, 'failure')
-      && needs.validate.outputs.wasm == 'true' && needs.validate.outputs.skip != 'true'
-      && needs.validate.outputs.dry-run != 'true'
-      && (needs.validate.outputs.release-type != 'nightly'
-          || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
-    uses: ./.github/workflows/release-wasm.yml
-    with:
-      release-type: ${{ needs.validate.outputs.release-type }}
-      rc-number: ${{ inputs.rc-number }}
-      ref: ${{ needs.validate.outputs.ref }}
-      pending-version: ${{ needs.plan.outputs.version }}
-      pending-kind: ${{ needs.plan.outputs.kind }}
-    secrets: inherit
-
   release-node-sdk:
     needs: [validate, plan]
     if: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,6 @@ on:
         required: false
         type: boolean
         default: false
-      node:
-        description: "Release Node Bindings"
-        required: false
-        type: boolean
-        default: false
-      wasm:
-        description: "Release WASM Bindings"
-        required: false
-        type: boolean
-        default: false
       node-sdk:
         description: "Release Node SDK"
         required: false
@@ -71,8 +61,6 @@ jobs:
       ref: ${{ steps.resolve.outputs.ref }}
       ios: ${{ steps.resolve.outputs.ios }}
       android: ${{ steps.resolve.outputs.android }}
-      node: ${{ steps.resolve.outputs.node }}
-      wasm: ${{ steps.resolve.outputs.wasm }}
       node-sdk: ${{ steps.resolve.outputs.node-sdk }}
       browser-sdk: ${{ steps.resolve.outputs.browser-sdk }}
       dry-run: ${{ steps.resolve.outputs.dry-run }}
@@ -87,8 +75,6 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
           INPUT_IOS: ${{ inputs.ios }}
           INPUT_ANDROID: ${{ inputs.android }}
-          INPUT_NODE: ${{ inputs.node }}
-          INPUT_WASM: ${{ inputs.wasm }}
           INPUT_NODE_SDK: ${{ inputs.node-sdk }}
           INPUT_BROWSER_SDK: ${{ inputs.browser-sdk }}
           INPUT_DRY_RUN: ${{ inputs.dry-run }}
@@ -98,8 +84,6 @@ jobs:
             echo "ref=main" >> "$GITHUB_OUTPUT"
             echo "ios=true" >> "$GITHUB_OUTPUT"
             echo "android=true" >> "$GITHUB_OUTPUT"
-            echo "node=true" >> "$GITHUB_OUTPUT"
-            echo "wasm=true" >> "$GITHUB_OUTPUT"
             echo "node-sdk=true" >> "$GITHUB_OUTPUT"
             echo "browser-sdk=true" >> "$GITHUB_OUTPUT"
             echo "dry-run=false" >> "$GITHUB_OUTPUT"
@@ -108,8 +92,6 @@ jobs:
             echo "ref=${INPUT_REF:-$GITHUB_REF}" >> "$GITHUB_OUTPUT"
             echo "ios=$INPUT_IOS" >> "$GITHUB_OUTPUT"
             echo "android=$INPUT_ANDROID" >> "$GITHUB_OUTPUT"
-            echo "node=$INPUT_NODE" >> "$GITHUB_OUTPUT"
-            echo "wasm=$INPUT_WASM" >> "$GITHUB_OUTPUT"
             echo "node-sdk=$INPUT_NODE_SDK" >> "$GITHUB_OUTPUT"
             echo "browser-sdk=$INPUT_BROWSER_SDK" >> "$GITHUB_OUTPUT"
             echo "dry-run=${INPUT_DRY_RUN:-false}" >> "$GITHUB_OUTPUT"
@@ -252,7 +234,6 @@ jobs:
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.node-sdk == 'true' && needs.validate.outputs.skip != 'true'
-      && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
           || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-node-sdk.yml
@@ -262,6 +243,7 @@ jobs:
       ref: ${{ needs.validate.outputs.ref }}
       pending-version: ${{ needs.plan.outputs.version }}
       pending-kind: ${{ needs.plan.outputs.kind }}
+      dry-run: ${{ needs.validate.outputs.dry-run }}
     secrets: inherit
 
   release-browser-sdk:
@@ -269,7 +251,6 @@ jobs:
     if: >-
       !cancelled() && !contains(needs.*.result, 'failure')
       && needs.validate.outputs.browser-sdk == 'true' && needs.validate.outputs.skip != 'true'
-      && needs.validate.outputs.dry-run != 'true'
       && (needs.validate.outputs.release-type != 'nightly'
           || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
     uses: ./.github/workflows/release-browser-sdk.yml
@@ -279,6 +260,7 @@ jobs:
       ref: ${{ needs.validate.outputs.ref }}
       pending-version: ${{ needs.plan.outputs.version }}
       pending-kind: ${{ needs.plan.outputs.kind }}
+      dry-run: ${{ needs.validate.outputs.dry-run }}
     secrets: inherit
 
   merge-pr:


### PR DESCRIPTION
## Problem

A standalone node-sdk dev release published `@xmtp/node-sdk@6.0.0-dev.a5f20d2`, which hard-depends on `@xmtp/node-bindings@1.11.0-dev.a5f20d2` — a binding version that **was never published** (npm 404). The SDK is unusable: its native binding can't resolve.

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @xmtp/node-bindings@1.11.0-dev.a5f20d2
```

Root cause: `release-node-sdk` / `release-browser-sdk` were independent hub jobs, and each pinned its binding to a version *computed* from the same git sha (`compute-version --sdk node-bindings`) — a **guess** that's only correct if the binding happened to publish from that same ref. An SDK could (and did) ship pinned to a binding that never published.

## Fix

Publish the binding **inside** the SDK release and pin the SDK to the version actually published.

- **`release-node-sdk.yml` / `release-browser-sdk.yml`**: a new `bindings` job calls `release-node.yml` / `release-wasm.yml` (nested reusable workflow); `build`/`publish` depend on it; the SDK's `@xmtp/{node,wasm}-bindings` dep is pinned to `needs.bindings.outputs.version` (the real published version) instead of the guessed `compute-version`. The `Compute binding version` step is deleted. Each SDK workflow now exposes a `binding-version` output.
- **`release.yml`**: dropped the standalone `node`/`wasm` dispatch inputs + `release-node`/`release-wasm` hub jobs; hub/notify/merge-pr rewired off them, sourcing the reported binding versions from the SDK jobs' `binding-version` output. Nightly still publishes the bindings transitively (it sets `node-sdk`/`browser-sdk` true).

### Dry-run is now a real integration test

Previously `dry-run` was a whole-job skip at the hub, so a dry-run couldn't exercise the SDK→binding graph at all. Now `dry-run` is threaded into the workflows and gates only the side-effecting leaf steps (`npm publish` + `Tag release` in `npm-publish.yml`). A `dry-run` build runs the entire binding+SDK graph and threads the real versions through the pin, **publishing/tagging nothing**. `hub`/`merge-pr` keep their own dry-run guards (they mutate the repo / GitHub releases).

## Scope

The binding stays a separately published npm package (bundling the `.node` addon was considered and rejected — 8 platform variants → 8 sub-packages, multiplies the pin problem). `@xmtp/content-type-primitives` and the content-types packages are untouched.

## Validation

- `actionlint` reports no undefined-`needs`/output/expression errors (only pre-existing warp-runner-label + shellcheck-style notes in untouched scripts).
- Integration test pending: a `dry-run=true` dev dispatch from this branch to confirm the nested graph runs, the binding-version pin resolves, the reusable-workflow nesting depth (hub → release-node-sdk → release-node → npm-publish) is accepted, and nothing publishes.

Design + plan: `docs/superpowers/specs/2026-06-05-binding-sdk-release-coupling-design.md`, `docs/superpowers/plans/2026-06-05-binding-sdk-release-coupling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish native bindings as part of SDK release workflows
> - Removes standalone `release-node` and `release-wasm` jobs from [release.yml](.github/workflows/release.yml); bindings are now published by the SDK release workflows (`release-node-sdk` and `release-browser-sdk`) via nested reusable workflow calls.
> - Each SDK workflow gains a `bindings` job that calls the corresponding bindings release workflow, then pins the SDK's dependency version to the output of that job.
> - Adds a `dry-run` boolean input propagated through all release workflows down to [npm-publish.yml](.github/workflows/npm-publish.yml), which skips the publish and tag steps when set.
> - The `hub` and notification jobs now read Node/WASM versions from `release-node-sdk.outputs.binding-version` and `release-browser-sdk.outputs.binding-version` respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f04632e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->