### PR TITLE
feat(messages): expose caller-settable idempotency_key across the FFI boundary

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1333,6 +1333,9 @@ pub struct FfiSendMessageOpts {
     pub should_push: bool,
     /// Optional idempotency key. Re-sending identical content with the same key
     /// produces the same message id and is deduplicated. Defaults to a timestamp.
+    /// Defaults to unset so existing foreign callers that construct
+    /// `FfiSendMessageOpts` without this field still compile.
+    #[uniffi(default = None)]
     pub idempotency_key: Option<String>,
 }
 

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1331,12 +1331,16 @@ impl From<FfiGroupQueryOrderBy> for GroupQueryOrderBy {
 #[derive(uniffi::Record, Clone, Default)]
 pub struct FfiSendMessageOpts {
     pub should_push: bool,
+    /// Optional idempotency key. Re-sending identical content with the same key
+    /// produces the same message id and is deduplicated. Defaults to a timestamp.
+    pub idempotency_key: Option<String>,
 }
 
 impl From<FfiSendMessageOpts> for xmtp_mls::groups::send_message_opts::SendMessageOpts {
     fn from(opts: FfiSendMessageOpts) -> Self {
         xmtp_mls::groups::send_message_opts::SendMessageOpts {
             should_push: opts.should_push,
+            idempotency_key: opts.idempotency_key,
         }
     }
 }
@@ -2499,7 +2503,10 @@ impl FfiConversation {
             TextCodec::encode(text.to_string()).map_err(|e| FfiError::generic(e.to_string()))?;
         self.send(
             encoded_content_to_bytes(content),
-            FfiSendMessageOpts { should_push: true },
+            FfiSendMessageOpts {
+                should_push: true,
+                idempotency_key: None,
+            },
         )
         .await
     }
@@ -2539,10 +2546,13 @@ impl FfiConversation {
         &self,
         content_bytes: Vec<u8>,
         should_push: bool,
+        idempotency_key: Option<String>,
     ) -> Result<Vec<u8>, FfiError> {
-        let id = self
-            .inner
-            .prepare_message_for_later_publish(content_bytes.as_slice(), should_push)?;
+        let id = self.inner.prepare_message_for_later_publish(
+            content_bytes.as_slice(),
+            should_push,
+            idempotency_key,
+        )?;
         Ok(id)
     }
 

--- a/bindings/node/src/conversation/content_types.rs
+++ b/bindings/node/src/conversation/content_types.rs
@@ -35,6 +35,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: TextCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -45,6 +46,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: MarkdownCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -59,6 +61,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: ReactionCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -69,6 +72,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: ReplyCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -79,6 +83,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: ReadReceiptCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -93,6 +98,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: AttachmentCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -108,6 +114,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: RemoteAttachmentCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -123,6 +130,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: MultiRemoteAttachmentCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -138,6 +146,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: TransactionReferenceCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -153,6 +162,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: WalletSendCallsCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -163,6 +173,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: ActionsCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -173,6 +184,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: IntentCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }

--- a/bindings/node/src/conversation/messages.rs
+++ b/bindings/node/src/conversation/messages.rs
@@ -16,12 +16,16 @@ use xmtp_proto::xmtp::mls::message_contents::EncodedContent as XmtpEncodedConten
 pub struct SendMessageOpts {
   pub should_push: bool,
   pub optimistic: Option<bool>,
+  /// Optional idempotency key. Re-sending identical content with the same key
+  /// produces the same message id and is deduplicated. Defaults to a timestamp.
+  pub idempotency_key: Option<String>,
 }
 
 impl From<SendMessageOpts> for xmtp_mls::groups::send_message_opts::SendMessageOpts {
   fn from(opts: SendMessageOpts) -> Self {
     xmtp_mls::groups::send_message_opts::SendMessageOpts {
       should_push: opts.should_push,
+      idempotency_key: opts.idempotency_key,
     }
   }
 }
@@ -130,11 +134,16 @@ impl Conversation {
     &self,
     encoded_content: EncodedContent,
     should_push: bool,
+    idempotency_key: Option<String>,
   ) -> Result<String> {
     let encoded_content: XmtpEncodedContent = encoded_content.into();
     let group = self.create_mls_group();
     let message_id = group
-      .prepare_message_for_later_publish(encoded_content.encode_to_vec().as_slice(), should_push)
+      .prepare_message_for_later_publish(
+        encoded_content.encode_to_vec().as_slice(),
+        should_push,
+        idempotency_key,
+      )
       .map_err(ErrorWrapper::from)?;
     Ok(hex::encode(message_id))
   }

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -64,12 +64,18 @@ pub struct SendMessageOpts {
   #[tsify(optional)]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub optimistic: Option<bool>,
+  /// Optional idempotency key. Re-sending identical content with the same key
+  /// produces the same message id and is deduplicated. Defaults to a timestamp.
+  #[tsify(optional)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub idempotency_key: Option<String>,
 }
 
 impl From<SendMessageOpts> for xmtp_mls::groups::send_message_opts::SendMessageOpts {
   fn from(opts: SendMessageOpts) -> Self {
     xmtp_mls::groups::send_message_opts::SendMessageOpts {
       should_push: opts.should_push,
+      idempotency_key: opts.idempotency_key,
     }
   }
 }
