### PR TITLE
fix(xmtp_db): make db-lock panic opt-out, default on

### DIFF
--- a/bindings/node/vitest.config.mts
+++ b/bindings/node/vitest.config.mts
@@ -12,6 +12,9 @@ const vitestConfig = defineVitestConfig({
   test: {
     globalSetup: ['./vitest.setup.mts'],
     testTimeout: 30000,
+    // Opt out of the Rust db-lock panic; transient contention is retried, not
+    // fatal, and panicking crashes fork workers. See xmtp/libxmtp#3765.
+    env: { XMTP_NO_PANIC_ON_DB_LOCK: 'true' },
   },
 })
 

--- a/crates/xmtp_db/src/encrypted_store/database/instrumentation.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/instrumentation.rs
@@ -3,11 +3,22 @@ use diesel::connection::InstrumentationEvent;
 use diesel::result::Error as DieselError;
 use std::fmt::Write;
 
-// Test instrumentatiomn
-// prints out query on error
-// panics on database lock
+// Logs query errors. Panics on `database is locked` by default — a held lock in
+// a pure Rust test is a real bug. Consumers with the client's retry machinery opt
+// OUT via `XMTP_NO_PANIC_ON_DB_LOCK` (e.g. node-sdk Vitest workers, #3765).
 #[allow(unused)]
 pub struct TestInstrumentation;
