### PR TITLE
fix(xmtp_db): make TestInstrumentation database-lock panic opt-in

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/database/instrumentation.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/instrumentation.rs
@@ -3,11 +3,32 @@ use diesel::connection::InstrumentationEvent;
 use diesel::result::Error as DieselError;
 use std::fmt::Write;
 
-// Test instrumentatiomn
+// Test instrumentation
 // prints out query on error
-// panics on database lock
+// panics on database lock ONLY when explicitly opted in via the
+// `XMTP_PANIC_ON_DB_LOCK` env var (accepts "1" or "true").
+//
+// `database is locked` is a transient, retryable condition in this codebase
+// (SQLite is configured with `PRAGMA busy_timeout` and the error is classified
+// as retryable). Panicking on it by default aborts the worker thread and crashes
+// downstream test harnesses (e.g. the node-sdk Vitest fork workers), so the panic
+// is opt-in for developers actively debugging lock contention.
 #[allow(unused)]
 pub struct TestInstrumentation;
+
+/// Returns true when the caller has explicitly opted in to panicking on
+/// `database is locked` via the `XMTP_PANIC_ON_DB_LOCK` env var.
+fn panic_on_db_lock_enabled() -> bool {
+    panic_on_db_lock_from_env(std::env::var("XMTP_PANIC_ON_DB_LOCK"))
+}
+
+/// Pure decision helper: the opt-in is enabled only when the env var resolves to
+/// exactly `"1"` or `"true"`. Anything else (unset, empty, other values) keeps the
+/// default non-panicking behavior. Kept separate from the env read so it can be
+/// unit-tested without mutating the process environment.
+fn panic_on_db_lock_from_env(var: Result<String, std::env::VarError>) -> bool {
+    matches!(var, Ok(s) if s == "1" || s == "true")
+}
 
 impl Instrumentation for TestInstrumentation {
     fn on_connection_event(&mut self, event: InstrumentationEvent<'_>) {
@@ -32,7 +53,7 @@ impl Instrumentation for TestInstrumentation {
                             tracing::error!("details: {},", details);
                         }
                         tracing::error!("{}", s);
-                        if s.contains("database is locked") {
+                        if s.contains("database is locked") && panic_on_db_lock_enabled() {
                             panic!("database locked");
                         }
                     }
@@ -49,6 +70,35 @@ impl Instrumentation for TestInstrumentation {
             }
 
             _ => (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::panic_on_db_lock_from_env;
+    use std::env::VarError;
+
+    #[test]
+    fn db_lock_panic_disabled_by_default() {
+        // Unset env var (the default in CI / node-sdk Vitest workers) must NOT
+        // opt in to panicking, so a `database is locked` error stays recoverable.
+        assert!(!panic_on_db_lock_from_env(Err(VarError::NotPresent)));
+    }
+
+    #[test]
+    fn db_lock_panic_opt_in_values() {
+        assert!(panic_on_db_lock_from_env(Ok("1".to_string())));
+        assert!(panic_on_db_lock_from_env(Ok("true".to_string())));
+    }
+
+    #[test]
+    fn db_lock_panic_ignores_other_values() {
+        for v in ["0", "false", "", "yes", "TRUE", "True"] {
+            assert!(
+                !panic_on_db_lock_from_env(Ok(v.to_string())),
+                "value {v:?} should not enable the panic"
+            );
         }
     }
 }

--- a/crates/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -596,6 +596,7 @@ pub mod tests {
     use crate::tester;
     use futures::stream::StreamExt;
     use rstest::*;
+    use xmtp_db::group_message::GroupMessageKind;
 
     #[xmtp_common::timeout(std::time::Duration::from_secs(30))]
     #[rstest]
@@ -613,15 +614,24 @@ pub mod tests {
         let bob_group = bob_groups.first().unwrap();
         alice_group.sync().await.unwrap();
 
-        let stream = alice_group.stream().await.unwrap();
+        // The `group_updated` membership-change commit from `add_members` above can
+        // race into the stream ahead of the application messages, which made this
+        // test flaky (see xmtp/libxmtp#3765). Filter to application messages so the
+        // assertions below are deterministic regardless of whether the commit
+        // message is delivered through the stream.
+        let stream = alice_group.stream().await.unwrap().filter(|msg| {
+            futures::future::ready(
+                msg.as_ref()
+                    .map(|m| m.kind == GroupMessageKind::Application)
+                    .unwrap_or(true),
+            )
+        });
         futures::pin_mut!(stream);
         bob_group
             .send_message(b"hello", SendMessageOpts::default())
             .await
             .unwrap();
 
-        // group updated msg/bob is added
-        // assert_msg_exists!(stream);
         assert_msg!(stream, "hello");
 
         bob_group

--- a/justfile
+++ b/justfile
@@ -85,11 +85,11 @@ _test-all *args="": (_test-v3 args) (_test-d14n args)
 
 [private]
 _test-v3 *args="":
-    {{ cargo_test }} --profile ci {{ args }}
+    XMTP_PANIC_ON_DB_LOCK=true {{ cargo_test }} --profile ci {{ args }}
 
 [private]
 _test-d14n *args="":
-    {{ cargo_test }} \
+    XMTP_PANIC_ON_DB_LOCK=true {{ cargo_test }} \
       --features d14n --profile ci-d14n \
       -E 'package(xmtp_mls)' -E 'rdeps(xmtp_mls)' {{ args }}
 

--- a/nix/package/nextest.nix
+++ b/nix/package/nextest.nix
@@ -46,6 +46,11 @@ rust.cargoNextest (
   // {
     inherit src cargoArtifacts;
     doCheck = true;
+    # Opt in to the diesel TestInstrumentation panic on `database is locked`
+    # for the workspace test run. The panic is off by default so it cannot crash
+    # the node-sdk Vitest workers (xmtp/libxmtp#3765), but we still want the Rust
+    # workspace tests to fail loudly on lock contention.
+    XMTP_PANIC_ON_DB_LOCK = "true";
     pnameSuffix = if d14n then "nextest-d14n" else "nextest-v3";
     partitions = 1;
     partitionType = "count";


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3765

## Problem

`TestInstrumentation` (`crates/xmtp_db/src/encrypted_store/database/instrumentation.rs`) called `panic!("database locked")` on **any** query that failed with `database is locked`. This instrumentation is installed on every SQLite connection whenever the `test` cfg **or** the `test-utils` feature is active — and the node-sdk Vitest suite (`bindings_node`) enables `test-utils`.

Under concurrent test load (CI node-sdk shard 2), Vitest fork workers transiently contend on SQLite locks. Each `database is locked` error panicked on an `r2d2-worker`/`tokio-rt-worker` thread, aborting the worker process and surfacing as flaky `Worker exited unexpectedly` failures with a non-zero Vitest exit code.

`database is locked` is **not** fatal in this codebase: SQLite is configured with `PRAGMA busy_timeout = 5000` and the error is explicitly classified as retryable (`PlatformStorageError::DatabaseLocked => true`; `ClientError` retries on `"database is locked"`). The panic short-circuited that designed retry/backoff machinery, turning a recoverable transient error into a hard crash.

## Fix

Gate the panic behind an opt-in `XMTP_PANIC_ON_DB_LOCK` environment variable (accepts `1`/`true`, matching the existing `SQLCIPHER_LOG` convention):

- **Default (unset):** log the query error at error level and return normally — the existing busy_timeout/retry machinery recovers. No worker crashes.
- **`XMTP_PANIC_ON_DB_LOCK=1`:** preserve the legacy panic for developers explicitly debugging lock contention.

The env read is split from a pure decision helper (`panic_on_db_lock_from_env`) so the opt-in logic is unit-tested without mutating the process environment (Rust 2024 `set_var` is unsafe/racy).

## Unchanged behavior
- Query-error logging (message/table/column/hint) is preserved.
- `DatabaseLocked` remains classified as retryable.
- Begin/Commit/Rollback transaction tracing is unchanged.

## Testing
- New unit tests in `instrumentation.rs` cover: panic disabled by default (unset env), opt-in values (`1`/`true`), and that other values (`0`, `false`, empty, `TRUE`, etc.) do not enable it.
- `cargo test -p xmtp_db --lib instrumentation` → 3 passed.
- `cargo clippy -p xmtp_db --all-features --tests` → clean.
- `cargo fmt -p xmtp_db --check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `TestInstrumentation` database-lock panic opt-in via `XMTP_PANIC_ON_DB_LOCK` env var
> - Panicking on SQLite "database is locked" errors in `TestInstrumentation` now requires `XMTP_PANIC_ON_DB_LOCK=1` or `XMTP_PANIC_ON_DB_LOCK=true`; previously any occurrence would panic unconditionally.
> - Adds `panic_on_db_lock_enabled` and `panic_on_db_lock_from_env` helpers in [instrumentation.rs](https://github.com/xmtp/libxmtp/pull/3767/files#diff-3f2f010aa407d2e385927c144accbd35ac3b8eb13e576e302dcedbb71aec28d8) to read and evaluate the env var.
> - Sets `XMTP_PANIC_ON_DB_LOCK=true` in the `justfile` test recipes and the [nextest.nix](https://github.com/xmtp/libxmtp/pull/3767/files#diff-aa45367a8dcf70261a484bcc1f097c399301d2c6819f730c07781fb8936eed8a) package so CI and local test runs still opt in.
> - Fixes a flaky test in [stream_messages.rs](https://github.com/xmtp/libxmtp/pull/3767/files#diff-cffe5828e751e2a749629b6acdb0a9a09b407756b9b89f3042a1ecf28055aeb6) by filtering the message stream to application messages only, avoiding races with membership-change commits.
> - Behavioral Change: the default behavior no longer panics on lock contention; environments outside the configured test runners must explicitly set the env var to preserve the old behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36e833a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->