### PR TITLE
fix: dont merge commits with unchanged authenticator

### DIFF
--- a/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
@@ -170,6 +170,31 @@ impl CommitLogStorer for MlsGroup {
     ) -> Result<(), GroupMessageProcessingError> {
         let last_epoch_authenticator = self.epoch_authenticator().as_slice().to_vec();
         self.merge_staged_commit(provider, staged_commit)?;
+        let applied_epoch_authenticator = self.epoch_authenticator().as_slice().to_vec();
+
+        // Invariant: a successful staged-commit merge always advances the
+        // epoch and therefore changes the epoch authenticator. If the
+        // authenticator did not change, the group state we merged onto was
+        // corrupt/torn (e.g. a cross-process race on a shared MLS DB handed
+        // us a reloaded group that already carried the post-commit epoch
+        // secrets). Recording a Success entry here would persist a forked
+        // commit log (observed in production as applied == last at the same
+        // epoch). Refuse instead: this error is retryable, so the enclosing
+        // transaction (cursor advance + merge + log write) rolls back and the
+        // message is reprocessed against settled state.
+        if applied_epoch_authenticator == last_epoch_authenticator {
+            tracing::error!(
+                group_id = hex::encode(self.group_id().as_slice()),
+                commit_sequence_id = sequence_id,
+                epoch = self.epoch().as_u64(),
+                "staged commit merge did not advance the epoch authenticator; \
+                 refusing to record corrupt commit log entry"
+            );
+            return Err(GroupMessageProcessingError::EpochAuthenticatorNotAdvanced {
+                commit_sequence_id: sequence_id,
+                epoch: self.epoch().as_u64(),
+            });
+        }
 
         if xmtp_configuration::ENABLE_COMMIT_LOG {
             NewLocalCommitLog {
@@ -178,7 +203,7 @@ impl CommitLogStorer for MlsGroup {
                 last_epoch_authenticator,
                 commit_result: CommitResult::Success,
                 applied_epoch_number: self.epoch().as_u64() as i64,
-                applied_epoch_authenticator: self.epoch_authenticator().as_slice().to_vec(),
+                applied_epoch_authenticator,
                 sender_inbox_id: Some(validated_commit.actor_inbox_id()),
                 sender_installation_id: Some(validated_commit.actor_installation_id()),
                 commit_type: Some(format!("{}", validated_commit.debug_commit_type())),

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -224,6 +224,17 @@ pub enum GroupMessageProcessingError {
     PreCommitProposalPhaseComplete,
     #[error(transparent)]
     Conversion(#[from] xmtp_proto::ConversionError),
+    /// A successful staged-commit merge must advance the epoch and therefore
+    /// change the epoch authenticator. If it did not, the group state the
+    /// commit was merged onto was corrupt/torn (e.g. produced by a
+    /// cross-process race on a shared MLS DB). Retryable: the enclosing
+    /// transaction (cursor + merge + commit log) rolls back and the message is
+    /// reprocessed against settled state.
+    #[error(
+        "commit at sequence [{commit_sequence_id}] merged to epoch [{epoch}] without advancing \
+         the epoch authenticator; refusing to record corrupt commit log entry"
+    )]
+    EpochAuthenticatorNotAdvanced { commit_sequence_id: i64, epoch: u64 },
 }
 
 impl RetryableError for GroupMessageProcessingError {
@@ -269,6 +280,10 @@ impl RetryableError for GroupMessageProcessingError {
             | Self::PreCommitProposalPhaseComplete => false,
             Self::Builder(_) => false,
             Self::Conversion(_) => false,
+            // Retry so the enclosing transaction rolls back (including the
+            // cursor advance) and the message converges via cursor dedup
+            // instead of persisting a forked commit log entry.
+            Self::EpochAuthenticatorNotAdvanced { .. } => true,
         }
     }
 }

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -1,11 +1,18 @@
+use crate::context::XmtpSharedContext;
+use crate::groups::app_data::process_message_with_app_data;
 use crate::groups::commit_log::{CommitLogTestFunction, CommitLogWorker};
+use crate::groups::mls_ext::CommitLogStorer;
+use crate::groups::validated_commit::ValidatedCommit;
 use crate::tester;
+use openmls::group::MlsGroup as OpenMlsGroup;
+use openmls::prelude::{ProcessedMessageContent, Sender};
 use xmtp_configuration::Originators;
 use xmtp_db::Store;
 use xmtp_db::encrypted_store::local_commit_log::NewLocalCommitLog;
 use xmtp_db::encrypted_store::remote_commit_log::{CommitResult, NewRemoteCommitLog};
 use xmtp_db::local_commit_log::CommitType;
 use xmtp_db::prelude::*;
+use xmtp_db::{MlsProviderExt, StorageError, TransactionalKeyStore, XmtpOpenMlsProvider};
 use xmtp_proto::types::Cursor;
 
 #[cfg_attr(all(feature = "d14n", target_arch = "wasm32"), ignore)]
@@ -580,6 +587,289 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
         Some(false),
         "Final database check: fork status should remain Some(false)"
     );
+
+    Ok(())
+}
+
+/// Regression test for the corrupt commit-log write observed in production
+/// (Convos group `e08a717548dc996845dc1f2d6986bdd0`, debug bundle `6E527FC8`).
+///
+/// The local commit log on the "forked" member contained a *successful*
+/// `UpdateGroupMembership` entry whose `applied_epoch_authenticator` equals its
+/// `last_epoch_authenticator`. For a successful staged-commit merge this is
+/// impossible: merging a commit always advances the epoch and therefore changes
+/// the epoch authenticator. `applied == last` is only valid for *failed*
+/// commits (`mark_failed_commit_logged`, which records that nothing was
+/// applied).
+///
+/// Root cause (see the commit-log fork investigation): the iOS main app and the
+/// Notification Service Extension share one MLS SQLite DB, but `GroupCommitLock`
+/// is in-process only — the two processes never contend. With both processes
+/// running the receive path's "process twice + reload" pattern
+/// (`validate_and_process_external_message`), interleaved per-key writes to the
+/// shared `openmls_key_value` store can leave a *torn* group state: some keys
+/// from the new epoch, some stale. A group loaded from such state merges a
+/// staged commit "successfully" without its authenticator advancing, and the
+/// single commit-log write path, `merge_staged_commit_logged`, faithfully
+/// records the corrupt `Success` row.
+///
+/// Note: the *cleanly* advanced case — where the concurrent writer fully
+/// applied the commit and the stale staged commit is merged on top of a
+/// consistent new-epoch group — is already (incidentally) rejected by openmls'
+/// keypair bookkeeping in `merge_commit` ("We should have all the private key
+/// material we need"). The torn case below is NOT rejected by anything today.
+///
+/// This test constructs the torn state deterministically:
+/// 1. Pass 1: process Bo's received commit in a rolled-back transaction and
+///    capture the `StagedCommit` + `ValidatedCommit` (what
+///    `validate_and_process_external_message` does at `mls_sync.rs:1092`).
+/// 2. Snapshot the raw `GroupContext` and epoch-keypair kv rows (epoch E).
+/// 3. "Concurrent process": apply the same commit via a normal `sync()` — the
+///    DB is now consistently at epoch E+1.
+/// 4. Tear the storage: write the stale epoch-E `GroupContext` and epoch-E
+///    keypair rows back, leaving tree/epoch-secrets/message-secrets at E+1.
+///    This simulates one process's writes landing on top of the other's.
+/// 5. Reload the group: it reports epoch E but carries E+1's epoch secrets —
+///    i.e. its authenticator is already the post-commit one.
+/// 6. Pass 2: merge the stale staged commit via `merge_staged_commit_logged`.
+///    The merge succeeds (epoch E -> E+1, keypair accounting balances), but the
+///    authenticator does not advance: last == applied == auth(E+1).
+///
+/// EXPECTED (once the invariant guard lands in `commit_log_storer.rs`):
+/// `merge_staged_commit_logged` must refuse to write a `Success` entry whose
+/// applied authenticator equals the last authenticator, and return an error
+/// instead. Erroring is safe: in the real receive path the cursor advance,
+/// merge, and log write share one transaction (`mls_sync.rs:1297`), so the
+/// error rolls everything back and the message is retried, converging via
+/// cursor dedup.
+///
+/// CURRENT (bug): the merge succeeds and the corrupt row is written — this
+/// test FAILS until the guard is added. Our production logs prove this class
+/// of write happens in the wild.
+#[cfg_attr(all(feature = "d14n", target_arch = "wasm32"), ignore)]
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
+-> Result<(), Box<dyn std::error::Error>> {
+    use diesel::{RunQueryDsl, sql_query};
+    use openmls_traits::storage::CURRENT_VERSION;
+
+    // Raw access to the openmls kv store, mirroring xmtp_db::sql_key_store's
+    // key layout: storage_key = label ++ bincode(inner_key) ++ version (u16 BE).
+    const KV_SELECT: &str =
+        "SELECT value_bytes FROM openmls_key_value WHERE key_bytes = ? AND version = ?";
+    const KV_REPLACE: &str =
+        "REPLACE INTO openmls_key_value (key_bytes, version, value_bytes) VALUES (?, ?, ?)";
+    const GROUP_CONTEXT_LABEL: &[u8] = b"GroupContext";
+    const EPOCH_KEY_PAIRS_LABEL: &[u8] = b"EpochKeyPairs";
+
+    #[derive(diesel::QueryableByName)]
+    struct KvRow {
+        #[diesel(sql_type = diesel::sql_types::Binary)]
+        value_bytes: Vec<u8>,
+    }
+
+    fn kv_storage_key(label: &[u8], inner_key: &[u8]) -> Vec<u8> {
+        let mut key = label.to_vec();
+        key.extend_from_slice(inner_key);
+        key.extend_from_slice(&(CURRENT_VERSION).to_be_bytes());
+        key
+    }
+
+    fn kv_select(
+        db: &impl xmtp_db::ConnectionExt,
+        storage_key: &[u8],
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let rows: Vec<KvRow> = db.raw_query(|conn| {
+            sql_query(KV_SELECT)
+                .bind::<diesel::sql_types::Binary, _>(storage_key)
+                .bind::<diesel::sql_types::Integer, _>(CURRENT_VERSION as i32)
+                .load(conn)
+        })?;
+        Ok(rows
+            .into_iter()
+            .next()
+            .expect("kv row must exist")
+            .value_bytes)
+    }
+
+    fn kv_replace(
+        db: &impl xmtp_db::ConnectionExt,
+        storage_key: &[u8],
+        value: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        db.raw_query(|conn| {
+            sql_query(KV_REPLACE)
+                .bind::<diesel::sql_types::Binary, _>(storage_key)
+                .bind::<diesel::sql_types::Integer, _>(CURRENT_VERSION as i32)
+                .bind::<diesel::sql_types::Binary, _>(value)
+                .execute(conn)
+        })?;
+        Ok(())
+    }
+
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+
+    // Alix creates a group and adds Bo.
+    let alix_group = alix.create_group(None, None)?;
+    alix_group.add_members(&[bo.inbox_id()]).await?;
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&alix_group.group_id)?;
+    bo_group.sync().await?;
+
+    // Alix publishes an UpdateGroupMembership commit (same commit type as the
+    // production bundle) that Bo has not yet processed.
+    alix_group.add_members(&[caro.inbox_id()]).await?;
+
+    // Bo fetches the raw commit envelope from the network.
+    let messages = bo
+        .mls_store()
+        .query_group_messages(bo_group.group_id)
+        .await?;
+    let commit_envelope = messages
+        .into_iter()
+        .max_by_key(|m| m.cursor.sequence_id)
+        .expect("the add-caro commit must be on the network");
+    let commit_sequence_id = commit_envelope.cursor.sequence_id as i64;
+
+    // Bo's group is at epoch E; compute the kv storage keys for the epoch-E
+    // GroupContext and epoch-keypair rows so they can be snapshotted.
+    let mut group_copy =
+        OpenMlsGroup::load(bo.context.mls_storage(), &bo_group.group_id.to_openmls())?
+            .expect("bo's group must exist");
+    let epoch_e = group_copy.epoch();
+    let auth_e = group_copy.epoch_authenticator().as_slice().to_vec();
+    let gid_ser = bincode::serialize(&bo_group.group_id.to_openmls())?;
+    let ctx_key = kv_storage_key(GROUP_CONTEXT_LABEL, &gid_ser);
+    let mut ekp_inner = gid_ser.clone();
+    ekp_inner.extend_from_slice(&bincode::serialize(&epoch_e)?);
+    ekp_inner.extend_from_slice(&bincode::serialize(&group_copy.own_leaf_index().u32())?);
+    let ekp_key = kv_storage_key(EPOCH_KEY_PAIRS_LABEL, &ekp_inner);
+
+    let db = bo.context.db();
+    let ctx_e_bytes = kv_select(&db, &ctx_key)?;
+    let ekp_e_bytes = kv_select(&db, &ekp_key)?;
+
+    // --- Pass 1 (the second process's view; mirrors mls_sync.rs:1092). ---
+    // Process the commit against a copy of Bo's group inside a transaction that
+    // is intentionally rolled back, capturing the staged + validated commit.
+    let provider = bo.context.mls_provider();
+    let mut processed_message = None;
+    let result = provider.key_store().transaction(|conn| {
+        let storage = conn.key_store();
+        let provider = XmtpOpenMlsProvider::new(storage);
+        processed_message = Some(process_message_with_app_data(
+            &mut group_copy,
+            &provider,
+            commit_envelope.message.clone(),
+        ));
+        Err::<(), StorageError>(StorageError::IntentionalRollback)
+    });
+    assert!(matches!(result, Err(StorageError::IntentionalRollback)));
+    let processed_message = processed_message
+        .expect("set in the transaction above")
+        .expect("processing the commit at the old epoch succeeds");
+
+    let committer_leaf_index = match processed_message.sender() {
+        Sender::Member(idx) => *idx,
+        _ => panic!("commit must come from a member"),
+    };
+    let staged_commit_ref = match processed_message.content() {
+        ProcessedMessageContent::StagedCommitMessage(staged) => staged,
+        _ => panic!("expected a staged commit message"),
+    };
+    let validated_commit = ValidatedCommit::from_staged_commit(
+        &bo_group.context,
+        staged_commit_ref,
+        committer_leaf_index,
+        &group_copy,
+    )
+    .await
+    .expect("commit validation succeeds");
+    let staged_commit = match processed_message.into_content() {
+        ProcessedMessageContent::StagedCommitMessage(staged) => *staged,
+        _ => unreachable!(),
+    };
+    drop(group_copy);
+
+    // --- The "concurrent process" applies the same commit normally. ---
+    // In production: the main app processes the commit while the NSE sits
+    // between its pass 1 and its reload(); the race exists because
+    // GroupCommitLock is per-process. The DB is now consistently at E+1.
+    bo_group.sync().await?;
+
+    let consistent =
+        OpenMlsGroup::load(bo.context.mls_storage(), &bo_group.group_id.to_openmls())?
+            .expect("bo's group must exist");
+    assert_eq!(consistent.epoch(), staged_commit.group_context().epoch());
+    let auth_e1 = consistent.epoch_authenticator().as_slice().to_vec();
+    assert_ne!(auth_e, auth_e1, "the applied commit advanced the authenticator");
+    drop(consistent);
+
+    // --- Tear the storage. ---
+    // Write the stale epoch-E GroupContext and epoch-E keypair rows back over
+    // the E+1 state, leaving tree / epoch secrets / message secrets at E+1.
+    // This simulates the second process's interleaved writes landing on the
+    // shared kv store without cross-process mutual exclusion.
+    kv_replace(&db, &ctx_key, &ctx_e_bytes)?;
+    kv_replace(&db, &ekp_key, &ekp_e_bytes)?;
+
+    // --- The reload (mls_sync.rs:1109 analog) hands back the torn group: ---
+    // it reports epoch E, but its epoch secrets (and therefore its
+    // authenticator) are already E+1's.
+    let mut torn = OpenMlsGroup::load(bo.context.mls_storage(), &bo_group.group_id.to_openmls())?
+        .expect("bo's group must exist");
+    assert_eq!(torn.epoch(), epoch_e, "torn group reports the stale epoch");
+    assert_eq!(
+        torn.epoch_authenticator().as_slice(),
+        auth_e1.as_slice(),
+        "torn group already carries the post-commit epoch secrets"
+    );
+
+    let logs_before = bo.context.db().get_group_logs(&bo_group.group_id)?.len();
+
+    // --- Pass 2: merge the stale staged commit on the torn group. ---
+    // From the torn group's perspective this is a perfectly ordinary merge
+    // (epoch E -> E+1), so openmls accepts it. But the authenticator read
+    // before the merge already equals the staged commit's: the logged row is
+    // Success with applied_epoch_authenticator == last_epoch_authenticator —
+    // the exact corruption from bundle 6E527FC8, which fork detection later
+    // (correctly) flags against remote consensus.
+    let merge_result = torn.merge_staged_commit_logged(
+        &provider,
+        staged_commit,
+        &validated_commit,
+        commit_sequence_id,
+    );
+
+    // INVARIANT (Fix 1): a Success merge must advance the epoch authenticator.
+    // merge_staged_commit_logged must detect applied == last and return an
+    // error instead of persisting the corrupt row.
+    assert!(
+        merge_result.is_err(),
+        "merge_staged_commit_logged should refuse to log a Success commit whose \
+         merge did not advance the epoch authenticator (applied == last); \
+         persisting it corrupts the local commit log and later surfaces as a fork"
+    );
+
+    // And the corrupt row must not have been written.
+    let logs = bo.context.db().get_group_logs(&bo_group.group_id)?;
+    assert_eq!(
+        logs.len(),
+        logs_before,
+        "no local commit log entry may be written for the rejected merge"
+    );
+    for log in &logs {
+        if log.commit_result == CommitResult::Success && !log.last_epoch_authenticator.is_empty() {
+            assert_ne!(
+                log.applied_epoch_authenticator, log.last_epoch_authenticator,
+                "successful commit at applied_epoch_number={} recorded an epoch \
+                 authenticator that did not advance",
+                log.applied_epoch_number
+            );
+        }
+    }
 
     Ok(())
 }

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -805,12 +805,14 @@ async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
     // GroupCommitLock is per-process. The DB is now consistently at E+1.
     bo_group.sync().await?;
 
