### PR TITLE
feat(xmtp_api_grpc): bidi_stream transport primitive

### DIFF
--- a/crates/xmtp_api_grpc/src/grpc_client/client.rs
+++ b/crates/xmtp_api_grpc/src/grpc_client/client.rs
@@ -80,12 +80,17 @@ impl GrpcClient {
         }
     }
 
-    /// Builds a tonic request from a body and a generic HTTP Request
-    fn build_tonic_request(
+    /// Builds a tonic request from a body and a generic HTTP Request.
+    ///
+    /// Generic over the body type `B` so the same path serves both the
+    /// unary / server-streaming transports (where `B` is `Bytes`) and the
+    /// XIP-83 bidirectional transport (where `B` is a `BoxDynStream` of
+    /// outbound frames). `tonic::Request<B>` is happy with either.
+    fn build_tonic_request<B>(
         &self,
         request: http::request::Builder,
-        body: Bytes,
-    ) -> Result<tonic::Request<Bytes>, Status> {
+        body: B,
+    ) -> Result<tonic::Request<B>, Status> {
         let request = request
             .body(body)
             .map_err(|e| tonic::Status::from_error(Box::new(e)))?;
@@ -175,6 +180,36 @@ impl Client for GrpcClient {
             let request = this.build_tonic_request(request, body)?;
             let codec = TransparentCodec::default();
             client.server_streaming(request, path, codec).await
+        };
+        let req = crate::streams::NonBlockingStreamRequest::new(
+            Box::pin(response) as crate::streams::ResponseFuture
+        );
+        let response = crate::streams::send(req).await.map_err(GrpcError::from)?;
+        let response = response.map(|body| {
+            BytesStream::new(GrpcStream {
+                inner: EscapableTonicStream::new(body),
+            })
+        });
+        Ok(response.to_http().map(Into::into))
+    }
+
+    // Full-duplex needs a real HTTP/2 transport; the gRPC-Web service used on
+    // wasm cannot carry it, so the browser keeps the trait's default error.
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn bidi_stream(
+        &self,
+        request: request::Builder,
+        path: PathAndQuery,
+        body: xmtp_common::BoxDynStream<'static, Bytes>,
+    ) -> Result<http::Response<BytesStream>, ApiClientError> {
+        let this = self.clone();
+        // client requires to be moved so it lives long enough for streaming response future.
+        let response = async move {
+            let mut client = this.inner.clone();
+            this.wait_for_ready(&mut client).await?;
+            let request = this.build_tonic_request(request, body)?;
+            let codec = TransparentCodec::default();
+            client.streaming(request, path, codec).await
         };
         let req = crate::streams::NonBlockingStreamRequest::new(
             Box::pin(response) as crate::streams::ResponseFuture
@@ -311,7 +346,7 @@ pub mod tests {
         let request = client
             .build_tonic_request(
                 Default::default(),
-                PublishRequest { envelopes: vec![] }.encode_to_vec().into(),
+                prost::bytes::Bytes::from(PublishRequest { envelopes: vec![] }.encode_to_vec()),
             )
             .unwrap();
 

--- a/crates/xmtp_proto/src/traits.rs
+++ b/crates/xmtp_proto/src/traits.rs
@@ -143,6 +143,22 @@ pub trait Client: MaybeSend + MaybeSync {
         body: Bytes,
     ) -> Result<http::Response<BytesStream>, ApiClientError>;
 
+    /// Open a bidirectional stream (XIP-83). `body` is the outbound stream of
+    /// encoded protobuf messages (one `Bytes` item per message); the response
+    /// carries the inbound message stream. Transports without full-duplex
+    /// support (e.g. gRPC-Web in the browser) keep this default and error.
+    async fn bidi_stream(
+        &self,
+        request: request::Builder,
+        path: http::uri::PathAndQuery,
+        body: BoxDynStream<'static, Bytes>,
+    ) -> Result<http::Response<BytesStream>, ApiClientError> {
+        let _ = (request, path, body);
+        Err(ApiClientError::OtherUnretryable(
+            "bidirectional streaming is not supported by this transport".into(),
+        ))
+    }
+
     /// start a "fake" stream that does not create a TCP connection and will always be pending
     fn fake_stream(&self) -> http::Response<BytesStream> {
         let fake = FakeEmptyStream::new();
@@ -179,6 +195,15 @@ where
     ) -> Result<http::Response<BytesStream>, ApiClientError> {
         (**self).stream(request, path, body).await
     }
+
+    async fn bidi_stream(
+        &self,
+        request: request::Builder,
+        path: http::uri::PathAndQuery,
+        body: BoxDynStream<'static, Bytes>,
+    ) -> Result<http::Response<BytesStream>, ApiClientError> {
+        (**self).bidi_stream(request, path, body).await
+    }
 }
 
 #[xmtp_common::async_trait]
@@ -203,6 +228,15 @@ where
     ) -> Result<http::Response<BytesStream>, ApiClientError> {
         (**self).stream(request, path, body).await
     }
+
+    async fn bidi_stream(
+        &self,
+        request: request::Builder,
+        path: http::uri::PathAndQuery,
+        body: BoxDynStream<'static, Bytes>,
+    ) -> Result<http::Response<BytesStream>, ApiClientError> {
+        (**self).bidi_stream(request, path, body).await
+    }
 }
 
 #[xmtp_common::async_trait]
@@ -226,6 +260,15 @@ where
         body: Bytes,
     ) -> Result<http::Response<BytesStream>, ApiClientError> {
         (**self).stream(request, path, body).await
+    }
+
+    async fn bidi_stream(
+        &self,
+        request: request::Builder,
+        path: PathAndQuery,
+        body: BoxDynStream<'static, Bytes>,
+    ) -> Result<http::Response<BytesStream>, ApiClientError> {
+        (**self).bidi_stream(request, path, body).await
     }
 }
 

