### PR TITLE
feat(xmtp_db): typed TransactionOutcome so intentional rollback is not a telemetry error

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/database/native.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/native.rs
@@ -888,8 +888,9 @@ mod tests {
     #[tokio::test]
     async fn single_connection_nested_transaction_no_deadlock() {
         use crate::{
-            ConnectionExt, StorageError, Store, StoreOrIgnore, TransactionalKeyStore,
-            XmtpMlsStorageProvider,
+            ConnectionExt, StorageError, Store, StoreOrIgnore,
+            TransactionOutcome::Continue,
+            TransactionalKeyStore, XmtpMlsStorageProvider,
             refresh_state::{EntityKind, RefreshState},
             sql_key_store::SqlKeyStore,
         };
@@ -936,9 +937,9 @@ mod tests {
                             originator_id: 0,
                         }
                         .store_or_ignore(&inner.db())?;
-                        Ok::<_, StorageError>(())
+                        Ok::<_, StorageError>(Continue(()))
                     })?;
-                    Ok::<_, StorageError>(())
+                    Ok::<_, StorageError>(Continue(()))
                 })
                 .unwrap();
 

--- a/crates/xmtp_db/src/errors.rs
+++ b/crates/xmtp_db/src/errors.rs
@@ -45,11 +45,6 @@ pub enum StorageError {
     /// OpenMLS key store operation failed. Not retryable.
     #[error(transparent)]
     OpenMlsStorage(#[from] SqlKeyStoreError),
-    /// Intentional rollback.
-    ///
-    /// Transaction was intentionally rolled back. Not retryable.
-    #[error("Transaction was intentionally rolled back")]
-    IntentionalRollback,
     /// DB deserialization failed.
     ///
     /// Failed to deserialize data from database. Not retryable.
@@ -273,7 +268,6 @@ impl RetryableError for StorageError {
             Self::MigrationError(_)
             | Self::Conversion(_)
             | Self::NotFound(_)
-            | Self::IntentionalRollback
             | Self::DbDeserialize
             | Self::DbSerialize
             | Self::Builder(_)

--- a/crates/xmtp_db/src/lib.rs
+++ b/crates/xmtp_db/src/lib.rs
@@ -8,7 +8,10 @@ pub mod sql_key_store;
 mod traits;
 pub use traits::*;
 pub mod xmtp_openmls_provider;
-pub use xmtp_openmls_provider::*;
+pub use xmtp_openmls_provider::{
+    TransactionOutcome, XmtpMlsStorageProvider, XmtpOpenMlsProvider, XmtpOpenMlsProviderRef,
+    XmtpOpenMlsProviderRefMut,
+};
 #[cfg(any(feature = "test-utils", test))]
 pub mod mock;
 

--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -1258,6 +1258,7 @@ pub(crate) mod tests {
     use serde::{Deserialize, Serialize};
 
     use super::SqlKeyStore;
+    use crate::TransactionOutcome::{Continue, Rollback};
     use crate::encrypted_store::MlsProviderExt;
     use crate::{
         XmtpTestDb, sql_key_store::SqlKeyStoreError, xmtp_openmls_provider::XmtpOpenMlsProvider,
@@ -1346,6 +1347,65 @@ pub(crate) mod tests {
         );
         assert!(result.is_ok(), "{}", result.err().unwrap());
         assert_eq!(result.unwrap(), Some(raw_value));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn transaction_commit_persists_rollback_does_not_and_error_propagates() {
+        use crate::{
+            StorageError, TransactionOutcome, traits::TransactionalKeyStore,
+            xmtp_openmls_provider::XmtpMlsStorageProvider,
+        };
+
+        let store = crate::TestDb::create_persistent_store(None).await;
+        let conn = store.conn();
+        let key_store = SqlKeyStore::new(conn);
+
+        let committed_key = bincode::serialize(&[10u8; 32])?;
+        let rolled_back_key = bincode::serialize(&[11u8; 32])?;
+        let value = bincode::serialize(&vec![7u8; 16])?;
+
+        let is_present = |k: &[u8]| {
+            key_store
+                .read::<CURRENT_VERSION, Vec<u8>>(
+                    crate::sql_key_store::COMMIT_LOG_SIGNER_PRIVATE_KEY,
+                    k,
+                )
+                .unwrap()
+                .is_some()
+        };
+
+        // Commit: a value written inside a committing transaction is visible after.
+        let outcome = key_store
+            .transaction(|conn| {
+                conn.key_store().write::<CURRENT_VERSION>(
+                    crate::sql_key_store::COMMIT_LOG_SIGNER_PRIVATE_KEY,
+                    &committed_key,
+                    &value,
+                )?;
+                Ok::<_, StorageError>(Continue(()))
+            })
+            .unwrap();
+        assert!(matches!(outcome, Continue(())));
+        assert!(is_present(&committed_key), "commit must persist");
+
+        // Rollback: returns Ok(Rollback), NOT an Err, and the write is discarded.
+        let outcome = key_store
+            .transaction(|conn| {
+                conn.key_store().write::<CURRENT_VERSION>(
+                    crate::sql_key_store::COMMIT_LOG_SIGNER_PRIVATE_KEY,
+                    &rolled_back_key,
+                    &value,
+                )?;
+                Ok::<TransactionOutcome<()>, StorageError>(Rollback)
+            })
+            .unwrap();
+        assert!(matches!(outcome, Rollback));
+        assert!(!is_present(&rolled_back_key), "rollback must not persist");
+
+        // Real error: a closure returning Err propagates as Err (and rolls back).
+        let result: Result<TransactionOutcome<()>, StorageError> =
+            key_store.transaction(|_conn| Err(StorageError::DbSerialize));
+        assert!(matches!(result, Err(StorageError::DbSerialize)));
     }
 
     #[xmtp_common::test]

--- a/crates/xmtp_db/src/sql_key_store/mock.rs
+++ b/crates/xmtp_db/src/sql_key_store/mock.rs
@@ -9,7 +9,7 @@ use crate::{
     MemoryStorage,
     sql_key_store::{SqlKeyStore, SqlKeyStoreError},
 };
-use crate::{MockTransactionalKeyStore, XmtpMlsStorageProvider};
+use crate::{MockTransactionalKeyStore, TransactionOutcome, XmtpMlsStorageProvider};
 
 /// An Mls provider that delegates MLS stuff to
 /// in-memory sqlite store,
@@ -53,18 +53,18 @@ impl XmtpMlsStorageProvider for MockSqlKeyStore {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    fn transaction<T, E, F>(&self, f: F) -> Result<T, E>
+    fn transaction<T, E, F>(&self, f: F) -> Result<TransactionOutcome<T>, E>
     where
-        F: FnOnce(&mut Self::TxQuery) -> Result<T, E>,
+        F: FnOnce(&mut Self::TxQuery) -> Result<TransactionOutcome<T>, E>,
         E: From<diesel::result::Error> + From<crate::ConnectionError> + std::error::Error,
     {
         let mut store = self.mock_mls.lock();
         f(&mut store)
     }
 
-    fn savepoint<T, E, F>(&self, f: F) -> Result<T, E>
+    fn savepoint<T, E, F>(&self, f: F) -> Result<TransactionOutcome<T>, E>
     where
-        F: FnOnce(&mut Self::TxQuery) -> Result<T, E>,
+        F: FnOnce(&mut Self::TxQuery) -> Result<TransactionOutcome<T>, E>,
         E: From<diesel::result::Error> + From<crate::ConnectionError> + std::error::Error,
     {
         let mut store = self.mock_mls.lock();

--- a/crates/xmtp_db/src/sql_key_store/transactions.rs
+++ b/crates/xmtp_db/src/sql_key_store/transactions.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::DbConnection;
+use crate::TransactionOutcome;
+use crate::TransactionOutcome::{Continue, Rollback};
 
 /// wrapper around a mutable connection (&mut SqliteConnection)
 /// Requires that all execution/transaction happens in one thread on one connection.
@@ -55,9 +57,9 @@ impl<C: ConnectionExt> XmtpMlsStorageProvider for SqlKeyStore<C> {
     }
 
     #[xmtp_common::db_span]
-    fn transaction<T, E, F>(&self, f: F) -> Result<T, E>
+    fn transaction<T, E, F>(&self, f: F) -> Result<TransactionOutcome<T>, E>
     where
-        F: FnOnce(&mut Self::TxQuery) -> Result<T, E>,
+        F: FnOnce(&mut Self::TxQuery) -> Result<TransactionOutcome<T>, E>,
         E: From<diesel::result::Error> + From<crate::ConnectionError> + std::error::Error,
     {
         let conn = &self.conn;
@@ -77,16 +79,59 @@ impl<C: ConnectionExt> XmtpMlsStorageProvider for SqlKeyStore<C> {
         //      transaction starts. Otherwise, we still run into problem #2, even if BUSY_TIMEOUT is
         //      set.
 
-        conn.raw_query(|c| Ok(c.immediate_transaction(|sqlite_c| f(sqlite_c))))?
+        // An intentional `Rollback` is turned into diesel's `RollbackTransaction`
+        // sentinel (the only way to make diesel roll back) and flagged, so below we
+        // can report it as `Ok(Rollback)` without inspecting the opaque `E`; any
+        // other `Err` is a real failure and propagates.
+        let mut rolled_back = false;
+        let inner_result: Result<TransactionOutcome<T>, E> = conn
+            .raw_query(|c| {
+                Ok(c.immediate_transaction(|sqlite_c| match f(sqlite_c) {
+                    Ok(Continue(v)) => Ok(Continue(v)),
+                    Ok(Rollback) => {
+                        rolled_back = true;
+                        Err(E::from(diesel::result::Error::RollbackTransaction))
+                    }
+                    Err(e) => Err(e),
+                }))
+            })
+            .map_err(E::from)?;
+
+        // A failed ROLLBACK after our sentinel is still reported as Ok(Rollback);
+        // that rare rollback-execution error is deliberately swallowed.
+        match inner_result {
+            Ok(outcome) => Ok(outcome),
+            Err(_) if rolled_back => Ok(Rollback),
+            Err(e) => Err(e),
+        }
     }
 
-    fn savepoint<T, E, F>(&self, f: F) -> Result<T, E>
+    // Same Rollback-sentinel handling as `transaction`; see there for the rationale.
+    fn savepoint<T, E, F>(&self, f: F) -> Result<TransactionOutcome<T>, E>
     where
-        F: FnOnce(&mut Self::TxQuery) -> Result<T, E>,
+        F: FnOnce(&mut Self::TxQuery) -> Result<TransactionOutcome<T>, E>,
         E: From<diesel::result::Error> + From<crate::ConnectionError> + std::error::Error,
     {
-        self.conn
-            .raw_query(|c| Ok(c.transaction(|sqlite_c| f(sqlite_c))))?
+        let mut rolled_back = false;
+        let inner_result: Result<TransactionOutcome<T>, E> = self
+            .conn
+            .raw_query(|c| {
+                Ok(c.transaction(|sqlite_c| match f(sqlite_c) {
+                    Ok(Continue(v)) => Ok(Continue(v)),
+                    Ok(Rollback) => {
+                        rolled_back = true;
+                        Err(E::from(diesel::result::Error::RollbackTransaction))
+                    }
+                    Err(e) => Err(e),
+                }))
+            })
+            .map_err(E::from)?;
+
+        match inner_result {
+            Ok(outcome) => Ok(outcome),
+            Err(_) if rolled_back => Ok(Rollback),
+            Err(e) => Err(e),
+        }
     }
 
     fn read<V: Entity<CURRENT_VERSION>>(
@@ -136,7 +181,7 @@ mod tests {
     #![allow(unused)]
 
     use crate::{
-        TestDb, XmtpTestDb,
+        TestDb, TransactionOutcome, XmtpTestDb,
         group_intent::{IntentKind, IntentState, NewGroupIntent},
         prelude::QueryGroupIntent,
     };
@@ -167,13 +212,16 @@ mod tests {
             self.key_store
                 .transaction(|conn| {
                     let storage = conn.key_store();
-                    storage.db().insert_group_intent(NewGroupIntent {
-                        kind: IntentKind::SendMessage,
-                        group_id: GroupId::default(),
-                        data: vec![],
-                        should_push: false,
-                        state: IntentState::ToPublish,
-                    })
+                    storage
+                        .db()
+                        .insert_group_intent(NewGroupIntent {
+                            kind: IntentKind::SendMessage,
+                            group_id: GroupId::default(),
+                            data: vec![],
+                            should_push: false,
+                            state: IntentState::ToPublish,
+                        })
+                        .map(Continue)
                 })
                 .unwrap();
             self.long_async_call().await;

--- a/crates/xmtp_db/src/test_utils/impls.rs
+++ b/crates/xmtp_db/src/test_utils/impls.rs
@@ -16,25 +16,25 @@ use crate::{
 // only cover errors that can happen in db access
 impl Distribution<StorageError> for StandardUniform {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> StorageError {
-        match rng.random_range(0..=13) {
+        match rng.random_range(0..=12) {
             0 => StorageError::DieselConnect(rand_diesel_conn_err(rng)),
             1 => StorageError::DieselResult(rand_diesel_result(rng)),
             2 => StorageError::NotFound(rand::random()),
             3 => StorageError::Duplicate(DuplicateItem::WelcomeId(Some(Cursor::default()))),
             4 => rand::random(),
-            5 => StorageError::IntentionalRollback,
-            6 => StorageError::DbSerialize,
-            7 => StorageError::DbDeserialize,
-            8 => StorageError::Builder(derive_builder::UninitializedFieldError::new("test field")),
-            10 => rand::random(), // platform
-            11 => StorageError::Prost(
+            5 => StorageError::DbSerialize,
+            6 => StorageError::DbDeserialize,
+            7 => StorageError::Builder(derive_builder::UninitializedFieldError::new("test field")),
+            8 => rand::random(), // platform
+            9 => StorageError::Prost(
                 <xmtp_proto::mls_v1::GroupMessage as prost::Message>::decode([].as_slice())
                     .unwrap_err(),
             ),
-            12 => StorageError::Connection(rand::random()),
-            13 => StorageError::Conversion(xmtp_proto::ConversionError::Unspecified(
+            10 => StorageError::Connection(rand::random()),
+            11 => StorageError::Conversion(xmtp_proto::ConversionError::Unspecified(
                 "random test error",
             )),
+            12 => StorageError::InvalidHmacLength,
             _ => unreachable!(),
         }
     }

--- a/crates/xmtp_db/src/xmtp_openmls_provider.rs
+++ b/crates/xmtp_db/src/xmtp_openmls_provider.rs
@@ -8,6 +8,39 @@ use openmls_traits::storage::CURRENT_VERSION;
 use openmls_traits::storage::{Entity, StorageProvider};
 use xmtp_common::{MaybeSend, MaybeSync};
 
+/// Outcome of a [`XmtpMlsStorageProvider::transaction`] or
+/// [`XmtpMlsStorageProvider::savepoint`] closure.
+///
+/// Returning `Ok(TransactionOutcome::Continue(value))` persists the transaction
+/// and returns `Ok(value)` to the caller.
+///
+/// Returning `Ok(TransactionOutcome::Rollback)` rolls back the transaction
+/// *without* recording a span error — the rollback was intentional.
+///
+/// Returning `Err(e)` rolls back the transaction *and* records `status=error`
+/// on the enclosing `#[db_span]` / `#[rpc_span]` span — the error was real.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransactionOutcome<T> {
+    /// Persist the transaction and return the enclosed value.
+    Continue(T),
+    /// Roll back the transaction without treating it as an error.
+    Rollback,
+}
+
+impl<T> TransactionOutcome<T> {
+    /// Unwrap the persisted value for call sites that never roll back.
+    ///
+    /// Panics if this is a `Rollback` (a bug at that call site).
+    pub fn into_continued(self) -> T {
+        match self {
+            TransactionOutcome::Continue(v) => v,
+            TransactionOutcome::Rollback => {
+                unreachable!("transaction caller never returns TransactionOutcome::Rollback")
+            }
+        }
+    }
+}
+
 /// Convenience super trait to constrain the storage provider to a
 /// specific error type and version
 /// This storage provider is likewise implemented on both &T and T references,
@@ -28,21 +61,26 @@ pub trait XmtpMlsStorageProvider:
 
     fn db<'a>(&'a self) -> Self::DbQuery<'a>;
 
-    /// Start a new transaction
-    fn transaction<T, E, F>(&self, f: F) -> Result<T, E>
+    /// Start a new transaction.
+    ///
+    /// The closure returns `Ok(TransactionOutcome::Continue(v))` to persist or
+    /// `Ok(TransactionOutcome::Rollback)` to roll back without an error.
+    /// Returning `Err(e)` also rolls back and propagates `e` as a real error.
+    fn transaction<T, E, F>(&self, f: F) -> Result<TransactionOutcome<T>, E>
     where
-        F: FnOnce(&mut Self::TxQuery) -> Result<T, E>,
+        F: FnOnce(&mut Self::TxQuery) -> Result<TransactionOutcome<T>, E>,
         E: From<diesel::result::Error> + From<crate::ConnectionError> + std::error::Error;
 
-    /// Start a savepoint within a transaction
-    /// Must only be used when already in a transaction
+    /// Start a savepoint within a transaction.
+    ///
+    /// Must only be used when already in a transaction.
     // TODO: enforce that this is only used within transactions
     // otherwise we run into sqlite race conditions b/c this does not
     // use BEGIN IMMEDIATE.
     // we can ensure this by checking sqlite transaction depth.
-    fn savepoint<T, E, F>(&self, f: F) -> Result<T, E>
+    fn savepoint<T, E, F>(&self, f: F) -> Result<TransactionOutcome<T>, E>
     where
-        F: FnOnce(&mut Self::TxQuery) -> Result<T, E>,
+        F: FnOnce(&mut Self::TxQuery) -> Result<TransactionOutcome<T>, E>,
         E: From<diesel::result::Error> + From<crate::ConnectionError> + std::error::Error;
 
     fn _disable_lint_for_self<'a>(_: Self::DbQuery<'a>) {}

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -32,8 +32,9 @@ use xmtp_api::{ApiClientWrapper, XmtpApi};
 use xmtp_common::{ErrorCode, Event, Retry, retry_async, retryable};
 use xmtp_configuration::{CREATE_PQ_KEY_PACKAGE_EXTENSION, KEY_PACKAGE_ROTATION_INTERVAL_NS};
 use xmtp_cryptography::signature::IdentifierValidationError;
+use xmtp_db::TransactionOutcome::Continue;
 use xmtp_db::{
-    ConnectionExt, NotFound, StorageError, XmtpDb,
+    ConnectionExt, NotFound, StorageError, TransactionOutcome, XmtpDb,
     consent_record::{ConsentState, ConsentType, StoredConsentRecord},
     db_connection::DbConnection,
     encrypted_store::conversation_list::ConversationListItem as DbConversationListItem,
@@ -1047,12 +1048,15 @@ where
         )?;
 
         // Clean up old key packages
-        self.context.mls_storage().transaction(|conn| {
-            conn.key_store()
-                .db()
-                .mark_key_package_before_id_to_be_deleted(history_id)?;
-            Ok::<(), StorageError>(())
-        })?;
+        self.context
+            .mls_storage()
+            .transaction(|conn| {
+                conn.key_store()
+                    .db()
+                    .mark_key_package_before_id_to_be_deleted(history_id)?;
+                Ok::<_, StorageError>(Continue(()))
+            })
+            .map(TransactionOutcome::into_continued)?;
 
         self.context
             .mls_storage()

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -15,6 +15,7 @@ use xmtp_common::RetryableError;
 use xmtp_common::hex::NormalizeHex;
 use xmtp_configuration::MAX_PAGE_SIZE;
 use xmtp_configuration::Originators;
+use xmtp_db::TransactionOutcome::Continue;
 use xmtp_db::consent_record::ConsentState;
 use xmtp_db::group::ConversationType;
 use xmtp_db::group::DmIdExt;
@@ -22,7 +23,7 @@ use xmtp_db::group::StoredGroupForRespondingReadds;
 use xmtp_db::remote_commit_log::RemoteCommitLog;
 use xmtp_db::remote_commit_log::RemoteCommitLogOrder;
 use xmtp_db::{
-    DbQuery, StorageError, Store,
+    DbQuery, StorageError, Store, TransactionOutcome,
     group::{StoredGroupCommitLogPublicKey, StoredGroupForReaddRequest},
     local_commit_log::{CommitType, LocalCommitLogOrder},
     prelude::*,
@@ -621,14 +622,18 @@ where
 
         for conversation_id in conversation_ids_for_forked_state_check {
             let conversation_id = GroupId::try_from(conversation_id)?;
-            self.context.mls_provider().storage().transaction(|conn| {
-                let key_store = conn.key_store();
-                let db = key_store.db();
-                let is_forked = self.check_conversation_fork_state(&db, &conversation_id)?;
-                // Persist the fork status to the database
-                db.set_group_commit_log_forked_status(&conversation_id, is_forked)?;
-                Ok::<(), CommitLogError>(())
-            })?;
+            self.context
+                .mls_provider()
+                .storage()
+                .transaction(|conn| {
+                    let key_store = conn.key_store();
+                    let db = key_store.db();
+                    let is_forked = self.check_conversation_fork_state(&db, &conversation_id)?;
+                    // Persist the fork status to the database
+                    db.set_group_commit_log_forked_status(&conversation_id, is_forked)?;
+                    Ok::<_, CommitLogError>(Continue(()))
+                })
+                .map(TransactionOutcome::into_continued)?;
             tokio::task::yield_now().await;
         }
 

--- a/crates/xmtp_mls/src/groups/intents/queue.rs
+++ b/crates/xmtp_mls/src/groups/intents/queue.rs
@@ -6,8 +6,9 @@ use crate::groups::intents::GROUP_KEY_ROTATION_INTERVAL_NS;
 use crate::groups::{GroupError, MlsGroup, XmtpSharedContext};
 use derive_builder::Builder;
 use itertools::Itertools;
+use xmtp_db::TransactionOutcome::Continue;
 use xmtp_db::{
-    DbQuery,
+    DbQuery, TransactionOutcome,
     group_intent::{IntentKind, NewGroupIntent, StoredGroupIntent},
     prelude::*,
 };
@@ -30,11 +31,15 @@ impl QueueIntentBuilder {
         C: XmtpSharedContext,
     {
         let intent = self.build()?;
-        group.context.mls_storage().transaction(move |conn| {
-            let storage = conn.key_store();
-            let db = storage.db();
-            intent.queue_with_conn(&db, group)
-        })
+        group
+            .context
+            .mls_storage()
+            .transaction(move |conn| {
+                let storage = conn.key_store();
+                let db = storage.db();
+                intent.queue_with_conn(&db, group).map(Continue)
+            })
+            .map(TransactionOutcome::into_continued)
     }
 
     /// Queue this intent for each group
@@ -69,26 +74,31 @@ impl QueueIntentBuilder {
             .partition_result();
         let mut errors = errors.into_iter().map(GroupError::from).collect::<Vec<_>>();
 
-        let (intents, errs): (Vec<StoredGroupIntent>, Vec<_>) = {
-            context.mls_storage().transaction(|conn| {
-                let intents = groups
+        let (intents, errs): (Vec<StoredGroupIntent>, Vec<_>) = context
+            .mls_storage()
+            .transaction(|conn| {
+                let (intents, errs): (Vec<StoredGroupIntent>, Vec<_>) = groups
                     .into_iter()
                     .map(|(group, data)| {
                         let storage = conn.key_store();
 
                         // nesting a transaction uses SQLite Savepoints
                         // https://sqlite.org/lang_savepoint.html
-                        storage.savepoint(|conn| {
-                            let intent = self.clone().data(data).build()?;
-                            let storage = conn.key_store();
-                            let db = storage.db();
-                            intent.queue_with_conn(&db, &group)
-                        })
+                        // Each savepoint here always commits or errors, so
+                        // unwrap the committed value directly.
+                        storage
+                            .savepoint(|conn| {
+                                let intent = self.clone().data(data).build()?;
+                                let storage = conn.key_store();
+                                let db = storage.db();
+                                intent.queue_with_conn(&db, &group).map(Continue)
+                            })
+                            .map(TransactionOutcome::into_continued)
                     })
                     .partition_result();
-                Ok::<_, GroupError>(intents)
+                Ok::<_, GroupError>(Continue((intents, errs)))
             })?
-        };
+            .into_continued();
         errors.extend(errs);
 
         for error in errors {

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -87,9 +87,10 @@ use xmtp_configuration::{
     WELCOME_HPKE_LABEL,
 };
 use xmtp_content_types::{CodecError, ContentCodec, group_updated::GroupUpdatedCodec};
+use xmtp_db::TransactionOutcome::{Continue, Rollback};
 use xmtp_db::message_deletion::{QueryMessageDeletion, StoredMessageDeletion};
 use xmtp_db::{
-    Fetch, MlsProviderExt, StorageError, StoreOrIgnore,
+    Fetch, MlsProviderExt, StorageError, StoreOrIgnore, TransactionOutcome,
     group::{ConversationType, StoredGroup},
     group_intent::{ID, IntentKind, IntentState, StoredGroupIntent},
     group_message::{ContentType, DeliveryStatus, GroupMessageKind, StoredGroupMessage},
@@ -1134,11 +1135,13 @@ where
                 &provider,
                 message.clone(),
             ));
-            // Rollback the transaction. We want to synchronize with the server before committing.
-            Err::<(), StorageError>(StorageError::IntentionalRollback)
+            // Roll back: sync with the server before committing.
+            Ok::<TransactionOutcome<()>, StorageError>(Rollback)
         });
-        if !matches!(result, Err(StorageError::IntentionalRollback)) {
-            result.inspect_err(|e| tracing::debug!("immutable process message failed {}", e))?;
+        if !matches!(result, Ok(Rollback)) {
+            result
+                .map(TransactionOutcome::into_continued)
+                .inspect_err(|e| tracing::debug!("immutable process message failed {}", e))?;
         }
         let processed_message = processed_message.expect("Was just set to Some")?;
 
@@ -1369,7 +1372,7 @@ where
                     envelope.created_ns
                  );
                 identifier.previously_processed(true);
-                return identifier.build();
+                return identifier.build().map(Continue);
             }
             // once the checks for processing pass, actually process the message
             let processed_message = super::app_data::process_message_with_app_data(
@@ -1385,8 +1388,9 @@ where
                 &storage,
                 &mut deferred_events,
             )?;
-            Ok::<_, GroupMessageProcessingError>(identifier)
-        })?;
+            Ok::<_, GroupMessageProcessingError>(Continue(identifier))
+        })
+        .map(TransactionOutcome::into_continued)?;
 
         // Send all deferred events after the transaction completes
         deferred_events.send_all(&self.context);
@@ -2239,7 +2243,7 @@ where
                         // In some cases, we may want to roll back the cursor if we updated the
                         // cursor, but actually cannot process the message.
                         identifier.previously_processed(true);
-                        return Ok(None);
+                        return Ok(Continue(None));
                     }
                     let result: Result<Option<Vec<u8>>, IntentResolutionError> = match validation_result {
                         Err(err) => Err(err),
@@ -2274,7 +2278,7 @@ where
                         // No state transition (e.g. a re-delivered message for an
                         // intent already in this state) — nothing new to report.
                         tracing::warn!("Intent [{}] is already in state [{:?}]", intent_id, next_intent_state);
-                        return Ok(None);
+                        return Ok(Continue(None));
                     }
                     let mut intent_error = None;
                     match next_intent_state {
@@ -2301,8 +2305,9 @@ where
                             db.set_group_intent_processed(intent_id)?;
                         }
                     }
-                    Ok(intent_error)
-                })?;
+                    Ok(Continue(intent_error))
+                })
+                .map(TransactionOutcome::into_continued)?;
                 let identifier = identifier.build()?;
                 Ok(ProcessedMessageOutcome {
                     identifier,
@@ -2456,8 +2461,10 @@ where
                                 accounting_error
                         );
                     }
-                    Ok::<(), GroupMessageProcessingError>(())
-                }) {
+                    Ok::<_, GroupMessageProcessingError>(Continue(()))
+                })
+                .map(TransactionOutcome::into_continued)
+                {
                     tracing::error!("Error post-processing non-retryable error: {transaction_error:?}");
                 };
 
@@ -2791,17 +2798,21 @@ where
                         let last_payload = payloads_to_publish.last().ok_or(GroupError::UninitializedResult)?;
                         let intent_hash = sha256(last_payload);
                         // removing this transaction causes missed messages
-                        self.context.mls_storage().transaction(|conn| {
-                            let storage = conn.key_store();
-                            let db = storage.db();
-                            db.set_group_intent_published(
-                                intent.id,
-                                &intent_hash,
-                                post_commit_action,
-                                staged_commit,
-                                group_epoch as i64,
-                            )
-                        })?;
+                        self.context
+                            .mls_storage()
+                            .transaction(|conn| {
+                                let storage = conn.key_store();
+                                let db = storage.db();
+                                db.set_group_intent_published(
+                                    intent.id,
+                                    &intent_hash,
+                                    post_commit_action,
+                                    staged_commit,
+                                    group_epoch as i64,
+                                )?;
+                                Ok::<_, StorageError>(Continue(()))
+                            })
+                            .map(TransactionOutcome::into_continued)?;
                         tracing::debug!(
                             inbox_id = self.context.inbox_id(),
                             installation_id = %self.context.installation_id(),
@@ -4511,19 +4522,14 @@ where
             .ok()
             .flatten();
 
-        // Rollback the transaction to avoid persisting the commit
-        Err::<(), StorageError>(StorageError::IntentionalRollback)
+        // Intentionally roll back: we captured everything we need; do not persist the commit.
+        Ok::<TransactionOutcome<()>, StorageError>(Rollback)
     });
 
-    let Err(e) = transaction_result else {
-        unreachable!("Transaction never returns ok");
-    };
-
-    // Check if the transaction was intentionally rolled back (expected)
-    // or if there was a real error
-
-    if !matches!(e, StorageError::IntentionalRollback) {
-        return Err(e.into());
+    match transaction_result {
+        Ok(Continue(_)) => unreachable!("Transaction always requests rollback"),
+        Ok(Rollback) => {}
+        Err(e) => return Err(e.into()),
     }
 
     // Return early if group epoch is not set otherwise unwrap the group epoch

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -8,11 +8,14 @@ use openmls::group::MlsGroup as OpenMlsGroup;
 use openmls::prelude::{ProcessedMessageContent, Sender};
 use xmtp_configuration::Originators;
 use xmtp_db::Store;
+use xmtp_db::TransactionOutcome::Rollback;
 use xmtp_db::encrypted_store::local_commit_log::NewLocalCommitLog;
 use xmtp_db::encrypted_store::remote_commit_log::{CommitResult, NewRemoteCommitLog};
 use xmtp_db::local_commit_log::CommitType;
 use xmtp_db::prelude::*;
-use xmtp_db::{MlsProviderExt, StorageError, TransactionalKeyStore, XmtpOpenMlsProvider};
+use xmtp_db::{
+    MlsProviderExt, StorageError, TransactionOutcome, TransactionalKeyStore, XmtpOpenMlsProvider,
+};
 use xmtp_proto::types::Cursor;
 
 #[cfg_attr(all(feature = "d14n", target_arch = "wasm32"), ignore)]
@@ -919,9 +922,9 @@ async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
             &provider,
             commit_envelope.message.clone(),
         ));
-        Err::<(), StorageError>(StorageError::IntentionalRollback)
+        Ok::<TransactionOutcome<()>, StorageError>(Rollback)
     });
