### PR TITLE
Return proper status code

### DIFF
--- a/apps/mls_validation_service/src/handlers.rs
+++ b/apps/mls_validation_service/src/handlers.rs
@@ -2,8 +2,9 @@ use futures::future::{join_all, try_join_all};
 use openmls::framing::ContentType;
 use openmls::prelude::{MlsMessageIn, ProtocolMessage, tls_codec::Deserialize};
 use openmls_rust_crypto::RustCrypto;
-use tonic::{Request, Response, Status};
+use tonic::{Code, Request, Response, Status, metadata::MetadataValue};
 
+use xmtp_common::{ErrorCode, RetryableError};
 use xmtp_id::key_package::{KeyPackageVerificationError, VerifiedKeyPackageV2};
 use xmtp_id::{
     associations::{
@@ -35,21 +36,54 @@ use xmtp_proto::xmtp::{
     },
 };
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, ErrorCode)]
 pub enum GrpcServerError {
     #[error(transparent)]
+    #[error_code(inherit)]
     Deserialization(#[from] DeserializationError),
     #[error(transparent)]
+    #[error_code(inherit)]
     Association(#[from] AssociationError),
     #[error(transparent)]
+    #[error_code(inherit)]
     Signature(#[from] SignatureError),
     #[error(transparent)]
+    #[error_code(inherit)]
     Conversion(#[from] xmtp_proto::ConversionError),
+}
+
+impl RetryableError for GrpcServerError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            GrpcServerError::Signature(e) => e.is_retryable(),
+            // An association can fail because verifying one of its signatures hit a
+            // transient error (e.g. the chain RPC), which should still be retryable.
+            GrpcServerError::Association(AssociationError::Signature(e)) => e.is_retryable(),
+            GrpcServerError::Conversion(e) => e.is_retryable(),
+            GrpcServerError::Deserialization(_) | GrpcServerError::Association(_) => false,
+        }
+    }
 }
 
 impl From<GrpcServerError> for Status {
     fn from(err: GrpcServerError) -> Self {
-        Status::invalid_argument(err.to_string())
+        // Retryable errors are transient and server-side (for example, failing to
+        // reach the chain RPC while verifying a smart contract wallet signature), so
+        // surface them as `Unavailable` and let callers retry. Everything else is a
+        // genuine bad request and stays `InvalidArgument`.
+        let code = if err.is_retryable() {
+            Code::Unavailable
+        } else {
+            Code::InvalidArgument
+        };
+
+        let mut status = Status::new(code, err.to_string());
+        // Attach the stable error label (e.g. "SignatureError::VerifierError") as
+        // metadata so callers get a precise reason instead of only a free-form string.
+        if let Ok(value) = MetadataValue::try_from(err.error_code()) {
+            status.metadata_mut().insert("error-code", value);
+        }
+        status
     }
 }
 
@@ -532,5 +566,30 @@ mod tests {
                 error: None
             }
         );
+    }
+
+    #[test]
+    fn deserialization_error_maps_to_invalid_argument() {
+        let status = Status::from(GrpcServerError::Deserialization(
+            DeserializationError::InvalidAccountId,
+        ));
+
+        assert_eq!(status.code(), Code::InvalidArgument);
+        assert!(status.metadata().get("error-code").is_some());
+    }
+
+    #[test]
+    fn retryable_signature_error_maps_to_unavailable() {
+        use xmtp_id::scw_verifier::VerifierError;
+
+        // A missing/unreachable chain verifier is a transient, server-side failure.
+        let err = GrpcServerError::Signature(SignatureError::VerifierError(
+            VerifierError::NoVerifier("eip155:1".to_string()),
+        ));
+        assert!(err.is_retryable());
+
+        let status = Status::from(err);
+        assert_eq!(status.code(), Code::Unavailable);
+        assert!(status.metadata().get("error-code").is_some());
     }
 }


### PR DESCRIPTION
Closes #3130

**What was happening?**
Every error was coming as InvalidArguement, even when the error was just a server side disconnect making users having difficulty understand if the error was permanent or retryable

**What I changed?**
Errors are now sorted by whether they’re temporary, so retryable and server disconnect ones returns unavailable, and the error's short name now gets passed along so users see exactly which error happened.

**How I tested**
Added two unit tests, a bad-input error stays InvalidArgument, a retryable verifier error now returns Unavailable, both carry the label. `cargo test`, `cargo +nightly fmt --check`, and `cargo clippy -- -D warnings` pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return `Unavailable` vs `InvalidArgument` gRPC status codes based on error retryability in MLS validation service
> - Implements `RetryableError` for `GrpcServerError` in [handlers.rs](https://github.com/xmtp/libxmtp/pull/3741/files#diff-ad601199ee09300a54b4df32946614a4e73d4a5872ce1517258590380e5cdd04), classifying `Signature` and retryable `Association` errors as transient.
> - Updates `From<GrpcServerError> for Status` to return `Code::Unavailable` for retryable errors and `Code::InvalidArgument` for non-retryable ones, replacing the previous single-code behavior.
> - Attaches a stable `"error-code"` metadata entry to every returned `Status` using `ErrorCode::error_code()`.
> - Behavioral Change: callers that previously received a uniform error code will now receive different codes depending on whether the error is transient.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1626702.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->