### PR TITLE
fix: replace Gnosis Chain SCW verification RPC default

### DIFF
--- a/crates/xmtp_id/src/scw_verifier/chain_urls_default.json
+++ b/crates/xmtp_id/src/scw_verifier/chain_urls_default.json
@@ -9,5 +9,5 @@
   "eip155:480": "https://worldchain-mainnet.g.alchemy.com/public",
   "eip155:232": "https://rpc.lens.xyz",
   "eip155:2741": "https://api.mainnet.abs.xyz",
-  "eip155:100": "https://public-gno-mainnet.fastnode.io"
+  "eip155:100": "https://rpc.gnosischain.com"
 }


### PR DESCRIPTION
public-gno-mainnet.fastnode.io sits behind a Cloudflare rule that rejects JSON-RPC bodies over ~2 KB with HTTP 413 "Payload Too Large" on some network routes — including the route used by XMTP's verification servers. The ERC-6492 ValidateSigOffchain eth_call is always ~4.1 KB, so every eip155:100 smart contract wallet verification fails with:

    Signature(VerifierError(Provider(Transport(HttpError(HttpError
      { status: 413, body: "Payload Too Large" })))))

reproducible against both api.production.xmtp.network and api.dev.xmtp.network via IdentityApi/VerifySmartContractWalletSignatures. This breaks Client.create ("Signature validation failed") for every Gnosis Safe — e.g. all Circles users.
Replace with https://rpc.gnosischain.com (official Gnosis Chain RPC): verified eth_chainId returns 0x64 and the full-size verification eth_call executes. Same class of fix as #3267.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace Gnosis Chain SCW verification RPC default endpoint
> Updates the RPC URL for `eip155:100` in [chain_urls_default.json](https://github.com/xmtp/libxmtp/pull/3755/files#diff-f492e34448589ad4e2913307eeaffba5309570d7a025ee1cfa3d17b4f8c474bb) from `https://public-gno-mainnet.fastnode.io` to `https://rpc.gnosischain.com`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90d970a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->