@@ -219,11 +225,16 @@ impl Conversation {
     &self,
     #[wasm_bindgen(js_name = encodedContent)] encoded_content: EncodedContent,
     #[wasm_bindgen(js_name = shouldPush)] should_push: bool,
+    #[wasm_bindgen(js_name = idempotencyKey)] idempotency_key: Option<String>,
   ) -> Result<String, JsError> {
     let encoded_content: XmtpEncodedContent = encoded_content.into();
     let group = self.to_mls_group();
     let message_id = group
-      .prepare_message_for_later_publish(encoded_content.encode_to_vec().as_slice(), should_push)
+      .prepare_message_for_later_publish(
+        encoded_content.encode_to_vec().as_slice(),
+        should_push,
+        idempotency_key,
+      )
       .map_err(ErrorWrapper::js)?;
     Ok(hex::encode(message_id))
   }
@@ -250,6 +261,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: TextCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -264,6 +276,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: MarkdownCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -278,6 +291,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: ReactionCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -292,6 +306,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: ReplyCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -302,6 +317,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: ReadReceiptCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -316,6 +332,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: AttachmentCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -331,6 +348,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: RemoteAttachmentCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -346,6 +364,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: MultiRemoteAttachmentCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -361,6 +380,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: TransactionReferenceCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -377,6 +397,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: WalletSendCallsCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -391,6 +412,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: ActionsCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -405,6 +427,7 @@ impl Conversation {
     let opts = SendMessageOpts {
       should_push: IntentCodec::should_push(),
       optimistic,
+      idempotency_key: None,
     };
     self.send(encoded_content.into(), opts).await
   }
@@ -1037,6 +1060,7 @@ mod tests {
       sequence_id: 0,
       expire_at_ns: None,
       should_push: true,
+      idempotency_key: 1738354508964432000i64.to_string(),
     };
     crate::to_value(&stored_message).unwrap();
   }

--- a/crates/xmtp_db/migrations/2026-06-10-000000-0000_add_idempotency_key_to_group_messages/down.sql
+++ b/crates/xmtp_db/migrations/2026-06-10-000000-0000_add_idempotency_key_to_group_messages/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE group_messages
+DROP COLUMN idempotency_key;

--- a/crates/xmtp_db/migrations/2026-06-10-000000-0000_add_idempotency_key_to_group_messages/up.sql
+++ b/crates/xmtp_db/migrations/2026-06-10-000000-0000_add_idempotency_key_to_group_messages/up.sql
@@ -1,0 +1,17 @@
+-- Add idempotency_key to group_messages.
+--
+-- The message id is derived from this key (see `calculate_message_id`), which
+-- historically was always the send timestamp (`sent_at_ns`). Exposing it lets
+-- callers make application-level retries idempotent: re-sending identical
+-- content with the same key yields the same message id, deduped by the PK.
+--
+-- The column is NOT NULL so it is always present (single source of truth). The
+-- constant '' default only exists to satisfy the ALTER for pre-existing rows and
+-- is immediately overwritten by the backfill below; new inserts always supply a
+-- value via the Insertable, so '' never persists.
+ALTER TABLE group_messages
+ADD COLUMN idempotency_key TEXT NOT NULL DEFAULT '';
+
+-- Backfill existing rows with the timestamp, matching the historical key.
+UPDATE group_messages
+SET idempotency_key = CAST(sent_at_ns AS TEXT);

--- a/crates/xmtp_db/src/encrypted_store/group_message.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message.rs
@@ -81,6 +81,9 @@ pub struct StoredGroupMessage {
     pub expire_at_ns: Option<i64>,
     /// Whether to send a push notification when publishing this message
     pub should_push: bool,
+    /// The idempotency key the message id is derived from. Defaults to the send
+    /// timestamp, but callers may supply their own to make retries idempotent.
+    pub idempotency_key: String,
 }
 
 impl StoredGroupMessage {
@@ -111,6 +114,7 @@ struct NewStoredGroupMessage {
     // inserted_at_ns is NOT included - let database set it
     pub expire_at_ns: Option<i64>,
     pub should_push: bool,
+    pub idempotency_key: String,
 }
 
 impl From<&StoredGroupMessage> for NewStoredGroupMessage {
@@ -133,6 +137,7 @@ impl From<&StoredGroupMessage> for NewStoredGroupMessage {
             sequence_id: msg.sequence_id,
             expire_at_ns: msg.expire_at_ns,
             should_push: msg.should_push,
+            idempotency_key: msg.idempotency_key.clone(),
         }
     }
 }

--- a/crates/xmtp_db/src/encrypted_store/group_message/convert.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/convert.rs
@@ -37,6 +37,10 @@ impl TryFrom<GroupMessageSave> for StoredGroupMessage {
             expire_at_ns: None,
             inserted_at_ns: 0,  // Will be set by database
             should_push: false, // Default to false for synced messages
+            // GroupMessageSave does not carry the idempotency key; fall back to
+            // the historical default (the send timestamp). Restored messages are
+            // already published, so this value is only informational.
+            idempotency_key: value.sent_at_ns.to_string(),
         })
     }
 }

--- a/crates/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
@@ -29,6 +29,7 @@ fn generate_message_with_cursor(
         originator_id,
         expire_at_ns: None,
         should_push: true,
+        idempotency_key: sent_at_ns.to_string(),
     }
 }
 

--- a/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -29,6 +29,7 @@ pub(crate) fn generate_message(
         expire_at_ns,
         inserted_at_ns: 0, // Will be set by database
         should_push: true,
+        idempotency_key: String::new(),
     }
 }
 
@@ -597,6 +598,7 @@ pub(crate) fn generate_message_with_reference<C: ConnectionExt>(
         expire_at_ns: None,
         inserted_at_ns: 0, // Will be set by database
         should_push: true,
+        idempotency_key: sent_at_ns.to_string(),
     };
     message.store(conn).unwrap();
     message

