### PR TITLE
chore(deny): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,7 @@ ignore = [
   { id = "RUSTSEC-2024-0436", reason = "required by uniffi" },
   { id = "RUSTSEC-2021-0139", reason = "ansi_term is only used in tests" },
   { id = "RUSTSEC-2025-0141", reason = "migrate from bincode" },
+  { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive via alloy-sol-macro, no upstream fix yet" },
 ]
 
 # This rustsec can be added to ignore list if using mls `test_utils` for tests


### PR DESCRIPTION
## What
Add `RUSTSEC-2026-0173` to the `deny.toml` advisories ignore list.

## Why
A new advisory landed today (2026-06-08): `proc-macro-error2` is now declared unmaintained. It turns the `cargo-deny (advisories)` matrix leg red across **every** branch/PR — `main`'s own latest run fails it too.

The crate is a deep transitive dependency, not anything we depend on directly:

```
proc-macro-error2 v2.0.1
└── alloy-sol-macro → alloy-sol-types → alloy
    (mls_validation_service + xmtp-workspace-hack)
```

There is no upstream fix to pull yet — the alloy stack still depends on it. The advisories check is already `continue-on-error: true` in `.github/workflows/cargo-deny-checker.yml` (so it never blocked merges), but silencing the noise keeps the check green and avoids masking future *real* advisories.

## How
One-line ignore entry, matching the existing pattern:

```toml
{ id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive via alloy-sol-macro, no upstream fix yet" },
```

Verified locally: `cargo deny check advisories` → `advisories ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore RUSTSEC-2026-0173 advisory for unmaintained `proc-macro-error2`
> Adds a cargo-deny ignore entry in [deny.toml](https://github.com/xmtp/libxmtp/pull/3746/files#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3de) for `RUSTSEC-2026-0173`, which flags `proc-macro-error2` as unmaintained. The dependency is transitive via `alloy-sol-macro` and has no upstream fix available yet.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81d65c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->