-    assert!(matches!(result, Err(StorageError::IntentionalRollback)));
+    assert!(matches!(result, Ok(Rollback)));
     let processed_message = processed_message
         .expect("set in the transaction above")
         .expect("processing the commit at the old epoch succeeds");

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -24,8 +24,9 @@ use xmtp_common::time::now_ns;
 use xmtp_configuration::Originators;
 use xmtp_content_types::ContentCodec;
 use xmtp_content_types::group_updated::GroupUpdatedCodec;
+use xmtp_db::TransactionOutcome::{Continue, Rollback};
 use xmtp_db::{
-    StorageError, XmtpOpenMlsProviderRef,
+    StorageError, TransactionOutcome, XmtpOpenMlsProviderRef,
     consent_record::{ConsentState, StoredConsentRecord},
     group::{ConversationType, GroupMembershipState, StoredGroup},
     group_message::{DeliveryStatus, GroupMessageKind, StoredGroupMessage},
@@ -251,27 +252,39 @@ where
         events: &mut DeferredEvents,
     ) -> Result<CommitResult<C>, GroupError> {
         tracing::debug!("attempting to commit welcome={}", &self.welcome.cursor);
-        let commit_result = self.context.mls_storage().transaction(|conn| {
-            let storage = conn.key_store();
-            // Savepoint transaction
-            let result = storage.savepoint(|conn| self.commit(conn, events, decrypted_welcome));
-            let db = storage.db();
-            // if we got an error
-            // and the error is not retryable
-            // and cursor increment is enabled
-            // update the cursor
-            match result {
-                Err(err) if !err.is_retryable() && self.cursor_increment => {
-                    tracing::warn!("welcome with cursor_id={} failed with a non-retryable error because of {err}, incrementing cursor", self.welcome.cursor);
-                    self.update_cursor(&db)?;
-                    // return ok to commit the transaction
-                    Ok(CommitResult::FailedForever(err))
-                },
-                // roll everything back to retry
-                Err(e) => Err(e),
-                Ok(group) => Ok(CommitResult::Ok(group)),
-            }
-        })?;
+        let commit_result = self
+            .context
+            .mls_storage()
+            .transaction(|conn| {
+                let storage = conn.key_store();
+                // Savepoint transaction
+                let result = storage.savepoint(|conn| {
+                    self.commit(conn, events, decrypted_welcome)
+                        .map(Continue)
+                });
+                let db = storage.db();
+                // if we got an error
+                // and the error is not retryable
+                // and cursor increment is enabled
+                // update the cursor
+                match result {
+                    Err(err) if !err.is_retryable() && self.cursor_increment => {
+                        tracing::warn!("welcome with cursor_id={} failed with a non-retryable error because of {err}, incrementing cursor", self.welcome.cursor);
+                        self.update_cursor(&db)?;
+                        // return ok to commit the transaction
+                        Ok(Continue(CommitResult::FailedForever(err)))
+                    }
+                    // roll everything back to retry
+                    Err(e) => Err(e),
+                    Ok(Continue(group)) => {
+                        Ok(Continue(CommitResult::Ok(group)))
+                    }
+                    Ok(Rollback) => {
+                        unreachable!("savepoint never intentionally rolls back here")
+                    }
+                }
+            })
+            .map(TransactionOutcome::into_continued)?;
         events.send_all(&self.context);
         Ok(commit_result)
     }