--- a/crates/xmtp_db/src/encrypted_store/message_deletion.rs
+++ b/crates/xmtp_db/src/encrypted_store/message_deletion.rs
@@ -226,6 +226,7 @@ mod tests {
             originator_id: 1,
             inserted_at_ns: 0,
             should_push: false,
+            idempotency_key: 1000.to_string(),
         }
         .store(conn)
         .unwrap();

--- a/crates/xmtp_db/src/encrypted_store/schema_gen.rs
+++ b/crates/xmtp_db/src/encrypted_store/schema_gen.rs
@@ -64,6 +64,7 @@ diesel::table! {
         inserted_at_ns -> BigInt,
         expire_at_ns -> Nullable<BigInt>,
         should_push -> Bool,
+        idempotency_key -> Text,
     }
 }
 

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -968,6 +968,9 @@ where
                         expire_at_ns: None, //Question: do we need to include this in conversation last message?
                         inserted_at_ns: 0, // Not used for conversation list display
                         should_push: true, // Not used for conversation list display
+                        // The conversation_list view does not carry the key; use
+                        // the timestamp proxy (display-only, never republished).
+                        idempotency_key: conversation_item.sent_at_ns.unwrap_or_default().to_string(),
                     });
                     if msg.is_none() {
                         tracing::warn!("tried listing message, but message had missing fields so it was skipped");

--- a/crates/xmtp_mls/src/groups/message_list.rs
+++ b/crates/xmtp_mls/src/groups/message_list.rs
@@ -117,6 +117,7 @@ mod tests {
             expire_at_ns: None,
             inserted_at_ns: 0,
             should_push: true,
+            idempotency_key: sent_at_ns.to_string(),
         }
     }
 
@@ -161,6 +162,7 @@ mod tests {
             expire_at_ns: None,
             inserted_at_ns: 0,
             should_push: true,
+            idempotency_key: sent_at_ns.to_string(),
         }
     }
 

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -1442,6 +1442,9 @@ where
                             expire_at_ns: Self::get_message_expire_at_ns(mls_group),
                             inserted_at_ns: 0, // Will be set by database
                             should_push: true,
+                            // Persist the key from the wire envelope — the exact
+                            // key this message id was derived from.
+                            idempotency_key,
                         };
                         message.store_or_ignore(&storage.db())?;
                         identifier.internal_id(message_id);
@@ -2616,6 +2619,8 @@ where
             expire_at_ns: None,
             inserted_at_ns: 0, // Will be set by database
             should_push: true,
+            // Matches the key used to derive `message_id` above.
+            idempotency_key: timestamp_ns.to_string(),
         };
 
         msg.store_or_ignore(&storage.db())?;
@@ -4733,6 +4738,7 @@ pub(crate) mod tests {
             originator_id: 1,
             inserted_at_ns: 0,
             should_push: false,
+            idempotency_key: String::new(),
         };
 
         // Use load_mls_group_with_lock to get access to the MLS group and call process_delete_message
@@ -4800,6 +4806,7 @@ pub(crate) mod tests {
             originator_id: 1,
             inserted_at_ns: 0,
             should_push: false,
+            idempotency_key: String::new(),
         };
 
         let storage = alix.context.mls_storage();
@@ -4874,6 +4881,7 @@ pub(crate) mod tests {
             originator_id: 1,
             inserted_at_ns: 0,
             should_push: false,
+            idempotency_key: String::new(),
         };
 
         let storage = alix.context.mls_storage();

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -1146,7 +1146,7 @@ where
         self.commit_pending_proposals_if_any().await?;
 
         let message_id =
-            self.prepare_message(message, opts, |now| Self::into_envelope(message, now))?;
+            self.prepare_message(message, opts, |key| Self::into_envelope(message, key))?;
 
         self.sync_until_last_intent_resolved().await?;
 
@@ -1217,7 +1217,7 @@ where
         opts: send_message_opts::SendMessageOpts,
     ) -> Result<Vec<u8>, GroupError> {
         let message_id =
-            self.prepare_message(message, opts, |now| Self::into_envelope(message, now))?;
+            self.prepare_message(message, opts, |key| Self::into_envelope(message, key))?;
         Ok(message_id)
     }
 
@@ -1229,17 +1229,23 @@ where
     /// # Arguments
     /// * `message` - The message content bytes
     /// * `should_push` - Whether to send a push notification when publishing
+    /// * `idempotency_key` - Optional caller-supplied key the message id is
+    ///   derived from. Defaults to the send timestamp when `None`.
     ///
     /// Returns the message ID.
     pub fn prepare_message_for_later_publish(
         &self,
         message: &[u8],
         should_push: bool,
+        idempotency_key: Option<String>,
     ) -> Result<Vec<u8>, GroupError> {
         let now = now_ns();
+        // Resolve the key once: a caller-supplied key makes the resulting id
+        // deterministic; otherwise we fall back to the timestamp (always unique).
+        let idempotency_key = idempotency_key.unwrap_or_else(|| now.to_string());
         let queryable_content_fields = Self::extract_queryable_content_fields(message);
 
-        let message_id = calculate_message_id(self.group_id, message, &now.to_string());
+        let message_id = calculate_message_id(self.group_id, message, &idempotency_key);
         let group_message = StoredGroupMessage {
             id: message_id.clone(),
             group_id: self.group_id,
@@ -1259,6 +1265,7 @@ where
             expire_at_ns: None,
             inserted_at_ns: 0,
             should_push,
+            idempotency_key,
         };
         group_message.store(&self.context.db())?;
 
@@ -1294,9 +1301,10 @@ where
             return Ok(());
         }
 
