### PR TITLE
fix(dev): bound anvil state cache so the d14n chain can't fill the Docker VM disk

### DIFF
--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -40,6 +40,48 @@ services:
     image: *x-xmtpd-contracts-image
     networks:
       - proxynet
+    # The contracts image bakes `anvil --load-state ./anvil-state.json --host 0.0.0.0
+    # --mixed-mining --block-time 1` as its CMD (the entrypoint is just `anvil`). Because
+    # of `--block-time 1`, anvil mines a block every second and, once its in-memory state
+    # buffer fills, offloads serialized world states (~51MB each, the size of the loaded
+    # contract set) to ~/.foundry/anvil/tmp/<session>/<state-root>.json. anvil does not
+    # bound that on-disk state cache by default, so the directory grows without limit
+    # (observed: 14GB after a few days, 171GB after ~8). It lands in the container's
+    # writable layer on the *shared* Docker VM disk, so it can exhaust the host and crash
+    # unrelated co-located containers (e.g. other devs' Postgres) with ENOSPC.
+    #
+    # Fix (eliminate the leak at the source): re-specify the baked CMD args verbatim — so
+    # --load-state still seeds the pre-deployed XMTP contracts and mining/clock behavior is
+    # unchanged — and add `--prune-history`, which forces max_persisted_states to 0, i.e.
+    # anvil writes *zero* state files to disk (verified: the dir is never even created,
+    # even after mining thousands of blocks) and stays lean on RAM too (~100MB; a
+    # `--prune-history N` lookback window instead would cost ~1GB). Mining, blocks,
+    # receipts, log queries/subscriptions, and *current* contract state all still work —
+    # everything xmtpd's indexer + registration/payer flows use (verified: stack healthy,
+    # d14n send/receive passes). The only thing dropped is `eth_call`/state reads at any
+    # non-latest block, which the d14n flows don't do. Overriding `command:` replaces only
+    # the CMD args; the `anvil` entrypoint is preserved.
+    command:
+      - "--load-state"
+      - "./anvil-state.json"
+      - "--host"
+      - "0.0.0.0"
+      - "--mixed-mining"
+      - "--block-time"
+      - "1"
+      - "--prune-history"
+    # Defense-in-depth (blast-radius containment): mount a size-capped, RAM-backed tmpfs
+    # over the state-cache dir. Even if a future image/flag change re-introduces on-disk
+    # offload, it is hard-capped at 512m, RAM-backed, cleared on every restart, and can
+    # never touch the shared persistent VM disk again.
+    tmpfs:
+      - /home/foundry/.foundry/anvil/tmp:size=512m
+    # anvil logs per mined block; cap container logs so they can't grow unbounded either.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   register-node-native:
     platform: linux/amd64


### PR DESCRIPTION
## Problem

The local d14n dev stack's `chain` service (`ghcr.io/xmtp/contracts`, an anvil dev chain) leaks state dumps onto the **shared, persistent** Docker VM disk and can exhaust the host. Observed: the container's writable layer grew to **49 GB locally** and **171 GB over ~8 days**, filling the Docker Desktop VM to 100% and crashing *unrelated* co-located containers (other projects' Postgres) with `ENOSPC` crash-recovery loops. This is a noisy-neighbor disk-exhaustion bug.

## Root cause (confirmed empirically on the live container)

It is **not** an `evm_snapshot` / `anvil_dumpState` leak — there are no snapshot/dumpState callers anywhere in libxmtp (or needed from xmtpd). It's anvil's own historical-state offload:

- The image bakes `anvil --load-state ./anvil-state.json --host 0.0.0.0 --mixed-mining --block-time 1` as its **CMD** (the entrypoint is just `anvil`).
- `--block-time 1` mines a block every second. anvil persists each block's state **delta** to `~/.foundry/anvil/tmp/<session>/<state-root>.json` (verified: the files are per-block diffs of changed accounts, not full snapshots).
- anvil does not bound that on-disk cache by default, and the `chain` service had no `command:` override, no `tmpfs`, and no logging caps — so the deltas pile up on the shared VM disk forever (one file per block, each fat under real indexer load).

## Fix (entirely in `dev/docker/`, no forked image)

Because the args live in CMD, a compose `command:` override replaces only the args (the `anvil` entrypoint is preserved), so `--load-state` still seeds the pre-deployed XMTP contracts and mining/clock behavior is unchanged:

1. **Eliminate the leak at source** — add `--prune-history`, which forces `max_persisted_states → 0`: anvil writes **zero** state files to disk.
2. **Defense-in-depth** — mount a **512 MB RAM-backed tmpfs** over the state-cache dir: a hard, blast-radius cap that is cleared on every restart and can never touch the persistent VM disk again.
3. **Logging caps** (`max-size: 10m`, `max-file: 3`) — bound the per-block container log growth.

### Why `--prune-history` over the alternatives

| Option | Disk | RAM | Lookback |
|---|---|---|---|
| **`--prune-history` (chosen)** | **0** | **~100 MB** | latest only |
| `--max-persisted-states N` | bounded delta history (load-dependent, not a hard ceiling) | ~1.1 GB | recent window |
| default (status quo) | unbounded | ~1.1 GB+ | full |

This is a *local dev* chain; d14n provably never reads non-latest state (the indexer reconstructs from logs + reads current state), so a lookback window buys nothing here while costing ~10× the RAM and a fuzzier disk bound. `--prune-history` stays lean on **both** disk and RAM. The only behavioral change: `eth_call` / state reads at a *non-latest* block now return `BlockOutOfRangeError` — unused by the d14n flows.

## Verification

| Check | Before | After |
|---|---|---|
| chain writable layer | **49 GB** | **36.9 kB**, flat under load |
| `~/.foundry/anvil/tmp` | 14 GB / 294 files | **0** — dir never created, even after mining 8000+ blocks |
| tmpfs hard cap | none | `size=512m`, RAM-backed, 0% used |
| d14n + v3 bring-up | — | all services healthy; nodes register; payer publish works |
| send / receive | — | `test_receive_message_from_other` passes |
| anvil stability with `--prune-history` | — | A/B vs baseline: 7+ min stable, no exit |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound anvil state cache in d14n Docker chain service to prevent disk exhaustion
> - Adds `--prune-history` to the anvil command in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/3777/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776) to prevent on-disk state accumulation.
> - Mounts `/home/foundry/.foundry/anvil/tmp` as a 512MB tmpfs to cap the state cache path.
> - Adds log rotation via the `json-file` driver with a 10MB max size and 3 file limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e264887.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->