### PR TITLE
feat(proto): add KpMaintenance task variant + regen xmtp_proto

### DIFF
--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -312,6 +312,12 @@ where
             )) => {
                 Self::process_pending_self_remove(task, pending, context).await?;
             }
+            Some(xmtp_proto::xmtp::mls::database::task::Task::KpMaintenance(_)) => {
+                // Key-package maintenance is implemented in the follow-up PR; this
+                // no-op arm only keeps the match exhaustive against the new proto
+                // variant so this PR builds standalone.
+                context.db().delete_task(task.id)?;
+            }
             None => {
                 tracing::error!("Task {} has no data. Deleting.", task.id);
                 context.db().delete_task(task.id)?;

--- a/crates/xmtp_proto/src/gen/xmtp.mls.database.rs
+++ b/crates/xmtp_proto/src/gen/xmtp.mls.database.rs
@@ -783,7 +783,7 @@ impl PermissionPolicyOption {
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Task {
-    #[prost(oneof = "task::Task", tags = "1, 2, 3")]
+    #[prost(oneof = "task::Task", tags = "1, 2, 3, 4")]
     pub task: ::core::option::Option<task::Task>,
 }
 /// Nested message and enum types in `Task`.
@@ -796,6 +796,8 @@ pub mod task {
         SendSyncArchive(super::SendSyncArchive),
         #[prost(message, tag = "3")]
         ProcessPendingSelfRemove(super::ProcessPendingSelfRemove),
+        #[prost(message, tag = "4")]
+        KpMaintenance(super::KpMaintenance),
     }
 }
 impl ::prost::Name for Task {
@@ -806,6 +808,22 @@ impl ::prost::Name for Task {
     }
     fn type_url() -> ::prost::alloc::string::String {
         "/xmtp.mls.database.Task".into()
+    }
+}
+/// Durable singleton TaskRunner intent: run key-package maintenance (delete
+/// expired key packages, rotate the local key package when due) and reschedule
+/// itself to the next rotation/deletion deadline. Empty payload — exactly one
+/// such task exists per installation (enforced by the tasks UNIQUE(data_hash)).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct KpMaintenance {}
+impl ::prost::Name for KpMaintenance {
+    const NAME: &'static str = "KpMaintenance";
+    const PACKAGE: &'static str = "xmtp.mls.database";
+    fn full_name() -> ::prost::alloc::string::String {
+        "xmtp.mls.database.KpMaintenance".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/xmtp.mls.database.KpMaintenance".into()
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/xmtp_proto/src/gen/xmtp.mls.database.serde.rs
+++ b/crates/xmtp_proto/src/gen/xmtp.mls.database.serde.rs
@@ -1002,6 +1002,78 @@ impl<'de> serde::Deserialize<'de> for InstallationIds {
         deserializer.deserialize_struct("xmtp.mls.database.InstallationIds", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for KpMaintenance {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("xmtp.mls.database.KpMaintenance", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for KpMaintenance {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            __SkipField__,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl serde::de::Visitor<'_> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Ok(GeneratedField::__SkipField__)
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = KpMaintenance;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct xmtp.mls.database.KpMaintenance")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<KpMaintenance, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(KpMaintenance {
+                })
+            }
+        }
+        deserializer.deserialize_struct("xmtp.mls.database.KpMaintenance", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for PermissionPolicyOption {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -2833,6 +2905,9 @@ impl serde::Serialize for Task {
                 task::Task::ProcessPendingSelfRemove(v) => {
                     struct_ser.serialize_field("process_pending_self_remove", v)?;
                 }
+                task::Task::KpMaintenance(v) => {
+                    struct_ser.serialize_field("kp_maintenance", v)?;
+                }
             }
         }
         struct_ser.end()
@@ -2851,6 +2926,8 @@ impl<'de> serde::Deserialize<'de> for Task {
             "sendSyncArchive",
             "process_pending_self_remove",
             "processPendingSelfRemove",
+            "kp_maintenance",
+            "kpMaintenance",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -2858,6 +2935,7 @@ impl<'de> serde::Deserialize<'de> for Task {
             ProcessWelcomePointer,
             SendSyncArchive,
             ProcessPendingSelfRemove,
+            KpMaintenance,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -2883,6 +2961,7 @@ impl<'de> serde::Deserialize<'de> for Task {
                             "processWelcomePointer" | "process_welcome_pointer" => Ok(GeneratedField::ProcessWelcomePointer),
                             "sendSyncArchive" | "send_sync_archive" => Ok(GeneratedField::SendSyncArchive),
                             "processPendingSelfRemove" | "process_pending_self_remove" => Ok(GeneratedField::ProcessPendingSelfRemove),
+                            "kpMaintenance" | "kp_maintenance" => Ok(GeneratedField::KpMaintenance),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -2924,6 +3003,13 @@ impl<'de> serde::Deserialize<'de> for Task {
                                 return Err(serde::de::Error::duplicate_field("processPendingSelfRemove"));
                             }
                             task__ = map_.next_value::<::std::option::Option<_>>()?.map(task::Task::ProcessPendingSelfRemove)
+;
+                        }
+                        GeneratedField::KpMaintenance => {
+                            if task__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("kpMaintenance"));
+                            }
+                            task__ = map_.next_value::<::std::option::Option<_>>()?.map(task::Task::KpMaintenance)
 ;
                         }
                         GeneratedField::__SkipField__ => {


### PR DESCRIPTION
Base of a 2-PR stack (the impl PR is stacked on this one). Adds an empty `KpMaintenance` variant (field `=4`) to the `Task` oneof and regenerates the vendored `xmtp_proto`. No behavior change on its own.

The impl PR uses this variant to run key-package maintenance as a recurring TaskRunner task, replacing the polling `KeyPackagesCleanerWorker` (~82M `worker_turn` spans/24h).

Note: `proto/mls/database/task.proto` must also land on `xmtp/proto` and `proto_version` be bumped for a stock regen; this PR vendors the generated `.rs` so the impl PR compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZTNgPeSH4WtQfN5qB33QF

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `KpMaintenance` task variant to the MLS database proto
> Adds a new `KpMaintenance` oneof variant (tag 4) to the `Task` message in the MLS database proto, along with serde serialization support. The new message type is empty and follows the same pattern as existing task variants. Generated files in [xmtp.mls.database.rs](https://github.com/xmtp/libxmtp/pull/3794/files#diff-1b48cc83eb618a15345516b946b4138dae9c2be24155cc8d9a950038f118096c) and [xmtp.mls.database.serde.rs](https://github.com/xmtp/libxmtp/pull/3794/files#diff-fc113d60966783e19f7aee5738ce2e99a205b0ba65cf81541386c8e27c12e682) are regenerated from the updated proto definition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09e8ff8. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->