### PR TITLE
fix(xmtp_mls): propagate retryable errors from own self-publish reaction handlers

### DIFF
--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -1075,9 +1075,61 @@ where
         if message_expire_at_ns.is_some() {
             *disappearing_stored = true;
         }
-        self.process_own_leave_request_message(mls_group, storage, &id);
-        self.process_own_delete_message(storage, &id);
+        // Best-effort follow-ups on our own just-published message. The message
+        // is already published and its delivery status persisted; these only
+        // update local state (leave / delete). A retryable storage failure must
+        // still roll the sync back and retry, matching the rest of
+        // process_message_inner; a non-retryable failure is logged and swallowed
+        // because re-publishing won't help and the local reaction is genuinely
+        // best-effort here.
+        self.resolve_own_reaction(
+            self.process_own_leave_request_message(mls_group, storage, &id),
+            intent,
+            &id,
+            "leave request",
+        )?;
+        self.resolve_own_reaction(
+            self.process_own_delete_message(storage, &id),
+            intent,
+            &id,
+            "delete",
+        )?;
         Ok(Some(id))
+    }
+
+    /// Resolve the result of a best-effort follow-up reaction on our own
+    /// just-published message.
+    ///
+    /// Retryable failures become an [`IntentResolutionError`] so the caller
+    /// rolls the sync transaction back and retries (the message was already
+    /// published, so the optimistic row is untouched on rollback). Non-retryable
+    /// failures are logged and swallowed: the publish already succeeded and
+    /// re-running won't help, so we don't wedge the intent.
+    fn resolve_own_reaction(
+        &self,
+        result: Result<(), GroupMessageProcessingError>,
+        intent: &StoredGroupIntent,
+        message_id: &[u8],
+        reaction: &str,
+    ) -> Result<(), IntentResolutionError> {
+        match result {
+            Ok(()) => Ok(()),
+            Err(err) if err.is_retryable() => Err(IntentResolutionError {
+                processing_error: err,
+                // Unused on the retryable path: the caller returns the
+                // processing_error directly (rollback + retry) rather than
+                // transitioning the intent to this state.
+                next_intent_state: intent.state,
+            }),
+            Err(err) => {
+                tracing::warn!(
+                    group_id = %self.group_id,
+                    message_id = hex::encode(message_id),
+                    "non-retryable error processing own {reaction} reaction, skipping: {err}"
+                );
+                Ok(())
+            }
+        }
     }
 
     #[tracing::instrument(level = "trace", skip(mls_group, envelope))]
@@ -1596,46 +1648,58 @@ where
         mls_group: &OpenMlsGroup,
         storage: &impl XmtpMlsStorageProvider,
         message_id: &[u8],
