### PR TITLE
fix(node-sdk): re-export WorkerJitterOverride type

### DIFF
--- a/sdks/js/node-sdk/src/index.ts
+++ b/sdks/js/node-sdk/src/index.ts
@@ -68,6 +68,7 @@ export type {
   WalletSendCalls,
   WorkerConfigOptions,
   WorkerIntervalOverride,
+  WorkerJitterOverride,
 } from "@xmtp/node-bindings";
 export {
   ActionStyle,


### PR DESCRIPTION
Closes #3736

## Problem

`@xmtp/node-sdk` re-exports `WorkerConfigOptions`, `WorkerIntervalOverride` and `WorkerKind` from `@xmtp/node-bindings`, but somehow `WorkerJitterOverride` didn't make the list. The funny part is `WorkerConfigOptions.workerJittersNs` is literally typed as `Array<WorkerJitterOverride>`, so the SDK gives you a field whose element type you can't even import:

```ts
import {
  type WorkerIntervalOverride, // ok
  type WorkerJitterOverride,   // TS2724: '"@xmtp/node-sdk"' has no exported member named 'WorkerJitterOverride'
} from "@xmtp/node-sdk";
```

The only way around it was reaching into `@xmtp/node-bindings` directly, which kind of defeats the point of the SDK re-exporting these types in the first place.

## Fix

One line: add `WorkerJitterOverride` to the type re-export list, right next to `WorkerIntervalOverride` where it belongs.

## Testing

Built the node bindings locally and ran the node-sdk typecheck, passes clean. The import in the snippet above now resolves.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-export `WorkerJitterOverride` type from node-sdk
> Adds `WorkerJitterOverride` to the type-only re-exports in [index.ts](https://github.com/xmtp/libxmtp/pull/3761/files#diff-fbcb53b330816c4284d6086f4c7bb5b9bb20ec87712f03485d88da791a8d1451) sourced from `@xmtp/node-bindings`. The type was available in the bindings but not exposed through the SDK's public API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 468e52a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->