--- a/crates/xmtp_proto/src/traits/boxed_client.rs
+++ b/crates/xmtp_proto/src/traits/boxed_client.rs
@@ -48,6 +48,15 @@ where
     ) -> Result<http::Response<BytesStream>, ApiClientError> {
         self.inner.stream(request, path, body).await
     }
+
+    async fn bidi_stream(
+        &self,
+        request: request::Builder,
+        path: http::uri::PathAndQuery,
+        body: xmtp_common::BoxDynStream<'static, Bytes>,
+    ) -> Result<http::Response<BytesStream>, ApiClientError> {
+        self.inner.bidi_stream(request, path, body).await
+    }
 }
 
 pub trait ToBoxedClient {


### PR DESCRIPTION
**Stack 2/4** of the XIP-83 bidi client lane: #3769 → #3770 → #3771 → #3772.

Adds one primitive to the protocol-agnostic `Client` trait: `bidi_stream(request, path, BoxDynStream<Bytes>) -> http::Response<BytesStream>` — outbound stream of encoded protobuf messages in, inbound message stream out. Default implementation errors ("not supported by this transport"), so gRPC-Web/wasm and mocks are untouched; forwarded through the `&T`/`Box`/`Arc`/boxed-client impls. `GrpcClient` overrides it natively via tonic `Grpc::streaming` + the existing `TransparentCodec`, reusing the NonBlocking stream machinery verbatim. `build_tonic_request` made generic over the body type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `bidi_stream` bidirectional streaming transport primitive to `GrpcClient`
> - Adds `bidi_stream` to the `Client` trait in [traits.rs](https://github.com/xmtp/libxmtp/pull/3770/files#diff-b1ac865eb97518e560fdf6a9a6b10829c3a9e0409741efeda43c4f69e3c737cf) with a default implementation that returns an unretryable error, so existing transports don't break.
> - Implements `bidi_stream` on `GrpcClient` (non-wasm only) in [client.rs](https://github.com/xmtp/libxmtp/pull/3770/files#diff-6b4c1564ab1155489bad3bf8a8e7a86b8b0f7971963879f8f8ddaee795ce4143), sending an outbound `BoxDynStream<Bytes>` and returning an inbound `BytesStream` over HTTP/2.
> - Makes `build_tonic_request` generic over the body type to support both unary/server-streaming (`Bytes`) and bidirectional (stream of frames) use cases.
> - Forwards `bidi_stream` through blanket impls for `&T`, `&mut T`, `Arc<T>`, and `BoxedClient<C>`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74f05a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->