### PR TITLE
test(d14n): bump xmtpd test images to the #2020 build (XIP-83 QueryApi.Subscribe bidi)

### DIFF
--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -1,6 +1,9 @@
-x-xmtpd-server-image: &x-xmtpd-server-image ghcr.io/xmtp/xmtpd:v1.3.0
-x-xmtpd-gateway-image: &x-xmtpd-gateway-image ghcr.io/xmtp/xmtpd-gateway:v1.3.0
-x-xmtpd-cli-image: &x-xmtpd-cli-image ghcr.io/xmtp/xmtpd-cli:v1.3.0
+# Pinned to the xmtpd #2020 merge commit (ac17e82), the first build with the XIP-83 d14n
+# QueryApi.Subscribe bidi-streaming RPC. No tagged release carries it yet (latest is v1.3.0,
+# Mar 2026); bump to a release tag once one ships with the RPC.
+x-xmtpd-server-image: &x-xmtpd-server-image ghcr.io/xmtp/xmtpd:sha-ac17e82
+x-xmtpd-gateway-image: &x-xmtpd-gateway-image ghcr.io/xmtp/xmtpd-gateway:sha-ac17e82
+x-xmtpd-cli-image: &x-xmtpd-cli-image ghcr.io/xmtp/xmtpd-cli:sha-ac17e82
 x-xmtpd-contracts-image: &x-xmtpd-contracts-image ghcr.io/xmtp/contracts:v2026.02.10-1
 x-postgres-image: &x-postgres-image postgres:16
 x-redis-image: &x-redis-image redis:7-alpine


### PR DESCRIPTION
## What

Bump the **d14n test stack** images (`dev/docker/docker-compose-d14n.yml`) from `v1.3.0` to the **#2020 build**:

| image | before | after |
|---|---|---|
| `ghcr.io/xmtp/xmtpd` | `v1.3.0` | `sha-ac17e82` |
| `ghcr.io/xmtp/xmtpd-gateway` | `v1.3.0` | `sha-ac17e82` |
| `ghcr.io/xmtp/xmtpd-cli` | `v1.3.0` | `sha-ac17e82` |

## Why

`v1.3.0` was cut **Mar 2026** — months before xmtpd [#2020](https://github.com/xmtp/xmtpd/pull/2020) (XIP-83 d14n `QueryApi.Subscribe` bidi streaming, **merged 2026-06-26**). So the d14n test containers had **no bidi-streaming RPC**, which blocks the upcoming d14n client integration tests. Pinning to the #2020 build gives them the capability.

**Why a SHA, not `:main`:** there is no tagged release with the RPC yet (latest is `v1.3.0`). `sha-ac17e82` is the **#2020 merge commit**, so it's a frozen, reproducible pin — it won't drift when unrelated xmtpd `main` changes land, matching this compose's existing fixed-pin philosophy. Swap to a release tag once one ships with the RPC.

## Verification

- Image **revision label** = `ac17e820b8d997e92c8006f69fc94049ffd3bdad` — exactly the #2020 merge commit, so the binary contains `QueryApi.Subscribe` by construction.
- `docker compose -f dev/docker/docker-compose-d14n.yml config` validates; all three images pull.

## Note on v3

The v3 stack (`docker-compose.yml`) uses `ghcr.io/xmtp/node-go:main`, which has carried the bidi RPC since node-go #562 — **no change needed** there (a stale local cache just needs a re-pull).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump xmtpd test images to build sha-ac17e82 for XIP-83 QueryApi.Subscribe bidi
> Updates [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/3787/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776) to pin `xmtpd`, `xmtpd-gateway`, and `xmtpd-cli` images from `v1.3.0` to `sha-ac17e82`, a specific merge commit that includes the XIP-83 `QueryApi.Subscribe` bidirectional streaming support needed for d14n tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fe1ecb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->