+
+/// Whether a `database is locked` error should panic. On by default; suppressed by
+/// `XMTP_NO_PANIC_ON_DB_LOCK`.
+fn panic_on_db_lock_enabled() -> bool {
+    panic_on_db_lock_from_env(std::env::var("XMTP_NO_PANIC_ON_DB_LOCK"))
+}
+
+/// Pure helper (testable without mutating env): panic unless the var is `"1"`/`"true"`.
+fn panic_on_db_lock_from_env(disable: Result<String, std::env::VarError>) -> bool {
+    !matches!(disable, Ok(s) if s == "1" || s == "true")
+}
 
 impl Instrumentation for TestInstrumentation {
     fn on_connection_event(&mut self, event: InstrumentationEvent<'_>) {
@@ -32,7 +43,7 @@ impl Instrumentation for TestInstrumentation {
                             tracing::error!("details: {},", details);
                         }
                         tracing::error!("{}", s);
-                        if s.contains("database is locked") {
+                        if s.contains("database is locked") && panic_on_db_lock_enabled() {
                             panic!("database locked");
                         }
                     }
@@ -49,6 +60,33 @@ impl Instrumentation for TestInstrumentation {
             }
 
             _ => (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::panic_on_db_lock_from_env;
+    use std::env::VarError;
+
+    #[test]
+    fn db_lock_panic_enabled_by_default() {
+        assert!(panic_on_db_lock_from_env(Err(VarError::NotPresent)));
+    }
+
+    #[test]
+    fn db_lock_panic_opt_out_values() {
+        assert!(!panic_on_db_lock_from_env(Ok("1".to_string())));
+        assert!(!panic_on_db_lock_from_env(Ok("true".to_string())));
+    }
+
+    #[test]
+    fn db_lock_panic_ignores_other_values() {
+        for v in ["0", "false", "", "yes", "TRUE", "True"] {
+            assert!(
+                panic_on_db_lock_from_env(Ok(v.to_string())),
+                "value {v:?} should not disable the panic"
+            );
         }
     }
 }

--- a/crates/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -596,6 +596,7 @@ pub mod tests {
     use crate::tester;
     use futures::stream::StreamExt;
     use rstest::*;
+    use xmtp_db::group_message::GroupMessageKind;
 
     #[xmtp_common::timeout(std::time::Duration::from_secs(30))]
     #[rstest]
@@ -613,15 +614,21 @@ pub mod tests {
         let bob_group = bob_groups.first().unwrap();
         alice_group.sync().await.unwrap();
 
-        let stream = alice_group.stream().await.unwrap();
+        // Filter to application messages: the `group_updated` commit from
+        // `add_members` can race the stream ahead of them, making this flaky (#3765).
+        let stream = alice_group.stream().await.unwrap().filter(|msg| {
+            futures::future::ready(
+                msg.as_ref()
+                    .map(|m| m.kind == GroupMessageKind::Application)
+                    .unwrap_or(true),
+            )
+        });
         futures::pin_mut!(stream);
         bob_group
             .send_message(b"hello", SendMessageOpts::default())
             .await
             .unwrap();
 
-        // group updated msg/bob is added
-        // assert_msg_exists!(stream);
         assert_msg!(stream, "hello");
 
         bob_group

--- a/sdks/js/node-sdk/vitest.config.ts
+++ b/sdks/js/node-sdk/vitest.config.ts
@@ -14,6 +14,9 @@ const vitestConfig = defineVitestConfig({
     testTimeout: 120000,
     hookTimeout: 60000,
     globalSetup: ["./vitest.setup.ts"],
+    // Opt out of the Rust db-lock panic; transient contention is retried, not
+    // fatal, and panicking crashes fork workers. See xmtp/libxmtp#3765.
+    env: { XMTP_NO_PANIC_ON_DB_LOCK: "true" },
   },
 });
 


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3765

Alternative to #3767 — same root cause, inverted default.

## Problem

`TestInstrumentation` (`crates/xmtp_db/src/encrypted_store/database/instrumentation.rs`) called `panic!("database locked")` on **any** query that failed with `database is locked`. This instrumentation is installed on every SQLite connection whenever the `test` cfg **or** the `test-utils` feature is active — and the node-sdk Vitest suite enables `test-utils`.

Under concurrent test load (CI node-sdk shard 2), Vitest fork workers transiently contend on SQLite locks. Each `database is locked` error panicked on an `r2d2-worker`/`tokio-rt-worker` thread, aborting the worker process and surfacing as flaky `Worker exited unexpectedly` failures.

`database is locked` is **not** fatal here: SQLite is configured with `PRAGMA busy_timeout` and the error is classified as retryable (`PlatformStorageError::DatabaseLocked => true`). The panic short-circuited that designed retry machinery.

## Fix (opt-out, default ON)

This differs from #3767 by keeping the panic **on by default** and inverting the env var to an opt-*out*:

- **Default (unset):** panic stays ON. In pure Rust tests there is no retry harness wrapping the call site, so a held lock is a real bug — and `cargo test` / `nextest` need *zero* config to keep panicking.
- **`XMTP_NO_PANIC_ON_DB_LOCK=1|true`:** suppresses the panic. Set in exactly one place per affected suite — the node-sdk and bindings/node `vitest.config` `test.env` — so it reaches the fork workers (unlike `globalSetup`, which only runs in the parent process).

This avoids sprinkling opt-*in* env vars across `justfile` + `nextest.nix` (which get lost and must be remembered for every new runner). The one broken context disables itself, next to the code it protects.

The env read is split from a pure decision helper (`panic_on_db_lock_from_env`) so the logic is unit-tested without mutating the process environment.

## Also

Filter `test_stream_messages` to application messages so the `group_updated` membership-change commit can't race the assertions (a separate flake in the same area).

## Testing

- `cargo test -p xmtp_db --lib instrumentation` → 3 passed (default-on, opt-out values, junk-ignored).
- `cargo check -p xmtp_mls --tests --features test-utils` → clean.
- `just lint-rust` → clippy / fmt / hakari clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make db-lock panic opt-out in `xmtp_db` instrumentation, defaulting to enabled
> - Changes `on_connection_event` in [instrumentation.rs](https://github.com/xmtp/libxmtp/pull/3785/files#diff-3f2f010aa407d2e385927c144accbd35ac3b8eb13e576e302dcedbb71aec28d8) to gate the 'database is locked' panic behind a new `panic_on_db_lock_enabled()` helper instead of panicking unconditionally.
> - The helper reads `XMTP_NO_PANIC_ON_DB_LOCK` from the environment; setting it to `'1'` or `'true'` disables the panic. All other values (including absent) keep the panic enabled.
> - Node SDK test configs ([vitest.config.mts](https://github.com/xmtp/libxmtp/pull/3785/files#diff-dea91d35614df439e39523ffef97356b0c75c7085782ec5b78504aaffc29e8ce), [vitest.config.ts](https://github.com/xmtp/libxmtp/pull/3785/files#diff-ee73d2c2280a863b6aec1eb64b98773321c39ccf129b89c165312e07224fc99a)) opt out by setting `XMTP_NO_PANIC_ON_DB_LOCK=true`.
> - Behavioral Change: panic on DB lock is now the default; previously it was always-on with no escape hatch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5a3020.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->