### PR TITLE
fix(browser-sdk): de-flake DeviceSync archive and Preferences stream tests

### DIFF
--- a/sdks/js/browser-sdk/test/DeviceSync.test.ts
+++ b/sdks/js/browser-sdk/test/DeviceSync.test.ts
@@ -2,7 +2,12 @@ import { ConsentEntityType, ConsentState } from "@xmtp/wasm-bindings";
 import { describe, expect, it } from "vitest";
 import { HistorySyncUrls } from "@/constants";
 import { uuid } from "@/utils/uuid";
-import { createRegisteredClient, createSigner, sleep } from "@test/helpers";
+import {
+  createRegisteredClient,
+  createSigner,
+  sleep,
+  waitFor,
+} from "@test/helpers";
 
 describe("DeviceSync", () => {
   it("should sync consent across installations", async () => {
@@ -130,11 +135,6 @@ describe("DeviceSync", () => {
     const messagesBefore = await group2Before!.messages();
     expect(messagesBefore.length).toBe(2);
 
-    await sleep(1000);
-    await alix.syncAllDeviceSyncGroups();
-    await sleep(1000);
-    await alix2.syncAllDeviceSyncGroups();
-
     // list available archives - may fail in some environments
     try {
       const archives = await alix2.listAvailableArchives(7);
@@ -143,7 +143,23 @@ describe("DeviceSync", () => {
       // listAvailableArchives may not be fully supported in all test environments
     }
 
-    await alix2.processSyncArchive("123");
+    // The archive payload propagates to alix2 over the network asynchronously,
+    // so a single device-sync pass can race ahead of delivery and leave
+    // processSyncArchive unable to find the payload (DeviceSyncError::MissingPayload).
+    // Re-sync the device-sync groups and retry until the pinned payload arrives.
+    await waitFor(
+      async () => {
+        await alix.syncAllDeviceSyncGroups();
+        await alix2.syncAllDeviceSyncGroups();
+        try {
+          await alix2.processSyncArchive("123");
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 30000, interval: 1000 },
+    );
     await sleep(1000);
     await alix2.conversations.syncAll();
 

--- a/sdks/js/browser-sdk/test/Preferences.test.ts
+++ b/sdks/js/browser-sdk/test/Preferences.test.ts
@@ -10,6 +10,7 @@ import {
   createRegisteredClient,
   createSigner,
   sleep,
+  waitFor,
 } from "@test/helpers";
 
 describe("Preferences", () => {
@@ -205,20 +206,34 @@ describe("Preferences", () => {
     });
 
     await client3.conversations.syncAll();
-    await sleep(1000);
-    await client1.conversations.syncAll();
-    await sleep(1000);
     await client2.conversations.syncAll();
-    await sleep(1000);
 
-    setTimeout(() => {
-      void stream.end();
-    }, 100);
-
+    // Collect updates concurrently while the preference changes propagate.
     const preferences: UserPreferenceUpdate[] = [];
-    for await (const update of stream) {
-      preferences.push(...update);
+    const collecting = (async () => {
+      for await (const update of stream) {
+        preferences.push(...update);
+      }
+    })();
+
+    // Four updates are expected: two consent updates (the group and the
+    // inbox-id consent changes) and two HMAC-key updates (one per new
+    // installation). These propagate over the network asynchronously, so
+    // re-sync until the stream has observed all of them rather than racing a
+    // fixed delay, which can cut off the last update and yield only 3.
+    try {
+      await waitFor(
+        async () => {
+          await client1.conversations.syncAll();
+          return preferences.length >= 4;
+        },
+        { timeout: 30000, interval: 1000 },
+      );
+    } finally {
+      await stream.end();
+      await collecting;
     }
+
     expect(preferences.length).toBe(4);
     const consentUpdate1 = preferences[0] as Extract<
       UserPreferenceUpdate,

--- a/sdks/js/browser-sdk/test/helpers.ts
+++ b/sdks/js/browser-sdk/test/helpers.ts
@@ -23,11 +23,11 @@ export const sleep = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 export const waitFor = async (
-  condition: () => boolean,
+  condition: () => boolean | Promise<boolean>,
   { timeout = 2000, interval = 10 } = {},
 ) => {
   const start = Date.now();
-  while (!condition()) {
+  while (!(await condition())) {
     if (Date.now() - start > timeout) {
       throw new Error(`waitFor timed out after ${timeout}ms`);
     }


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3784

## Problem

Two browser-sdk (WASM) tests fail intermittently in CI (`test-browser-sdk` shard 1). Both share one root cause: a fixed delay is used as a proxy for *"the async, network-driven operation has completed"*, which is racy under CI timing variability.

- **`DeviceSync.test.ts` → "should sync device archive …"**: after `alix.sendSyncArchive("123")`, the test did a single `syncAllDeviceSyncGroups()` pass and immediately called `alix2.processSyncArchive("123")`. When the archive payload hadn't propagated to `alix2`, it threw `DeviceSyncError::MissingPayload ("Could not find payload with pin Some(\"123\")")`.
- **`Preferences.test.ts` → "should stream preferences"**: expected 4 updates (2 `ConsentUpdate` + 2 `HmacKeyUpdate` from two new installations) but ended the stream after a fixed `setTimeout(…, 100)`. A late update left only 3 collected (`expected 3 to be 4`).

## Fix

- **DeviceSync**: retry `processSyncArchive("123")` — re-syncing the device-sync groups on each attempt — until the pinned payload is found, bounded by a 30s timeout.
- **Preferences**: collect stream updates concurrently and keep the stream open, re-syncing the streaming client, until all 4 expected updates are observed (bounded by 30s), then close it deterministically.
- Extend the shared `waitFor` test helper to accept async (`Promise<boolean>`) conditions in addition to sync ones. Backward compatible — `await` on a synchronous boolean returns it unchanged.

All existing assertions (counts, types, entities, states, message contents) are unchanged. This is a **test-only** change; production WASM/SDK code is untouched.

## Validation

- `yarn lint` (eslint) passes on the three changed files.
- The new control-flow patterns (extended `waitFor`, retry loop, concurrent collector) were typechecked in isolation. The only outstanding workspace `tsc` errors are the pre-existing unbuilt `@xmtp/wasm-bindings` portal, unrelated to this change.
- Behavioral validation is the CI `test-browser-sdk` job (builds WASM bindings, runs Playwright/Chromium against a local XMTP node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### De-flake DeviceSync archive and Preferences stream tests by replacing fixed sleeps with polling
> - Replaces fixed `sleep` calls in [`DeviceSync.test.ts`](https://github.com/xmtp/libxmtp/pull/3786/files#diff-3b766774cb49132df20a7115e21a02c1f13baa791d2575124b09ed9e57b96fd6) with a `waitFor` loop that retries `processSyncArchive` until it succeeds (up to 30s, 1s interval).
> - Replaces fixed sleeps and `setTimeout`-based stream termination in [`Preferences.test.ts`](https://github.com/xmtp/libxmtp/pull/3786/files#diff-dfca7a9e688244959eead5c9545b25d98bd0b8535025e8244ba16410fa5566d3) with a `waitFor` loop that polls until 4 preference updates are observed before ending the stream.
> - Extends `waitFor` in [`helpers.ts`](https://github.com/xmtp/libxmtp/pull/3786/files#diff-991c5f12cc0b3b6bd46e844ea6e682f635b513eff525462e05425c9cd33660ee) to accept async conditions (returning `Promise<boolean>`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9f195b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->