-    ) {
-        if let Ok(Some(message)) = storage.db().get_group_message(message_id)
-            && message.content_type == ContentType::LeaveRequest
-        {
-            match self.process_leave_request_message(mls_group, storage, &message, None) {
-                Ok(()) => {
-                    debug!("Successfully processed leave request message");
-                }
-                Err(e) => {
-                    debug!("Failed to process leave request message: {}", e);
-                }
-            }
+    ) -> Result<(), GroupMessageProcessingError> {
+        #[cfg(any(test, feature = "test-utils"))]
+        crate::utils::test_mocks_helpers::maybe_mock_own_reaction_retryable_error()?;
+
+        // Propagate read failures (`?`) instead of dropping them: a retryable
+        // storage error here must roll the sync back and retry. A missing row is
+        // still a benign no-op.
+        let Some(message) = storage.db().get_group_message(message_id)? else {
+            return Ok(());
+        };
+        // Not a leave request: correct early return, not an error.
+        if message.content_type != ContentType::LeaveRequest {
+            return Ok(());
         }
+
+        self.process_leave_request_message(mls_group, storage, &message, None)
     }
 
-    fn process_own_delete_message(&self, storage: &impl XmtpMlsStorageProvider, message_id: &[u8]) {
+    fn process_own_delete_message(
+        &self,
+        storage: &impl XmtpMlsStorageProvider,
+        message_id: &[u8],
+    ) -> Result<(), GroupMessageProcessingError> {
+        #[cfg(any(test, feature = "test-utils"))]
+        crate::utils::test_mocks_helpers::maybe_mock_own_reaction_retryable_error()?;
+
         let db = storage.db();
 
-        let Ok(Some(message)) = db.get_group_message(message_id) else {
-            return;
+        // Propagate read failures (`?`); a missing row remains a benign no-op,
+        // handled by the `else` arms below.
+        let Some(message) = db.get_group_message(message_id)? else {
+            return Ok(());
         };
 
         if message.content_type != ContentType::DeleteMessage {
-            return;
+            return Ok(());
         }
 
-        let Ok(Some(deletion)) = db.get_message_deletion(message_id) else {
+        let Some(deletion) = db.get_message_deletion(message_id)? else {
             tracing::warn!(
                 message_id = hex::encode(message_id),
                 "Deletion record not found for own delete message"
             );
-            return;
+            return Ok(());
         };
 
-        let Ok(Some(original_msg)) = db.get_group_message(&deletion.deleted_message_id) else {
+        let Some(original_msg) = db.get_group_message(&deletion.deleted_message_id)? else {
             tracing::debug!(
                 deleted_message_id = hex::encode(&deletion.deleted_message_id),
                 "Original message not found for deletion event (may be out-of-order)"
             );
-            return;
+            return Ok(());
         };
 
         let _ = self
@@ -1644,6 +1708,8 @@ where
             .send(crate::subscriptions::LocalEvents::MsgsDeleted(vec![
                 original_msg,
             ]));
+
+        Ok(())
     }
 
     fn process_leave_request_message(
@@ -4890,6 +4956,104 @@ pub(crate) mod tests {
         assert!(
             result.is_ok(),
             "Invalid hex message_id should not cause error"
+        );
+    }
+
+    /// The self-publish follow-up reaction handlers must *surface* a retryable
+    /// storage failure (so the sync transaction rolls back and retries) instead
+    /// of silently swallowing it. Regression guard for the dropped-error paths
+    /// in `process_own_leave_request_message` / `process_own_delete_message`.
+    #[xmtp_common::test(flavor = "current_thread", unwrap_try = true)]
+    async fn test_own_reaction_handlers_surface_retryable_errors() {
+        use crate::tester;
+        use crate::utils::test_mocks_helpers::set_test_mode_own_reaction_retryable_error;
+
+        tester!(alix);
+        let alix_group = alix.create_group(None, None)?;
+        let storage = alix.context.mls_storage();
+        let message_id = vec![1, 2, 3];
+
+        // Inject a transient (retryable) storage error into both handlers.
+        set_test_mode_own_reaction_retryable_error(true);
+
+        let leave_result = alix_group.load_mls_group_with_lock(storage, |mls_group| {
+            Ok::<_, crate::groups::GroupError>(alix_group.process_own_leave_request_message(
+                &mls_group,
+                storage,
+                &message_id,
+            ))
+        })?;
+        assert!(
+            matches!(&leave_result, Err(e) if e.is_retryable()),
+            "own leave-request handler should surface the retryable error, got {leave_result:?}"
+        );
+
+        let delete_result = alix_group.process_own_delete_message(storage, &message_id);
+        assert!(
+            matches!(&delete_result, Err(e) if e.is_retryable()),
+            "own delete handler should surface the retryable error, got {delete_result:?}"
+        );
+
+        // With the fault cleared, a message id with no stored row is a benign
+        // no-op (Ok), not an error — the missing-row guards still hold.
+        set_test_mode_own_reaction_retryable_error(false);
+
+        let leave_ok = alix_group.load_mls_group_with_lock(storage, |mls_group| {
+            Ok::<_, crate::groups::GroupError>(alix_group.process_own_leave_request_message(
+                &mls_group,
+                storage,
+                &message_id,
+            ))
+        })?;
+        assert!(
+            leave_ok.is_ok(),
+            "expected benign no-op for missing leave-request row, got {leave_ok:?}"
+        );
+        assert!(
+            alix_group
+                .process_own_delete_message(storage, &message_id)
+                .is_ok(),
+            "expected benign no-op for missing delete row"
+        );
+
+        // End-to-end: the same fault must surface through the real sync path,
+        // not just the handler return value. Publish an own message, inject
+        // the retryable failure, and receive: the sync transaction must roll
+        // back and report the failure in the process summary instead of
+        // silently succeeding.
+        use crate::groups::send_message_opts::SendMessageOpts;
+
+        alix_group.sync().await?;
+        alix_group.send_message_optimistic(b"own message", SendMessageOpts::default())?;
+        alix_group.publish_intents().await?;
+
+        set_test_mode_own_reaction_retryable_error(true);
+        let summary = alix_group.receive().await?;
+        set_test_mode_own_reaction_retryable_error(false);
+        assert!(
+            !summary.errored.is_empty(),
+            "retryable failure in an own-reaction handler should be reported by the sync, got {summary:?}"
+        );
+        assert!(
+            summary.errored.iter().all(|(_, e)| e.is_retryable()),
+            "the injected failure should still be retryable when surfaced, got {summary:?}"
+        );
+        assert!(
+            summary.new_messages.is_empty(),
+            "the message must not count as processed while its reaction fails retryably, got {summary:?}"
+        );
+
+        // The rollback left the cursor untouched: with the fault cleared, the
+        // same message is re-processed successfully on the next sync.
+        let summary = alix_group.receive().await?;
+        assert!(
+            summary.errored.is_empty(),
+            "re-sync after clearing the fault should succeed, got {summary:?}"
+        );
+        assert_eq!(
+            summary.new_messages.len(),
+            1,
+            "the rolled-back message should be processed on retry, got {summary:?}"
         );
     }
 

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -4963,6 +4963,11 @@ pub(crate) mod tests {
     /// storage failure (so the sync transaction rolls back and retries) instead
     /// of silently swallowing it. Regression guard for the dropped-error paths
     /// in `process_own_leave_request_message` / `process_own_delete_message`.
+    ///
+    /// Not on wasm: the fault injection uses an env-var flag, and wasm targets
+    /// cannot set environment variables (same gating as the other
+    /// `test_mocks_helpers` based tests).
+    #[cfg(not(target_arch = "wasm32"))]
     #[xmtp_common::test(flavor = "current_thread", unwrap_try = true)]
     async fn test_own_reaction_handlers_surface_retryable_errors() {
         use crate::tester;

--- a/crates/xmtp_mls/src/utils/test/test_mocks_helpers.rs
+++ b/crates/xmtp_mls/src/utils/test/test_mocks_helpers.rs
@@ -151,3 +151,32 @@ pub fn maybe_mock_package_lifetime() -> Lifetime {
         Lifetime::default()
     }
 }
+
+/* ---------- own-reaction follow-up storage fault ---------- */
+
+const OWN_REACTION_RETRYABLE_ERROR: EnvFlag = EnvFlag("TEST_MODE_OWN_REACTION_RETRYABLE_ERROR");
+
+/// Toggle injection of a retryable storage error into the self-publish
+/// follow-up reaction handlers (`process_own_leave_request_message` and
+/// `process_own_delete_message`). Used to prove those handlers surface a
+/// transient failure instead of silently swallowing it.
+#[inline]
+pub fn set_test_mode_own_reaction_retryable_error(enable: bool) {
+    OWN_REACTION_RETRYABLE_ERROR.set(enable);
+}
+
+#[inline]
+pub fn is_test_mode_own_reaction_retryable_error() -> bool {
+    OWN_REACTION_RETRYABLE_ERROR.get()
+}
+
+/// If the flag is set, fail with a *retryable* storage error, standing in for a
+/// transient DB read failure inside the own-reaction follow-up handlers.
+pub fn maybe_mock_own_reaction_retryable_error() -> Result<(), GroupMessageProcessingError> {
+    if is_test_mode_own_reaction_retryable_error() {
+        return Err(GroupMessageProcessingError::Db(
+            xmtp_db::ConnectionError::ReconnectInTransaction,
+        ));
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes #3747

## Problem

When you do something in a group like leaving it, or deleting one of your own messages, your app first publishes that action to the network, then gets it back and runs a little followup step locally to update your status. Something like "I want to leave the group" (`process_own_leave_request_message`) and "I deleted a message" (`process_own_delete_message`).

Those two followups had a bad habit: if something went wrong while they ran, they just quietly threw the error away. One will catch the failure and only write a simple debug line, the other will use a coding shortcut that treats "the database read failed" exactly like "nothing found" and just returns as if all was well.

The problem is that some of these failures are actually temporary, like the database was briefly busy or a little connection shake. Everywhere else in the sync code, a temporary failure causes the system to roll back and try again. However, on these two specific paths, a temporary failure during a leave or delete silently drops. The operation incorrectly appears successful when in fact it failed.

## Fix

Both handlers now return `Result` and pass database read errors up with `?` instead of hiding them. A missing row or a different content type is still a normal early return, since those cases are genuinely fine.

A new `resolve_own_reaction` helper in `process_own_message` decides what to do with a failure:
- retryable: forward it, so the sync transaction rolls back and the message is retried, same as the rest of the processing path.
- non-retryable: log it at `warn!` with the group and message ids and move on, because the message is already published and retrying won't help.

The reasoning is documented in comments at the call site so the intent is clear to the next reader.

## Testing

Added `test_own_reaction_handlers_surface_retryable_errors`. It injects a retryable storage error into both handlers and checks two things: the handlers themselves return the error, and the error survives the full sync path. The end-to-end part publishes a real message, makes the reaction fail, and asserts that the sync reports the failure in its summary without counting the message as processed. It then clears the fault and confirms the same message is processed cleanly on the next sync, proving the rollback left the cursor in the right place.

Existing `test_self_removal*` and delete-message tests still pass, and clippy and rustfmt are clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate retryable errors from own leave/delete reaction handlers in `MlsGroup`
> - `process_own_leave_request_message` and `process_own_delete_message` now return `Result<(), GroupMessageProcessingError>` instead of swallowing errors, so database read failures can trigger sync transaction rollback and retry.
> - A new `resolve_own_reaction` helper in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/3758/files#diff-160aadcd7de477c1116260a79601a0548842f3bd91bf16bd8443debb66ce6684) maps handler results: retryable errors become `IntentResolutionError` (triggering rollback), non-retryable errors are logged at `warn` and skipped, and missing rows are treated as benign no-ops.
> - A fault-injection flag `TEST_MODE_OWN_REACTION_RETRYABLE_ERROR` is added in [test_mocks_helpers.rs](https://github.com/xmtp/libxmtp/pull/3758/files#diff-f76127127f3ea73dae0d461d6e7b322b38389a7235ff1cbbfb85cf8c9eaa46d7) with a regression test that verifies retryable errors surface correctly and that clearing the fault allows a subsequent sync to succeed.
> - Behavioral Change: own-reaction failures that were previously silently ignored will now cause the sync transaction to roll back and be retried if the error is retryable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66fdd7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->