-        // Create envelope from stored message
+        // Create envelope from stored message, reusing the idempotency key the
+        // message id was derived from so receivers recompute the same id.
         let plain_envelope =
-            Self::into_envelope(&message.decrypted_message_bytes, message.sent_at_ns);
+            Self::into_envelope(&message.decrypted_message_bytes, &message.idempotency_key);
         let mut encoded_envelope = vec![];
         plain_envelope.encode(&mut encoded_envelope)?;
 
@@ -1425,20 +1433,24 @@ where
         envelope: F,
     ) -> Result<Vec<u8>, GroupError>
     where
-        F: FnOnce(i64) -> PlaintextEnvelope,
+        F: FnOnce(&str) -> PlaintextEnvelope,
     {
         // Store the message locally first (with should_push preference)
-        let message_id = self.prepare_message_for_later_publish(message, opts.should_push)?;
+        let message_id = self.prepare_message_for_later_publish(
+            message,
+            opts.should_push,
+            opts.idempotency_key,
+        )?;
 
-        // Fetch the stored message to get the sent_at_ns timestamp
+        // Fetch the stored message to get the resolved idempotency key
         let stored_message = self
             .context
             .db()
             .get_group_message(&message_id)?
             .ok_or_else(|| GroupError::NotFound(NotFound::MessageById(message_id.clone())))?;
 
-        // Create envelope using the stored timestamp for consistency
-        let plain_envelope = envelope(stored_message.sent_at_ns);
+        // Create envelope using the stored idempotency key so the id stays consistent
+        let plain_envelope = envelope(&stored_message.idempotency_key);
         let mut encoded_envelope = vec![];
         plain_envelope.encode(&mut encoded_envelope)?;
 
@@ -1452,7 +1464,7 @@ where
         Ok(message_id)
     }
 
-    fn into_envelope(encoded_msg: &[u8], idempotency_key: i64) -> PlaintextEnvelope {
+    fn into_envelope(encoded_msg: &[u8], idempotency_key: &str) -> PlaintextEnvelope {
         PlaintextEnvelope {
             content: Some(Content::V1(V1 {
                 content: encoded_msg.to_vec(),

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -1246,6 +1246,14 @@ where
         let queryable_content_fields = Self::extract_queryable_content_fields(message);
 
         let message_id = calculate_message_id(self.group_id, message, &idempotency_key);
+
+        // Idempotent: a retry with the same key + content resolves to the same id.
+        // Return the existing message rather than failing on the PK conflict, so
+        // crash-recovery retries are at-least-once-with-dedup instead of an error.
+        if let Some(existing) = self.context.db().get_group_message(&message_id)? {
+            return Ok(existing.id);
+        }
+
         let group_message = StoredGroupMessage {
             id: message_id.clone(),
             group_id: self.group_id,

--- a/crates/xmtp_mls/src/groups/send_message_opts.rs
+++ b/crates/xmtp_mls/src/groups/send_message_opts.rs
@@ -4,6 +4,12 @@ use derive_builder::Builder;
 #[derive(Debug, Clone, Builder, Default)]
 pub struct SendMessageOpts {
     pub should_push: bool,
+    /// Optional caller-supplied idempotency key. The message id is derived from
+    /// this key, so re-sending identical content with the same key yields the
+    /// same id and is deduplicated. When `None`, defaults to the send timestamp,
+    /// preserving the historical (always-unique) behavior.
+    #[builder(default)]
+    pub idempotency_key: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/xmtp_mls/src/groups/subscriptions.rs
+++ b/crates/xmtp_mls/src/groups/subscriptions.rs
@@ -328,6 +328,7 @@ pub(crate) mod tests {
                         expire_at_ns: None,
                         inserted_at_ns: 0,
                         should_push: true,
+                        idempotency_key: timestamp.to_string(),
                     }))
                 });
             mock_db
@@ -416,6 +417,7 @@ pub(crate) mod tests {
                         expire_at_ns: None,
                         inserted_at_ns: 0,
                         should_push: true,
+                        idempotency_key: timestamp.to_string(),
                     }))
                 });
             mock_db.expect_future_dependents().returning(|_| Ok(vec![]));

--- a/crates/xmtp_mls/src/groups/tests/test_delete_message.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_delete_message.rs
@@ -280,6 +280,7 @@ async fn test_true_out_of_order_deletion_by_sender() {
         originator_id: 1,
         inserted_at_ns: 0,
         should_push: false,
+        idempotency_key: String::new(),
     };
     delete_message.store(&alix_conn)?;
 
@@ -326,6 +327,7 @@ async fn test_true_out_of_order_deletion_by_sender() {
         originator_id: 1,
         inserted_at_ns: 0,
         should_push: false,
+        idempotency_key: String::new(),
     };
     message.store(&alix_conn)?;
 
@@ -400,6 +402,7 @@ async fn test_out_of_order_unauthorized_deletion_rejected() {
         originator_id: 1,
         inserted_at_ns: 0,
         should_push: false,
+        idempotency_key: String::new(),
     };
     malicious_delete_message.store(&bo_conn)?;
 
@@ -438,6 +441,7 @@ async fn test_out_of_order_unauthorized_deletion_rejected() {
         originator_id: 1,
         inserted_at_ns: 0,
         should_push: false,
+        idempotency_key: String::new(),
     };
     message.store(&bo_conn)?;
 
