### PR TITLE
feat(xmtp_mls): KeyPackageCleaner scheduled-wake worker (kill the 5s poll)

### DIFF
--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -385,6 +385,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             task_channels: workers.task_channels().clone(),
             disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(
             ),
+            key_package_channels: crate::worker::rearm_channel::RearmChannel::new(),
             cancellation_token: CancellationToken::new(),
             shutdown_complete: Arc::new(AtomicBool::new(false)),
         });

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1079,7 +1079,7 @@ where
         self.identity()
             .queue_key_rotation(&self.context.db())
             .await?;
-
+        self.context.wake_key_package_worker();
         Ok(())
     }
 

--- a/crates/xmtp_mls/src/context.rs
+++ b/crates/xmtp_mls/src/context.rs
@@ -6,6 +6,7 @@ use crate::utils::VersionInfo;
 use crate::worker::device_sync::worker::SyncMetric;
 use crate::worker::disappearing_messages::DisappearingChannels;
 use crate::worker::metrics::WorkerMetrics;
+use crate::worker::rearm_channel::RearmChannel;
 use crate::worker::tasks::TaskWorkerChannels;
 use crate::worker::{DynMetrics, MetricsCasting, WorkerConfig, WorkerKind};
 use crate::{
@@ -55,6 +56,7 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     pub(crate) worker_metrics: Arc<Mutex<HashMap<WorkerKind, DynMetrics>>>,
     pub(crate) task_channels: TaskWorkerChannels,
     pub(crate) disappearing_channels: DisappearingChannels,
+    pub(crate) key_package_channels: RearmChannel,
     pub(crate) cancellation_token: CancellationToken,
     // Set only after a successful `Client::close` (workers stopped + DB
     // disconnected). The cancellation token tracks "shutdown initiated";
@@ -129,6 +131,7 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
             worker_metrics: self.worker_metrics,
             task_channels: self.task_channels,
             disappearing_channels: self.disappearing_channels,
+            key_package_channels: self.key_package_channels,
             cancellation_token: self.cancellation_token,
             shutdown_complete: self.shutdown_complete,
         }
@@ -247,6 +250,20 @@ where
     fn local_events(&self) -> &broadcast::Sender<LocalEvents>;
     fn task_channels(&self) -> &TaskWorkerChannels;
     fn disappearing_channels(&self) -> &DisappearingChannels;
+    fn key_package_channels(&self) -> &RearmChannel;
+
+    /// Nudge the KeyPackageCleaner worker to run soon (e.g. after a rotation was
+    /// queued). Best-effort; no-op if the worker is disabled. Keeps `Identity`
+    /// ignorant of worker channels — callers go through this facade.
+    fn wake_key_package_worker(&self) {
+        if self
+            .worker_config()
+            .worker_enabled(crate::worker::WorkerKind::KeyPackageCleaner)
+        {
+            self.key_package_channels().rearm();
+        }
+    }
+
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>>;
     fn mls_commit_lock(&self) -> &Arc<GroupCommitLock>;
     fn mutexes(&self) -> &MutexRegistry;