-    let consistent =
-        OpenMlsGroup::load(bo.context.mls_storage(), &bo_group.group_id.to_openmls())?
-            .expect("bo's group must exist");
+    let consistent = OpenMlsGroup::load(bo.context.mls_storage(), &bo_group.group_id.to_openmls())?
+        .expect("bo's group must exist");
     assert_eq!(consistent.epoch(), staged_commit.group_context().epoch());
     let auth_e1 = consistent.epoch_authenticator().as_slice().to_vec();
-    assert_ne!(auth_e, auth_e1, "the applied commit advanced the authenticator");
+    assert_ne!(
+        auth_e, auth_e1,
+        "the applied commit advanced the authenticator"
+    );
     drop(consistent);
 
     // --- Tear the storage. ---

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -653,10 +653,13 @@ async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
     use diesel::{RunQueryDsl, sql_query};
     use openmls_traits::storage::CURRENT_VERSION;
 
-    // Raw access to the openmls kv store, mirroring xmtp_db::sql_key_store's
-    // key layout: storage_key = label ++ bincode(inner_key) ++ version (u16 BE).
-    const KV_SELECT: &str =
-        "SELECT value_bytes FROM openmls_key_value WHERE key_bytes = ? AND version = ?";
+    // Raw access to the openmls kv store. Rows are located by label prefix +
+    // raw group id containment rather than by reconstructing the exact
+    // bincode-encoded storage key, so the test does not depend on
+    // xmtp_db::sql_key_store's key encoding. Restores use the exact key_bytes
+    // returned by the scan.
+    const KV_SCAN: &str = "SELECT key_bytes, value_bytes FROM openmls_key_value \
+         WHERE substr(key_bytes, 1, ?) = ? AND instr(key_bytes, ?) > 0 AND version = ?";
     const KV_REPLACE: &str =
         "REPLACE INTO openmls_key_value (key_bytes, version, value_bytes) VALUES (?, ?, ?)";
     const GROUP_CONTEXT_LABEL: &[u8] = b"GroupContext";
