### PR TITLE
feat(js-sdk): expose idempotencyKey on top-level send helpers

### DIFF
--- a/sdks/js/browser-sdk/src/Conversation.ts
+++ b/sdks/js/browser-sdk/src/Conversation.ts
@@ -10,6 +10,7 @@ import {
   type RemoteAttachment,
   type Reply,
   type SendMessageOpts,
+  type SendOpts,
   type TransactionReference,
   type WalletSendCalls,
   type DecodedMessage as XmtpDecodedMessage,
@@ -160,8 +161,10 @@ export class Conversation<ContentTypes = unknown> {
    * @param options - Optional send options
    * @param options.shouldPush - Indicates whether this message should be
    * included in push notifications
-   * @param options.isOptimistic - Indicates whether this message should be
+   * @param options.optimistic - Indicates whether this message should be
    * sent optimistically and published later via `publishMessages`
+   * @param options.idempotencyKey - Optional idempotency key; re-sending
+   * identical content with the same key produces the same deduplicated message id
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async send(content: EncodedContent, options?: SendMessageOpts) {
@@ -176,14 +179,14 @@ export class Conversation<ContentTypes = unknown> {
    * Sends a text message
    *
    * @param text - The text to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendText(text: string, isOptimistic?: boolean) {
+  async sendText(text: string, opts?: SendOpts) {
     return this.#worker.action("conversation.sendText", {
       id: this.#id,
       text,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -191,14 +194,14 @@ export class Conversation<ContentTypes = unknown> {
    * Sends a markdown message
    *
    * @param markdown - The markdown to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendMarkdown(markdown: string, isOptimistic?: boolean) {
+  async sendMarkdown(markdown: string, opts?: SendOpts) {
     return this.#worker.action("conversation.sendMarkdown", {
       id: this.#id,
       markdown,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -206,27 +209,27 @@ export class Conversation<ContentTypes = unknown> {
    * Sends a reaction message
    *
    * @param reaction - The reaction to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendReaction(reaction: Reaction, isOptimistic?: boolean) {
+  async sendReaction(reaction: Reaction, opts?: SendOpts) {
     return this.#worker.action("conversation.sendReaction", {
       id: this.#id,
       reaction,
-      isOptimistic,
+      opts,
     });
   }
 
   /**
    * Sends a read receipt message
    *
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendReadReceipt(isOptimistic?: boolean) {
+  async sendReadReceipt(opts?: SendOpts) {
     return this.#worker.action("conversation.sendReadReceipt", {
       id: this.#id,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -234,14 +237,14 @@ export class Conversation<ContentTypes = unknown> {
    * Sends a reply message
    *
    * @param reply - The reply to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendReply(reply: Reply, isOptimistic?: boolean) {
+  async sendReply(reply: Reply, opts?: SendOpts) {
     return this.#worker.action("conversation.sendReply", {
       id: this.#id,
       reply,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -249,17 +252,17 @@ export class Conversation<ContentTypes = unknown> {
    * Sends a transaction reference message
    *
    * @param transactionReference - The transaction reference to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendTransactionReference(
     transactionReference: TransactionReference,
-    isOptimistic?: boolean,
+    opts?: SendOpts,
   ) {
     return this.#worker.action("conversation.sendTransactionReference", {
       id: this.#id,
       transactionReference,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -267,17 +270,14 @@ export class Conversation<ContentTypes = unknown> {
    * Sends a wallet send calls message
    *
    * @param walletSendCalls - The wallet send calls to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendWalletSendCalls(
-    walletSendCalls: WalletSendCalls,
-    isOptimistic?: boolean,
-  ) {
+  async sendWalletSendCalls(walletSendCalls: WalletSendCalls, opts?: SendOpts) {
     return this.#worker.action("conversation.sendWalletSendCalls", {
       id: this.#id,
       walletSendCalls,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -285,14 +285,14 @@ export class Conversation<ContentTypes = unknown> {
    * Sends an actions message
    *
    * @param actions - The actions to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendActions(actions: Actions, isOptimistic?: boolean) {
+  async sendActions(actions: Actions, opts?: SendOpts) {
     return this.#worker.action("conversation.sendActions", {
       id: this.#id,
       actions,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -300,14 +300,14 @@ export class Conversation<ContentTypes = unknown> {
    * Sends an intent message
    *
    * @param intent - The intent to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendIntent(intent: Intent, isOptimistic?: boolean) {
+  async sendIntent(intent: Intent, opts?: SendOpts) {
     return this.#worker.action("conversation.sendIntent", {
       id: this.#id,
       intent,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -315,14 +315,14 @@ export class Conversation<ContentTypes = unknown> {
    * Sends an attachment message
    *
    * @param attachment - The attachment to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendAttachment(attachment: Attachment, isOptimistic?: boolean) {
+  async sendAttachment(attachment: Attachment, opts?: SendOpts) {
     return this.#worker.action("conversation.sendAttachment", {
       id: this.#id,
       attachment,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -330,17 +330,17 @@ export class Conversation<ContentTypes = unknown> {
    * Sends a multi remote attachment message
    *
    * @param multiRemoteAttachment - The multi remote attachment to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendMultiRemoteAttachment(
     multiRemoteAttachment: MultiRemoteAttachment,
-    isOptimistic?: boolean,
+    opts?: SendOpts,
   ) {
     return this.#worker.action("conversation.sendMultiRemoteAttachment", {
       id: this.#id,
       multiRemoteAttachment,
-      isOptimistic,
+      opts,
     });
   }
 
@@ -348,17 +348,17 @@ export class Conversation<ContentTypes = unknown> {
    * Sends a remote attachment message
    *
    * @param remoteAttachment - The remote attachment to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendRemoteAttachment(
     remoteAttachment: RemoteAttachment,
-    isOptimistic?: boolean,
+    opts?: SendOpts,
   ) {
     return this.#worker.action("conversation.sendRemoteAttachment", {
       id: this.#id,
       remoteAttachment,
-      isOptimistic,
+      opts,
     });
   }
 

--- a/sdks/js/browser-sdk/src/WorkerConversation.ts
+++ b/sdks/js/browser-sdk/src/WorkerConversation.ts
@@ -23,6 +23,7 @@ import {
   type RemoteAttachment,
   type Reply,
   type SendMessageOpts,
+  type SendOpts,
   type TransactionReference,
   type WalletSendCalls,
 } from "@xmtp/wasm-bindings";
@@ -196,72 +197,61 @@ export class WorkerConversation {
     return this.#group.send(encodedContent, opts ?? { shouldPush: true });
   }
 
-  async sendText(text: string, isOptimistic?: boolean) {
-    return this.#group.sendText(text, { optimistic: isOptimistic });
+  async sendText(text: string, opts?: SendOpts) {
+    return this.#group.sendText(text, opts);
   }
 
-  async sendMarkdown(markdown: string, isOptimistic?: boolean) {
-    return this.#group.sendMarkdown(markdown, { optimistic: isOptimistic });
+  async sendMarkdown(markdown: string, opts?: SendOpts) {
+    return this.#group.sendMarkdown(markdown, opts);
   }
 
-  async sendReaction(reaction: Reaction, isOptimistic?: boolean) {
-    return this.#group.sendReaction(reaction, { optimistic: isOptimistic });
+  async sendReaction(reaction: Reaction, opts?: SendOpts) {
+    return this.#group.sendReaction(reaction, opts);
   }
 
-  async sendReadReceipt(isOptimistic?: boolean) {
-    return this.#group.sendReadReceipt({ optimistic: isOptimistic });
+  async sendReadReceipt(opts?: SendOpts) {
+    return this.#group.sendReadReceipt(opts);
   }
 
-  async sendReply(reply: Reply, isOptimistic?: boolean) {
-    return this.#group.sendReply(reply, { optimistic: isOptimistic });
+  async sendReply(reply: Reply, opts?: SendOpts) {
+    return this.#group.sendReply(reply, opts);
   }
 
   async sendTransactionReference(
     transactionReference: TransactionReference,
-    isOptimistic?: boolean,
+    opts?: SendOpts,
   ) {
-    return this.#group.sendTransactionReference(transactionReference, {
-      optimistic: isOptimistic,
-    });
+    return this.#group.sendTransactionReference(transactionReference, opts);
   }
 
-  async sendWalletSendCalls(
-    walletSendCalls: WalletSendCalls,
-    isOptimistic?: boolean,
-  ) {
-    return this.#group.sendWalletSendCalls(walletSendCalls, {
-      optimistic: isOptimistic,
-    });
+  async sendWalletSendCalls(walletSendCalls: WalletSendCalls, opts?: SendOpts) {
+    return this.#group.sendWalletSendCalls(walletSendCalls, opts);
   }
 
-  async sendActions(actions: Actions, isOptimistic?: boolean) {
-    return this.#group.sendActions(actions, { optimistic: isOptimistic });
+  async sendActions(actions: Actions, opts?: SendOpts) {
+    return this.#group.sendActions(actions, opts);
   }
 
-  async sendIntent(intent: Intent, isOptimistic?: boolean) {
-    return this.#group.sendIntent(intent, { optimistic: isOptimistic });
+  async sendIntent(intent: Intent, opts?: SendOpts) {
+    return this.#group.sendIntent(intent, opts);
   }
 
-  async sendAttachment(attachment: Attachment, isOptimistic?: boolean) {
-    return this.#group.sendAttachment(attachment, { optimistic: isOptimistic });
+  async sendAttachment(attachment: Attachment, opts?: SendOpts) {
+    return this.#group.sendAttachment(attachment, opts);
   }
 
   async sendMultiRemoteAttachment(
     multiRemoteAttachment: MultiRemoteAttachment,
-    isOptimistic?: boolean,
+    opts?: SendOpts,
   ) {
-    return this.#group.sendMultiRemoteAttachment(multiRemoteAttachment, {
-      optimistic: isOptimistic,
-    });
+    return this.#group.sendMultiRemoteAttachment(multiRemoteAttachment, opts);
   }
 
   async sendRemoteAttachment(
     remoteAttachment: RemoteAttachment,
-    isOptimistic?: boolean,
+    opts?: SendOpts,
   ) {
-    return this.#group.sendRemoteAttachment(remoteAttachment, {
-      optimistic: isOptimistic,
-    });
+    return this.#group.sendRemoteAttachment(remoteAttachment, opts);
   }
 
   async messages(options?: ListMessagesOptions): Promise<DecodedMessage[]> {

--- a/sdks/js/browser-sdk/src/index.ts
+++ b/sdks/js/browser-sdk/src/index.ts
@@ -58,6 +58,7 @@ export type {
   RemoteAttachment,
   Reply,
   SendMessageOpts,
+  SendOpts,
   SignatureRequestHandle,
   TransactionMetadata,
   TransactionReference,

--- a/sdks/js/browser-sdk/src/types/actions/conversation.ts
+++ b/sdks/js/browser-sdk/src/types/actions/conversation.ts
@@ -15,6 +15,7 @@ import type {
   RemoteAttachment,
   Reply,
   SendMessageOpts,
+  SendOpts,
   TransactionReference,
   WalletSendCalls,
 } from "@xmtp/wasm-bindings";
@@ -199,7 +200,7 @@ export type ConversationAction =
       data: {
         id: string;
         text: string;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -209,7 +210,7 @@ export type ConversationAction =
       data: {
         id: string;
         markdown: string;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -219,7 +220,7 @@ export type ConversationAction =
       data: {
         id: string;
         reaction: Reaction;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -228,7 +229,7 @@ export type ConversationAction =
       result: string;
       data: {
         id: string;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -238,7 +239,7 @@ export type ConversationAction =
       data: {
         id: string;
         reply: Reply;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -248,7 +249,7 @@ export type ConversationAction =
       data: {
         id: string;
         transactionReference: TransactionReference;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -258,7 +259,7 @@ export type ConversationAction =
       data: {
         id: string;
         walletSendCalls: WalletSendCalls;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -268,7 +269,7 @@ export type ConversationAction =
       data: {
         id: string;
         actions: Actions;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -278,7 +279,7 @@ export type ConversationAction =
       data: {
         id: string;
         intent: Intent;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -288,7 +289,7 @@ export type ConversationAction =
       data: {
         id: string;
         attachment: Attachment;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -298,7 +299,7 @@ export type ConversationAction =
       data: {
         id: string;
         multiRemoteAttachment: MultiRemoteAttachment;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     }
   | {
@@ -308,6 +309,6 @@ export type ConversationAction =
       data: {
         id: string;
         remoteAttachment: RemoteAttachment;
-        isOptimistic?: boolean;
+        opts?: SendOpts;
       };
     };

--- a/sdks/js/browser-sdk/src/workers/client.ts
+++ b/sdks/js/browser-sdk/src/workers/client.ts
@@ -1057,37 +1057,31 @@ self.onmessage = async (
       }
       case "conversation.sendText": {
         const group = getGroup(data.id);
-        const result = await group.sendText(data.text, data.isOptimistic);
+        const result = await group.sendText(data.text, data.opts);
         postMessage({ id, action, result });
         break;
       }
       case "conversation.sendMarkdown": {
         const group = getGroup(data.id);
-        const result = await group.sendMarkdown(
-          data.markdown,
-          data.isOptimistic,
-        );
+        const result = await group.sendMarkdown(data.markdown, data.opts);
         postMessage({ id, action, result });
         break;
       }
       case "conversation.sendReaction": {
         const group = getGroup(data.id);
-        const result = await group.sendReaction(
-          data.reaction,
-          data.isOptimistic,
-        );
+        const result = await group.sendReaction(data.reaction, data.opts);
         postMessage({ id, action, result });
         break;
       }
       case "conversation.sendReadReceipt": {
         const group = getGroup(data.id);
-        const result = await group.sendReadReceipt(data.isOptimistic);
+        const result = await group.sendReadReceipt(data.opts);
         postMessage({ id, action, result });
         break;
       }
       case "conversation.sendReply": {
         const group = getGroup(data.id);
-        const result = await group.sendReply(data.reply, data.isOptimistic);
+        const result = await group.sendReply(data.reply, data.opts);
         postMessage({ id, action, result });
         break;
       }
@@ -1095,7 +1089,7 @@ self.onmessage = async (
         const group = getGroup(data.id);
         const result = await group.sendTransactionReference(
           data.transactionReference,
-          data.isOptimistic,
+          data.opts,
         );
         postMessage({ id, action, result });
         break;
@@ -1104,29 +1098,26 @@ self.onmessage = async (
         const group = getGroup(data.id);
         const result = await group.sendWalletSendCalls(
           data.walletSendCalls,
-          data.isOptimistic,
+          data.opts,
         );
         postMessage({ id, action, result });
         break;
       }
       case "conversation.sendActions": {
         const group = getGroup(data.id);
-        const result = await group.sendActions(data.actions, data.isOptimistic);
+        const result = await group.sendActions(data.actions, data.opts);
         postMessage({ id, action, result });
         break;
       }
       case "conversation.sendIntent": {
         const group = getGroup(data.id);
-        const result = await group.sendIntent(data.intent, data.isOptimistic);
+        const result = await group.sendIntent(data.intent, data.opts);
         postMessage({ id, action, result });
         break;
       }
       case "conversation.sendAttachment": {
         const group = getGroup(data.id);
-        const result = await group.sendAttachment(
-          data.attachment,
-          data.isOptimistic,
-        );
+        const result = await group.sendAttachment(data.attachment, data.opts);
         postMessage({ id, action, result });
         break;
       }
@@ -1134,7 +1125,7 @@ self.onmessage = async (
         const group = getGroup(data.id);
         const result = await group.sendMultiRemoteAttachment(
           data.multiRemoteAttachment,
-          data.isOptimistic,
+          data.opts,
         );
         postMessage({ id, action, result });
         break;
@@ -1143,7 +1134,7 @@ self.onmessage = async (
         const group = getGroup(data.id);
         const result = await group.sendRemoteAttachment(
           data.remoteAttachment,
-          data.isOptimistic,
+          data.opts,
         );
         postMessage({ id, action, result });
         break;

--- a/sdks/js/browser-sdk/test/Dm.test.ts
+++ b/sdks/js/browser-sdk/test/Dm.test.ts
@@ -127,7 +127,7 @@ describe("Dm", () => {
     const dm = await client1.conversations.createDm(client2.inboxId!);
 
     const text = "gm";
-    await dm.sendText(text, true);
+    await dm.sendText(text, { optimistic: true });
 
     const messages = await dm.messages();
     expect(messages.length).toBe(2);

--- a/sdks/js/browser-sdk/test/Group.test.ts
+++ b/sdks/js/browser-sdk/test/Group.test.ts
@@ -139,7 +139,7 @@ describe("Group", () => {
     expect(group.addedByInboxId).toBe(client1.inboxId);
 
     const text = "gm";
-    await group.sendText(text, true);
+    await group.sendText(text, { optimistic: true });
 
     const messages = await group.messages();
     expect(messages.length).toBe(1);
@@ -152,6 +152,29 @@ describe("Group", () => {
     expect(messages2.length).toBe(1);
     expect(messages2[0].content).toBe(text);
     expect(messages2[0].deliveryStatus).toBe(DeliveryStatus.Published);
+  });
+
+  it("should produce deterministic ids for a caller-set idempotency key", async () => {
+    const { signer: signer1 } = createSigner();
+    const { signer: signer2 } = createSigner();
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
+    const group = await client1.conversations.createGroup([client2.inboxId!]);
+
+    // Same content + same key => same id, deduplicated (no new stored message).
+    const id1 = await group.sendText("gm", { idempotencyKey: "key-1" });
+    const countAfterFirst = (await group.messages()).length;
+    const id2 = await group.sendText("gm", { idempotencyKey: "key-1" });
+    expect(id2).toBe(id1);
+    expect((await group.messages()).length).toBe(countAfterFirst);
+
+    // Different key (or no key) => different id, stored as a new message.
+    const id3 = await group.sendText("gm", { idempotencyKey: "key-2" });
+    const id4 = await group.sendText("gm");
+    expect(id3).not.toBe(id1);
+    expect(id4).not.toBe(id1);
+    expect(id4).not.toBe(id3);
+    expect((await group.messages()).length).toBe(countAfterFirst + 2);
   });
 
   it("should optimistically create a group with members", async () => {
@@ -171,7 +194,7 @@ describe("Group", () => {
     expect(group.addedByInboxId).toBe(client1.inboxId);
 
     const text = "gm";
-    await group.sendText(text, true);
+    await group.sendText(text, { optimistic: true });
 
     const messages = await group.messages();
     expect(messages.length).toBe(1);
@@ -380,7 +403,7 @@ describe("Group", () => {
     const group = await client1.conversations.createGroup([client2.inboxId!]);
 
     const text = "gm";
-    await group.sendText(text, true);
+    await group.sendText(text, { optimistic: true });
 
     const messages = await group.messages();
     expect(messages.length).toBe(2);
@@ -586,7 +609,7 @@ describe("Group", () => {
     });
     expect(filteredMessages9.length).toBe(2);
 
-    await group.sendText("gm", true);
+    await group.sendText("gm", { optimistic: true });
     const filteredMessages10 = await group.messages({
       deliveryStatus: DeliveryStatus.Published,
     });

--- a/sdks/js/node-sdk/src/Conversation.ts
+++ b/sdks/js/node-sdk/src/Conversation.ts
@@ -12,6 +12,7 @@ import {
   type RemoteAttachment,
   type Reply,
   type SendMessageOpts,
+  type SendOpts,
   type TransactionReference,
   type WalletSendCalls,
   type Conversation as XmtpConversation,
@@ -192,8 +193,10 @@ export class Conversation<ContentTypes = unknown> {
    * @param sendOptions - Options for sending the message
    * @param sendOptions.shouldPush - Indicates whether this message should be
    * included in push notifications
-   * @param sendOptions.isOptimistic - Indicates whether this message should be
+   * @param sendOptions.optimistic - Indicates whether this message should be
    * sent optimistically and published later via `publishMessages`
+   * @param sendOptions.idempotencyKey - Optional idempotency key; re-sending
+   * identical content with the same key produces the same deduplicated message id
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async send(encodedContent: EncodedContent, sendOptions?: SendMessageOpts) {
@@ -210,160 +213,146 @@ export class Conversation<ContentTypes = unknown> {
    * Sends a text message
    *
    * @param text - The text to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendText(text: string, isOptimistic?: boolean) {
-    return this.#conversation.sendText(text, { optimistic: isOptimistic });
+  async sendText(text: string, opts?: SendOpts) {
+    return this.#conversation.sendText(text, opts);
   }
 
   /**
    * Sends a markdown message
    *
    * @param markdown - The markdown to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendMarkdown(markdown: string, isOptimistic?: boolean) {
-    return this.#conversation.sendMarkdown(markdown, {
-      optimistic: isOptimistic,
-    });
+  async sendMarkdown(markdown: string, opts?: SendOpts) {
+    return this.#conversation.sendMarkdown(markdown, opts);
   }
 
   /**
    * Sends a reaction message
    *
    * @param reaction - The reaction to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendReaction(reaction: Reaction, isOptimistic?: boolean) {
-    return this.#conversation.sendReaction(reaction, {
-      optimistic: isOptimistic,
-    });
+  async sendReaction(reaction: Reaction, opts?: SendOpts) {
+    return this.#conversation.sendReaction(reaction, opts);
   }
 
   /**
    * Sends a read receipt message
    *
-   * @param readReceipt - The read receipt to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendReadReceipt(isOptimistic?: boolean) {
-    return this.#conversation.sendReadReceipt({ optimistic: isOptimistic });
+  async sendReadReceipt(opts?: SendOpts) {
+    return this.#conversation.sendReadReceipt(opts);
   }
 
   /**
    * Sends a reply message
    *
    * @param reply - The reply to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendReply(reply: Reply, isOptimistic?: boolean) {
-    return this.#conversation.sendReply(reply, { optimistic: isOptimistic });
+  async sendReply(reply: Reply, opts?: SendOpts) {
+    return this.#conversation.sendReply(reply, opts);
   }
 
   /**
    * Sends a transaction reference message
    *
    * @param transactionReference - The transaction reference to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendTransactionReference(
     transactionReference: TransactionReference,
-    isOptimistic?: boolean,
+    opts?: SendOpts,
   ) {
-    return this.#conversation.sendTransactionReference(transactionReference, {
-      optimistic: isOptimistic,
-    });
+    return this.#conversation.sendTransactionReference(
+      transactionReference,
+      opts,
+    );
   }
 
   /**
    * Sends a wallet send calls message
    *
    * @param walletSendCalls - The wallet send calls to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendWalletSendCalls(
-    walletSendCalls: WalletSendCalls,
-    isOptimistic?: boolean,
-  ) {
-    return this.#conversation.sendWalletSendCalls(walletSendCalls, {
-      optimistic: isOptimistic,
-    });
+  async sendWalletSendCalls(walletSendCalls: WalletSendCalls, opts?: SendOpts) {
+    return this.#conversation.sendWalletSendCalls(walletSendCalls, opts);
   }
 
   /**
    * Sends a actions message
    *
    * @param actions - The actions to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendActions(actions: Actions, isOptimistic?: boolean) {
-    return this.#conversation.sendActions(actions, {
-      optimistic: isOptimistic,
-    });
+  async sendActions(actions: Actions, opts?: SendOpts) {
+    return this.#conversation.sendActions(actions, opts);
   }
 
   /**
    * Sends a intent message
    *
    * @param intent - The intent to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendIntent(intent: Intent, isOptimistic?: boolean) {
-    return this.#conversation.sendIntent(intent, { optimistic: isOptimistic });
+  async sendIntent(intent: Intent, opts?: SendOpts) {
+    return this.#conversation.sendIntent(intent, opts);
   }
 
   /**
    * Sends an attachment message
    *
    * @param attachment - The attachment to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
-  async sendAttachment(attachment: Attachment, isOptimistic?: boolean) {
-    return this.#conversation.sendAttachment(attachment, {
-      optimistic: isOptimistic,
-    });
+  async sendAttachment(attachment: Attachment, opts?: SendOpts) {
+    return this.#conversation.sendAttachment(attachment, opts);
   }
 
   /**
    * Sends a multi remote attachment message
    *
    * @param multiRemoteAttachment - The multi remote attachment to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendMultiRemoteAttachment(
     multiRemoteAttachment: MultiRemoteAttachment,
-    isOptimistic?: boolean,
+    opts?: SendOpts,
   ) {
-    return this.#conversation.sendMultiRemoteAttachment(multiRemoteAttachment, {
-      optimistic: isOptimistic,
-    });
+    return this.#conversation.sendMultiRemoteAttachment(
+      multiRemoteAttachment,
+      opts,
+    );
   }
 
   /**
    * Sends a remote attachment message
    *
    * @param remoteAttachment - The remote attachment to send
-   * @param isOptimistic - Whether to send the message optimistically
+   * @param opts - Send options (optimistic delivery, idempotency key)
    * @returns Promise that resolves with the message ID after it has been sent
    */
   async sendRemoteAttachment(
     remoteAttachment: RemoteAttachment,
-    isOptimistic?: boolean,
+    opts?: SendOpts,
   ) {
-    return this.#conversation.sendRemoteAttachment(remoteAttachment, {
-      optimistic: isOptimistic,
-    });
+    return this.#conversation.sendRemoteAttachment(remoteAttachment, opts);
   }
 
   /**

--- a/sdks/js/node-sdk/src/index.ts
+++ b/sdks/js/node-sdk/src/index.ts
@@ -59,6 +59,7 @@ export type {
   RemoteAttachment,
   Reply,
   SendMessageOpts,
+  SendOpts,
   SignatureRequestHandle,
   TransactionMetadata,
   TransactionReference,

--- a/sdks/js/node-sdk/test/Dm.test.ts
+++ b/sdks/js/node-sdk/test/Dm.test.ts
@@ -128,7 +128,7 @@ describe("Dm", () => {
     const dm = await client1.conversations.createDm(client2.inboxId);
 
     const text = "gm";
-    await dm.sendText(text, true);
+    await dm.sendText(text, { optimistic: true });
 
     const messages = await dm.messages();
     expect(messages.length).toBe(2);

--- a/sdks/js/node-sdk/test/Group.test.ts
+++ b/sdks/js/node-sdk/test/Group.test.ts
@@ -137,7 +137,7 @@ describe("Group", () => {
     expect(group.addedByInboxId).toBe(client1.inboxId);
 
     const text = "gm";
-    await group.sendText(text, true);
+    await group.sendText(text, { optimistic: true });
 
     const messages = await group.messages();
     expect(messages.length).toBe(1);
@@ -150,6 +150,29 @@ describe("Group", () => {
     expect(messages2.length).toBe(1);
     expect(messages2[0].content).toBe(text);
     expect(messages2[0].deliveryStatus).toBe(DeliveryStatus.Published);
+  });
+
+  it("should produce deterministic ids for a caller-set idempotency key", async () => {
+    const { signer: signer1 } = createSigner();
+    const { signer: signer2 } = createSigner();
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
+    const group = await client1.conversations.createGroup([client2.inboxId]);
+
+    // Same content + same key => same id, deduplicated (no new stored message).
+    const id1 = await group.sendText("gm", { idempotencyKey: "key-1" });
+    const countAfterFirst = (await group.messages()).length;
+    const id2 = await group.sendText("gm", { idempotencyKey: "key-1" });
+    expect(id2).toBe(id1);
+    expect((await group.messages()).length).toBe(countAfterFirst);
+
+    // Different key (or no key) => different id, stored as a new message.
+    const id3 = await group.sendText("gm", { idempotencyKey: "key-2" });
+    const id4 = await group.sendText("gm");
+    expect(id3).not.toBe(id1);
+    expect(id4).not.toBe(id1);
+    expect(id4).not.toBe(id3);
+    expect((await group.messages()).length).toBe(countAfterFirst + 2);
   });
 
   it("should optimistically create a group with members", async () => {
@@ -169,7 +192,7 @@ describe("Group", () => {
     expect(group.addedByInboxId).toBe(client1.inboxId);
 
     const text = "gm";
-    await group.sendText(text, true);
+    await group.sendText(text, { optimistic: true });
 
     const messages = await group.messages();
     expect(messages.length).toBe(1);
@@ -330,7 +353,7 @@ describe("Group", () => {
     const group = await client1.conversations.createGroup([client2.inboxId]);
 
     const text = "gm";
-    await group.sendText(text, true);
+    await group.sendText(text, { optimistic: true });
 
     const messages = await group.messages();
     expect(messages.length).toBe(2);
@@ -536,7 +559,7 @@ describe("Group", () => {
     });
     expect(filteredMessages9.length).toBe(2);
 
-    await group.sendText("gm", true);
+    await group.sendText("gm", { optimistic: true });
     const filteredMessages10 = await group.messages({
       deliveryStatus: DeliveryStatus.Published,
     });


### PR DESCRIPTION
## Summary

Follow-up to #3762, which exposed `idempotency_key` on the **binding** `send_*` helpers (node + wasm). The JS **SDKs** (`@xmtp/node-sdk`, `@xmtp/browser-sdk`, now in this repo per #3720) still only forwarded `optimistic`, so SDK callers wanting idempotent (crash-safe / dedup-able) resends couldn't reach the key exposed one layer below. This closes that gap.

Because the message id is `calculate_message_id(group_id, content, key)` and the key rides the wire, a stable caller key makes a resend of identical content produce the **same** id, which every consumer already dedups (libxmtp + receive-side PK upsert).

## Changes

All 12 `send*` convenience helpers now take the binding's `SendOpts` bag (`{ optimistic?, idempotencyKey? }`) in place of the trailing `isOptimistic?: boolean`, mirroring #3762.

**node-sdk**
- `Conversation.ts` — 12 helpers pass `SendOpts` straight through (inherited by `Group`/`Dm`).
- Re-export `SendOpts` from `index.ts`.

**browser-sdk** (threaded across all 4 layers of the worker boundary)
- `Conversation.ts` — 12 public helpers put `opts` on the worker action payload.
- `types/actions/conversation.ts` — 12 action `data` payloads carry `opts?: SendOpts`.
- `workers/client.ts` — 12 dispatch cases forward `data.opts`.
- `WorkerConversation.ts` — 12 helpers pass `opts` to the wasm binding.
- Re-export `SendOpts` from `index.ts`.

**Docs**
- Fixed stale `send()` JSDoc (`isOptimistic` → `optimistic`, the actual `SendMessageOpts` field) and documented `idempotencyKey`.

**Tests**
- Same-key→same-id / different-key→different-id determinism tests in both SDKs' `Group.test.ts`.
- Updated positional callers `sendText(x, true)` → `sendText(x, { optimistic: true })` (node + browser, Group + Dm).

## Notes

- ⚠️ **Breaking** for SDK callers passing `optimistic` positionally to a `send*` helper — now `{ optimistic }` in the opts bag. Chosen over an appended positional param for extensibility, consistent with the binding change in #3762.
- Default behavior unchanged when no key is passed (core falls back to `now_ns()`).
- The portal-linked bindings (`@xmtp/node-bindings`, `@xmtp/wasm-bindings`) are gitignored build artifacts rebuilt by CI via Nix; local typecheck wasn't possible without Nix (same constraint as #3762). Prettier verified clean locally. **Verify in CI:** `just node test`, `just wasm test`, `just lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `isOptimistic` boolean with `SendOpts` object on all `Conversation` send helpers
> - All typed send methods (`sendText`, `sendMarkdown`, `sendReaction`, `sendReply`, etc.) in both the browser and node SDKs now accept a `SendOpts` object instead of a bare `boolean` for the optimistic flag.
> - `SendOpts` carries both `optimistic` and `idempotencyKey` fields, enabling callers to supply a deterministic key for deduplication.
> - `SendOpts` is re-exported from both `@xmtp/browser-sdk` and `@xmtp/node-sdk` so consumers can import it directly.
> - Tests are updated to pass `{ optimistic: true }` and new tests verify that repeated sends with the same `idempotencyKey` produce identical message IDs.
> - Behavioral Change: the second parameter of all typed send helpers is now an options object; passing a raw boolean will break at the TypeScript level.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b871b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->