### PR TITLE
feat(xmtp_mls): KeyPackageCleaner sleeps to the exact rotation deadline (no poll)

### DIFF
--- a/crates/xmtp_common/src/time.rs
+++ b/crates/xmtp_common/src/time.rs
@@ -84,7 +84,10 @@ where
 /// JS `setTimeout` (via gloo-timers) casts the millisecond value to `i32`,
 /// so any duration > ~24.8 days overflows and fires immediately. Chunking into
 /// at-most-1-day pieces lets callers sleep the full requested duration.
-#[allow(dead_code)] // only called from wasm arm; also exercised by unit tests
+///
+/// Only the wasm `sleep` path needs this; compiled for wasm (real use) and under
+/// `test` (native coverage of the pure arithmetic), so it is never dead code.
+#[cfg(any(all(target_family = "wasm", target_os = "unknown"), test))]
 fn sleep_chunks(duration: Duration, max: Duration) -> (u64, Duration) {
     let max_ns = max.as_nanos().max(1);
     let full = (duration.as_nanos() / max_ns) as u64;

--- a/crates/xmtp_common/src/time.rs
+++ b/crates/xmtp_common/src/time.rs
@@ -78,11 +78,34 @@ where
     }
 }
 
+/// Split `duration` into whole `max`-sized chunks plus a remainder.
+/// Returns `(number_of_full_chunks, remainder)`. Pure; used for wasm-safe sleeping.
+///
+/// JS `setTimeout` (via gloo-timers) casts the millisecond value to `i32`,
+/// so any duration > ~24.8 days overflows and fires immediately. Chunking into
+/// at-most-1-day pieces lets callers sleep the full requested duration.
+#[allow(dead_code)] // only called from wasm arm; also exercised by unit tests
+fn sleep_chunks(duration: Duration, max: Duration) -> (u64, Duration) {
+    let max_ns = max.as_nanos().max(1);
+    let full = (duration.as_nanos() / max_ns) as u64;
+    let rem = Duration::from_nanos((duration.as_nanos() % max_ns) as u64);
+    (full, rem)
+}
+
 #[doc(hidden)]
 pub async fn sleep(duration: Duration) {
     wasm_or_native! {
         native => {tokio::time::sleep(duration).await},
-        wasm => {gloo_timers::future::sleep(duration).await},
+        wasm => {
+            // JS setTimeout (via gloo-timers) caps near i32::MAX ms; chunk so a
+            // multi-day sleep elapses fully instead of wrapping to ~0.
+            const MAX_CHUNK: Duration = Duration::from_secs(60 * 60 * 24); // 1 day
+            let (full, rem) = sleep_chunks(duration, MAX_CHUNK);
+            for _ in 0..full {
+                gloo_timers::future::sleep(MAX_CHUNK).await;
+            }
+            gloo_timers::future::sleep(rem).await;
+        }
     }
 }
 
@@ -204,6 +227,24 @@ mod tests {
     fn test_now_secs_returns_positive() {
         let secs = now_secs();
         assert!(secs > 0, "now_secs should return a positive value");
+    }
+
+    #[test]
+    fn sleep_chunks_splits_correctly() {
+        let day = Duration::from_secs(86400);
+        assert_eq!(
+            sleep_chunks(Duration::from_secs(30 * 86400), day),
+            (30, Duration::ZERO)
+        );
+        assert_eq!(
+            sleep_chunks(Duration::from_secs(5), day),
+            (0, Duration::from_secs(5))
+        );
+        assert_eq!(
+            sleep_chunks(day + Duration::from_secs(5), day),
+            (1, Duration::from_secs(5))
+        );
+        assert_eq!(sleep_chunks(Duration::ZERO, day), (0, Duration::ZERO));
     }
 
     // Jitter tests rely on tokio's paused virtual clock, native-only.

--- a/crates/xmtp_db/src/encrypted_store/identity.rs
+++ b/crates/xmtp_db/src/encrypted_store/identity.rs
@@ -52,6 +52,7 @@ pub trait QueryIdentity {
         rotation_interval_ns: i64,
     ) -> Result<(), StorageError>;
     fn is_identity_needs_rotation(&self) -> Result<bool, StorageError>;
+    fn next_key_package_rotation_ns(&self) -> Result<Option<i64>, StorageError>;
 }
 
 impl<T> QueryIdentity for &T
