### PR TITLE
fix(docs): fix broken links in overview and advanced pages

### DIFF
--- a/sdks/ios/README.md
+++ b/sdks/ios/README.md
@@ -6,7 +6,9 @@
 
 Use `xmtp-ios` to build with XMTP to send messages between blockchain accounts, including DMs, notifications, announcements, and more.
 
-To keep up with the latest SDK developments, see the [Issues tab](https://github.com/xmtp/xmtp-ios/issues) in this repo.
+> **Note:** This SDK is now part of the [libxmtp monorepo](https://github.com/xmtp/libxmtp). For issues and contributions, please use the main repository.
+
+To keep up with the latest SDK developments, see the [Issues tab](https://github.com/xmtp/libxmtp/issues) in this repo.
 
 ## Documentation
 
@@ -18,7 +20,7 @@ Access the [iOS client SDK reference documentation](https://xmtp.github.io/xmtp-
 
 ## Example app built with `xmtp-ios`
 
-Use the [XMTP iOS quickstart app](https://github.com/xmtp/xmtp-ios/tree/main/example) as a tool to start building an app with XMTP. This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with.
+Use the [XMTP iOS quickstart app](./example) as a tool to start building an app with XMTP. This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with.
 
 ## Install from Swift Package Manager
 
@@ -28,7 +30,7 @@ You can add XMTP-iOS via Swift Package Manager by adding it to your `Package.swi
 
 Because `xmtp-ios` is in active development, you should expect breaking revisions that might require you to adopt the latest SDK release to enable your app to continue working as expected.
 
-Breaking revisions in an `xmtp-ios` release are described on the [Releases page](https://github.com/xmtp/xmtp-ios/releases).
+Breaking revisions in an `xmtp-ios` release are described on the [Releases page](https://github.com/xmtp/libxmtp/releases).
 
 ## Deprecation
 
@@ -45,4 +47,4 @@ The following table provides the deprecation schedule.
 |------------------------|---------------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | No more support for XMTP V2 | May 1, 2025 | >=4.0.3 | In a move toward better security with MLS and the ability to decentralize, we will be shutting down XMTP V2 and moving entirely to XMTP V3. To learn more about V2 deprecation, see [XIP-53: XMTP V2 deprecation plan](https://community.xmtp.org/t/xip-53-xmtp-v2-deprecation-plan/867). To learn how to upgrade, see [xmtp-ios v4.0.4](https://github.com/xmtp/xmtp-ios/releases/tag/4.0.4). |
 
-Bug reports, feature requests, and PRs are welcome in accordance with these [contribution guidelines](https://github.com/xmtp/xmtp-android/blob/main/CONTRIBUTING.md).
+Bug reports, feature requests, and PRs are welcome in accordance with these [libxmtp contribution guidelines](../../CONTRIBUTING.md).


### PR DESCRIPTION
## Problem
The iOS SDK README contains outdated links pointing to the old `xmtp-ios` repository after the SDK was migrated into the `libxmtp` monorepo.

## Root Cause
The README was not updated as part of the monorepo migration (PR #3065, #3082), leaving 5 references to the old repo and missing the monorepo note.

## Fix
**`sdks/ios/README.md`**
- Added monorepo note referencing `libxmtp`
- Before: `[Issues tab](https://github.com/xmtp/xmtp-ios/issues)`
- After: `[Issues tab](https://github.com/xmtp/libxmtp/issues)`
- Before: `[XMTP iOS quickstart app](https://github.com/xmtp/xmtp-ios/tree/main/example)`
- After: `[XMTP iOS quickstart app](./example)`
- Before: `[Releases page](https://github.com/xmtp/xmtp-ios/releases)`
- After: `[Releases page](https://github.com/xmtp/libxmtp/releases)`
- Before: `[contribution guidelines](https://github.com/xmtp/xmtp-android/blob/main/CONTRIBUTING.md)`
- After: `[libxmtp contribution guidelines](../../CONTRIBUTING.md)`

## Verification
Confirmed all target URLs resolve correctly and match the pattern used in `sdks/android/README.md`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken links in iOS SDK README to point to libxmtp monorepo
> Updates [sdks/ios/README.md](https://github.com/xmtp/libxmtp/pull/3775/files#diff-930070135f38e6f3064006bb4e8f4b6d16143cb6b27cb3c90d0524c3052de78f) to reflect that the iOS SDK now lives in the libxmtp monorepo. Issues, releases, and contribution links are updated from the old `xmtp-ios` repo to `libxmtp`, and the example app link is changed to a relative path. A prominent note is added to direct contributors to the main repository.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66853a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->