### PR TITLE
docs: add ios and js SDKs to repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,11 @@ protocol buffers
 
 ├ sdks/
 
-│ └ [`android`](./sdks/android): Android SDK (Kotlin)
+│ ├ [`android`](./sdks/android): Android SDK (Kotlin)
+
+│ ├ [`ios`](./sdks/ios): iOS SDK (Swift)
+
+│ └ [`js`](./sdks/js): Browser and Node SDK (TypeScript)
 
 ### Run the benchmarks
 


### PR DESCRIPTION
## Problem
The `sdks/` section in `README.md` lists only the Android SDK, but two additional SDKs exist in the same directory and are actively maintained:
- `sdks/ios` — iOS SDK (Swift)
- `sdks/js` — Browser and Node SDK (TypeScript)

## Root Cause
Both SDKs were recently migrated into the libxmtp monorepo via #3720 (`Migrate browser-sdk + node-sdk from xmtp-js into libxmtp`), but the README Structure section was not updated to reflect this change.

## Fix
**`README.md`**

Before:

├ sdks/

│ └ [`android`](./sdks/android): Android SDK (Kotlin)

After:

├ sdks/

│ ├ [`android`](./sdks/android): Android SDK (Kotlin)

│ ├ [`ios`](./sdks/ios): iOS SDK (Swift)

│ └ [`js`](./sdks/js): Browser and Node SDK (TypeScript)

## Verification
Confirmed both directories exist and contain active code with commits within the last week.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add iOS and JS SDK entries to repository structure in README
> Expands the `sdks/` directory tree in [README.md](https://github.com/xmtp/libxmtp/pull/3774/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to list iOS (Swift) and JS (TypeScript) alongside the existing Android (Kotlin) entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cac688.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->