@@ -71,6 +72,10 @@ where
 
     fn is_identity_needs_rotation(&self) -> Result<bool, StorageError> {
         (**self).is_identity_needs_rotation()
+    }
+
+    fn next_key_package_rotation_ns(&self) -> Result<Option<i64>, StorageError> {
+        (**self).next_key_package_rotation_ns()
     }
 }
 
@@ -123,6 +128,17 @@ impl<C: ConnectionExt> QueryIdentity for DbConnection<C> {
             Some(rotate_at) => now_ns() >= rotate_at,
             None => true,
         })
+    }
+
+    fn next_key_package_rotation_ns(&self) -> Result<Option<i64>, StorageError> {
+        use crate::schema::identity::dsl;
+
+        let v: Option<i64> = self.raw_query(|conn| {
+            dsl::identity
+                .select(dsl::next_key_package_rotation_ns)
+                .first::<Option<i64>>(conn)
+        })?;
+        Ok(v)
     }
 }
 

--- a/crates/xmtp_db/src/encrypted_store/key_package_history.rs
+++ b/crates/xmtp_db/src/encrypted_store/key_package_history.rs
@@ -47,6 +47,11 @@ pub trait QueryKeyPackageHistory {
 
     fn get_expired_key_packages(&self) -> Result<Vec<StoredKeyPackageHistoryEntry>, StorageError>;
 
+    /// Soonest `delete_at_ns` across all key packages pending deletion, or `None`
+    /// if none are scheduled. Used by the cleaner worker to wake at the next
+    /// deletion deadline (not just the rotation deadline).
+    fn min_key_package_delete_at_ns(&self) -> Result<Option<i64>, StorageError>;
+
     fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError>;
 
     fn delete_key_package_entry_with_id(&self, id: i32) -> Result<(), StorageError>;
@@ -84,6 +89,10 @@ where
 
     fn get_expired_key_packages(&self) -> Result<Vec<StoredKeyPackageHistoryEntry>, StorageError> {
         (**self).get_expired_key_packages()
+    }
+
+    fn min_key_package_delete_at_ns(&self) -> Result<Option<i64>, StorageError> {
+        (**self).min_key_package_delete_at_ns()
     }
 
     fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError> {
@@ -161,6 +170,18 @@ impl<C: ConnectionExt> QueryKeyPackageHistory for DbConnection<C> {
                 .load::<StoredKeyPackageHistoryEntry>(conn)
         })
         .map_err(StorageError::from) // convert ConnectionError into StorageError
+    }
+
+    fn min_key_package_delete_at_ns(&self) -> Result<Option<i64>, StorageError> {
+        use crate::schema::key_package_history::dsl;
+        use diesel::dsl::min;
+        let v: Option<i64> = self.raw_query(|conn| {
+            dsl::key_package_history
+                .filter(dsl::delete_at_ns.is_not_null())
+                .select(min(dsl::delete_at_ns))
+                .first::<Option<i64>>(conn)
+        })?;
+        Ok(v)
     }
 
     fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError> {

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -505,6 +505,8 @@ mock! {
         fn reset_key_package_rotation_queue(&self, rotation_interval: i64) -> Result<(), StorageError>;
 
         fn is_identity_needs_rotation(&self) -> Result<bool, StorageError>;
+
+        fn next_key_package_rotation_ns(&self) -> Result<Option<i64>, StorageError>;
     }
 
     impl QueryIdentityCache for DbQuery {
@@ -544,6 +546,8 @@ mock! {
         fn get_expired_key_packages(
             &self,
         ) -> Result<Vec<crate::key_package_history::StoredKeyPackageHistoryEntry>, StorageError>;
+
+        fn min_key_package_delete_at_ns(&self) -> Result<Option<i64>, StorageError>;
 
         fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError>;
 

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -385,6 +385,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             task_channels: workers.task_channels().clone(),
             disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(
             ),
+            key_package_channels: crate::worker::rearm_channel::RearmChannel::new(),
             cancellation_token: CancellationToken::new(),
             shutdown_complete: Arc::new(AtomicBool::new(false)),
         });

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1079,6 +1079,7 @@ where
         self.identity()
             .queue_key_rotation(&self.context.db())
             .await?;
+        self.context.wake_key_package_worker();
 
         Ok(())
     }

