### PR TITLE
fix: false positive fork after group removal

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/local_commit_log.rs
+++ b/crates/xmtp_db/src/encrypted_store/local_commit_log.rs
@@ -14,6 +14,11 @@ pub enum CommitType {
     UpdateGroupMembership,
     UpdateAdminList,
     UpdatePermission,
+    /// A commit (authored by anyone) that removed this installation's leaf
+    /// from the group. The member merges only the public part of such a
+    /// commit and cannot derive the new epoch's secrets, so the logged entry
+    /// records the pre-commit epoch and authenticator.
+    RemovedFromGroup,
 }
 
 impl std::fmt::Display for CommitType {
@@ -27,6 +32,7 @@ impl std::fmt::Display for CommitType {
             CommitType::UpdateGroupMembership => "UpdateGroupMembership",
             CommitType::UpdateAdminList => "UpdateAdminList",
             CommitType::UpdatePermission => "UpdatePermission",
+            CommitType::RemovedFromGroup => "RemovedFromGroup",
         };
         write!(f, "{}", description)
     }
@@ -150,6 +156,15 @@ pub trait QueryLocalCommitLog {
         &self,
         group_id: &GroupId,
     ) -> Result<Option<i32>, crate::ConnectionError>;
+
+    /// Rowid of the most recent chain-start entry for this group, if any.
+    /// Chain-start entries have `commit_sequence_id == 0` (Welcome /
+    /// GroupCreation / BackupRestore) and mark the beginning of the member's
+    /// current membership session.
+    fn get_latest_chain_start_rowid(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<i32>, crate::ConnectionError>;
 }
 
 impl<T> QueryLocalCommitLog for &T
@@ -184,6 +199,13 @@ where
         group_id: &GroupId,
     ) -> Result<Option<i32>, crate::ConnectionError> {
         (**self).get_local_commit_log_cursor(group_id)
+    }
+
+    fn get_latest_chain_start_rowid(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<i32>, crate::ConnectionError> {
+        (**self).get_latest_chain_start_rowid(group_id)
     }
 }
 