@@ -1006,6 +1010,7 @@ async fn test_out_of_order_sender_deletion_shows_correct_deleted_by() {
         originator_id: 1,
         inserted_at_ns: 0,
         should_push: false,
+        idempotency_key: String::new(),
     };
     delete_message.store(&alix_conn)?;
 
@@ -1043,6 +1048,7 @@ async fn test_out_of_order_sender_deletion_shows_correct_deleted_by() {
         originator_id: 1,
         inserted_at_ns: 0,
         should_push: false,
+        idempotency_key: String::new(),
     };
     original_message.store(&alix_conn)?;
 

--- a/crates/xmtp_mls/src/groups/tests/test_prepare_message_for_later_publish.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_prepare_message_for_later_publish.rs
@@ -167,6 +167,31 @@ async fn test_default_idempotency_key_is_unique_per_send() {
     );
 }
 
+/// Re-preparing the same content with the same explicit key is idempotent: it
+/// returns the existing message id instead of erroring on the PK conflict, and
+/// does not create a duplicate row. This is the sender side of
+/// at-least-once-with-dedup (e.g. a crash-recovery retry).
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_duplicate_idempotency_key_is_idempotent() {
+    tester!(alix);
+    let group = alix.create_group(None, None)?;
+
+    let key = "retry-key".to_string();
+    let id_1 = group.prepare_message_for_later_publish(b"retry me", true, Some(key.clone()))?;
+    // Second identical prepare must not error and must return the same id.
+    let id_2 = group.prepare_message_for_later_publish(b"retry me", true, Some(key))?;
+
+    assert_eq!(id_1, id_2);
+
+    // Only one row was stored.
+    let messages = group.find_messages(&MsgQueryArgs {
+        kind: Some(GroupMessageKind::Application),
+        ..Default::default()
+    })?;
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].id, id_1);
+}
+
 /// End-to-end: the idempotency key rides the wire so the receiver recomputes the
 /// exact same message id. This is the foundation of at-least-once-with-dedup:
 /// a retry of identical content with the same key collapses to one message id.

--- a/crates/xmtp_mls/src/groups/tests/test_prepare_message_for_later_publish.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_prepare_message_for_later_publish.rs
@@ -1,5 +1,7 @@
 use crate::groups::DeliveryStatus;
+use crate::groups::send_message_opts::SendMessageOpts;
 use crate::tester;
+use crate::utils::id::calculate_message_id;
 use xmtp_db::group_message::{GroupMessageKind, MsgQueryArgs};
 
 /// Test that `prepare_message_for_later_publish` stores messages locally with Unpublished status