--- a/crates/xmtp_mls/src/context.rs
+++ b/crates/xmtp_mls/src/context.rs
@@ -6,6 +6,7 @@ use crate::utils::VersionInfo;
 use crate::worker::device_sync::worker::SyncMetric;
 use crate::worker::disappearing_messages::DisappearingChannels;
 use crate::worker::metrics::WorkerMetrics;
+use crate::worker::rearm_channel::RearmChannel;
 use crate::worker::tasks::TaskWorkerChannels;
 use crate::worker::{DynMetrics, MetricsCasting, WorkerConfig, WorkerKind};
 use crate::{
@@ -55,6 +56,7 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     pub(crate) worker_metrics: Arc<Mutex<HashMap<WorkerKind, DynMetrics>>>,
     pub(crate) task_channels: TaskWorkerChannels,
     pub(crate) disappearing_channels: DisappearingChannels,
+    pub(crate) key_package_channels: RearmChannel,
     pub(crate) cancellation_token: CancellationToken,
     // Set only after a successful `Client::close` (workers stopped + DB
     // disconnected). The cancellation token tracks "shutdown initiated";
@@ -129,6 +131,7 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
             worker_metrics: self.worker_metrics,
             task_channels: self.task_channels,
             disappearing_channels: self.disappearing_channels,
+            key_package_channels: self.key_package_channels,
             cancellation_token: self.cancellation_token,
             shutdown_complete: self.shutdown_complete,
         }
@@ -247,7 +250,18 @@ where
     fn local_events(&self) -> &broadcast::Sender<LocalEvents>;
     fn task_channels(&self) -> &TaskWorkerChannels;
     fn disappearing_channels(&self) -> &DisappearingChannels;
+    fn key_package_channels(&self) -> &RearmChannel;
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>>;
+
+    /// Nudge the KeyPackageCleaner worker (best-effort; no-op if disabled).
+    fn wake_key_package_worker(&self) {
+        if self
+            .worker_config()
+            .worker_enabled(crate::worker::WorkerKind::KeyPackageCleaner)
+        {
+            self.key_package_channels().rearm();
+        }
+    }
     fn mls_commit_lock(&self) -> &Arc<GroupCommitLock>;
     fn mutexes(&self) -> &MutexRegistry;
     fn cancellation_token(&self) -> &CancellationToken;