--- a/crates/xmtp_mls/src/identity.rs
+++ b/crates/xmtp_mls/src/identity.rs
@@ -40,12 +40,13 @@ use xmtp_configuration::{
 use xmtp_cryptography::configuration::POST_QUANTUM_CIPHERSUITE;
 use xmtp_cryptography::signature::IdentifierValidationError;
 use xmtp_cryptography::{CredentialSign, XmtpInstallationCredential};
+use xmtp_db::TransactionOutcome::Continue;
 use xmtp_db::db_connection::DbConnection;
 use xmtp_db::identity::StoredIdentity;
 use xmtp_db::sql_key_store::{
     KEY_PACKAGE_REFERENCES, KEY_PACKAGE_WRAPPER_PRIVATE_KEY, SqlKeyStoreError,
 };
-use xmtp_db::{ConnectionExt, MlsProviderExt};
+use xmtp_db::{ConnectionExt, MlsProviderExt, TransactionOutcome};
 use xmtp_db::{Fetch, StorageError, Store};
 use xmtp_db::{XmtpOpenMlsProviderRef, prelude::*};
 use xmtp_id::associations::unverified::UnverifiedSignature;
@@ -731,13 +732,16 @@ impl Identity {
             Ok(()) => {
                 // Successfully uploaded. Delete previous KPs
                 let provider = XmtpOpenMlsProviderRef::new(mls_storage);
-                provider.storage().transaction(|conn| {
-                    let storage = conn.key_store();
-                    storage
-                        .db()
-                        .mark_key_package_before_id_to_be_deleted(history_id)?;
-                    Ok::<(), StorageError>(())
-                })?;
+                provider
+                    .storage()
+                    .transaction(|conn| {
+                        let storage = conn.key_store();
+                        storage
+                            .db()
+                            .mark_key_package_before_id_to_be_deleted(history_id)?;
+                        Ok::<_, StorageError>(Continue(()))
+                    })
+                    .map(TransactionOutcome::into_continued)?;
                 mls_storage
                     .db()
                     .reset_key_package_rotation_queue(KEY_PACKAGE_ROTATION_INTERVAL_NS)?;


### PR DESCRIPTION
## Problem

`#[db_span]` on `transaction()` expands to `#[tracing::instrument(err, …)]`, which records span `status=error` on **any** `Err` return. But `transaction()` returned `Err(StorageError::IntentionalRollback)` **by design** to roll back — diesel only rolls back when the closure returns `Err`. Every commit-generation path (`generate_commit_with_rollback`, process-message double-process) therefore emitted a false `ERROR` span.

Downstream this inflated Datadog APM error stats, `xmtp.{mls,db}.calls{status.code=error}`, and caused the Collector's `keep-errors` tail-sampling policy to retain every rollback trace. It was the dominant source of false error-signal in libxmtp telemetry.

A blanket `skip_err` won't do: a real DB-locked error at `BEGIN IMMEDIATE`/`COMMIT` surfaces *only* at the `transaction` boundary, so we must keep `err` for genuine failures and remove it *only* for intentional rollback.

## Fix

Rollback leaves the error channel entirely. New `TransactionOutcome<T> { Commit(T), Rollback }`; `transaction`/`savepoint` now return `Result<TransactionOutcome<T>, E>`. On `Rollback` the impl forces diesel's blessed `Error::RollbackTransaction` sentinel to perform the rollback, then swallows it via a `rolled_back` flag — it never inspects the opaque `E`, and the rollback returns `Ok(Rollback)`, so `#[db_span]`'s `err` never fires. Real errors still propagate as `Err` and still record `status=error`.

- 20 call sites migrated (happy path → `Ok(Commit(x))` + `.into_committed()`; the rollback sites → `Ok(Rollback)`).
- Dead `StorageError::IntentionalRollback` variant removed.
- New `xmtp_db` unit test: commit persists, rollback returns `Ok(Rollback)` and discards the write, a real error propagates as `Err` — against real SQLite.

## Notes

Worker `tick()` span-volume noise is a separate, follow-up change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `StorageError::IntentionalRollback` with typed `TransactionOutcome` enum for intentional DB rollbacks
> - Introduces `TransactionOutcome<T>` with `Continue(T)` and `Rollback` variants in [`xmtp_openmls_provider.rs`](https://github.com/xmtp/libxmtp/pull/3782/files#diff-34f81df348c7e429604a663ed7f1470260006cbcb8349500042b75798bf97a09); `XmtpMlsStorageProvider::transaction` and `savepoint` now return `Result<TransactionOutcome<T>, E>` and accept closures yielding the same type.
> - Removes `StorageError::IntentionalRollback` and replaces all uses across `mls_sync.rs`, `welcomes`, and tests with `Ok(Rollback)`, so intentional rollbacks no longer appear as errors in telemetry.
> - All commit paths wrap their return value in `Continue(v)` and call `into_continued()` to unwrap, preserving existing behavior.
> - Behavioral Change: call sites that previously caught `StorageError::IntentionalRollback` must now match on `Ok(TransactionOutcome::Rollback)`; the error variant no longer exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 461d717.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->