@@ -9,7 +11,7 @@ async fn test_prepare_message_stores_unpublished() {
     tester!(alix);
     let group = alix.create_group(None, None)?;
 
-    let message_id = group.prepare_message_for_later_publish(b"test message", true)?;
+    let message_id = group.prepare_message_for_later_publish(b"test message", true, None)?;
 
     let messages = group.find_messages(&MsgQueryArgs {
         kind: Some(GroupMessageKind::Application),
@@ -28,7 +30,7 @@ async fn test_publish_messages_does_not_publish_prepared_messages() {
     tester!(alix);
     let group = alix.create_group(None, None)?;
 
-    let message_id = group.prepare_message_for_later_publish(b"prepared message", true)?;
+    let message_id = group.prepare_message_for_later_publish(b"prepared message", true, None)?;
 
     // publish_messages should be a no-op for prepared messages (no intent was created)
     group.publish_messages().await?;
@@ -49,7 +51,7 @@ async fn test_publish_stored_message_publishes_prepared_message() {
     tester!(alix);
     let group = alix.create_group(None, None)?;
 
-    let message_id = group.prepare_message_for_later_publish(b"test message", true)?;
+    let message_id = group.prepare_message_for_later_publish(b"test message", true, None)?;
     assert_eq!(
         group.find_messages(&MsgQueryArgs::default())?[0].delivery_status,
         DeliveryStatus::Unpublished
@@ -75,7 +77,7 @@ async fn test_publish_stored_message_is_idempotent() {
     tester!(alix);
     let group = alix.create_group(None, None)?;
 
-    let message_id = group.prepare_message_for_later_publish(b"idempotent test", true)?;
+    let message_id = group.prepare_message_for_later_publish(b"idempotent test", true, None)?;
 
     // Publish three times - should not error or create duplicates
     group.publish_stored_message(&message_id).await?;
@@ -98,9 +100,9 @@ async fn test_selective_publish_of_prepared_messages() {
     tester!(alix);
     let group = alix.create_group(None, None)?;
 
-    let id_1 = group.prepare_message_for_later_publish(b"message one", true)?;
-    let id_2 = group.prepare_message_for_later_publish(b"message two", true)?;
-    let _id_3 = group.prepare_message_for_later_publish(b"message three", true)?;
+    let id_1 = group.prepare_message_for_later_publish(b"message one", true, None)?;
+    let id_2 = group.prepare_message_for_later_publish(b"message two", true, None)?;
+    let _id_3 = group.prepare_message_for_later_publish(b"message three", true, None)?;
 
     // Only publish messages 1 and 2
     group.publish_stored_message(&id_1).await?;
@@ -126,4 +128,85 @@ async fn test_selective_publish_of_prepared_messages() {
     assert_eq!(published.len(), 2);
     assert_eq!(unpublished.len(), 1);
     assert_eq!(unpublished[0].decrypted_message_bytes, b"message three");
+}
+
+/// A caller-supplied idempotency key fully determines the message id (instead of
+/// a timestamp) and is persisted on the stored message.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_explicit_idempotency_key_produces_deterministic_id() {
+    tester!(alix);
+    let group = alix.create_group(None, None)?;
+
+    let key = "stable-key-123".to_string();
+    let content = b"hello idempotent";
+    let id = group.prepare_message_for_later_publish(content, true, Some(key.clone()))?;
+
+    // The id is derived from the supplied key, not from a timestamp.
+    assert_eq!(id, calculate_message_id(group.group_id, content, &key));
+
+    // The resolved key is persisted alongside the message.
+    let stored = group.find_messages(&MsgQueryArgs::default())?;
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].id, id);
+    assert_eq!(stored[0].idempotency_key, key);
+}
+
+/// Without an explicit key, two identical-content sends still get distinct ids
+/// (the timestamp default), preserving the historical always-unique behavior.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_default_idempotency_key_is_unique_per_send() {
+    tester!(alix);
+    let group = alix.create_group(None, None)?;
+
+    let id_1 = group.prepare_message_for_later_publish(b"same content", true, None)?;
+    let id_2 = group.prepare_message_for_later_publish(b"same content", true, None)?;
+
+    assert_ne!(
+        id_1, id_2,
+        "default (timestamp) keys must yield unique message ids"
+    );
+}
+
+/// End-to-end: the idempotency key rides the wire so the receiver recomputes the
+/// exact same message id. This is the foundation of at-least-once-with-dedup:
+/// a retry of identical content with the same key collapses to one message id.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_idempotency_key_crosses_the_wire() {
+    tester!(alix);
+    tester!(bo);
+    let group = alix.create_group(None, None)?;
+    group.add_members(&[bo.inbox_id()]).await?;
+
+    let key = "wire-key-xyz".to_string();
+    let content = b"crash-safe message";
+    let sent_id = group
+        .send_message(
+            content,
+            SendMessageOpts {
+                should_push: true,
+                idempotency_key: Some(key.clone()),
+            },
+        )
+        .await?;
+
+    // bo receives the message and must derive the same id from the shared key.
+    let bo_groups = bo.sync_welcomes().await?;
+    let bo_group = &bo_groups[0];
+    bo_group.sync().await?;
+
+    let received = bo_group
+        .find_messages(&MsgQueryArgs {
+            kind: Some(GroupMessageKind::Application),
+            ..Default::default()
+        })?
+        .into_iter()
+        .find(|m| m.decrypted_message_bytes == content)
+        .expect("bo should receive the message");
+
+    assert_eq!(received.id, sent_id);
+    assert_eq!(
+        received.id,
+        calculate_message_id(bo_group.group_id, content, &key)
+    );
+    assert_eq!(received.idempotency_key, key);
 }

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -535,10 +535,11 @@ where
         let mut encoded_added_payload_bytes = Vec::new();
         encoded_added_payload.encode(&mut encoded_added_payload_bytes)?;
 
+        let added_idempotency_key = format!("{}_welcome_added", welcome.created_ns);
         let added_message_id = crate::utils::id::calculate_message_id(
             stored_group.id,
             encoded_added_payload_bytes.as_slice(),
-            &format!("{}_welcome_added", welcome.created_ns),
+            &added_idempotency_key,
         );
 
         let added_content_type = encoded_added_payload.r#type.unwrap_or_else(|| {
@@ -575,6 +576,8 @@ where
             expire_at_ns: None,
             inserted_at_ns: 0, // Will be set by database
             should_push: true,
+            // Matches the key used to derive `added_message_id` above.
+            idempotency_key: added_idempotency_key,
         };
 
         added_msg.store_or_ignore(&db)?;

--- a/crates/xmtp_mls/src/messages/tests/test_deletion_validation.rs
+++ b/crates/xmtp_mls/src/messages/tests/test_deletion_validation.rs
@@ -32,6 +32,7 @@ fn create_test_message(
         originator_id: 1,
         inserted_at_ns: 0,
         should_push: false,
+        idempotency_key: 1000.to_string(),
     }
 }
 

--- a/crates/xmtp_mls/src/test/mock/generate.rs
+++ b/crates/xmtp_mls/src/test/mock/generate.rs
@@ -176,5 +176,6 @@ pub fn generate_stored_msg(
         expire_at_ns: None,
         inserted_at_ns: 0,
         should_push: true,
+        idempotency_key: 100.to_string(),
     }
 }

--- a/crates/xmtp_mls/src/utils/cleanup_duplicate_updates.rs
+++ b/crates/xmtp_mls/src/utils/cleanup_duplicate_updates.rs
@@ -160,6 +160,7 @@ mod tests {
                 expire_at_ns: None,
                 inserted_at_ns: 0,
                 should_push: true,
+                idempotency_key: String::new(),
             }
         };
 