@@ -337,6 +351,10 @@ where
 
     fn disappearing_channels(&self) -> &DisappearingChannels {
         &self.disappearing_channels
+    }
+
+    fn key_package_channels(&self) -> &RearmChannel {
+        &self.key_package_channels
     }
 
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {
@@ -434,6 +452,10 @@ where
 
     fn disappearing_channels(&self) -> &DisappearingChannels {
         <T as XmtpSharedContext>::disappearing_channels(self)
+    }
+
+    fn key_package_channels(&self) -> &RearmChannel {
+        <T as XmtpSharedContext>::key_package_channels(self)
     }
 
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {

--- a/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -163,6 +163,7 @@ async fn test_spoofed_inbox_id() {
         worker_config: alix.context.worker_config.clone(),
         task_channels: alix.context.task_channels.clone(),
         disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(),
+        key_package_channels: crate::worker::rearm_channel::RearmChannel::new(),
         worker_metrics: alix.context.worker_metrics.clone(),
         cancellation_token: alix.context.cancellation_token.clone(),
         shutdown_complete: alix.context.shutdown_complete.clone(),

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -161,6 +161,7 @@ where
         // rotation interval.
         if num_envelopes > 0 {
             self.context.identity().queue_key_rotation(&db).await?;
+            self.context.wake_key_package_worker();
         }
 
         Ok(groups)

--- a/crates/xmtp_mls/src/test/mock.rs
+++ b/crates/xmtp_mls/src/test/mock.rs
@@ -93,6 +93,7 @@ impl Clone for NewMockContext {
             task_channels: self.task_channels.clone(),
             disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(
             ),
+            key_package_channels: crate::worker::rearm_channel::RearmChannel::new(),
             worker_metrics: self.worker_metrics.clone(),
             cancellation_token: self.cancellation_token.clone(),
             shutdown_complete: self.shutdown_complete.clone(),
@@ -170,6 +171,10 @@ impl XmtpSharedContext for NewMockContext {
 
     fn disappearing_channels(&self) -> &crate::worker::disappearing_messages::DisappearingChannels {
         &self.disappearing_channels
+    }
+
+    fn key_package_channels(&self) -> &crate::worker::rearm_channel::RearmChannel {
+        &self.key_package_channels
     }
 
     fn sync_metrics(&self) -> Option<Arc<crate::worker::metrics::WorkerMetrics<SyncMetric>>> {

--- a/crates/xmtp_mls/src/test/mock/generate.rs
+++ b/crates/xmtp_mls/src/test/mock/generate.rs
@@ -39,6 +39,7 @@ pub fn context() -> NewMockContext {
         mls_storage: SqlKeyStore::new(MemoryStorage::new()),
         task_channels: TaskWorkerChannels::default(),
         disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(),
+        key_package_channels: crate::worker::rearm_channel::RearmChannel::new(),
         worker_metrics: Arc::default(),
         cancellation_token: tokio_util::sync::CancellationToken::new(),
         shutdown_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -2,6 +2,7 @@ pub mod device_sync;
 pub mod disappearing_messages;
 pub mod key_package_cleaner;
 pub mod metrics;
+pub mod rearm_channel;
 pub mod tasks;
 
 use crate::context::XmtpSharedContext;

--- a/crates/xmtp_mls/src/worker/disappearing_messages.rs
+++ b/crates/xmtp_mls/src/worker/disappearing_messages.rs
@@ -2,7 +2,6 @@ use crate::context::XmtpSharedContext;
 use crate::worker::{BoxedWorker, NeedsDbReconnect, Worker, WorkerFactory};
 use crate::worker::{WorkerKind, WorkerResult};
 use futures::TryFutureExt;
-use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use xmtp_common::time::now_ns;
@@ -16,42 +15,9 @@ use xmtp_db::{StorageError, prelude::*};
 const FALLBACK_INTERVAL: Duration = Duration::from_secs(24 * 3600);
 
 /// Dedicated wake channel for the disappearing-messages worker.
-///
-/// A **capacity-1** mpsc carrying unit `()` "recompute the next expiry deadline"
-/// nudges. Capacity 1 is deliberate: the worker drains and re-queries the DB on
-/// every wake, so a single pending nudge already captures "something changed" —
-/// more would be redundant. It also bounds memory to one slot even when no worker
-/// is consuming the channel (e.g. the disappearing worker is disabled or
-/// `disable_workers` is set), so `rearm()` can never accumulate without bound.
-#[derive(Clone)]
-pub struct DisappearingChannels {
-    sender: tokio::sync::mpsc::Sender<()>,
-    pub receiver: Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<()>>>,
-}
-
-impl Default for DisappearingChannels {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DisappearingChannels {
-    pub fn new() -> Self {
-        let (sender, receiver) = tokio::sync::mpsc::channel(1);
-        Self {
-            sender,
-            receiver: Arc::new(tokio::sync::Mutex::new(receiver)),
-        }
-    }
-
-    /// Wake the worker to recompute its next-expiry deadline. Best-effort and
-    /// non-blocking: if a nudge is already queued (slot full) or no worker is
-    /// consuming, the send is dropped — the worker recomputes from the DB on its
-    /// next wake regardless, so a dropped duplicate nudge changes nothing.
-    pub fn rearm(&self) {
-        let _ = self.sender.try_send(());
-    }
-}
+/// Re-uses the shared [`RearmChannel`] type — see its docs for the capacity-1
+/// rationale.
+pub type DisappearingChannels = crate::worker::rearm_channel::RearmChannel;
 
 #[derive(Debug, Error)]
 pub enum DisappearingMessagesCleanerError {
@@ -197,18 +163,5 @@ where
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[xmtp_common::test(unwrap_try = true)]
-    async fn rearm_delivers_a_signal() {
-        let ch = DisappearingChannels::new();
-        ch.rearm();
-        let mut rx = ch.receiver.lock().await;
-        assert!(rx.recv().await.is_some());
     }
 }

--- a/crates/xmtp_mls/src/worker/key_package_cleaner.rs
+++ b/crates/xmtp_mls/src/worker/key_package_cleaner.rs
@@ -5,20 +5,41 @@ use crate::worker::BoxedWorker;
 use crate::worker::NeedsDbReconnect;
 use crate::worker::WorkerResult;
 use crate::worker::{Worker, WorkerFactory, WorkerKind};
-use futures::StreamExt;
 use futures::TryFutureExt;
 use openmls_traits::storage::StorageProvider;
-use std::time::Duration;
 use thiserror::Error;
+use tracing::Instrument;
 use xmtp_configuration::CREATE_PQ_KEY_PACKAGE_EXTENSION;
 use xmtp_db::prelude::*;
 use xmtp_db::{
     MlsProviderExt, StorageError,
+    encrypted_store::key_package_history::StoredKeyPackageHistoryEntry,
     sql_key_store::{KEY_PACKAGE_REFERENCES, KEY_PACKAGE_WRAPPER_PRIVATE_KEY},
 };
 
-/// Interval at which the KeyPackagesCleanerWorker runs to delete expired messages.
-pub const INTERVAL_DURATION: Duration = Duration::from_secs(5);
+#[derive(Debug, PartialEq, Eq)]
+enum WakePlan {
+    RunNow,
+    SleepUntil(i64), // absolute deadline ns
+}
+
+/// Decide the next wake from the two maintenance deadlines:
+/// - `next_rotation`: `None` (NULL) = rotation due now; else the absolute rotation time.
+/// - `next_deletion`: soonest pending `delete_at_ns`, or `None` if nothing to delete.
+///
+/// Run now if either is already due; otherwise sleep until the SOONEST future deadline.
+fn plan(next_rotation: Option<i64>, next_deletion: Option<i64>, now: i64) -> WakePlan {
+    // NULL rotation or a past rotation/deletion deadline => act now. This also
+    // means `next_rotation` is `Some` (and future) past this point.
+    let Some(rotation) = next_rotation.filter(|&at| at > now) else {
+        return WakePlan::RunNow;
+    };
+    if next_deletion.is_some_and(|at| at <= now) {
+        return WakePlan::RunNow;
+    }
+    // Both deadlines (whichever are present) are in the future; sleep to the soonest.
+    WakePlan::SleepUntil(next_deletion.map_or(rotation, |del| rotation.min(del)))
+}
 
 #[derive(Clone)]
 pub struct Factory<Context> {
@@ -116,21 +137,83 @@ where
     Context: XmtpSharedContext + 'static,
 {
     async fn run(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        let (base, jitter) = self
-            .context
-            .worker_interval(WorkerKind::KeyPackageCleaner, INTERVAL_DURATION);
-        let mut intervals = xmtp_common::time::jittered_interval_stream(base, jitter);
-        while (intervals.next().await).is_some() {
-            self.tick().await?;
+        let receiver = self.context.key_package_channels().receiver.clone();
+        let mut receiver = receiver.lock().await;
+        loop {
+            // Drain any pending re-arm signals before computing the plan so we
+            // don't lose a wakeup that arrived while we were working.
+            while receiver.try_recv().is_ok() {}
+
+            let db = self.context.db();
+            let next_rotation = db
+                .next_key_package_rotation_ns()
+                .map_err(KeyPackagesCleanerError::Metadata)?;
+            match plan(
+                next_rotation,
+                db.min_key_package_delete_at_ns()
+                    .map_err(KeyPackagesCleanerError::Metadata)?,
+                xmtp_common::time::now_ns(),
+            ) {
+                WakePlan::RunNow => {
+                    self.maintain(next_rotation).await?;
+                }
+                WakePlan::SleepUntil(deadline) => {
+                    let dur = std::time::Duration::from_nanos(
+                        (deadline - xmtp_common::time::now_ns()).max(0) as u64,
+                    );
+                    tokio::select! {
+                        // Re-arm signal: recompute the deadline, do NOT run work.
+                        // `None` means every sender was dropped (context torn down) —
+                        // stop rather than busy-spin on a closed channel.
+                        msg = receiver.recv() => { if msg.is_none() { return Ok(()); } }
+                        // Deadline elapsed: time to do maintenance.
+                        () = xmtp_common::time::sleep(dur) => {
+                            self.maintain(next_rotation).await?;
+                        }
+                    }
+                }
+            }
         }
-        Ok(())
     }
 
-    #[tracing::instrument(skip_all, fields(worker = ?self.kind(), operation = "worker_turn"))]
-    async fn tick(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        self.delete_expired_key_packages()?;
-        self.rotate_last_key_package_if_needed().await?;
-        Ok(())
+    /// One maintenance pass. `next_rotation` is the rotation deadline already
+    /// read by the caller (`None`/past = rotation due) — reused here so we don't
+    /// re-query the identity row. Guards read OUTSIDE the span; if nothing is
+    /// due, returns immediately with no span. Otherwise a single `worker_turn`
+    /// span wraps the work so tracing records the full operation (incl. errors).
+    async fn maintain(
+        &mut self,
+        next_rotation: Option<i64>,
+    ) -> Result<(), KeyPackagesCleanerError> {
+        let expired = self
+            .context
+            .db()
+            .get_expired_key_packages()
+            .map_err(KeyPackagesCleanerError::Fetch)?;
+        // Same predicate as `is_identity_needs_rotation()`, from the value the
+        // caller already fetched: NULL or a past deadline means rotate now.
+        let rotate_due = next_rotation.is_none_or(|at| at <= xmtp_common::time::now_ns());
+
+        if expired.is_empty() && !rotate_due {
+            return Ok(());
+        }
+
+        let span = tracing::info_span!(
+            "worker_turn",
+            worker = ?self.kind(),
+            operation = "worker_turn"
+        );
+        async {
+            if !expired.is_empty() {
+                self.delete_key_packages(expired)?;
+            }
+            if rotate_due {
+                self.rotate_last_key_package_if_needed().await?;
+            }
+            Ok::<(), KeyPackagesCleanerError>(())
+        }
+        .instrument(span)
+        .await
     }
 
     /// Delete a key package from the local database.
@@ -156,65 +239,116 @@ where
         Ok(())
     }
 
-    /// Delete all the expired keys
-    fn delete_expired_key_packages(&mut self) -> Result<(), KeyPackagesCleanerError> {
+    /// Delete an already-fetched list of expired key packages from local state
+    /// and the database history table.
+    fn delete_key_packages(
+        &mut self,
+        expired: Vec<StoredKeyPackageHistoryEntry>,
+    ) -> Result<(), KeyPackagesCleanerError> {
         let conn = self.context.db();
-
-        // Propagate (don't swallow): a swallowed fetch error never triggered the supervisor's
-        // reconnect path, so a pool outage retried silently every 5s.
-        let expired_kps = conn
-            .get_expired_key_packages()
-            .map_err(KeyPackagesCleanerError::Fetch)?;
-        if expired_kps.is_empty() {
-            return Ok(());
-        }
-
-        tracing::info!("Deleting {} expired key packages", expired_kps.len());
-        // Delete from local db
-        for kp in &expired_kps {
+        for kp in &expired {
             self.delete_key_package(
                 kp.key_package_hash_ref.clone(),
                 kp.post_quantum_public_key.clone(),
             )
             .map_err(KeyPackagesCleanerError::DeleteKeyPackage)?;
         }
-
-        // Delete from database using the max expired ID
-        if let Some(max_id) = expired_kps.iter().map(|kp| kp.id).max() {
+        if let Some(max_id) = expired.iter().map(|kp| kp.id).max() {
             conn.delete_key_package_history_up_to_id(max_id)
                 .map_err(KeyPackagesCleanerError::Deletion)?;
             tracing::info!(
-                "Deleted {} expired key packages (up to ID {}) from local DB and state",
-                expired_kps.len(),
+                "Deleted {} expired key packages (up to ID {})",
+                expired.len(),
                 max_id
             );
         }
-
         Ok(())
     }
 
-    /// Check if we need to rotate the keys and upload new keypackage if the las one rotate in has passed
+    /// Upload a fresh key package if the current one has passed its rotation deadline.
     async fn rotate_last_key_package_if_needed(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        let conn = self.context.db();
+        tracing::info!("Rotating key package");
+        self.context
+            .identity()
+            .rotate_and_upload_key_package(
+                self.context.api(),
+                self.context.mls_storage(),
+                CREATE_PQ_KEY_PACKAGE_EXTENSION,
+            )
+            .await
+            .map_err(KeyPackagesCleanerError::Rotation)?;
+        tracing::info!("Key package rotation successful");
+        Ok(())
+    }
+}
 
-        if conn
-            .is_identity_needs_rotation()
-            .map_err(KeyPackagesCleanerError::Metadata)?
-        {
-            tracing::info!("Rotating key package");
-            self.context
-                .identity()
-                .rotate_and_upload_key_package(
-                    self.context.api(),
-                    self.context.mls_storage(),
-                    CREATE_PQ_KEY_PACKAGE_EXTENSION,
-                )
-                .await
-                .map_err(KeyPackagesCleanerError::Rotation)?;
-            tracing::info!("Key package rotation successful");
-            return Ok(());
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn plan_cases() {
+        use super::{WakePlan, plan};
+        // NULL rotation = due now (regardless of deletion).
+        assert_eq!(plan(None, None, 100), WakePlan::RunNow);
+        assert_eq!(plan(None, Some(200), 100), WakePlan::RunNow);
+        // Past rotation/deletion = due now.
+        assert_eq!(plan(Some(99), None, 100), WakePlan::RunNow);
+        assert_eq!(plan(Some(100), None, 100), WakePlan::RunNow);
+        assert_eq!(plan(Some(200), Some(99), 100), WakePlan::RunNow); // deletion past
+        // Both future: sleep to the soonest.
+        assert_eq!(plan(Some(101), None, 100), WakePlan::SleepUntil(101));
+        assert_eq!(plan(Some(300), Some(150), 100), WakePlan::SleepUntil(150)); // deletion sooner
+        assert_eq!(plan(Some(150), Some(300), 100), WakePlan::SleepUntil(150)); // rotation sooner
+        assert_eq!(plan(Some(200), None, 100), WakePlan::SleepUntil(200));
+    }
+
+    /// Requires a live XMTP node. Verifies that `queue_key_rotation` marks the
+    /// identity for rotation and wakes the KeyPackageCleaner worker, which then
+    /// uploads a new key package within ~12 s.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn queue_key_rotation_wakes_worker_and_rotates() {
+        use crate::tester;
+
+        tester!(client);
+
+        let installation_id = client.installation_public_key().to_vec();
+
+        // Snapshot the current on-network init key.
+        // `VerifiedKeyPackageV2::hpke_init_key()` returns an owned Vec<u8>.
+        let before = {
+            let mut map = client
+                .get_key_packages_for_installation_ids(vec![installation_id.clone()])
+                .await?;
+            let entry = map
+                .remove(&installation_id)
+                .expect("installation not found in response")?;
+            entry.hpke_init_key()
+        };
+
+        // Queue a rotation and wake the worker.
+        client.queue_key_rotation().await?;
+
+        // Poll up to 12 s (60 × 200 ms) for the on-network key to change.
+        // Uses `xmtp_common::time::sleep` so the test compiles for wasm too
+        // (std::time::Instant panics on wasm).
+        let mut after = None;
+        for _ in 0..60u32 {
+            xmtp_common::time::sleep(std::time::Duration::from_millis(200)).await;
+            let mut map = client
+                .get_key_packages_for_installation_ids(vec![installation_id.clone()])
+                .await?;
+            let entry = map
+                .remove(&installation_id)
+                .expect("installation not found in response")?;
+            let key = entry.hpke_init_key();
+            if key != before {
+                after = Some(key);
+                break;
+            }
         }
 
-        Ok(())
+        assert!(
+            after.is_some(),
+            "key package did not rotate after queue_key_rotation + worker wake"
+        );
     }
 }

--- a/crates/xmtp_mls/src/worker/rearm_channel.rs
+++ b/crates/xmtp_mls/src/worker/rearm_channel.rs
@@ -1,0 +1,56 @@
+//! A capacity-1 "wake the worker" channel: a unit `()` mpsc nudge. Capacity 1
+//! because a worker drains and re-checks on every wake, so one pending nudge
+//! already means "something changed". `rearm()` is best-effort (full slot or
+//! absent consumer drops the send harmlessly). Each worker owns its OWN instance.
+
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct RearmChannel {
+    sender: tokio::sync::mpsc::Sender<()>,
+    pub receiver: Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<()>>>,
+}
+
+impl Default for RearmChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RearmChannel {
+    pub fn new() -> Self {
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
+        Self {
+            sender,
+            receiver: Arc::new(tokio::sync::Mutex::new(receiver)),
+        }
+    }
+
+    /// Best-effort wake. A full slot or absent consumer drops the nudge.
+    pub fn rearm(&self) {
+        let _ = self.sender.try_send(());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[xmtp_common::test]
+    async fn rearm_delivers_a_signal() {
+        let ch = RearmChannel::new();
+        ch.rearm();
+        let mut rx = ch.receiver.lock().await;
+        assert!(rx.try_recv().is_ok());
+    }
+
+    #[xmtp_common::test]
+    async fn rearm_is_capacity_one_and_lossy() {
+        let ch = RearmChannel::new();
+        ch.rearm();
+        ch.rearm();
+        let mut rx = ch.receiver.lock().await;
+        assert!(rx.try_recv().is_ok());
+        assert!(rx.try_recv().is_err());
+    }
+}


### PR DESCRIPTION
**Draft** — alternative to #3788 implementing @tylerhawkes's review feedback. Opening for review, not yet ready to merge.

## What

Replaces KeyPackageCleaner's **5-second poll** with a worker that **sleeps until the exact next rotation deadline** (`next_key_package_rotation_ns`) — no fixed-interval poll, so sleeping apps aren't woken for work whose time we already know.

This is the approach from the #3788 review:
> *"This can all be done on the existing worker with a specific timeout in the future instead of regular polling. If they expire after 90 days, we update the task to roll it to 30 days out every time we create one — as long as the app wakes up sometime in the 60-day window it gets rolled."*

## Why

The 5s poll cost ~**82M** empty `worker_turn` spans/day (99.9994% of `worker_turn` volume) + ~**2,000 no-op DB queries/sec** at 5,000 clients/process. Real work is ~monthly (30-day rotation; deletion ~1 day after a KP is superseded).

## How

- **`xmtp_common::time::sleep` is now wasm-safe** — it chunks long durations internally so a multi-day sleep doesn't overflow `gloo-timers` (which casts ms to `i32` for JS `setTimeout`; a 30-day sleep would otherwise wrap and fire immediately). Benefits every long sleep in the codebase.
- **The worker sleeps to `next_key_package_rotation_ns`.** A pure `WakePlan { RunNow, SleepUntil(deadline) }` decides; on `RunNow` (NULL/past deadline) it runs maintenance, on `SleepUntil` it `select!`s a re-arm-channel recompute vs `sleep(deadline - now) → maintain()`. Existing code already rolls the rotation deadline 30 days forward after each rotation, so the worker self-perpetuates. Deletion of expired KPs is opportunistic in the work pass (latency-tolerant; local-only with a grace).
- **The ~5s welcome-queued rotation** still fires promptly: `Client::queue_key_rotation` (welcome + public) lowers the deadline to `now+5s` and nudges the worker via a `wake_key_package_worker()` facade → the parked worker recomputes and rotates ~5s later.
- **Span-gated** `maintain()` — one `worker_turn` span only when there's real work, wrapping it so failures are recorded.

`WorkerKind::KeyPackageCleaner` and registration are kept (no bindings break); supervisor restart is the failure backstop.

## Relationship to #3788

#3788 is the 1-hour-fallback version of this worker; this is the exact-deadline version (no fallback poll). If #3788 lands first, this becomes a small follow-up swapping the interval for the deadline sleep.

## MLS safety

Last-resort reusable KPs; on-network expiry ~90d vs 30d rotation = 60-day window; deletion local-only where late deletion is strictly safe. A worker waking at the rotation deadline (or any time in the window) is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace polling loop in `KeyPackagesCleanerWorker` with deadline-driven sleep and re-arm channel
> - Replaces the periodic 5-second jittered poll in `KeyPackagesCleanerWorker.run` with an event-driven loop that sleeps until the exact next rotation or deletion deadline, waking early via a new `RearmChannel` when work is queued.
> - Adds `RearmChannel`, a capacity-1 lossy wake channel, replacing the duplicate implementation previously used by `DisappearingMessages`.
> - Adds `next_key_package_rotation_ns` and `min_key_package_delete_at_ns` DB queries to `QueryIdentity` and `QueryKeyPackageHistory` traits so the worker can determine precise sleep durations.
> - `queue_key_rotation` and `WelcomeSync::process_new_welcome` now call `wake_key_package_worker()` to immediately signal the cleaner when rotation is queued.
> - Fixes a wasm `setTimeout` i32 overflow for sleeps longer than ~24.8 days by chunking into 1-day intervals in `xmtp_common::time::sleep`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e40d81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->