### PR TITLE
fix(xmtp_logging): stdout_level / native_level were inert at install (per-layer filter didn't override global)

### DIFF
--- a/crates/xmtp_logging/src/filter.rs
+++ b/crates/xmtp_logging/src/filter.rs
@@ -33,4 +33,51 @@ mod tests {
         filter_directive("TRACE");
         filter_directive("INCORRECT_DOES_NOT_PANIC");
     }
+
+    #[test]
+    fn stdout_filter_at_warn_drops_xmtp_info() {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+        use tracing::dispatcher::{self, Dispatch};
+        use tracing_subscriber::{Registry, fmt, prelude::*};
+
+        #[derive(Clone, Default)]
+        struct Buf(Arc<Mutex<Vec<u8>>>);
+        impl Write for Buf {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Buf {
+            type Writer = Buf;
+            fn make_writer(&'a self) -> Buf {
+                self.clone()
+            }
+        }
+
+        let buf = Buf::default();
+        let layer = fmt::layer()
+            .with_writer(buf.clone())
+            .with_filter(super::filter_directive("warn"));
+        let subscriber = Registry::default().with(layer);
+
+        dispatcher::with_default(&Dispatch::new(subscriber), || {
+            tracing::info!(target: "xmtp_api", "should be dropped at warn");
+            tracing::warn!(target: "xmtp_api", "should be kept at warn");
+        });
+
+        let out = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            !out.contains("should be dropped"),
+            "INFO leaked to stdout at warn:\n{out}"
+        );
+        assert!(
+            out.contains("should be kept"),
+            "WARN was wrongly dropped:\n{out}"
+        );
+    }
 }

--- a/crates/xmtp_logging/src/layers/fmt.rs
+++ b/crates/xmtp_logging/src/layers/fmt.rs
@@ -1,24 +1,20 @@
 use tracing_subscriber::Layer;
 use tracing_subscriber::fmt;
 use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::{EnvFilter, filter::LevelFilter};
 
 use crate::config::Level;
+use crate::filter::filter_directive;
 
 /// A stdout fmt layer: JSON (flattened) when `json`, else compact.
 ///