--- a/crates/xmtp_mls/src/worker/device_sync/mod.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/mod.rs
@@ -321,11 +321,14 @@ where
 
         let message_id = sync_group.prepare_message(
             &content_bytes,
-            send_message_opts::SendMessageOpts { should_push: false },
-            |now| PlaintextEnvelope {
+            send_message_opts::SendMessageOpts {
+                should_push: false,
+                idempotency_key: None,
+            },
+            |key| PlaintextEnvelope {
                 content: Some(Content::V1(V1 {
                     content: content_bytes.clone(),
-                    idempotency_key: now.to_string(),
+                    idempotency_key: key.to_string(),
                 })),
             },
         )?;

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Dm.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Dm.kt
@@ -165,7 +165,7 @@ class Dm(
     ): String =
         withContext(Dispatchers.IO) {
             if (noSend) {
-                libXMTPGroup.prepareMessage(encodedContent.toByteArray(), opts.shouldPush).toHex()
+                libXMTPGroup.prepareMessage(encodedContent.toByteArray(), opts.shouldPush, null).toHex()
             } else {
                 libXMTPGroup.sendOptimistic(encodedContent.toByteArray(), opts.toFfi()).toHex()
             }

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -210,7 +210,7 @@ class Group(
     ): String =
         withContext(Dispatchers.IO) {
             if (noSend) {
-                libXMTPGroup.prepareMessage(encodedContent.toByteArray(), opts.shouldPush).toHex()
+                libXMTPGroup.prepareMessage(encodedContent.toByteArray(), opts.shouldPush, null).toHex()
             } else {
                 libXMTPGroup.sendOptimistic(encodedContent.toByteArray(), opts.toFfi()).toHex()
             }

--- a/sdks/ios/Sources/XMTPiOS/Dm.swift
+++ b/sdks/ios/Sources/XMTPiOS/Dm.swift
@@ -235,7 +235,8 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		if noSend {
 			messageId = try ffiConversation.prepareMessage(
 				contentBytes: encodedContent.serializedData(),
-				shouldPush: shouldPush
+				shouldPush: shouldPush,
+				idempotencyKey: nil
 			)
 		} else {
 			let opts = visibilityOptions?.toFfi() ?? FfiSendMessageOpts(shouldPush: true)

--- a/sdks/ios/Sources/XMTPiOS/Group.swift
+++ b/sdks/ios/Sources/XMTPiOS/Group.swift
@@ -478,7 +478,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 		if noSend {
 			messageId = try ffiGroup.prepareMessage(
 				contentBytes: encodedContent.serializedData(),
-				shouldPush: shouldPush
+				shouldPush: shouldPush,
+				idempotencyKey: nil
 			)
 		} else {
 			let opts = visibilityOptions?.toFfi() ?? FfiSendMessageOpts(shouldPush: true)

--- a/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -1341,7 +1341,7 @@ public protocol FfiConversationProtocol: AnyObject, Sendable {
      * Prepare a message for later publishing.
      * Stores the message locally without publishing. Returns the message ID.
      */
-    func prepareMessage(contentBytes: Data, shouldPush: Bool) throws  -> Data
+    func prepareMessage(contentBytes: Data, shouldPush: Bool, idempotencyKey: String?) throws  -> Data
     
     func processStreamedConversationMessage(envelopeBytes: Data) async throws  -> [FfiMessage]
     
@@ -1869,12 +1869,13 @@ open func pausedForVersion()throws  -> String?  {
      * Prepare a message for later publishing.
      * Stores the message locally without publishing. Returns the message ID.
      */
-open func prepareMessage(contentBytes: Data, shouldPush: Bool)throws  -> Data  {
+open func prepareMessage(contentBytes: Data, shouldPush: Bool, idempotencyKey: String?)throws  -> Data  {
     return try  FfiConverterData.lift(try rustCallWithError(FfiConverterTypeFfiError_lift) {
     uniffi_xmtpv3_fn_method_fficonversation_prepare_message(
             self.uniffiCloneHandle(),
         FfiConverterData.lower(contentBytes),
-        FfiConverterBool.lower(shouldPush),$0
+        FfiConverterBool.lower(shouldPush),
+        FfiConverterOptionString.lower(idempotencyKey),$0
     )
 })
 }
@@ -6282,11 +6283,21 @@ public struct DbOptions: Equatable, Hashable {
     public var encryptionKey: Data?
     public var maxDbPoolSize: UInt32?
     public var minDbPoolSize: UInt32?
+    /**
+     * When true, use a single DB connection instead of a pool (one file
+     * descriptor). Pool-size options are ignored. Defaults to unset so existing
+     * foreign callers that construct `DbOptions` without this field still compile.
+     */
     public var useSingleConnection: Bool?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(db: String?, encryptionKey: Data?, maxDbPoolSize: UInt32?, minDbPoolSize: UInt32?, useSingleConnection: Bool? = nil) {
+    public init(db: String?, encryptionKey: Data?, maxDbPoolSize: UInt32?, minDbPoolSize: UInt32?, 
+        /**
+         * When true, use a single DB connection instead of a pool (one file
+         * descriptor). Pool-size options are ignored. Defaults to unset so existing
+         * foreign callers that construct `DbOptions` without this field still compile.
+         */useSingleConnection: Bool? = nil) {
         self.db = db
         self.encryptionKey = encryptionKey
         self.maxDbPoolSize = maxDbPoolSize
@@ -6310,10 +6321,10 @@ public struct FfiConverterTypeDbOptions: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DbOptions {
         return
             try DbOptions(
-                db: FfiConverterOptionString.read(from: &buf),
-                encryptionKey: FfiConverterOptionData.read(from: &buf),
-                maxDbPoolSize: FfiConverterOptionUInt32.read(from: &buf),
-                minDbPoolSize: FfiConverterOptionUInt32.read(from: &buf),
+                db: FfiConverterOptionString.read(from: &buf), 
+                encryptionKey: FfiConverterOptionData.read(from: &buf), 
+                maxDbPoolSize: FfiConverterOptionUInt32.read(from: &buf), 
+                minDbPoolSize: FfiConverterOptionUInt32.read(from: &buf), 
                 useSingleConnection: FfiConverterOptionBool.read(from: &buf)
         )
     }
@@ -9422,11 +9433,25 @@ public func FfiConverterTypeFfiReply_lower(_ value: FfiReply) -> RustBuffer {
 
 public struct FfiSendMessageOpts: Equatable, Hashable {
     public var shouldPush: Bool
+    /**
+     * Optional idempotency key. Re-sending identical content with the same key
+     * produces the same message id and is deduplicated. Defaults to a timestamp.
+     * Defaults to unset so existing foreign callers that construct
+     * `FfiSendMessageOpts` without this field still compile.
+     */
+    public var idempotencyKey: String?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(shouldPush: Bool) {
+    public init(shouldPush: Bool, 
+        /**
+         * Optional idempotency key. Re-sending identical content with the same key
+         * produces the same message id and is deduplicated. Defaults to a timestamp.
+         * Defaults to unset so existing foreign callers that construct
+         * `FfiSendMessageOpts` without this field still compile.
+         */idempotencyKey: String? = nil) {
         self.shouldPush = shouldPush
+        self.idempotencyKey = idempotencyKey
     }
 
     
@@ -9445,12 +9470,14 @@ public struct FfiConverterTypeFfiSendMessageOpts: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiSendMessageOpts {
         return
             try FfiSendMessageOpts(
-                shouldPush: FfiConverterBool.read(from: &buf)
+                shouldPush: FfiConverterBool.read(from: &buf), 
+                idempotencyKey: FfiConverterOptionString.read(from: &buf)
         )
     }
 
     public static func write(_ value: FfiSendMessageOpts, into buf: inout [UInt8]) {
         FfiConverterBool.write(value.shouldPush, into: &buf)
+        FfiConverterOptionString.write(value.idempotencyKey, into: &buf)
     }
 }
 
@@ -16289,7 +16316,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_fficonversation_paused_for_version() != 17083) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_method_fficonversation_prepare_message() != 38231) {
+    if (uniffi_xmtpv3_checksum_method_fficonversation_prepare_message() != 48127) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonversation_process_streamed_conversation_message() != 45021) {


### PR DESCRIPTION
## Summary

Application messages could not be made idempotent: every send entry point hardcoded `idempotency_key = now_ns()`, so an application-level retry of identical content always produced a **new** message id. This exposes an optional, caller-settable `idempotency_key`.

The message id is derived from this key (`calculate_message_id(group_id, content, key)`) and the key rides the wire via `PlaintextEnvelope.V1.idempotency_key`, so receivers recompute the same id and deduplicate via the existing `group_messages` PK constraint — enabling **at-least-once-with-dedup** semantics for durable agent runtimes.

Closes #3750

## Changes

**Core (`xmtp_mls`)**
- `SendMessageOpts.idempotency_key: Option<String>` — defaults to `now_ns().to_string()`, preserving current (always-unique) behavior.
- Threaded through `send_message`, `send_message_optimistic`, `prepare_message_for_later_publish`, and `publish_stored_message` (which now reuses the stored key so the wire id matches). `into_envelope` takes `&str`.

**Storage (`xmtp_db`)**
- New migration adds a non-null `idempotency_key` column to `group_messages` (`NOT NULL DEFAULT ''` + backfill `= CAST(sent_at_ns AS TEXT)`; the `''` default never persists — new inserts always supply a value). No table rebuild.
- `StoredGroupMessage.idempotency_key: String` — every construction site persists the exact key its id derives from (incoming messages use the wire-envelope key; group-updates/welcomes use their respective keys; device-sync restore falls back to the timestamp).

**Bindings**
- `idempotencyKey` surfaced on `SendMessageOpts`/`FfiSendMessageOpts` and the `prepareMessage` entry point in **node**, **wasm**, and **mobile**.

## Tests
- New: `test_explicit_idempotency_key_produces_deterministic_id`, `test_default_idempotency_key_is_unique_per_send`, and an end-to-end `test_idempotency_key_crosses_the_wire` (proves the key rides the wire and the receiver derives the same id).
- Verified locally: `xmtp_mls` prepare-message suite (8) + regression sweep (delete/welcome/cleanup/message_list/subscriptions, 73), `xmtp_db` (56), `xmtp_archive` (5). `clippy`/`fmt` clean on touched crates.

## Notes / follow-ups
- **wasm** was not compiled locally (no Nix in this environment); it mirrors the node change and needs `just wasm check` in CI.
- **Downstream deferred** (out of scope here): `@xmtp/node-sdk` re-exports `SendMessageOpts` from the bindings, so `idempotencyKey` flows through once a new `@xmtp/node-bindings` is published; convos-cli then passes `{ idempotencyKey }` at its retry site.
- **Known limitation:** the device-sync `GroupMessageSave` proto carries no idempotency key, so restored messages fall back to `sent_at_ns.to_string()` (harmless — already published). A proto field is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose caller-settable `idempotency_key` for message deduplication across FFI bindings
> - Adds an optional `idempotency_key` field to `SendMessageOpts` in the core Rust library and propagates it through all FFI layers (mobile, WASM, Node, iOS, Android).
> - When a key is provided, `prepare_message_for_later_publish` derives the `message_id` deterministically from `(group_id, content, idempotency_key)`; repeated calls with the same key return the existing message ID without creating duplicates.
> - When no key is provided, a unique timestamp-based key is generated per send, preserving existing behavior.
> - Adds a new `idempotency_key` column to the `group_messages` DB table via migration; existing rows are backfilled from `sent_at_ns`.
> - `publish_stored_message` now passes the stored `idempotency_key` in the wire envelope so receivers derive the same `message_id` as the sender.
> - Risk: the DB migration adds a `NOT NULL` column with a default backfill — schema change requires migration on all existing databases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75e982a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->