@@ -337,6 +354,10 @@ where
 
     fn disappearing_channels(&self) -> &DisappearingChannels {
         &self.disappearing_channels
+    }
+
+    fn key_package_channels(&self) -> &RearmChannel {
+        &self.key_package_channels
     }
 
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {
@@ -434,6 +455,10 @@ where
 
     fn disappearing_channels(&self) -> &DisappearingChannels {
         <T as XmtpSharedContext>::disappearing_channels(self)
+    }
+
+    fn key_package_channels(&self) -> &RearmChannel {
+        <T as XmtpSharedContext>::key_package_channels(self)
     }
 
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {

--- a/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -163,6 +163,7 @@ async fn test_spoofed_inbox_id() {
         worker_config: alix.context.worker_config.clone(),
         task_channels: alix.context.task_channels.clone(),
         disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(),
+        key_package_channels: crate::worker::rearm_channel::RearmChannel::new(),
         worker_metrics: alix.context.worker_metrics.clone(),
         cancellation_token: alix.context.cancellation_token.clone(),
         shutdown_complete: alix.context.shutdown_complete.clone(),

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -161,6 +161,7 @@ where
         // rotation interval.
         if num_envelopes > 0 {
             self.context.identity().queue_key_rotation(&db).await?;
+            self.context.wake_key_package_worker();
         }
 
         Ok(groups)

--- a/crates/xmtp_mls/src/test/mock.rs
+++ b/crates/xmtp_mls/src/test/mock.rs
@@ -93,6 +93,7 @@ impl Clone for NewMockContext {
             task_channels: self.task_channels.clone(),
             disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(
             ),
+            key_package_channels: crate::worker::rearm_channel::RearmChannel::new(),
             worker_metrics: self.worker_metrics.clone(),
             cancellation_token: self.cancellation_token.clone(),
             shutdown_complete: self.shutdown_complete.clone(),
@@ -170,6 +171,10 @@ impl XmtpSharedContext for NewMockContext {
 
     fn disappearing_channels(&self) -> &crate::worker::disappearing_messages::DisappearingChannels {
         &self.disappearing_channels
+    }
+
+    fn key_package_channels(&self) -> &crate::worker::rearm_channel::RearmChannel {
+        &self.key_package_channels
     }
 
     fn sync_metrics(&self) -> Option<Arc<crate::worker::metrics::WorkerMetrics<SyncMetric>>> {

--- a/crates/xmtp_mls/src/test/mock/generate.rs
+++ b/crates/xmtp_mls/src/test/mock/generate.rs
@@ -39,6 +39,7 @@ pub fn context() -> NewMockContext {
         mls_storage: SqlKeyStore::new(MemoryStorage::new()),
         task_channels: TaskWorkerChannels::default(),
         disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(),
+        key_package_channels: crate::worker::rearm_channel::RearmChannel::new(),
         worker_metrics: Arc::default(),
         cancellation_token: tokio_util::sync::CancellationToken::new(),
         shutdown_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/xmtp_mls/src/utils/test/mod.rs
+++ b/crates/xmtp_mls/src/utils/test/mod.rs
@@ -78,6 +78,8 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
             .enable_sqlite_triggers()
             .default_mls_store()
             .unwrap()
+            // Fast KeyPackageCleaner interval so rotation tests don't wait 1 hour.
+            .worker_config(crate::worker::WorkerConfig::for_testing())
             .local()
     }
 

--- a/crates/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/crates/xmtp_mls/src/utils/test/tester_utils.rs
@@ -464,7 +464,9 @@ impl Default for TesterBuilder<PrivateKeySigner> {
             snapshot: None,
             snapshot_path: None,
             disable_workers: false,
-            worker_config: None,
+            // Fast KeyPackageCleaner interval for tests: overrides the 1-hour
+            // production const so timing-dependent rotation tests don't hang.
+            worker_config: Some(crate::worker::WorkerConfig::for_testing()),
         }
     }
 }

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -2,6 +2,7 @@ pub mod device_sync;
 pub mod disappearing_messages;
 pub mod key_package_cleaner;
 pub mod metrics;
+pub mod rearm_channel;
 pub mod tasks;
 
 use crate::context::XmtpSharedContext;

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -88,6 +88,21 @@ impl WorkerConfig {
     pub fn worker_enabled(&self, kind: WorkerKind) -> bool {
         self.enabled.get(&kind).copied().unwrap_or(true)
     }
+
+    /// A test-only `WorkerConfig` with a fast `KeyPackageCleaner` interval so
+    /// timing-dependent tests don't wait the production 1-hour coarse cadence.
+    ///
+    /// 100 ms is fast enough for tests that sleep ≤11 s but slow enough that it
+    /// won't busy-loop under a normal test run.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn for_testing() -> Self {
+        let mut cfg = Self::default();
+        cfg.interval_overrides.insert(
+            WorkerKind::KeyPackageCleaner,
+            std::time::Duration::from_millis(100).as_nanos() as u64,
+        );
+        cfg
+    }
 }
 
 pub struct WorkerRunner {

--- a/crates/xmtp_mls/src/worker/disappearing_messages.rs
+++ b/crates/xmtp_mls/src/worker/disappearing_messages.rs
@@ -2,7 +2,6 @@ use crate::context::XmtpSharedContext;
 use crate::worker::{BoxedWorker, NeedsDbReconnect, Worker, WorkerFactory};
 use crate::worker::{WorkerKind, WorkerResult};
 use futures::TryFutureExt;
-use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use xmtp_common::time::now_ns;
@@ -15,43 +14,9 @@ use xmtp_db::{StorageError, prelude::*};
 /// re-arm, and is the sleep when no disappearing messages are scheduled.
 const FALLBACK_INTERVAL: Duration = Duration::from_secs(24 * 3600);
 
-/// Dedicated wake channel for the disappearing-messages worker.
-///
-/// A **capacity-1** mpsc carrying unit `()` "recompute the next expiry deadline"
-/// nudges. Capacity 1 is deliberate: the worker drains and re-queries the DB on
-/// every wake, so a single pending nudge already captures "something changed" —
-/// more would be redundant. It also bounds memory to one slot even when no worker
-/// is consuming the channel (e.g. the disappearing worker is disabled or
-/// `disable_workers` is set), so `rearm()` can never accumulate without bound.
-#[derive(Clone)]
-pub struct DisappearingChannels {
-    sender: tokio::sync::mpsc::Sender<()>,
-    pub receiver: Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<()>>>,
-}
-
-impl Default for DisappearingChannels {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DisappearingChannels {
-    pub fn new() -> Self {
-        let (sender, receiver) = tokio::sync::mpsc::channel(1);
-        Self {
-            sender,
-            receiver: Arc::new(tokio::sync::Mutex::new(receiver)),
-        }
-    }
-
-    /// Wake the worker to recompute its next-expiry deadline. Best-effort and
-    /// non-blocking: if a nudge is already queued (slot full) or no worker is
-    /// consuming, the send is dropped — the worker recomputes from the DB on its
-    /// next wake regardless, so a dropped duplicate nudge changes nothing.
-    pub fn rearm(&self) {
-        let _ = self.sender.try_send(());
-    }
-}
+/// Wake channel for the disappearing-messages worker. Alias of the shared
+/// [`RearmChannel`](crate::worker::rearm_channel::RearmChannel).
+pub type DisappearingChannels = crate::worker::rearm_channel::RearmChannel;
 
 #[derive(Debug, Error)]
 pub enum DisappearingMessagesCleanerError {
@@ -197,18 +162,5 @@ where
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[xmtp_common::test(unwrap_try = true)]
-    async fn rearm_delivers_a_signal() {
-        let ch = DisappearingChannels::new();
-        ch.rearm();
-        let mut rx = ch.receiver.lock().await;
-        assert!(rx.recv().await.is_some());
     }
 }

--- a/crates/xmtp_mls/src/worker/key_package_cleaner.rs
+++ b/crates/xmtp_mls/src/worker/key_package_cleaner.rs
@@ -10,15 +10,26 @@ use futures::TryFutureExt;
 use openmls_traits::storage::StorageProvider;
 use std::time::Duration;
 use thiserror::Error;
+use tracing::Instrument;
 use xmtp_configuration::CREATE_PQ_KEY_PACKAGE_EXTENSION;
+use xmtp_db::encrypted_store::key_package_history::StoredKeyPackageHistoryEntry;
 use xmtp_db::prelude::*;
 use xmtp_db::{
     MlsProviderExt, StorageError,
     sql_key_store::{KEY_PACKAGE_REFERENCES, KEY_PACKAGE_WRAPPER_PRIVATE_KEY},
 };
 
-/// Interval at which the KeyPackagesCleanerWorker runs to delete expired messages.
-pub const INTERVAL_DURATION: Duration = Duration::from_secs(5);
+/// Coarse fallback cadence: backstops the 30-day rotation and 1-day deletion.
+/// Welcome-queued rotation does NOT wait for this — it rides the wake channel.
+/// Configurable per-kind via WorkerConfig; a small global default also applies
+/// to this worker unless a KeyPackageCleaner override is set.
+pub const INTERVAL_DURATION: Duration = Duration::from_secs(60 * 60); // 1 hour
+
+/// Debounce window matching KEY_PACKAGE_QUEUE_INTERVAL_NS (5 s).
+/// After a channel nudge we sleep this long so the queued rotation is due,
+/// then drain any further nudges that arrived during the sleep.
+const KEY_PACKAGE_QUEUE_INTERVAL: Duration =
+    Duration::from_nanos(xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS as u64);
 
 #[derive(Clone)]
 pub struct Factory<Context> {
@@ -120,17 +131,64 @@ where
             .context
             .worker_interval(WorkerKind::KeyPackageCleaner, INTERVAL_DURATION);
         let mut intervals = xmtp_common::time::jittered_interval_stream(base, jitter);
-        while (intervals.next().await).is_some() {
-            self.tick().await?;
+        let receiver = self.context.key_package_channels().receiver.clone();
+        let mut receiver = receiver.lock().await;
+
+        // No explicit startup pass: on native, jittered_interval_stream's first
+        // tick is immediate, so the first loop iteration covers an overdue/NULL
+        // client. (On wasm the first interval tick waits one period; a fresh
+        // client there relies on the queue→wake path, and overdue rotation is
+        // bounded by the coarse interval — fine at 30d/1d work cadence.)
+        loop {
+            tokio::select! {
+                _ = intervals.next() => {}                 // coarse fallback wake
+                _ = receiver.recv()  => {                  // a rotation was queued (now+5s)
+                    // Wait out the debounce window so the queued rotation is due,
+                    // THEN drain: a nudge that arrived during the sleep is consumed
+                    // here (not re-slept), avoiding a redundant second 5s sleep.
+                    xmtp_common::time::sleep(KEY_PACKAGE_QUEUE_INTERVAL).await;
+                    while receiver.try_recv().is_ok() {}
+                }
+            }
+            self.maintain().await?;
         }
-        Ok(())
     }
 
-    #[tracing::instrument(skip_all, fields(worker = ?self.kind(), operation = "worker_turn"))]
-    async fn tick(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        self.delete_expired_key_packages()?;
-        self.rotate_last_key_package_if_needed().await?;
-        Ok(())
+    /// Run a maintenance pass. Reads two cheap guards OUTSIDE any span; returns
+    /// early (NO span) when idle. Otherwise opens exactly ONE `worker_turn` span
+    /// wrapping the real work, so a failing delete/rotate is recorded.
+    async fn maintain(&mut self) -> Result<(), KeyPackagesCleanerError> {
+        let expired_kps = self
+            .context
+            .db()
+            .get_expired_key_packages()
+            .map_err(KeyPackagesCleanerError::Fetch)?;
+        let rotate_due = self
+            .context
+            .db()
+            .is_identity_needs_rotation()
+            .map_err(KeyPackagesCleanerError::Metadata)?;
+
+        if expired_kps.is_empty() && !rotate_due {
+            return Ok(()); // idle: no span, no work
+        }
+
+        let span = tracing::info_span!(
+            "worker_turn",
+            worker = ?self.kind(),
+            operation = "worker_turn"
+        );
+        async {
+            if !expired_kps.is_empty() {
+                self.delete_key_packages(expired_kps)?;
+            }
+            if rotate_due {
+                self.rotate_last_key_package_if_needed().await?;
+            }
+            Ok::<(), KeyPackagesCleanerError>(())
+        }
+        .instrument(span)
+        .await
     }
 
     /// Delete a key package from the local database.
@@ -156,21 +214,15 @@ where
         Ok(())
     }
 
-    /// Delete all the expired keys
-    fn delete_expired_key_packages(&mut self) -> Result<(), KeyPackagesCleanerError> {
+    /// Delete the given already-fetched expired key packages. The caller fetched
+    /// the list so the span-gate can decide whether to open a span without a
+    /// second scan of key_package_history.
+    fn delete_key_packages(
+        &mut self,
+        expired_kps: Vec<StoredKeyPackageHistoryEntry>,
+    ) -> Result<(), KeyPackagesCleanerError> {
         let conn = self.context.db();
-
-        // Propagate (don't swallow): a swallowed fetch error never triggered the supervisor's
-        // reconnect path, so a pool outage retried silently every 5s.
-        let expired_kps = conn
-            .get_expired_key_packages()
-            .map_err(KeyPackagesCleanerError::Fetch)?;
-        if expired_kps.is_empty() {
-            return Ok(());
-        }
-
         tracing::info!("Deleting {} expired key packages", expired_kps.len());
-        // Delete from local db
         for kp in &expired_kps {
             self.delete_key_package(
                 kp.key_package_hash_ref.clone(),
@@ -178,8 +230,6 @@ where
             )
             .map_err(KeyPackagesCleanerError::DeleteKeyPackage)?;
         }
-
-        // Delete from database using the max expired ID
         if let Some(max_id) = expired_kps.iter().map(|kp| kp.id).max() {
             conn.delete_key_package_history_up_to_id(max_id)
                 .map_err(KeyPackagesCleanerError::Deletion)?;
@@ -189,7 +239,6 @@ where
                 max_id
             );
         }
-
         Ok(())
     }
 

--- a/crates/xmtp_mls/src/worker/key_package_cleaner.rs
+++ b/crates/xmtp_mls/src/worker/key_package_cleaner.rs
@@ -267,3 +267,80 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{identity::serialize_key_package_hash_ref, tester};
+    use std::time::Duration;
+    use xmtp_db::prelude::QueryIdentity;
+
+    /// Helper: fetch the network key package's HPKE init key for `client`.
+    async fn current_init_key<C: crate::context::XmtpSharedContext>(
+        client: &crate::Client<C>,
+    ) -> Vec<u8> {
+        let installation_id = client.installation_public_key().to_vec();
+        let mut map = client
+            .get_key_packages_for_installation_ids(vec![installation_id.clone()])
+            .await
+            .expect("fetch key packages");
+        let kp = map
+            .remove(&installation_id)
+            .expect("installation id present")
+            .expect("key package resolved");
+        serialize_key_package_hash_ref(&kp.inner, &client.context.mls_provider())
+            .expect("serialize hash ref")
+    }
+
+    /// Asserts that calling `queue_key_rotation` wakes the `KeyPackageCleaner`
+    /// worker and causes a real key-package rotation within a bounded wait.
+    ///
+    /// The worker interval is overridden to 100 ms by `WorkerConfig::for_testing()`
+    /// (injected via `TesterBuilder::default`), so the coarse-cadence tick fires
+    /// quickly.  The wake channel fires even sooner: after the 5-second debounce
+    /// the worker calls `maintain()` and uploads the new key package.
+    ///
+    /// NOTE: this test requires a live XMTP node.  In environments without one
+    /// it will fail with a connection-refused error, which is an infrastructure
+    /// limitation rather than a logic failure.
+    #[xmtp_common::test]
+    async fn queue_key_rotation_wakes_worker_and_rotates() {
+        tester!(client);
+
+        // Snapshot the current on-network key-package hash.
+        let init_key_before = current_init_key(&client).await;
+
+        // Queue a rotation: lowers next_key_package_rotation_ns to now+5s and
+        // fires the wake channel. (It does NOT make rotation due *now* — the
+        // deadline is 5s out, which is the debounce the worker waits through.)
+        client.queue_key_rotation().await.unwrap();
+
+        // Bounded poll: the debounce is 5 s, so wait up to 12 s total
+        // (60 × 200 ms). Iteration-counted rather than wall-clock so it works on
+        // wasm, where std::time::Instant::now() panics (no std clock).
+        let mut init_key_after = None;
+        for _ in 0..60 {
+            xmtp_common::time::sleep(Duration::from_millis(200)).await;
+            let key = current_init_key(&client).await;
+            if key != init_key_before {
+                init_key_after = Some(key);
+                break;
+            }
+        }
+        let init_key_after = init_key_after.expect(
+            "key package did not rotate within 12 s after queue_key_rotation; \
+             worker wake path may be broken",
+        );
+
+        assert_ne!(
+            init_key_before, init_key_after,
+            "key package should have rotated after queue_key_rotation + worker wake"
+        );
+
+        // Rotation flag should be cleared by the worker.
+        let still_needs_rotation = client.context.db().is_identity_needs_rotation().unwrap();
+        assert!(
+            !still_needs_rotation,
+            "rotation flag should be cleared after worker ran"
+        );
+    }
+}

--- a/crates/xmtp_mls/src/worker/rearm_channel.rs
+++ b/crates/xmtp_mls/src/worker/rearm_channel.rs
@@ -1,0 +1,61 @@
+//! A minimal, shared "wake the worker" channel: a capacity-1 mpsc carrying unit
+//! `()` nudges. Capacity 1 because a worker drains and re-checks on every wake,
+//! so a single pending nudge already means "something changed". `rearm()` is
+//! best-effort: a full slot or absent consumer drops the send harmlessly.
+//!
+//! Each worker owns its OWN instance — the single receiver must never be shared
+//! between workers or they would steal each other's signals.
+
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct RearmChannel {
+    sender: tokio::sync::mpsc::Sender<()>,
+    pub receiver: Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<()>>>,
+}
+
+impl Default for RearmChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RearmChannel {
+    pub fn new() -> Self {
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
+        Self {
+            sender,
+            receiver: Arc::new(tokio::sync::Mutex::new(receiver)),
+        }
+    }
+
+    /// Wake the worker. Best-effort and non-blocking: a full slot or absent
+    /// consumer drops the nudge — the worker re-checks the DB on its next wake
+    /// regardless, so a dropped duplicate changes nothing.
+    pub fn rearm(&self) {
+        let _ = self.sender.try_send(());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[xmtp_common::test]
+    async fn rearm_delivers_a_signal() {
+        let ch = RearmChannel::new();
+        ch.rearm();
+        let mut rx = ch.receiver.lock().await;
+        assert!(rx.try_recv().is_ok());
+    }
+
+    #[xmtp_common::test]
+    async fn rearm_is_capacity_one_and_lossy() {
+        let ch = RearmChannel::new();
+        ch.rearm();
+        ch.rearm(); // second send dropped (slot full) — must not panic/block
+        let mut rx = ch.receiver.lock().await;
+        assert!(rx.try_recv().is_ok());
+        assert!(rx.try_recv().is_err(), "only one nudge buffered");
+    }
+}


### PR DESCRIPTION
## Problem

`KeyPackagesCleanerWorker` polls the DB every **5 seconds** and opens a `worker_turn` span on every tick. The real work is **~monthly** (30-day key-package rotation + a deletion ~1 day after a rotation marks the old KP). So >99.999% of ticks are no-ops, with two costs:

1. **Telemetry:** ~**82M** empty `worker_turn` spans/day (99.9994% of all `worker_turn` volume, measured in Datadog).
2. **Fleet DB load:** two queries/tick × thousands of clients/process on shared encrypted SQLite ≈ **~2,000 queries/sec** of pure no-op polling at 5,000 clients, scaling linearly.

## Approach

Replace the poll with a **scheduled-wake** worker:

- A coarse **1-hour** fallback interval (configurable per-kind via `WorkerConfig`; backstops the 30-day rotation + 1-day deletion).
- A capacity-1 **re-arm channel** nudged via a context `wake_key_package_worker()` facade, fired after `queue_key_rotation` lowers the rotation deadline to `now+5s`.
- On a nudge the worker waits out the **5s debounce** (a deliberate behavior from #2044 — welcomes *queue* a rotation 5s out to collapse bursts and avoid HPKE errors; rotation is **not** done inline) then runs `maintain()`; on an interval tick it runs `maintain()` directly.
- `maintain()` reads two cheap guards, returns early with **no span** when idle, else opens exactly **one** `worker_turn` span wrapping the delete+rotate work (so failures are still recorded).

A parked client now issues ~no maintenance queries and emits no idle spans; `worker_turn` fires only on real work (~2/month/client). The welcome-queued rotation still fires within ~5-10s (rides the wake channel, independent of the interval — so an operator can set a 24h interval on server infra without slowing rotation).

## Notes

- `WorkerKind::KeyPackageCleaner` and the worker registration are **kept** — no bindings break; the supervisor still restarts the worker on error.
- Extracts a shared `RearmChannel` (`DisappearingChannels` becomes an alias).
- An MLS-invariant audit confirmed the coarse interval is safe: XMTP uses last-resort (reusable) key packages, on-network expiry (~84d) is far beyond the 30-day rotation, and deletion is local-only with a 1-day grace where late deletion is strictly safe.
- Test interval override (`WorkerConfig::for_testing()`, 100ms KP) keeps timing-dependent rotation tests fast; new behavior test exercises the queue→wake→rotate pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace 5s poll with wake-channel event loop in `KeyPackageCleaner` worker
> - Replaces the previous 5-second polling interval in `KeyPackageCleaner` with a `RearmChannel` (capacity-1 lossy mpsc) that lets callers explicitly wake the worker; the fallback idle interval is now 1 hour.
> - `queue_key_rotation` and `process_new_welcome` now call `wake_key_package_worker()` after queuing a rotation, triggering a 5-second debounce window before the worker runs maintenance.
> - Introduces `RearmChannel` as a shared primitive in [`worker/rearm_channel.rs`](https://github.com/xmtp/libxmtp/pull/3788/files#diff-9d19a401ec11f9d747ea657bcbe4a74d7a9d161cc4adb9ab04c942e0864f2ed8), replacing the bespoke `DisappearingChannels` struct with a type alias to it.
> - Test builds use a `WorkerConfig::for_testing()` helper that overrides the `KeyPackageCleaner` interval to 100ms for timing-sensitive tests.
> - Behavioral Change: key-package maintenance no longer runs every 5 seconds by default; it runs within ~5 seconds of an explicit wake signal or after 1 hour if idle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53e8377.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->