-/// The layer carries its own per-layer `EnvFilter` defaulting to `stdout_level`
-/// (RUST_LOG still overrides), so stdout can be quieted independently of the
-/// global `level` — e.g. `level = Info` exports INFO+ to OTLP while
-/// `stdout_level = Warn` keeps the console/log-shipper at WARN+ (no duplicate of
-/// the OTLP stream). The per-layer filter narrows under the global filter.
+/// Filtered via `filter_directive` (explicit per-crate directives at
+/// `stdout_level`) so it overrides the global per-crate filter and narrows
+/// stdout below `level` — a bare default directive would not (INFO leaks).
 pub(crate) fn stdout_layer<S>(json: bool, stdout_level: Level) -> Box<dyn Layer<S> + Send + Sync>
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
 {
-    let filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::from(stdout_level).into())
-        .from_env_lossy();
+    let filter = filter_directive(stdout_level.as_str());
     if json {
         fmt::layer()
             .json()

--- a/crates/xmtp_logging/src/layers/native.rs
+++ b/crates/xmtp_logging/src/layers/native.rs
@@ -1,31 +1,28 @@
 use crate::config::Level;
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-use tracing::level_filters::LevelFilter;
 use tracing_subscriber::reload;
 use tracing_subscriber::{EnvFilter, Layer, Registry};
 
 /// The native primary layer plus the reloadable filter handles for each native
 /// layer. The Vec holds one handle per reloadable native layer (driven by
 /// [`crate::LoggingHandle::set_native_level`]): one element on the non-mobile
-/// server build (its stdout fmt-layer `EnvFilter`, defaulting to `native_level`
-/// with RUST_LOG overriding), one element on iOS, and two on android (logcat +
-/// AndroidTrace, each with its own cell).
+/// server build (its stdout fmt-layer `EnvFilter`, set to `native_level` via
+/// explicit per-crate directives), one element on iOS, and two on android
+/// (logcat + AndroidTrace, each with its own cell).
 pub(crate) type NativeLayer = (
     Box<dyn Layer<Registry> + Send + Sync>,
     Vec<reload::Handle<EnvFilter, Registry>>,
 );
 
 /// Server / non-mobile native layer: a compact stdout fmt layer whose only field
-/// formatting concern is rendering the `message` field, with an `EnvFilter`
-/// defaulting to `native_level` (RUST_LOG still overrides). Reloadable, so the
-/// handle Vec carries one element driving `set_native_level`.
+/// formatting concern is rendering the `message` field, with a per-crate
+/// `EnvFilter` at `native_level`. Reloadable, so the handle Vec carries one
+/// element driving `set_native_level`.
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub(crate) fn native_layer(native_level: Level) -> NativeLayer {
     use tracing_subscriber::fmt::{self, format};
-    // native_level is the default; RUST_LOG still overrides (ops escape hatch).
-    let filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::from(native_level).into())
-        .from_env_lossy();
+    // Per-crate directives (like the global filter + `set_native_level`) so
+    // `native_level` actually narrows below `level`; a bare default would not.
+    let filter = crate::filter::filter_directive(native_level.as_str());
     let (reloadable, handle) = reload::Layer::new(filter);
     let layer = fmt::layer()
         .compact()


### PR DESCRIPTION
## Problem

`stdoutLevel` (FFI `LogOptions.stdoutLevel` → `LoggingConfig.stdout_level`) is plumbed end-to-end but was **inert**: setting it to a level quieter than the global `level` did nothing — the console kept emitting at `level`.

Root cause is in how the per-layer filter is built. The **global Slot-1 filter** uses explicit per-crate directives (`filter_directive` → `xmtp_mls=info,xmtp_api=info,…`). The **stdout layer's** per-layer filter was built with a *bare default directive*:

```rust
EnvFilter::builder()
    .with_default_directive(LevelFilter::from(stdout_level).into())
    .from_env_lossy()
```

When both are `EnvFilter`s, the global filter's **explicit per-target** directives win for those targets, and the stdout layer's **default** directive does not narrow them. So with `level = Info`, `stdout_level = Warn`, an `xmtp_api` / `xmtp_mls` INFO event still reaches stdout.

The **server `native_layer`** (`native_level`, the `with_native(true)` compact layer) had the identical construction and the identical bug. Notably its *runtime* path was already correct — `set_native_level` reloads via `filter_directive` — so `native_level` was inert only at install, becoming correct after the first `set_native_level`. The mobile (android/ios) arms already use `filter_directive` and were unaffected.

## Fix

Build both layers' filters via `filter_directive(<level>.as_str())` — the same explicit per-crate directive list the global filter and `set_native_level` already use — so the per-layer filter names each libxmtp target and genuinely narrows it below the global `level`.

- `crates/xmtp_logging/src/layers/fmt.rs` — `stdout_layer`
- `crates/xmtp_logging/src/layers/native.rs` — server `native_layer` (initial filter; mobile arms untouched)

**Behavior note:** this drops the `from_env_lossy()` `RUST_LOG`-override on these two layers. That is intentional and consistent — the global Slot-1 filter and `set_level`/`set_native_level` already ignore `RUST_LOG` (they use `filter_directive`). The doc comments are updated to match. Narrows-only is preserved: the global filter still drops anything below `level` before any layer sees it, so a `stdout_level`/`native_level` *more verbose* than `level` has no effect.

## Reproduced (before → after)

A/B with `loggingLevel: "Info"`, varying only `stdoutLoggingLevel`, provoking real libxmtp logging (`Client.create` → identity ops), counting libxmtp INFO lines on **stdout**:

| `stdoutLevel` | before fix | after fix |
|---|---|---|
| `Warn` | INFO leaks (same as Info) | **0 INFO** |
| `Info` | INFO present | INFO present |

Verified by rebuilding the node binding and running the A/B against the built addon.

## Tests

- New regression guard `filter::tests::stdout_filter_at_warn_drops_xmtp_info` — proves `filter_directive("warn")` as a per-layer filter drops `xmtp_api` INFO and keeps WARN (isolated subscriber, no global install).
- `cargo test -p xmtp_logging` — 11 passed.
- `cargo clippy -p xmtp_logging --all-targets -- -D warnings` — clean.
- `cargo build -p bindings_node` — clean.

## Scope

Only the two server/console layers that are meant to narrow under the global filter. The global Slot-1 filter, file layer, OTLP layer, and mobile native arms are unchanged — OTLP still receives the full `level` stream (this is what makes the stdout/OTLP de-dup work for log shippers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `stdout_level` and `native_level` filters being ignored at install in `xmtp_logging`
> Both `stdout_layer` and `native_layer` were building their `EnvFilter` using `with_default_directive(...).from_env_lossy()`, which allowed environment variables to override the per-layer level and caused the configured level to have no effect. Both now use `filter_directive(level.as_str())` from [filter.rs](https://github.com/xmtp/libxmtp/pull/3742/files#diff-1b96e7ddb227839277e5c9c406cfa589e89f820fc49ed4f6c1a7455a34d306a8), which applies the intended per-crate directive correctly. A regression test in [filter.rs](https://github.com/xmtp/libxmtp/pull/3742/files#diff-1b96e7ddb227839277e5c9c406cfa589e89f820fc49ed4f6c1a7455a34d306a8) verifies that INFO events are dropped when the filter is set to WARN.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24655b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->