@@ -665,31 +668,28 @@ async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
     #[derive(diesel::QueryableByName)]
     struct KvRow {
         #[diesel(sql_type = diesel::sql_types::Binary)]
+        key_bytes: Vec<u8>,
+        #[diesel(sql_type = diesel::sql_types::Binary)]
         value_bytes: Vec<u8>,
     }
 
-    fn kv_storage_key(label: &[u8], inner_key: &[u8]) -> Vec<u8> {
-        let mut key = label.to_vec();
-        key.extend_from_slice(inner_key);
-        key.extend_from_slice(&(CURRENT_VERSION).to_be_bytes());
-        key
-    }
-
-    fn kv_select(
+    fn kv_scan(
         db: &impl xmtp_db::ConnectionExt,
-        storage_key: &[u8],
-    ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        label: &[u8],
+        group_id: &[u8],
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Box<dyn std::error::Error>> {
         let rows: Vec<KvRow> = db.raw_query(|conn| {
-            sql_query(KV_SELECT)
-                .bind::<diesel::sql_types::Binary, _>(storage_key)
+            sql_query(KV_SCAN)
+                .bind::<diesel::sql_types::Integer, _>(label.len() as i32)
+                .bind::<diesel::sql_types::Binary, _>(label)
+                .bind::<diesel::sql_types::Binary, _>(group_id)
                 .bind::<diesel::sql_types::Integer, _>(CURRENT_VERSION as i32)
                 .load(conn)
         })?;
         Ok(rows
             .into_iter()
-            .next()
-            .expect("kv row must exist")
-            .value_bytes)
+            .map(|r| (r.key_bytes, r.value_bytes))
+            .collect())
     }
 
     fn kv_replace(
@@ -733,23 +733,27 @@ async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
         .expect("the add-caro commit must be on the network");
     let commit_sequence_id = commit_envelope.cursor.sequence_id as i64;
 
-    // Bo's group is at epoch E; compute the kv storage keys for the epoch-E
-    // GroupContext and epoch-keypair rows so they can be snapshotted.
+    // Bo's group is at epoch E; snapshot the raw epoch-E GroupContext and
+    // epoch-keypair kv rows so they can be written back after the sync.
     let mut group_copy =
         OpenMlsGroup::load(bo.context.mls_storage(), &bo_group.group_id.to_openmls())?
             .expect("bo's group must exist");
     let epoch_e = group_copy.epoch();
     let auth_e = group_copy.epoch_authenticator().as_slice().to_vec();
-    let gid_ser = bincode::serialize(&bo_group.group_id.to_openmls())?;
-    let ctx_key = kv_storage_key(GROUP_CONTEXT_LABEL, &gid_ser);
-    let mut ekp_inner = gid_ser.clone();
-    ekp_inner.extend_from_slice(&bincode::serialize(&epoch_e)?);
-    ekp_inner.extend_from_slice(&bincode::serialize(&group_copy.own_leaf_index().u32())?);
-    let ekp_key = kv_storage_key(EPOCH_KEY_PAIRS_LABEL, &ekp_inner);
 
     let db = bo.context.db();
-    let ctx_e_bytes = kv_select(&db, &ctx_key)?;
-    let ekp_e_bytes = kv_select(&db, &ekp_key)?;
+    let ctx_rows_e = kv_scan(&db, GROUP_CONTEXT_LABEL, bo_group.group_id.as_ref())?;
+    assert_eq!(
+        ctx_rows_e.len(),
+        1,
+        "expected exactly one GroupContext kv row for the group"
+    );
+    // A welcome-joined member that has not yet merged a commit has no
+    // epoch-keypair row yet — openmls only writes that row in merge_commit
+    // (store_epoch_keypairs), and reads of a missing row gracefully return an
+    // empty set. Snapshot whatever rows exist (possibly none) so the torn
+    // state mirrors Bo's real epoch-E state.
+    let ekp_rows_e = kv_scan(&db, EPOCH_KEY_PAIRS_LABEL, bo_group.group_id.as_ref())?;
 
     // --- Pass 1 (the second process's view; mirrors mls_sync.rs:1092). ---
     // Process the commit against a copy of Bo's group inside a transaction that
@@ -808,12 +812,13 @@ async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
     drop(consistent);
 
     // --- Tear the storage. ---
-    // Write the stale epoch-E GroupContext and epoch-E keypair rows back over
-    // the E+1 state, leaving tree / epoch secrets / message secrets at E+1.
-    // This simulates the second process's interleaved writes landing on the
-    // shared kv store without cross-process mutual exclusion.
-    kv_replace(&db, &ctx_key, &ctx_e_bytes)?;
-    kv_replace(&db, &ekp_key, &ekp_e_bytes)?;
+    // Write the stale epoch-E GroupContext (and any epoch-E keypair rows)
+    // back over the E+1 state, leaving tree / epoch secrets / message secrets
+    // at E+1. This simulates the second process's interleaved writes landing
+    // on the shared kv store without cross-process mutual exclusion.
+    for (key, value) in ctx_rows_e.iter().chain(ekp_rows_e.iter()) {
+        kv_replace(&db, key, value)?;
+    }
 
     // --- The reload (mls_sync.rs:1109 analog) hands back the torn group: ---
     // it reports epoch E, but its epoch secrets (and therefore its

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -672,11 +672,14 @@ async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
         value_bytes: Vec<u8>,
     }
 
+    /// (key_bytes, value_bytes) pairs from the openmls kv store.
+    type KvRows = Vec<(Vec<u8>, Vec<u8>)>;
+
     fn kv_scan(
         db: &impl xmtp_db::ConnectionExt,
         label: &[u8],
         group_id: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Box<dyn std::error::Error>> {
+    ) -> Result<KvRows, Box<dyn std::error::Error>> {
         let rows: Vec<KvRow> = db.raw_query(|conn| {
             sql_query(KV_SCAN)
                 .bind::<diesel::sql_types::Integer, _>(label.len() as i32)

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -592,7 +592,6 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
 }
 
 /// Regression test for the corrupt commit-log write observed in production
-/// (Convos group `e08a717548dc996845dc1f2d6986bdd0`, debug bundle `6E527FC8`).
 ///
 /// The local commit log on the "forked" member contained a *successful*
 /// `UpdateGroupMembership` entry whose `applied_epoch_authenticator` equals its
@@ -602,7 +601,7 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
 /// commits (`mark_failed_commit_logged`, which records that nothing was
 /// applied).
 ///
-/// Root cause (see the commit-log fork investigation): the iOS main app and the
+/// Root cause: the iOS main app and the
 /// Notification Service Extension share one MLS SQLite DB, but `GroupCommitLock`
 /// is in-process only — the two processes never contend. With both processes
 /// running the receive path's "process twice + reload" pattern


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Reject commits with unchanged authenticator in `merge_staged_commit_logged`
Adds a regression test that verifies `merge_staged_commit_logged` returns an error and writes no Success commit-log entry when merging a staged commit does not advance the epoch authenticator (i.e. applied authenticator equals last authenticator).

- The test constructs a "torn" group state for Bo by syncing past a commit to E+1, then restoring the raw E-epoch `GroupContext` and `EpochKeyPairs` KV rows while leaving other E+1 state intact.
- It performs two passes: Pass 1 captures a `StagedCommit` and `ValidatedCommit` via a rolled-back transaction; Pass 2 calls `merge_staged_commit_logged` on the torn group and asserts it errors.
- Any Success log entries are checked to ensure they record advancing authenticators only.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 46fc597. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->