@@ -247,6 +269,20 @@ impl<C: ConnectionExt> QueryLocalCommitLog for DbConnection<C> {
     ) -> Result<Option<i32>, crate::ConnectionError> {
         let query = dsl::local_commit_log
             .filter(dsl::group_id.eq(group_id))
+            .select(dsl::rowid)
+            .order(dsl::rowid.desc())
+            .limit(1);
+
+        self.raw_query(|conn| query.first::<i32>(conn).optional())
+    }
+
+    fn get_latest_chain_start_rowid(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<i32>, crate::ConnectionError> {
+        let query = dsl::local_commit_log
+            .filter(dsl::group_id.eq(group_id))
+            .filter(dsl::commit_sequence_id.eq(0))
             .select(dsl::rowid)
             .order(dsl::rowid.desc())
             .limit(1);

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -683,6 +683,11 @@ mock! {
             &self,
             group_id: &GroupId,
         ) -> Result<Option<i32>, crate::ConnectionError>;
+
+        fn get_latest_chain_start_rowid(
+            &self,
+            group_id: &GroupId,
+        ) -> Result<Option<i32>, crate::ConnectionError>;
     }
 
     impl QueryRemoteCommitLog for DbQuery {

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -351,7 +351,9 @@ where
             let max_rowid = logs.last().map(|log| log.rowid);
             let plaintext_commit_log_entries: Vec<PlaintextCommitLogEntry> = logs
                 .iter()
-                .filter(|log| log.commit_type.as_deref() != Some(removed_from_group_marker.as_str()))
+                .filter(|log| {
+                    log.commit_type.as_deref() != Some(removed_from_group_marker.as_str())
+                })
                 .map(PlaintextCommitLogEntry::from)
                 .collect();
 

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -956,6 +956,10 @@ where
             if local_log.commit_result == CommitResult::Success
                 && local_log.applied_epoch_authenticator == local_log.last_epoch_authenticator
             {
+                // Note: `update_cursor` is monotonic (it only ever moves the
+                // cursor forward), so the cursor updates below for older
+                // matched rows — the loop walks descending rowids — cannot
+                // regress the cursor behind this terminal row.
                 conn.update_cursor(
                     conversation_id,
                     xmtp_db::refresh_state::EntityKind::CommitLogForkCheckLocal,

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -24,7 +24,7 @@ use xmtp_db::remote_commit_log::RemoteCommitLogOrder;
 use xmtp_db::{
     DbQuery, StorageError, Store,
     group::{StoredGroupCommitLogPublicKey, StoredGroupForReaddRequest},
-    local_commit_log::LocalCommitLogOrder,
+    local_commit_log::{CommitType, LocalCommitLogOrder},
     prelude::*,
     readd_status::QueryReaddStatus,
     remote_commit_log::{CommitResult, NewRemoteCommitLog},
@@ -333,18 +333,30 @@ where
             // Step 2: collect all the commit log entries for this conversation
             // Local commit log entries are returned sorted in ascending order of `rowid`
             // All local commit log will have rowid > 0 since sqlite rowid starts at 1 https://www.sqlite.org/autoinc.html
-            let (plaintext_commit_log_entries, rowids): (Vec<PlaintextCommitLogEntry>, Vec<i32>) =
-                conn.get_local_commit_log_after_cursor(
-                    &conversation.id,
-                    published_commit_log_cursor as i64,
-                    LocalCommitLogOrder::AscendingByRowid,
-                )?
+            let logs = conn.get_local_commit_log_after_cursor(
+                &conversation.id,
+                published_commit_log_cursor as i64,
+                LocalCommitLogOrder::AscendingByRowid,
+            )?;
+            // A commit that removed us is recorded locally (RemovedFromGroup,
+            // with the pre-commit epoch/authenticator) for debuggability, but
+            // must never be published: it does not attest the new epoch and
+            // could shadow the real consensus entry published by the
+            // remaining members. In practice a removed member is not a
+            // publisher (only super admins and DM participants publish, super
+            // admins cannot be removed, and DMs have no removals) — this
+            // filter makes that property structural. The publish cursor still
+            // advances past skipped rows.
+            let removed_from_group_marker = CommitType::RemovedFromGroup.to_string();
+            let max_rowid = logs.last().map(|log| log.rowid);
+            let plaintext_commit_log_entries: Vec<PlaintextCommitLogEntry> = logs
                 .iter()
-                .map(|log| (PlaintextCommitLogEntry::from(log), log.rowid))
-                .unzip();
+                .filter(|log| log.commit_type.as_deref() != Some(removed_from_group_marker.as_str()))
+                .map(PlaintextCommitLogEntry::from)
+                .collect();
 
             // Step 3: Compile the conversation cursor info and all the commit log entries for this conversation
-            if let Some(max_rowid) = rowids.into_iter().last() {
+            if let Some(max_rowid) = max_rowid {
                 let signed_entries =
                     self.sign_group_logs(conversation, &plaintext_commit_log_entries)?;
                 all_entries.extend(signed_entries);

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -897,10 +897,32 @@ where
             Originators::REMOTE_COMMIT_LOG,
         )?;
 
+        // Chain-start anchor: rows with `commit_sequence_id == 0` (Welcome /
+        // GroupCreation / BackupRestore) mark the beginning of this member's
+        // current membership session — e.g. rejoining via a new welcome after
+        // having been removed. History before the latest chain start is not
+        // attestable by this member and must not be compared against remote
+        // consensus. Those rows are filtered out of
+        // `get_local_commit_log_after_cursor`, so the anchor is looked up
+        // separately and applied as a floor on the local fork-check cursor.
+        let mut local_cursor = fork_check_local_cursor.sequence_id as i64;
+        let mut crossed_chain_start = false;
+        if let Some(anchor_rowid) = conn.get_latest_chain_start_rowid(conversation_id)?
+            && anchor_rowid as i64 > local_cursor
+        {
+            local_cursor = anchor_rowid as i64;
+            crossed_chain_start = true;
+            conn.update_cursor(
+                conversation_id,
+                xmtp_db::refresh_state::EntityKind::CommitLogForkCheckLocal,
+                Cursor::commit_log(anchor_rowid as u64),
+            )?;
+        }
+
         // Get local and remote commit logs
         let local_logs = conn.get_local_commit_log_after_cursor(
             conversation_id,
-            fork_check_local_cursor.sequence_id as i64,
+            local_cursor,
             LocalCommitLogOrder::DescendingByRowid,
         )?;
         let remote_logs = conn.get_remote_commit_log_after_cursor(
@@ -911,12 +933,37 @@ where
 
         // If there are no new commits to check, preserve the existing fork status
         if local_logs.is_empty() {
+            if crossed_chain_start {
+                // A new chain start (e.g. a welcome from being re-added)
+                // invalidates any previously computed status: nothing after
+                // it has been verified against remote consensus yet.
+                return Ok(None);
+            }
             return Ok(conn.get_group_commit_log_forked_status(conversation_id)?);
         }
 
         let mut is_remote_log_up_to_date = true;
         // Check each local log against remote logs for matching commit_sequence_id
         for local_log in &local_logs {
+            // Terminal removal marker: a commit that removed us merges only
+            // the public diff — we cannot derive the new epoch's secrets, so
+            // a Success row whose applied authenticator equals its last
+            // authenticator means "this commit removed us", not a fork. The
+            // remaining members publish the real post-commit authenticator,
+            // which can never match ours, so this row must be excluded from
+            // comparison. (Covers both new RemovedFromGroup rows and legacy
+            // rows that recorded the new epoch with the stale authenticator.)
+            if local_log.commit_result == CommitResult::Success
+                && local_log.applied_epoch_authenticator == local_log.last_epoch_authenticator
+            {
+                conn.update_cursor(
+                    conversation_id,
+                    xmtp_db::refresh_state::EntityKind::CommitLogForkCheckLocal,
+                    Cursor::commit_log(local_log.rowid as u64),
+                )?;
+                continue;
+            }
+
             let Some(matching_remote_log) =
                 self.find_matching_remote_log(&remote_logs, local_log.commit_sequence_id)
             else {

--- a/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
@@ -214,14 +214,10 @@ impl CommitLogStorer for MlsGroup {
         // enclosing transaction (cursor advance + merge + log write) rolls
         // back and the message is reprocessed against settled state.
         if applied_epoch_authenticator == last_epoch_authenticator {
-            tracing::error!(
-                group_id = hex::encode(self.group_id().as_slice()),
-                commit_sequence_id = sequence_id,
-                epoch = self.epoch().as_u64(),
-                "staged commit merge did not advance the epoch authenticator; \
-                 refusing to record corrupt commit log entry"
-            );
+            // No tracing here: the error carries the full context and is
+            // logged when it surfaces at its destination.
             return Err(GroupMessageProcessingError::EpochAuthenticatorNotAdvanced {
+                group_id: hex::encode(self.group_id().as_slice()),
                 commit_sequence_id: sequence_id,
                 epoch: self.epoch().as_u64(),
             });

--- a/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
@@ -168,8 +168,64 @@ impl CommitLogStorer for MlsGroup {
         validated_commit: &ValidatedCommit,
         sequence_id: i64,
     ) -> Result<(), GroupMessageProcessingError> {
+        // Whether this commit removes our own leaf (authored by anyone — an
+        // admin removal or our own leave request). Captured before the merge
+        // consumes the staged commit.
+        let removed_us = staged_commit.self_removed();
+        let last_epoch_number = self.epoch().as_u64() as i64;
         let last_epoch_authenticator = self.epoch_authenticator().as_slice().to_vec();
         self.merge_staged_commit(provider, staged_commit)?;
+        let applied_epoch_authenticator = self.epoch_authenticator().as_slice().to_vec();
+
+        if removed_us {
+            // A commit that removes us merges only the public diff (openmls
+            // `StagedCommitState::PublicState`): the group context epoch
+            // advances and the group becomes inactive, but a removed member
+            // cannot derive the new epoch's secrets. Record what is actually
+            // true — we processed the commit, remained at the pre-commit
+            // epoch, and exited — instead of claiming we applied the new
+            // epoch with a stale authenticator (which fork detection would
+            // misread as a fork; see commit-log fork investigation).
+            if xmtp_configuration::ENABLE_COMMIT_LOG {
+                NewLocalCommitLog {
+                    group_id: self.group_id().try_into()?,
+                    commit_sequence_id: sequence_id,
+                    last_epoch_authenticator: last_epoch_authenticator.clone(),
+                    commit_result: CommitResult::Success,
+                    applied_epoch_number: last_epoch_number,
+                    applied_epoch_authenticator: last_epoch_authenticator,
+                    sender_inbox_id: Some(validated_commit.actor_inbox_id()),
+                    sender_installation_id: Some(validated_commit.actor_installation_id()),
+                    commit_type: Some(format!("{}", CommitType::RemovedFromGroup)),
+                    error_message: None,
+                }
+                .store(&provider.key_store().db())?;
+            }
+            return Ok(());
+        }
+
+        // Invariant: a successful staged-commit merge by a member that
+        // remains in the group always advances the epoch and therefore
+        // changes the epoch authenticator. If it did not, the group state we
+        // merged onto was corrupt/torn (e.g. a cross-process race on a shared
+        // MLS DB handed us a reloaded group that already carried the
+        // post-commit epoch secrets). Recording a Success entry would persist
+        // a forked commit log. Refuse instead: the error is retryable, so the
+        // enclosing transaction (cursor advance + merge + log write) rolls
+        // back and the message is reprocessed against settled state.
+        if applied_epoch_authenticator == last_epoch_authenticator {
+            tracing::error!(
+                group_id = hex::encode(self.group_id().as_slice()),
+                commit_sequence_id = sequence_id,
+                epoch = self.epoch().as_u64(),
+                "staged commit merge did not advance the epoch authenticator; \
+                 refusing to record corrupt commit log entry"
+            );
+            return Err(GroupMessageProcessingError::EpochAuthenticatorNotAdvanced {
+                commit_sequence_id: sequence_id,
+                epoch: self.epoch().as_u64(),
+            });
+        }
 
         if xmtp_configuration::ENABLE_COMMIT_LOG {
             NewLocalCommitLog {
@@ -178,7 +234,7 @@ impl CommitLogStorer for MlsGroup {
                 last_epoch_authenticator,
                 commit_result: CommitResult::Success,
                 applied_epoch_number: self.epoch().as_u64() as i64,
-                applied_epoch_authenticator: self.epoch_authenticator().as_slice().to_vec(),
+                applied_epoch_authenticator,
                 sender_inbox_id: Some(validated_commit.actor_inbox_id()),
                 sender_installation_id: Some(validated_commit.actor_installation_id()),
                 commit_type: Some(format!("{}", validated_commit.debug_commit_type())),

--- a/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
@@ -217,7 +217,7 @@ impl CommitLogStorer for MlsGroup {
             // No tracing here: the error carries the full context and is
             // logged when it surfaces at its destination.
             return Err(GroupMessageProcessingError::EpochAuthenticatorNotAdvanced {
-                group_id: hex::encode(self.group_id().as_slice()),
+                group_id: self.group_id().try_into()?,
                 commit_sequence_id: sequence_id,
                 epoch: self.epoch().as_u64(),
             });

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -231,10 +231,15 @@ pub enum GroupMessageProcessingError {
     /// DB). Retryable: the enclosing transaction (cursor + merge + commit
     /// log) rolls back and the message is reprocessed against settled state.
     #[error(
-        "commit at sequence [{commit_sequence_id}] merged to epoch [{epoch}] without advancing \
-         the epoch authenticator; refusing to record corrupt commit log entry"
+        "staged commit merge for group [{group_id}] at sequence [{commit_sequence_id}] reached \
+         epoch [{epoch}] without advancing the epoch authenticator; refusing to record corrupt \
+         commit log entry"
     )]
-    EpochAuthenticatorNotAdvanced { commit_sequence_id: i64, epoch: u64 },
+    EpochAuthenticatorNotAdvanced {
+        group_id: String,
+        commit_sequence_id: i64,
+        epoch: u64,
+    },
 }
 
 impl RetryableError for GroupMessageProcessingError {

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -236,7 +236,7 @@ pub enum GroupMessageProcessingError {
          commit log entry"
     )]
     EpochAuthenticatorNotAdvanced {
-        group_id: String,
+        group_id: GroupId,
         commit_sequence_id: i64,
         epoch: u64,
     },

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -224,6 +224,17 @@ pub enum GroupMessageProcessingError {
     PreCommitProposalPhaseComplete,
     #[error(transparent)]
     Conversion(#[from] xmtp_proto::ConversionError),
+    /// A successful staged-commit merge by a member that remains in the group
+    /// must advance the epoch and therefore change the epoch authenticator.
+    /// If it did not, the group state the commit was merged onto was
+    /// corrupt/torn (e.g. produced by a cross-process race on a shared MLS
+    /// DB). Retryable: the enclosing transaction (cursor + merge + commit
+    /// log) rolls back and the message is reprocessed against settled state.
+    #[error(
+        "commit at sequence [{commit_sequence_id}] merged to epoch [{epoch}] without advancing \
+         the epoch authenticator; refusing to record corrupt commit log entry"
+    )]
+    EpochAuthenticatorNotAdvanced { commit_sequence_id: i64, epoch: u64 },
 }
 
 impl RetryableError for GroupMessageProcessingError {
@@ -269,6 +280,10 @@ impl RetryableError for GroupMessageProcessingError {
             | Self::PreCommitProposalPhaseComplete => false,
             Self::Builder(_) => false,
             Self::Conversion(_) => false,
+            // Retry so the enclosing transaction rolls back (including the
+            // cursor advance) and the message converges via cursor dedup
+            // instead of persisting a forked commit log entry.
+            Self::EpochAuthenticatorNotAdvanced { .. } => true,
         }
     }
 }

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -592,11 +592,10 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
 }
 
 /// Regression test for the fork-detection false positive observed in
-/// production (Convos group `e08a717548dc996845dc1f2d6986bdd0`, bundle
-/// `6E527FC8`): a member that is removed from a group — and possibly re-added
+/// production: a member that is removed from a group — and possibly re-added
 /// later — was flagged as forked, even though nothing diverged.
 ///
-/// Why: when a commit removes *us*, openmls merges only the public diff
+/// Why: when a commit removes us, openmls merges only the public diff
 /// (`StagedCommitState::PublicState`) — the group context epoch advances and
 /// the group becomes inactive, but a removed member cannot derive the new
 /// epoch's secrets. The remaining members derive them and publish the real

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -1,11 +1,18 @@
+use crate::context::XmtpSharedContext;
+use crate::groups::app_data::process_message_with_app_data;
 use crate::groups::commit_log::{CommitLogTestFunction, CommitLogWorker};
+use crate::groups::mls_ext::CommitLogStorer;
+use crate::groups::validated_commit::ValidatedCommit;
 use crate::tester;
+use openmls::group::MlsGroup as OpenMlsGroup;
+use openmls::prelude::{ProcessedMessageContent, Sender};
 use xmtp_configuration::Originators;
 use xmtp_db::Store;
 use xmtp_db::encrypted_store::local_commit_log::NewLocalCommitLog;
 use xmtp_db::encrypted_store::remote_commit_log::{CommitResult, NewRemoteCommitLog};
 use xmtp_db::local_commit_log::CommitType;
 use xmtp_db::prelude::*;
+use xmtp_db::{MlsProviderExt, StorageError, TransactionalKeyStore, XmtpOpenMlsProvider};
 use xmtp_proto::types::Cursor;
 
 #[cfg_attr(all(feature = "d14n", target_arch = "wasm32"), ignore)]
@@ -580,6 +587,440 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
         Some(false),
         "Final database check: fork status should remain Some(false)"
     );
+
+    Ok(())
+}
+
+/// Regression test for the fork-detection false positive observed in
+/// production (Convos group `e08a717548dc996845dc1f2d6986bdd0`, bundle
+/// `6E527FC8`): a member that is removed from a group — and possibly re-added
+/// later — was flagged as forked, even though nothing diverged.
+///
+/// Why: when a commit removes *us*, openmls merges only the public diff
+/// (`StagedCommitState::PublicState`) — the group context epoch advances and
+/// the group becomes inactive, but a removed member cannot derive the new
+/// epoch's secrets. The remaining members derive them and publish the real
+/// post-commit authenticator to the remote commit log; the removed member's
+/// value can never match it.
+///
+/// This test verifies the fix end to end:
+/// 1. The removal is recorded truthfully (`CommitType::RemovedFromGroup`,
+///    pre-commit epoch, `applied == last`) instead of claiming the new epoch
+///    with a stale authenticator.
+/// 2. While removed, fork detection skips the removal row (terminal marker)
+///    and reports `Some(false)` based on the consistent earlier history.
+/// 3. After re-adding via a new welcome, the `commit_sequence_id == 0` anchor
+///    stops comparison at the rejoin boundary and reports `None` (unknown) —
+///    never `Some(true)`.
+#[cfg_attr(all(feature = "d14n", target_arch = "wasm32"), ignore)]
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_fork_detection_not_triggered_by_removal_and_readd()
+-> Result<(), Box<dyn std::error::Error>> {
+    tester!(alix);
+    tester!(bo);
+
+    // Alix creates a group and adds Bo; Bo joins and settles.
+    let alix_group = alix.create_group(None, None)?;
+    alix_group.add_members(&[bo.inbox_id()]).await?;
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&alix_group.group_id)?;
+    bo_group.sync().await?;
+
+    // A normal commit Bo applies as an active member, so the commit log has a
+    // genuine consensus row before the removal.
+    alix_group
+        .update_group_name("before removal".to_string())
+        .await?;
+    bo_group.sync().await?;
+
+    // Alix removes Bo; Bo processes the commit that removes him.
+    alix_group.remove_members(&[bo.inbox_id()]).await?;
+    bo_group.sync().await?;
+
+    // The removal is recorded truthfully: RemovedFromGroup, Success, and the
+    // PRE-commit epoch + authenticator (a removed member cannot derive the
+    // new epoch's secrets).
+    let bo_logs = bo.context.db().get_group_logs(&bo_group.group_id)?;
+    let bo_removal = bo_logs.last().expect("bo logged the removal commit");
+    assert_eq!(
+        bo_removal.commit_type,
+        Some(CommitType::RemovedFromGroup.to_string())
+    );
+    assert_eq!(bo_removal.commit_result, CommitResult::Success);
+    assert_eq!(
+        bo_removal.applied_epoch_authenticator, bo_removal.last_epoch_authenticator,
+        "a removed member's merge does not advance the authenticator"
+    );
+    let bo_pre_removal = &bo_logs[bo_logs.len() - 2];
+    assert_eq!(
+        bo_removal.applied_epoch_number, bo_pre_removal.applied_epoch_number,
+        "the removal row records the pre-commit epoch"
+    );
+
+    // The remaining member applied the commit fully: new epoch, new
+    // authenticator, different from anything Bo could compute.
+    let alix_logs = alix.context.db().get_group_logs(&alix_group.group_id)?;
+    let alix_removal = alix_logs
+        .iter()
+        .find(|l| l.commit_sequence_id == bo_removal.commit_sequence_id)
+        .expect("alix logged the removal commit");
+    assert_eq!(
+        alix_removal.applied_epoch_number,
+        bo_removal.applied_epoch_number + 1
+    );
+    assert_ne!(
+        alix_removal.applied_epoch_authenticator,
+        bo_removal.applied_epoch_authenticator
+    );
+
+    // Simulate Bo downloading remote commit log consensus: matching entries
+    // for the commits he applied while active, and the remaining members'
+    // (true) authenticator for the commit that removed him.
+    let mut log_sequence_id = 1000;
+    for log in &bo_logs {
+        if log.commit_result != CommitResult::Success || log.commit_sequence_id == 0 {
+            continue; // welcome rows are never uploaded
+        }
+        let (epoch, auth) = if log.commit_sequence_id == bo_removal.commit_sequence_id {
+            (
+                alix_removal.applied_epoch_number,
+                alix_removal.applied_epoch_authenticator.clone(),
+            )
+        } else {
+            (
+                log.applied_epoch_number,
+                log.applied_epoch_authenticator.clone(),
+            )
+        };
+        NewRemoteCommitLog {
+            log_sequence_id,
+            group_id: bo_group.group_id,
+            commit_sequence_id: log.commit_sequence_id,
+            commit_result: CommitResult::Success,
+            applied_epoch_number: epoch,
+            applied_epoch_authenticator: auth,
+        }
+        .store(&bo.context.db())?;
+        log_sequence_id += 1;
+    }
+
+    // --- Check 1: while removed. ---
+    // The removal row is skipped as a terminal marker; the earlier history
+    // matches consensus, so Bo is NOT forked.
+    let mut worker = CommitLogWorker::new(bo.context.clone());
+    let results = worker
+        .run_test(CommitLogTestFunction::CheckForkedState, None)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    let fork_status = results[0]
+        .is_forked
+        .as_ref()
+        .unwrap()
+        .get(bo_group.group_id.as_ref())
+        .unwrap();
+    assert_eq!(
+        *fork_status,
+        Some(false),
+        "a removed member with consistent prior history must not be reported as forked"
+    );
+
+    // --- Check 2: after being re-added. ---
+    // Bo's original key package was consumed when he first joined and its
+    // rotation is only queued (not yet uploaded) at this point — re-adding
+    // with the consumed key package would produce a welcome Bo cannot
+    // process. Upload a fresh one first, as would have happened naturally by
+    // the time of a real-world re-add.
+    bo.rotate_and_upload_key_package().await?;
+    alix_group.add_members(&[bo.inbox_id()]).await?;
+    bo.sync_welcomes().await?;
+    bo_group.sync().await?;
+    assert!(
+        bo_group.is_active()?,
+        "bo must have rejoined via the new welcome"
+    );
+
+    let results = worker
+        .run_test(CommitLogTestFunction::CheckForkedState, None)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    let fork_status = results[0]
+        .is_forked
+        .as_ref()
+        .unwrap()
+        .get(bo_group.group_id.as_ref())
+        .unwrap();
+    assert_eq!(
+        *fork_status, None,
+        "after rejoining via welcome, comparison anchors at the new chain start (unknown)"
+    );
+
+    let db_status = bo
+        .context
+        .db()
+        .get_group_commit_log_forked_status(&bo_group.group_id)?;
+    assert_eq!(db_status, None, "stored status must not be forked");
+
+    Ok(())
+}
+
+/// Regression test for the `EpochAuthenticatorNotAdvanced` merge guard.
+///
+/// Invariant: a successful staged-commit merge by a member that remains in
+/// the group always advances the epoch and therefore changes the epoch
+/// authenticator. The only legitimate exception — a commit that removes us —
+/// is handled separately (`CommitType::RemovedFromGroup`). If the
+/// authenticator does not advance for an active member, the group state the
+/// commit was merged onto was corrupt/torn (e.g. a cross-process race on a
+/// shared MLS DB: the iOS main app and the Notification Service Extension
+/// share one SQLite DB, but `GroupCommitLock` is in-process only).
+///
+/// This test constructs such a torn state deterministically:
+/// 1. Pass 1: process a received commit in a rolled-back transaction and
+///    capture the `StagedCommit` + `ValidatedCommit` (what
+///    `validate_and_process_external_message` does).
+/// 2. "Concurrent process": apply the same commit via a normal `sync()` — the
+///    DB is now consistently at epoch E+1.
+/// 3. Tear the storage: write the stale epoch-E `GroupContext` (and epoch-E
+///    keypair rows, if any) back over the E+1 state, leaving tree / epoch
+///    secrets / message secrets at E+1.
+/// 4. Reload the group: it reports epoch E but already carries E+1's epoch
+///    secrets. Merging the stale staged commit then "succeeds" without
+///    advancing the authenticator.
+///
+/// `merge_staged_commit_logged` must refuse to record that merge: it returns
+/// the retryable `EpochAuthenticatorNotAdvanced` error and writes no row. In
+/// the real receive path the cursor advance, merge, and log write share one
+/// transaction, so the rollback is safe and the message converges via cursor
+/// dedup on retry.
+#[cfg_attr(all(feature = "d14n", target_arch = "wasm32"), ignore)]
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
+-> Result<(), Box<dyn std::error::Error>> {
+    use diesel::{RunQueryDsl, sql_query};
+    use openmls_traits::storage::CURRENT_VERSION;
+
+    // Raw access to the openmls kv store. Rows are located by label prefix +
+    // raw group id containment rather than by reconstructing the exact
+    // bincode-encoded storage key, so the test does not depend on
+    // xmtp_db::sql_key_store's key encoding. Restores use the exact key_bytes
+    // returned by the scan.
+    const KV_SCAN: &str = "SELECT key_bytes, value_bytes FROM openmls_key_value \
+         WHERE substr(key_bytes, 1, ?) = ? AND instr(key_bytes, ?) > 0 AND version = ?";
+    const KV_REPLACE: &str =
+        "REPLACE INTO openmls_key_value (key_bytes, version, value_bytes) VALUES (?, ?, ?)";
+    const GROUP_CONTEXT_LABEL: &[u8] = b"GroupContext";
+    const EPOCH_KEY_PAIRS_LABEL: &[u8] = b"EpochKeyPairs";
+
+    #[derive(diesel::QueryableByName)]
+    struct KvRow {
+        #[diesel(sql_type = diesel::sql_types::Binary)]
+        key_bytes: Vec<u8>,
+        #[diesel(sql_type = diesel::sql_types::Binary)]
+        value_bytes: Vec<u8>,
+    }
+
+    /// (key_bytes, value_bytes) pairs from the openmls kv store.
+    type KvRows = Vec<(Vec<u8>, Vec<u8>)>;
+
+    fn kv_scan(
+        db: &impl xmtp_db::ConnectionExt,
+        label: &[u8],
+        group_id: &[u8],
+    ) -> Result<KvRows, Box<dyn std::error::Error>> {
+        let rows: Vec<KvRow> = db.raw_query(|conn| {
+            sql_query(KV_SCAN)
+                .bind::<diesel::sql_types::Integer, _>(label.len() as i32)
+                .bind::<diesel::sql_types::Binary, _>(label)
+                .bind::<diesel::sql_types::Binary, _>(group_id)
+                .bind::<diesel::sql_types::Integer, _>(CURRENT_VERSION as i32)
+                .load(conn)
+        })?;
+        Ok(rows
+            .into_iter()
+            .map(|r| (r.key_bytes, r.value_bytes))
+            .collect())
+    }
+
+    fn kv_replace(
+        db: &impl xmtp_db::ConnectionExt,
+        storage_key: &[u8],
+        value: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        db.raw_query(|conn| {
+            sql_query(KV_REPLACE)
+                .bind::<diesel::sql_types::Binary, _>(storage_key)
+                .bind::<diesel::sql_types::Integer, _>(CURRENT_VERSION as i32)
+                .bind::<diesel::sql_types::Binary, _>(value)
+                .execute(conn)
+        })?;
+        Ok(())
+    }
+
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+
+    // Alix creates a group and adds Bo.
+    let alix_group = alix.create_group(None, None)?;
+    alix_group.add_members(&[bo.inbox_id()]).await?;
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&alix_group.group_id)?;
+    bo_group.sync().await?;
+
+    // Alix publishes an UpdateGroupMembership commit that Bo has not yet
+    // processed.
+    alix_group.add_members(&[caro.inbox_id()]).await?;
+
+    // Bo fetches the raw commit envelope from the network.
+    let messages = bo
+        .mls_store()
+        .query_group_messages(bo_group.group_id)
+        .await?;
+    let commit_envelope = messages
+        .into_iter()
+        .max_by_key(|m| m.cursor.sequence_id)
+        .expect("the add-caro commit must be on the network");
+    let commit_sequence_id = commit_envelope.cursor.sequence_id as i64;
+
+    // Bo's group is at epoch E; snapshot the raw epoch-E GroupContext and
+    // epoch-keypair kv rows so they can be written back after the sync.
+    let mut group_copy =
+        OpenMlsGroup::load(bo.context.mls_storage(), &bo_group.group_id.to_openmls())?
+            .expect("bo's group must exist");
+    let epoch_e = group_copy.epoch();
+    let auth_e = group_copy.epoch_authenticator().as_slice().to_vec();
+
+    let db = bo.context.db();
+    let ctx_rows_e = kv_scan(&db, GROUP_CONTEXT_LABEL, bo_group.group_id.as_ref())?;
+    assert_eq!(
+        ctx_rows_e.len(),
+        1,
+        "expected exactly one GroupContext kv row for the group"
+    );
+    // A welcome-joined member that has not yet merged a commit has no
+    // epoch-keypair row yet — openmls only writes that row in merge_commit
+    // (store_epoch_keypairs), and reads of a missing row gracefully return an
+    // empty set. Snapshot whatever rows exist (possibly none) so the torn
+    // state mirrors Bo's real epoch-E state.
+    let ekp_rows_e = kv_scan(&db, EPOCH_KEY_PAIRS_LABEL, bo_group.group_id.as_ref())?;
+
+    // --- Pass 1 (the second process's view; mirrors the receive path). ---
+    // Process the commit against a copy of Bo's group inside a transaction
+    // that is intentionally rolled back, capturing the staged + validated
+    // commit.
+    let provider = bo.context.mls_provider();
+    let mut processed_message = None;
+    let result = provider.key_store().transaction(|conn| {
+        let storage = conn.key_store();
+        let provider = XmtpOpenMlsProvider::new(storage);
+        processed_message = Some(process_message_with_app_data(
+            &mut group_copy,
+            &provider,
+            commit_envelope.message.clone(),
+        ));
+        Err::<(), StorageError>(StorageError::IntentionalRollback)
+    });
+    assert!(matches!(result, Err(StorageError::IntentionalRollback)));
+    let processed_message = processed_message
+        .expect("set in the transaction above")
+        .expect("processing the commit at the old epoch succeeds");
+
+    let committer_leaf_index = match processed_message.sender() {
+        Sender::Member(idx) => *idx,
+        _ => panic!("commit must come from a member"),
+    };
+    let staged_commit_ref = match processed_message.content() {
+        ProcessedMessageContent::StagedCommitMessage(staged) => staged,
+        _ => panic!("expected a staged commit message"),
+    };
+    let validated_commit = ValidatedCommit::from_staged_commit(
+        &bo_group.context,
+        staged_commit_ref,
+        committer_leaf_index,
+        &group_copy,
+    )
+    .await
+    .expect("commit validation succeeds");
+    let staged_commit = match processed_message.into_content() {
+        ProcessedMessageContent::StagedCommitMessage(staged) => *staged,
+        _ => unreachable!(),
+    };
+    drop(group_copy);
+
+    // --- The "concurrent process" applies the same commit normally. ---
+    bo_group.sync().await?;
+
+    let consistent = OpenMlsGroup::load(bo.context.mls_storage(), &bo_group.group_id.to_openmls())?
+        .expect("bo's group must exist");
+    assert_eq!(consistent.epoch(), staged_commit.group_context().epoch());
+    let auth_e1 = consistent.epoch_authenticator().as_slice().to_vec();
+    assert_ne!(
+        auth_e, auth_e1,
+        "the applied commit advanced the authenticator"
+    );
+    drop(consistent);
+
+    // --- Tear the storage. ---
+    // Write the stale epoch-E GroupContext (and any epoch-E keypair rows)
+    // back over the E+1 state, leaving tree / epoch secrets / message secrets
+    // at E+1. This simulates a second process's interleaved writes landing on
+    // the shared kv store without cross-process mutual exclusion.
+    for (key, value) in ctx_rows_e.iter().chain(ekp_rows_e.iter()) {
+        kv_replace(&db, key, value)?;
+    }
+
+    // --- The reload hands back the torn group: it reports epoch E, but its
+    // epoch secrets (and therefore its authenticator) are already E+1's.
+    let mut torn = OpenMlsGroup::load(bo.context.mls_storage(), &bo_group.group_id.to_openmls())?
+        .expect("bo's group must exist");
+    assert_eq!(torn.epoch(), epoch_e, "torn group reports the stale epoch");
+    assert_eq!(
+        torn.epoch_authenticator().as_slice(),
+        auth_e1.as_slice(),
+        "torn group already carries the post-commit epoch secrets"
+    );
+
+    let logs_before = bo.context.db().get_group_logs(&bo_group.group_id)?.len();
+
+    // --- Pass 2: merge the stale staged commit on the torn group. ---
+    // From the torn group's perspective this is an ordinary merge (epoch E ->
+    // E+1), so openmls accepts it — but the authenticator cannot advance.
+    let merge_result = torn.merge_staged_commit_logged(
+        &provider,
+        staged_commit,
+        &validated_commit,
+        commit_sequence_id,
+    );
+
+    assert!(
+        merge_result.is_err(),
+        "merge_staged_commit_logged must refuse to log a Success commit whose \
+         merge did not advance the epoch authenticator (applied == last); \
+         persisting it would corrupt the local commit log"
+    );
+
+    // And the corrupt row must not have been written.
+    let logs = bo.context.db().get_group_logs(&bo_group.group_id)?;
+    assert_eq!(
+        logs.len(),
+        logs_before,
+        "no local commit log entry may be written for the rejected merge"
+    );
+    for log in &logs {
+        if log.commit_result == CommitResult::Success
+            && !log.last_epoch_authenticator.is_empty()
+            && log.commit_type != Some(CommitType::RemovedFromGroup.to_string())
+        {
+            assert_ne!(
+                log.applied_epoch_authenticator, log.last_epoch_authenticator,
+                "successful commit at applied_epoch_number={} recorded an epoch \
+                 authenticator that did not advance",
+                log.applied_epoch_number
+            );
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix false positive fork detection after group removal and re-add
- Adds a `RemovedFromGroup` commit type that records the pre-commit epoch authenticator when this installation's leaf is removed from a group, allowing fork detection to treat it as a terminal, non-forking marker.
- Updates `check_forked_state` in [`commit_log.rs`](https://github.com/xmtp/libxmtp/pull/3760/files#diff-523943065ed63a511a3a552e44cb0ba0a05fecab9163088d5588cb5c949e6a5d) to anchor fork checks at the latest chain-start rowid (Welcome/GroupCreation/BackupRestore), ignoring history before a re-add.
- Filters `RemovedFromGroup` entries from remote publish while still advancing the publish cursor past them.
- Adds `EpochAuthenticatorNotAdvanced` as a retryable error for merges that do not advance the epoch authenticator, preventing a stale log entry from being written.
- Adds regression tests covering removal-then-re-add fork detection and the non-advancing authenticator rejection.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 126cfc1.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->