### PR TITLE
feat(messages): expose idempotency_key on top-level send helpers

### DIFF
--- a/bindings/node/src/conversation/content_types.rs
+++ b/bindings/node/src/conversation/content_types.rs
@@ -7,7 +7,7 @@ use crate::{
     wallet_send_calls::WalletSendCalls,
   },
   conversation::Conversation,
-  conversation::messages::SendMessageOpts,
+  conversation::messages::{SendMessageOpts, SendOpts},
 };
 use napi::bindgen_prelude::Result;
 use napi_derive::napi;
@@ -27,64 +27,53 @@ use xmtp_content_types::{
   wallet_send_calls::WalletSendCallsCodec,
 };
 
+impl SendMessageOpts {
+  /// Build full send opts from a codec-derived `should_push` and the caller's
+  /// convenience `SendOpts` bag.
+  fn from_send_opts(should_push: bool, opts: Option<SendOpts>) -> Self {
+    let opts = opts.unwrap_or_default();
+    SendMessageOpts {
+      should_push,
+      optimistic: opts.optimistic,
+      idempotency_key: opts.idempotency_key,
+    }
+  }
+}
+
 #[napi]
 impl Conversation {
   #[napi]
-  pub async fn send_text(&self, text: String, optimistic: Option<bool>) -> Result<String> {
+  pub async fn send_text(&self, text: String, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = TextCodec::encode(text).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: TextCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(TextCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
   #[napi]
-  pub async fn send_markdown(&self, markdown: String, optimistic: Option<bool>) -> Result<String> {
+  pub async fn send_markdown(&self, markdown: String, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = MarkdownCodec::encode(markdown).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: MarkdownCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(MarkdownCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
   #[napi]
-  pub async fn send_reaction(
-    &self,
-    reaction: Reaction,
-    optimistic: Option<bool>,
-  ) -> Result<String> {
+  pub async fn send_reaction(&self, reaction: Reaction, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = ReactionCodec::encode(reaction.into()).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: ReactionCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(ReactionCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
   #[napi]
-  pub async fn send_reply(&self, reply: Reply, optimistic: Option<bool>) -> Result<String> {
+  pub async fn send_reply(&self, reply: Reply, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = ReplyCodec::encode(reply.into()).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: ReplyCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(ReplyCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
   #[napi]
-  pub async fn send_read_receipt(&self, optimistic: Option<bool>) -> Result<String> {
+  pub async fn send_read_receipt(&self, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = ReadReceiptCodec::encode(ReadReceipt {}).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: ReadReceiptCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(ReadReceiptCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -92,14 +81,10 @@ impl Conversation {
   pub async fn send_attachment(
     &self,
     attachment: Attachment,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String> {
     let encoded_content = AttachmentCodec::encode(attachment.into()).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: AttachmentCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(AttachmentCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -107,15 +92,11 @@ impl Conversation {
   pub async fn send_remote_attachment(
     &self,
     remote_attachment: RemoteAttachment,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String> {
     let encoded_content =
       RemoteAttachmentCodec::encode(remote_attachment.into()).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: RemoteAttachmentCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(RemoteAttachmentCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -123,15 +104,11 @@ impl Conversation {
   pub async fn send_multi_remote_attachment(
     &self,
     multi_remote_attachment: MultiRemoteAttachment,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String> {
     let encoded_content = MultiRemoteAttachmentCodec::encode(multi_remote_attachment.into())
       .map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: MultiRemoteAttachmentCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(MultiRemoteAttachmentCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -139,15 +116,11 @@ impl Conversation {
   pub async fn send_transaction_reference(
     &self,
     transaction_reference: TransactionReference,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String> {
     let encoded_content = TransactionReferenceCodec::encode(transaction_reference.into())
       .map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: TransactionReferenceCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(TransactionReferenceCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -155,37 +128,25 @@ impl Conversation {
   pub async fn send_wallet_send_calls(
     &self,
     wallet_send_calls: WalletSendCalls,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String> {
     let wsc = wallet_send_calls.try_into()?;
     let encoded_content = WalletSendCallsCodec::encode(wsc).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: WalletSendCallsCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(WalletSendCallsCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
   #[napi]
-  pub async fn send_actions(&self, actions: Actions, optimistic: Option<bool>) -> Result<String> {
+  pub async fn send_actions(&self, actions: Actions, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = ActionsCodec::encode(actions.into()).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: ActionsCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(ActionsCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
   #[napi]
-  pub async fn send_intent(&self, intent: Intent, optimistic: Option<bool>) -> Result<String> {
+  pub async fn send_intent(&self, intent: Intent, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = IntentCodec::encode(intent.into()).map_err(ErrorWrapper::from)?;
-    let opts = SendMessageOpts {
-      should_push: IntentCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(IntentCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 }

--- a/bindings/node/src/conversation/messages.rs
+++ b/bindings/node/src/conversation/messages.rs
@@ -21,6 +21,18 @@ pub struct SendMessageOpts {
   pub idempotency_key: Option<String>,
 }
 
+/// Options for the top-level `send_*` convenience helpers. `should_push` is
+/// derived from the content type's codec, so callers only control optimistic
+/// delivery and the idempotency key.
+#[napi(object)]
+#[derive(Default)]
+pub struct SendOpts {
+  pub optimistic: Option<bool>,
+  /// Optional idempotency key. Re-sending identical content with the same key
+  /// produces the same message id and is deduplicated. Defaults to a timestamp.
+  pub idempotency_key: Option<String>,
+}
+
 impl From<SendMessageOpts> for xmtp_mls::groups::send_message_opts::SendMessageOpts {
   fn from(opts: SendMessageOpts) -> Self {
     xmtp_mls::groups::send_message_opts::SendMessageOpts {

--- a/bindings/node/test/Conversation.test.ts
+++ b/bindings/node/test/Conversation.test.ts
@@ -271,18 +271,20 @@ describe.concurrent('Conversation', () => {
       },
     ])
 
-    // Same content + same key => same id (deduplicated to a single message).
+    // Same content + same key => same id, deduplicated (no new stored message).
     const id1 = await conversation.sendText('gm', { idempotencyKey: 'key-1' })
+    const countAfterFirst = (await conversation.listMessages()).length
     const id2 = await conversation.sendText('gm', { idempotencyKey: 'key-1' })
     expect(id2).toBe(id1)
-    expect((await conversation.listMessages()).length).toBe(1)
+    expect((await conversation.listMessages()).length).toBe(countAfterFirst)
 
-    // Different key (or no key) => different id.
+    // Different key (or no key) => different id, stored as a new message.
     const id3 = await conversation.sendText('gm', { idempotencyKey: 'key-2' })
     const id4 = await conversation.sendText('gm')
     expect(id3).not.toBe(id1)
     expect(id4).not.toBe(id1)
     expect(id4).not.toBe(id3)
+    expect((await conversation.listMessages()).length).toBe(countAfterFirst + 2)
   })
 
   it('should stream messages', async () => {

--- a/bindings/node/test/Conversation.test.ts
+++ b/bindings/node/test/Conversation.test.ts
@@ -234,7 +234,7 @@ describe.concurrent('Conversation', () => {
       },
     ])
 
-    await conversation.sendText('gm', true)
+    await conversation.sendText('gm', { optimistic: true })
 
     const messages = await conversation.listMessages()
     expect(messages.length).toBe(2)
@@ -257,6 +257,32 @@ describe.concurrent('Conversation', () => {
 
     const messages4 = await conversation2.listMessages()
     expect(messages4.length).toBe(2)
+  })
+
+  it('should produce deterministic ids for a caller-set idempotency key', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    await createRegisteredClient(user2)
+    const conversation = await client1.conversations().createGroupByIdentity([
+      {
+        identifier: user2.account.address,
+        identifierKind: IdentifierKind.Ethereum,
+      },
+    ])
+
+    // Same content + same key => same id (deduplicated to a single message).
+    const id1 = await conversation.sendText('gm', { idempotencyKey: 'key-1' })
+    const id2 = await conversation.sendText('gm', { idempotencyKey: 'key-1' })
+    expect(id2).toBe(id1)
+    expect((await conversation.listMessages()).length).toBe(1)
+
+    // Different key (or no key) => different id.
+    const id3 = await conversation.sendText('gm', { idempotencyKey: 'key-2' })
+    const id4 = await conversation.sendText('gm')
+    expect(id3).not.toBe(id1)
+    expect(id4).not.toBe(id1)
+    expect(id4).not.toBe(id3)
   })
 
   it('should stream messages', async () => {

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -80,6 +80,36 @@ impl From<SendMessageOpts> for xmtp_mls::groups::send_message_opts::SendMessageO
   }
 }
 
+/// Options for the top-level `send*` convenience helpers. `shouldPush` is
+/// derived from the content type's codec, so callers only control optimistic
+/// delivery and the idempotency key.
+#[derive(Clone, Default, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct SendOpts {
+  #[tsify(optional)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub optimistic: Option<bool>,
+  /// Optional idempotency key. Re-sending identical content with the same key
+  /// produces the same message id and is deduplicated. Defaults to a timestamp.
+  #[tsify(optional)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub idempotency_key: Option<String>,
+}
+
+impl SendMessageOpts {
+  /// Build full send opts from a codec-derived `should_push` and the caller's
+  /// convenience `SendOpts` bag.
+  fn from_send_opts(should_push: bool, opts: Option<SendOpts>) -> Self {
+    let opts = opts.unwrap_or_default();
+    SendMessageOpts {
+      should_push,
+      optimistic: opts.optimistic,
+      idempotency_key: opts.idempotency_key,
+    }
+  }
+}
+
 /// Options for [`Conversation::enableProposals`]. Mirrors
 /// [`xmtp_mls::groups::EnableProposalsOptions`].
 #[derive(Clone, Serialize, Deserialize, Tsify)]
@@ -256,13 +286,9 @@ impl Conversation {
   }
 
   #[wasm_bindgen(js_name = sendText)]
-  pub async fn send_text(&self, text: String, optimistic: Option<bool>) -> Result<String, JsError> {
+  pub async fn send_text(&self, text: String, opts: Option<SendOpts>) -> Result<String, JsError> {
     let encoded_content = TextCodec::encode(text).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: TextCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(TextCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -270,14 +296,10 @@ impl Conversation {
   pub async fn send_markdown(
     &self,
     markdown: String,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String, JsError> {
     let encoded_content = MarkdownCodec::encode(markdown).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: MarkdownCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(MarkdownCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -285,40 +307,24 @@ impl Conversation {
   pub async fn send_reaction(
     &self,
     reaction: Reaction,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String, JsError> {
     let encoded_content = ReactionCodec::encode(reaction.into()).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: ReactionCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(ReactionCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
   #[wasm_bindgen(js_name = sendReply)]
-  pub async fn send_reply(
-    &self,
-    reply: Reply,
-    optimistic: Option<bool>,
-  ) -> Result<String, JsError> {
+  pub async fn send_reply(&self, reply: Reply, opts: Option<SendOpts>) -> Result<String, JsError> {
     let encoded_content = ReplyCodec::encode(reply.into()).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: ReplyCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(ReplyCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
   #[wasm_bindgen(js_name = sendReadReceipt)]
-  pub async fn send_read_receipt(&self, optimistic: Option<bool>) -> Result<String, JsError> {
+  pub async fn send_read_receipt(&self, opts: Option<SendOpts>) -> Result<String, JsError> {
     let encoded_content = ReadReceiptCodec::encode(ReadReceipt {}).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: ReadReceiptCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(ReadReceiptCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -326,14 +332,10 @@ impl Conversation {
   pub async fn send_attachment(
     &self,
     attachment: Attachment,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String, JsError> {
     let encoded_content = AttachmentCodec::encode(attachment.into()).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: AttachmentCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(AttachmentCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -341,15 +343,11 @@ impl Conversation {
   pub async fn send_remote_attachment(
     &self,
     #[wasm_bindgen(js_name = remoteAttachment)] remote_attachment: RemoteAttachment,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String, JsError> {
     let encoded_content =
       RemoteAttachmentCodec::encode(remote_attachment.into()).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: RemoteAttachmentCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(RemoteAttachmentCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -357,15 +355,11 @@ impl Conversation {
   pub async fn send_multi_remote_attachment(
     &self,
     #[wasm_bindgen(js_name = multiRemoteAttachment)] multi_remote_attachment: MultiRemoteAttachment,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String, JsError> {
     let encoded_content = MultiRemoteAttachmentCodec::encode(multi_remote_attachment.into())
       .map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: MultiRemoteAttachmentCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(MultiRemoteAttachmentCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -373,15 +367,11 @@ impl Conversation {
   pub async fn send_transaction_reference(
     &self,
     #[wasm_bindgen(js_name = transactionReference)] transaction_reference: TransactionReference,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String, JsError> {
     let encoded_content =
       TransactionReferenceCodec::encode(transaction_reference.into()).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: TransactionReferenceCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(TransactionReferenceCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -389,16 +379,12 @@ impl Conversation {
   pub async fn send_wallet_send_calls(
     &self,
     #[wasm_bindgen(js_name = walletSendCalls)] wallet_send_calls: WalletSendCalls,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String, JsError> {
     let wsc: xmtp_content_types::wallet_send_calls::WalletSendCalls =
       wallet_send_calls.try_into()?;
     let encoded_content = WalletSendCallsCodec::encode(wsc).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: WalletSendCallsCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(WalletSendCallsCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -406,14 +392,10 @@ impl Conversation {
   pub async fn send_actions(
     &self,
     actions: Actions,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String, JsError> {
     let encoded_content = ActionsCodec::encode(actions.into()).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: ActionsCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(ActionsCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 
@@ -421,14 +403,10 @@ impl Conversation {
   pub async fn send_intent(
     &self,
     intent: Intent,
-    optimistic: Option<bool>,
+    opts: Option<SendOpts>,
   ) -> Result<String, JsError> {
     let encoded_content = IntentCodec::encode(intent.into()).map_err(ErrorWrapper::js)?;
-    let opts = SendMessageOpts {
-      should_push: IntentCodec::should_push(),
-      optimistic,
-      idempotency_key: None,
-    };
+    let opts = SendMessageOpts::from_send_opts(IntentCodec::should_push(), opts);
     self.send(encoded_content.into(), opts).await
   }
 

--- a/bindings/wasm/test/Conversations.test.ts
+++ b/bindings/wasm/test/Conversations.test.ts
@@ -48,4 +48,26 @@ describe("Conversations", () => {
 
     stream.end();
   });
+
+  it("should produce deterministic ids for a caller-set idempotency key", async () => {
+    const client1 = await createTestClient();
+    const client2 = await createTestClient();
+
+    const conversation = await client1
+      .conversations()
+      .createGroupByInboxIds([client2.inboxId]);
+
+    // Same content + same key => same id (deduplicated to a single message).
+    const id1 = await conversation.sendText("gm", { idempotencyKey: "key-1" });
+    const id2 = await conversation.sendText("gm", { idempotencyKey: "key-1" });
+    expect(id2).toBe(id1);
+    expect((await conversation.findMessages()).length).toBe(1);
+
+    // Different key (or no key) => different id.
+    const id3 = await conversation.sendText("gm", { idempotencyKey: "key-2" });
+    const id4 = await conversation.sendText("gm");
+    expect(id3).not.toBe(id1);
+    expect(id4).not.toBe(id1);
+    expect(id4).not.toBe(id3);
+  });
 });

--- a/bindings/wasm/test/Conversations.test.ts
+++ b/bindings/wasm/test/Conversations.test.ts
@@ -57,17 +57,21 @@ describe("Conversations", () => {
       .conversations()
       .createGroupByInboxIds([client2.inboxId]);
 
-    // Same content + same key => same id (deduplicated to a single message).
+    // Same content + same key => same id, deduplicated (no new stored message).
     const id1 = await conversation.sendText("gm", { idempotencyKey: "key-1" });
+    const countAfterFirst = (await conversation.findMessages()).length;
     const id2 = await conversation.sendText("gm", { idempotencyKey: "key-1" });
     expect(id2).toBe(id1);
-    expect((await conversation.findMessages()).length).toBe(1);
+    expect((await conversation.findMessages()).length).toBe(countAfterFirst);
 
-    // Different key (or no key) => different id.
+    // Different key (or no key) => different id, stored as a new message.
     const id3 = await conversation.sendText("gm", { idempotencyKey: "key-2" });
     const id4 = await conversation.sendText("gm");
     expect(id3).not.toBe(id1);
     expect(id4).not.toBe(id1);
     expect(id4).not.toBe(id3);
+    expect((await conversation.findMessages()).length).toBe(
+      countAfterFirst + 2,
+    );
   });
 });

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Dm.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Dm.kt
@@ -144,7 +144,10 @@ class Dm(
             if (compression != null) {
                 encoded = encoded.compress(compression)
             }
-            val sendOpts = MessageVisibilityOptions(shouldPush = typedCodec.shouldPush(content))
+            val sendOpts = MessageVisibilityOptions(
+                shouldPush = typedCodec.shouldPush(content),
+                idempotencyKey = options?.idempotencyKey,
+            )
             return Pair(encoded, sendOpts)
         } catch (e: Exception) {
             throw XMTPException("Codec type is not registered")
@@ -165,7 +168,7 @@ class Dm(
     ): String =
         withContext(Dispatchers.IO) {
             if (noSend) {
-                libXMTPGroup.prepareMessage(encodedContent.toByteArray(), opts.shouldPush, null).toHex()
+                libXMTPGroup.prepareMessage(encodedContent.toByteArray(), opts.shouldPush, opts.idempotencyKey).toHex()
             } else {
                 libXMTPGroup.sendOptimistic(encodedContent.toByteArray(), opts.toFfi()).toHex()
             }

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Dm.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Dm.kt
@@ -144,10 +144,11 @@ class Dm(
             if (compression != null) {
                 encoded = encoded.compress(compression)
             }
-            val sendOpts = MessageVisibilityOptions(
-                shouldPush = typedCodec.shouldPush(content),
-                idempotencyKey = options?.idempotencyKey,
-            )
+            val sendOpts =
+                MessageVisibilityOptions(
+                    shouldPush = typedCodec.shouldPush(content),
+                    idempotencyKey = options?.idempotencyKey,
+                )
             return Pair(encoded, sendOpts)
         } catch (e: Exception) {
             throw XMTPException("Codec type is not registered")

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -189,10 +189,11 @@ class Group(
             if (compression != null) {
                 encoded = encoded.compress(compression)
             }
-            val sendOpts = MessageVisibilityOptions(
-                shouldPush = typedCodec.shouldPush(content),
-                idempotencyKey = options?.idempotencyKey,
-            )
+            val sendOpts =
+                MessageVisibilityOptions(
+                    shouldPush = typedCodec.shouldPush(content),
+                    idempotencyKey = options?.idempotencyKey,
+                )
             return Pair(encoded, sendOpts)
         } catch (e: Exception) {
             throw XMTPException("Codec type is not registered")

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -189,7 +189,10 @@ class Group(
             if (compression != null) {
                 encoded = encoded.compress(compression)
             }
-            val sendOpts = MessageVisibilityOptions(shouldPush = typedCodec.shouldPush(content))
+            val sendOpts = MessageVisibilityOptions(
+                shouldPush = typedCodec.shouldPush(content),
+                idempotencyKey = options?.idempotencyKey,
+            )
             return Pair(encoded, sendOpts)
         } catch (e: Exception) {
             throw XMTPException("Codec type is not registered")
@@ -210,7 +213,7 @@ class Group(
     ): String =
         withContext(Dispatchers.IO) {
             if (noSend) {
-                libXMTPGroup.prepareMessage(encodedContent.toByteArray(), opts.shouldPush, null).toHex()
+                libXMTPGroup.prepareMessage(encodedContent.toByteArray(), opts.shouldPush, opts.idempotencyKey).toHex()
             } else {
                 libXMTPGroup.sendOptimistic(encodedContent.toByteArray(), opts.toFfi()).toHex()
             }

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/SendOptions.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/SendOptions.kt
@@ -8,10 +8,17 @@ data class SendOptions(
     var contentType: Content.ContentTypeId? = null,
     @Deprecated("This option is no longer supported and does nothing")
     var ephemeral: Boolean = false,
+    // Optional idempotency key. Re-sending identical content with the same key
+    // produces the same message id and is deduplicated. Defaults to a timestamp.
+    var idempotencyKey: String? = null,
 )
 
 data class MessageVisibilityOptions(
     val shouldPush: Boolean,
+    // Optional idempotency key. Re-sending identical content with the same key
+    // produces the same message id and is deduplicated. Defaults to a timestamp.
+    val idempotencyKey: String? = null,
 ) {
-    fun toFfi(): FfiSendMessageOpts = FfiSendMessageOpts(shouldPush = shouldPush)
+    fun toFfi(): FfiSendMessageOpts =
+        FfiSendMessageOpts(shouldPush = shouldPush, idempotencyKey = idempotencyKey)
 }

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/SendOptions.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/SendOptions.kt
@@ -19,6 +19,5 @@ data class MessageVisibilityOptions(
     // produces the same message id and is deduplicated. Defaults to a timestamp.
     val idempotencyKey: String? = null,
 ) {
-    fun toFfi(): FfiSendMessageOpts =
-        FfiSendMessageOpts(shouldPush = shouldPush, idempotencyKey = idempotencyKey)
+    fun toFfi(): FfiSendMessageOpts = FfiSendMessageOpts(shouldPush = shouldPush, idempotencyKey = idempotencyKey)
 }

--- a/sdks/ios/Sources/XMTPiOS/Dm.swift
+++ b/sdks/ios/Sources/XMTPiOS/Dm.swift
@@ -217,7 +217,8 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		}
 
 		let visibilityOptions = try MessageVisibilityOptions(
-			shouldPush: shouldPush(codec: codec, content: content)
+			shouldPush: shouldPush(codec: codec, content: content),
+			idempotencyKey: options?.idempotencyKey
 		)
 
 		return (encoded, visibilityOptions)
@@ -236,7 +237,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 			messageId = try ffiConversation.prepareMessage(
 				contentBytes: encodedContent.serializedData(),
 				shouldPush: shouldPush,
-				idempotencyKey: nil
+				idempotencyKey: visibilityOptions?.idempotencyKey
 			)
 		} else {
 			let opts = visibilityOptions?.toFfi() ?? FfiSendMessageOpts(shouldPush: true)

--- a/sdks/ios/Sources/XMTPiOS/Group.swift
+++ b/sdks/ios/Sources/XMTPiOS/Group.swift
@@ -460,7 +460,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}
 
 		let visibilityOptions = try MessageVisibilityOptions(
-			shouldPush: shouldPush(codec: codec, content: content)
+			shouldPush: shouldPush(codec: codec, content: content),
+			idempotencyKey: options?.idempotencyKey
 		)
 
 		return (encoded, visibilityOptions)
@@ -479,7 +480,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 			messageId = try ffiGroup.prepareMessage(
 				contentBytes: encodedContent.serializedData(),
 				shouldPush: shouldPush,
-				idempotencyKey: nil
+				idempotencyKey: visibilityOptions?.idempotencyKey
 			)
 		} else {
 			let opts = visibilityOptions?.toFfi() ?? FfiSendMessageOpts(shouldPush: true)

--- a/sdks/ios/Sources/XMTPiOS/MessageVisibilityOptions.swift
+++ b/sdks/ios/Sources/XMTPiOS/MessageVisibilityOptions.swift
@@ -12,15 +12,22 @@ public struct MessageVisibilityOptions {
 	/// Whether this message should trigger a push notification
 	public var shouldPush: Bool
 
+	/// Optional idempotency key. Re-sending identical content with the same key
+	/// produces the same message id and is deduplicated. Defaults to a timestamp.
+	public var idempotencyKey: String?
+
 	/// Creates message visibility options
-	/// - Parameter shouldPush: Whether this message should trigger a push notification (default: true)
-	public init(shouldPush: Bool = true) {
+	/// - Parameters:
+	///   - shouldPush: Whether this message should trigger a push notification (default: true)
+	///   - idempotencyKey: Optional idempotency key for deterministic, deduplicated sends
+	public init(shouldPush: Bool = true, idempotencyKey: String? = nil) {
 		self.shouldPush = shouldPush
+		self.idempotencyKey = idempotencyKey
 	}
 
 	/// Converts the visibility options to FFI send message options
 	/// - Returns: FfiSendMessageOpts instance with the appropriate settings
 	public func toFfi() -> FfiSendMessageOpts {
-		FfiSendMessageOpts(shouldPush: shouldPush)
+		FfiSendMessageOpts(shouldPush: shouldPush, idempotencyKey: idempotencyKey)
 	}
 }

--- a/sdks/ios/Sources/XMTPiOS/SendOptions.swift
+++ b/sdks/ios/Sources/XMTPiOS/SendOptions.swift
@@ -11,12 +11,16 @@ public struct SendOptions {
 	public var compression: EncodedContentCompression?
 	public var contentType: ContentTypeID?
 	public var ephemeral = false
+	/// Optional idempotency key. Re-sending identical content with the same key
+	/// produces the same message id and is deduplicated. Defaults to a timestamp.
+	public var idempotencyKey: String?
 
 	public init(compression: EncodedContentCompression? = nil, contentType: ContentTypeID? = nil,
-	            ephemeral: Bool = false)
+	            ephemeral: Bool = false, idempotencyKey: String? = nil)
 	{
 		self.compression = compression
 		self.contentType = contentType
 		self.ephemeral = ephemeral
+		self.idempotencyKey = idempotencyKey
 	}
 }

--- a/sdks/js/browser-sdk/src/WorkerConversation.ts
+++ b/sdks/js/browser-sdk/src/WorkerConversation.ts
@@ -197,69 +197,71 @@ export class WorkerConversation {
   }
 
   async sendText(text: string, isOptimistic?: boolean) {
-    return this.#group.sendText(text, isOptimistic);
+    return this.#group.sendText(text, { optimistic: isOptimistic });
   }
 
   async sendMarkdown(markdown: string, isOptimistic?: boolean) {
-    return this.#group.sendMarkdown(markdown, isOptimistic);
+    return this.#group.sendMarkdown(markdown, { optimistic: isOptimistic });
   }
 
   async sendReaction(reaction: Reaction, isOptimistic?: boolean) {
-    return this.#group.sendReaction(reaction, isOptimistic);
+    return this.#group.sendReaction(reaction, { optimistic: isOptimistic });
   }
 
   async sendReadReceipt(isOptimistic?: boolean) {
-    return this.#group.sendReadReceipt(isOptimistic);
+    return this.#group.sendReadReceipt({ optimistic: isOptimistic });
   }
 
   async sendReply(reply: Reply, isOptimistic?: boolean) {
-    return this.#group.sendReply(reply, isOptimistic);
+    return this.#group.sendReply(reply, { optimistic: isOptimistic });
   }
 
   async sendTransactionReference(
     transactionReference: TransactionReference,
     isOptimistic?: boolean,
   ) {
-    return this.#group.sendTransactionReference(
-      transactionReference,
-      isOptimistic,
-    );
+    return this.#group.sendTransactionReference(transactionReference, {
+      optimistic: isOptimistic,
+    });
   }
 
   async sendWalletSendCalls(
     walletSendCalls: WalletSendCalls,
     isOptimistic?: boolean,
   ) {
-    return this.#group.sendWalletSendCalls(walletSendCalls, isOptimistic);
+    return this.#group.sendWalletSendCalls(walletSendCalls, {
+      optimistic: isOptimistic,
+    });
   }
 
   async sendActions(actions: Actions, isOptimistic?: boolean) {
-    return this.#group.sendActions(actions, isOptimistic);
+    return this.#group.sendActions(actions, { optimistic: isOptimistic });
   }
 
   async sendIntent(intent: Intent, isOptimistic?: boolean) {
-    return this.#group.sendIntent(intent, isOptimistic);
+    return this.#group.sendIntent(intent, { optimistic: isOptimistic });
   }
 
   async sendAttachment(attachment: Attachment, isOptimistic?: boolean) {
-    return this.#group.sendAttachment(attachment, isOptimistic);
+    return this.#group.sendAttachment(attachment, { optimistic: isOptimistic });
   }
 
   async sendMultiRemoteAttachment(
     multiRemoteAttachment: MultiRemoteAttachment,
     isOptimistic?: boolean,
   ) {
-    return this.#group.sendMultiRemoteAttachment(
-      multiRemoteAttachment,
-      isOptimistic,
-    );
+    return this.#group.sendMultiRemoteAttachment(multiRemoteAttachment, {
+      optimistic: isOptimistic,
+    });
   }
 
   async sendRemoteAttachment(
     remoteAttachment: RemoteAttachment,
     isOptimistic?: boolean,
   ) {
-    return this.#group.sendRemoteAttachment(remoteAttachment, isOptimistic);
+    return this.#group.sendRemoteAttachment(remoteAttachment, {
+      optimistic: isOptimistic,
+    });
   }
 
   async messages(options?: ListMessagesOptions): Promise<DecodedMessage[]> {

--- a/sdks/js/node-sdk/src/Conversation.ts
+++ b/sdks/js/node-sdk/src/Conversation.ts
@@ -214,7 +214,7 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendText(text: string, isOptimistic?: boolean) {
-    return this.#conversation.sendText(text, isOptimistic);
+    return this.#conversation.sendText(text, { optimistic: isOptimistic });
   }
 
   /**
@@ -225,7 +225,9 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendMarkdown(markdown: string, isOptimistic?: boolean) {
-    return this.#conversation.sendMarkdown(markdown, isOptimistic);
+    return this.#conversation.sendMarkdown(markdown, {
+      optimistic: isOptimistic,
+    });
   }
 
   /**
@@ -236,7 +238,9 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendReaction(reaction: Reaction, isOptimistic?: boolean) {
-    return this.#conversation.sendReaction(reaction, isOptimistic);
+    return this.#conversation.sendReaction(reaction, {
+      optimistic: isOptimistic,
+    });
   }
 
   /**
@@ -247,7 +251,7 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendReadReceipt(isOptimistic?: boolean) {
-    return this.#conversation.sendReadReceipt(isOptimistic);
+    return this.#conversation.sendReadReceipt({ optimistic: isOptimistic });
   }
 
   /**
@@ -258,7 +262,7 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendReply(reply: Reply, isOptimistic?: boolean) {
-    return this.#conversation.sendReply(reply, isOptimistic);
+    return this.#conversation.sendReply(reply, { optimistic: isOptimistic });
   }
 
   /**
@@ -272,10 +276,9 @@ export class Conversation<ContentTypes = unknown> {
     transactionReference: TransactionReference,
     isOptimistic?: boolean,
   ) {
-    return this.#conversation.sendTransactionReference(
-      transactionReference,
-      isOptimistic,
-    );
+    return this.#conversation.sendTransactionReference(transactionReference, {
+      optimistic: isOptimistic,
+    });
   }
 
   /**
@@ -289,10 +292,9 @@ export class Conversation<ContentTypes = unknown> {
     walletSendCalls: WalletSendCalls,
     isOptimistic?: boolean,
   ) {
-    return this.#conversation.sendWalletSendCalls(
-      walletSendCalls,
-      isOptimistic,
-    );
+    return this.#conversation.sendWalletSendCalls(walletSendCalls, {
+      optimistic: isOptimistic,
+    });
   }
 
   /**
@@ -303,7 +305,9 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendActions(actions: Actions, isOptimistic?: boolean) {
-    return this.#conversation.sendActions(actions, isOptimistic);
+    return this.#conversation.sendActions(actions, {
+      optimistic: isOptimistic,
+    });
   }
 
   /**
@@ -314,7 +318,7 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendIntent(intent: Intent, isOptimistic?: boolean) {
-    return this.#conversation.sendIntent(intent, isOptimistic);
+    return this.#conversation.sendIntent(intent, { optimistic: isOptimistic });
   }
 
   /**
@@ -325,7 +329,9 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendAttachment(attachment: Attachment, isOptimistic?: boolean) {
-    return this.#conversation.sendAttachment(attachment, isOptimistic);
+    return this.#conversation.sendAttachment(attachment, {
+      optimistic: isOptimistic,
+    });
   }
 
   /**
@@ -339,10 +345,9 @@ export class Conversation<ContentTypes = unknown> {
     multiRemoteAttachment: MultiRemoteAttachment,
     isOptimistic?: boolean,
   ) {
-    return this.#conversation.sendMultiRemoteAttachment(
-      multiRemoteAttachment,
-      isOptimistic,
-    );
+    return this.#conversation.sendMultiRemoteAttachment(multiRemoteAttachment, {
+      optimistic: isOptimistic,
+    });
   }
 
   /**
@@ -356,10 +361,9 @@ export class Conversation<ContentTypes = unknown> {
     remoteAttachment: RemoteAttachment,
     isOptimistic?: boolean,
   ) {
-    return this.#conversation.sendRemoteAttachment(
-      remoteAttachment,
-      isOptimistic,
-    );
+    return this.#conversation.sendRemoteAttachment(remoteAttachment, {
+      optimistic: isOptimistic,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #3756 (closes the convenience-helper gap from #3750).

#3756 added a caller-settable `idempotency_key` but only on the low-level generic `send(content, opts)` / `prepareMessage`. Every top-level convenience helper (`send_text`, `send_reply`, `send_remote_attachment`, …) still hardcoded `idempotency_key: None`, so a caller wanting idempotent (crash-safe / dedup-able) resends had to drop to the generic `send` and hand-encode the content. This exposes the key on all of them so it's a one-liner.

Because the message id is `calculate_message_id(group_id, content, key)` and the key rides the wire (`PlaintextEnvelope.V1.idempotency_key`), a stable caller key makes a resend of identical content produce the **same** id, which every consumer already dedups (libxmtp + receive-side PK upsert). Downstream agents (herald-lite#106, convos-assistants#2067) need this for crash-safe resends.

## Changes

**Node** (`bindings/node/src/conversation/`)
- New `#[napi(object)] SendOpts { optimistic?, idempotencyKey? }` bag.
- All 12 `send_*` helpers now take `opts?: SendOpts` (replacing the trailing positional `optimistic` bool), building full opts via a shared `SendMessageOpts::from_send_opts(codec_should_push, opts)`.

**Wasm** (`bindings/wasm/src/conversation.rs`)
- Mirror `Tsify SendOpts` + the same 12-helper rewrite.

**iOS** (`sdks/ios/Sources/XMTPiOS/`) / **Android** (`sdks/android/.../library/`)
- Added `idempotencyKey` to `SendOptions` **and** `MessageVisibilityOptions` (→ `toFfi()`), threaded through `encodeContent` and the `prepareMessage` `noSend` branch (was hardcoded `nil`/`null`). No uniffi regen — `FfiSendMessageOpts` already carries the field from #3756.

**Tests**
- Same-key→same-id / different-key→different-id determinism tests in both node and wasm suites.
- Updated the one positional caller `sendText('gm', true)` → `sendText('gm', { optimistic: true })`.

## Notes

- ⚠️ **Breaking** for direct binding consumers passing `optimistic` positionally to a `send_*` helper — now `{ optimistic }` in the opts bag. Chosen over an appended positional param to keep the signature extensible (per ticket design preference).
- Default behavior unchanged when no key is passed (core still falls back to `now_ns()`).
- **node-sdk** (`@xmtp/node-sdk`, separate repo) deferred to a companion PR after a `@xmtp/node-bindings` publish.
- `cargo check` / `clippy` / `rustfmt` clean on `bindings_node` (native). **wasm and the `just node/wasm/ios/android` recipes need Nix (absent in the authoring env)** — verify in CI: `just wasm check`, `just node test`, `just ios check`, `just android check`, `just lint`. wasm mirrors the node change exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `idempotency_key` on all top-level `send_*` helpers across iOS, Android, Node, and Wasm bindings
> - Introduces a `SendOpts` object (with `optimistic` and `idempotency_key` fields) accepted by all `send_*` helpers, replacing the bare `optimistic: bool` parameter across Node and Wasm bindings.
> - Adds `SendMessageOpts::from_send_opts(should_push, opts)` in both Node and Wasm bindings to centralize option construction, keeping `should_push` codec-derived.
> - Propagates `idempotencyKey` through `SendOptions` and `MessageVisibilityOptions` down to the FFI layer in iOS and Android SDKs.
> - Tests added in Node and Wasm verify that the same `idempotencyKey` produces deterministic, deduplicated message IDs, while different or absent keys produce distinct IDs.
> - Behavioral Change: existing callers passing a bare boolean for `optimistic` in Node/Wasm bindings must switch to `{ optimistic: bool }` options object.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60dc8fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->