### PR TITLE
feat: run key-package maintenance on the TaskRunner (kill the poll loop)

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/identity.rs
+++ b/crates/xmtp_db/src/encrypted_store/identity.rs
@@ -174,7 +174,10 @@ pub(crate) mod tests {
                 .unwrap();
 
             // Reader returns the currently-scheduled deadline.
-            assert_eq!(conn.next_key_package_rotation_ns().unwrap(), Some(far_future));
+            assert_eq!(
+                conn.next_key_package_rotation_ns().unwrap(),
+                Some(far_future)
+            );
 
             // Queuing a rotation pulls the deadline earlier (~5s out).
             conn.queue_key_package_rotation().unwrap();

--- a/crates/xmtp_db/src/encrypted_store/identity.rs
+++ b/crates/xmtp_db/src/encrypted_store/identity.rs
@@ -52,6 +52,8 @@ pub trait QueryIdentity {
         rotation_interval_ns: i64,
     ) -> Result<(), StorageError>;
     fn is_identity_needs_rotation(&self) -> Result<bool, StorageError>;
+    /// Absolute ns of the next scheduled key-package rotation, or None if not queued.
+    fn next_key_package_rotation_ns(&self) -> Result<Option<i64>, StorageError>;
 }
 
 impl<T> QueryIdentity for &T
@@ -71,6 +73,10 @@ where
 
     fn is_identity_needs_rotation(&self) -> Result<bool, StorageError> {
         (**self).is_identity_needs_rotation()
+    }
+
+    fn next_key_package_rotation_ns(&self) -> Result<Option<i64>, StorageError> {
+        (**self).next_key_package_rotation_ns()
     }
 }
 
@@ -124,13 +130,61 @@ impl<C: ConnectionExt> QueryIdentity for DbConnection<C> {
             None => true,
         })
     }
+
+    fn next_key_package_rotation_ns(&self) -> Result<Option<i64>, StorageError> {
+        use crate::schema::identity::dsl;
+
+        let v: Option<i64> = self.raw_query(|conn| {
+            dsl::identity
+                .select(dsl::next_key_package_rotation_ns)
+                .first::<Option<i64>>(conn)
+        })?;
+        Ok(v)
+    }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
     use super::StoredIdentity;
+    use crate::identity::QueryIdentity;
     use crate::{Store, XmtpTestDb};
     use xmtp_common::rand_vec;
+
+    #[xmtp_common::test]
+    fn next_key_package_rotation_ns_reads_queue() {
+        use crate::test_utils::with_connection;
+        use xmtp_common::{NS_IN_30_DAYS, time::now_ns};
+        use xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS;
+
+        with_connection(|conn| {
+            // Seed the single identity row with a far-future rotation deadline,
+            // as registration does. `queue_key_package_rotation` only moves the
+            // deadline *earlier* (its filter requires the existing value be
+            // greater than the queued time), so the row must exist with a
+            // future value for the queue to fire.
+            let far_future = now_ns() + NS_IN_30_DAYS;
+            StoredIdentity::builder()
+                .inbox_id("".to_string())
+                .installation_keys(rand_vec::<24>())
+                .credential_bytes(rand_vec::<24>())
+                .next_key_package_rotation_ns(Some(far_future))
+                .build()
+                .unwrap()
+                .store(conn)
+                .unwrap();
+
+            // Reader returns the currently-scheduled deadline.
+            assert_eq!(conn.next_key_package_rotation_ns().unwrap(), Some(far_future));
+
+            // Queuing a rotation pulls the deadline earlier (~5s out).
+            conn.queue_key_package_rotation().unwrap();
+            let queued = conn.next_key_package_rotation_ns().unwrap();
+            assert!(queued.is_some());
+            let queued = queued.unwrap();
+            assert!(queued < far_future);
+            assert!(queued <= now_ns() + KEY_PACKAGE_QUEUE_INTERVAL_NS);
+        })
+    }
 
     #[xmtp_common::test]
     async fn can_only_store_one_identity() {

--- a/crates/xmtp_db/src/encrypted_store/key_package_history.rs
+++ b/crates/xmtp_db/src/encrypted_store/key_package_history.rs
@@ -47,6 +47,9 @@ pub trait QueryKeyPackageHistory {
 
     fn get_expired_key_packages(&self) -> Result<Vec<StoredKeyPackageHistoryEntry>, StorageError>;
 
+    /// Soonest `delete_at_ns` across all key packages pending deletion, or None.
+    fn min_key_package_delete_at_ns(&self) -> Result<Option<i64>, StorageError>;
+
     fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError>;
 
     fn delete_key_package_entry_with_id(&self, id: i32) -> Result<(), StorageError>;
@@ -84,6 +87,10 @@ where
 
     fn get_expired_key_packages(&self) -> Result<Vec<StoredKeyPackageHistoryEntry>, StorageError> {
         (**self).get_expired_key_packages()
+    }
+
+    fn min_key_package_delete_at_ns(&self) -> Result<Option<i64>, StorageError> {
+        (**self).min_key_package_delete_at_ns()
     }
 
     fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError> {
@@ -161,6 +168,18 @@ impl<C: ConnectionExt> QueryKeyPackageHistory for DbConnection<C> {
                 .load::<StoredKeyPackageHistoryEntry>(conn)
         })
         .map_err(StorageError::from) // convert ConnectionError into StorageError
+    }
+
+    fn min_key_package_delete_at_ns(&self) -> Result<Option<i64>, StorageError> {
+        use crate::schema::key_package_history::dsl;
+        use diesel::dsl::min;
+        let v: Option<i64> = self.raw_query(|conn| {
+            dsl::key_package_history
+                .filter(dsl::delete_at_ns.is_not_null())
+                .select(min(dsl::delete_at_ns))
+                .first::<Option<i64>>(conn)
+        })?;
+        Ok(v)
     }
 
     fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError> {
@@ -253,6 +272,19 @@ mod tests {
                 .find_key_package_history_entries_before_id(entry_3.id)
                 .unwrap();
             assert_eq!(earlier_entries.len(), 2);
+        })
+    }
+
+    #[xmtp_common::test]
+    fn min_key_package_delete_at_ns_returns_soonest() {
+        with_connection(|conn| {
+            assert_eq!(conn.min_key_package_delete_at_ns().unwrap(), None);
+            conn.store_key_package_history_entry(rand_vec::<24>(), None)
+                .unwrap();
+            conn.store_key_package_history_entry(rand_vec::<24>(), None)
+                .unwrap();
+            conn.mark_key_package_before_id_to_be_deleted(99).unwrap();
+            assert!(conn.min_key_package_delete_at_ns().unwrap().is_some());
         })
     }
 }

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -396,11 +396,7 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
                 // concurrent backoff write can't slip between read and write.
                 let existing: Option<(i32, i32, i64)> = tasks::table
                     .filter(tasks::data_hash.eq(&data_hash))
-                    .select((
-                        tasks::id,
-                        tasks::attempts,
-                        tasks::next_attempt_at_ns,
-                    ))
+                    .select((tasks::id, tasks::attempts, tasks::next_attempt_at_ns))
                     .first::<(i32, i32, i64)>(conn)
                     .optional()?;
                 match existing {

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -17,6 +17,13 @@ pub fn kp_maintenance_task_proto() -> TaskProto {
     }
 }
 
+/// The constant `data_hash` of the singleton `KpMaintenance` task. Because the
+/// payload is constant, this hash is constant, so it can be used to target the
+/// singleton row directly without first loading it by id.
+fn kp_maintenance_data_hash() -> Vec<u8> {
+    xmtp_common::sha256_bytes(&kp_maintenance_task_proto().encode_to_vec())
+}
+
 #[derive(Queryable, Identifiable, Debug, Clone)]
 #[diesel(table_name = tasks)]
 #[diesel(primary_key(id))]
@@ -135,6 +142,10 @@ pub trait QueryTasks {
         expires_at_ns: i64,
     ) -> Result<Task, StorageError>;
 
+    /// Nudge the KP maintenance task to run at `at` — only when it is NOT mid-backoff
+    /// (attempts == 0). If no KP row exists (a prior seed failed), lazily ensure one.
+    fn bump_kp_maintenance_task(&self, at: i64) -> Result<(), StorageError>;
+
     fn update_task(
         &self,
         id: i32,
@@ -178,6 +189,10 @@ impl<T: QueryTasks> QueryTasks for &'_ T {
         expires_at_ns: i64,
     ) -> Result<Task, StorageError> {
         (**self).reschedule_kp_task(id, fallback_next_ns, expires_at_ns)
+    }
+
+    fn bump_kp_maintenance_task(&self, at: i64) -> Result<(), StorageError> {
+        (**self).bump_kp_maintenance_task(at)
     }
 
     fn update_task(
@@ -357,6 +372,60 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
                         tasks::next_attempt_at_ns.eq(next),
                     ))
                     .get_result::<Task>(conn)
+            })
+        })
+        .map_err(Into::into)
+    }
+
+    fn bump_kp_maintenance_task(&self, at: i64) -> Result<(), StorageError> {
+        let now = now_ns();
+        let data_hash = kp_maintenance_data_hash();
+        // Build the lazy-seed task up front so its StorageError-typed `?` happens
+        // here, not inside the diesel txn closure (whose error is diesel::Error).
+        let seed = NewTask::builder()
+            .originating_message_sequence_id(0)
+            .originating_message_originator_id(0)
+            .next_attempt_at_ns(at)
+            .expires_at_ns(now + NS_IN_DAY)
+            .build(kp_maintenance_task_proto())?;
+        self.raw_query(|conn| {
+            conn.transaction(|conn| {
+                // Find the singleton KP row by its constant data_hash. Read its
+                // current (id, attempts, next_attempt_at_ns) so we can decide
+                // whether to pull the deadline in, all inside this txn so a
+                // concurrent backoff write can't slip between read and write.
+                let existing: Option<(i32, i32, i64)> = tasks::table
+                    .filter(tasks::data_hash.eq(&data_hash))
+                    .select((
+                        tasks::id,
+                        tasks::attempts,
+                        tasks::next_attempt_at_ns,
+                    ))
+                    .first::<(i32, i32, i64)>(conn)
+                    .optional()?;
+                match existing {
+                    // Live row, idle: pull next_attempt in to MIN(existing, at).
+                    // We never push it OUT, so a sooner deadline is preserved.
+                    Some((id, 0, next)) => {
+                        diesel::update(tasks::table.filter(tasks::id.eq(id)))
+                            .set(tasks::next_attempt_at_ns.eq(next.min(at)))
+                            .execute(conn)?;
+                    }
+                    // Row exists but is mid-backoff (attempts > 0): no-op, so a
+                    // flood of welcomes can't trample an upload-outage schedule.
+                    Some((_id, _attempts, _next)) => {}
+                    // Missing (a prior startup seed failed): lazily insert a fresh
+                    // singleton scheduled at `at`. Inlined here (not via
+                    // ensure_kp_maintenance_task) to avoid nesting a second
+                    // raw_query/connection inside this transaction. The fresh row
+                    // has attempts == 0, so the same idle pull-in semantics apply.
+                    None => {
+                        diesel::insert_or_ignore_into(tasks::table)
+                            .values(&seed)
+                            .execute(conn)?;
+                    }
+                }
+                Ok(())
             })
         })
         .map_err(Into::into)
@@ -691,6 +760,30 @@ pub(crate) mod tests {
             assert_eq!(
                 task.next_attempt_at_ns, delete_at,
                 "reschedule must floor to the soonest live deadline (the delete deadline)"
+            );
+        })
+    }
+
+    #[xmtp_common::test]
+    fn bump_kp_maintenance_task_pulls_in_only_when_idle_and_lazy_seeds() {
+        use crate::test_utils::with_connection;
+        use xmtp_common::time::now_ns;
+        with_connection(|conn| {
+            let at = now_ns() + 5 * xmtp_common::NS_IN_SEC;
+            // No row yet -> lazy seed creates exactly one.
+            conn.bump_kp_maintenance_task(at).unwrap();
+            assert_eq!(conn.get_tasks().unwrap().len(), 1);
+            // attempts == 0 -> pulls next_attempt in to <= at.
+            let t = conn.get_next_task().unwrap().unwrap();
+            assert!(t.next_attempt_at_ns <= at);
+            // Mid-backoff (attempts > 0, far next) -> bump is a no-op.
+            let far = now_ns() + xmtp_common::NS_IN_DAY;
+            conn.update_task(t.id, 3, now_ns(), far).unwrap();
+            conn.bump_kp_maintenance_task(now_ns() + 5 * xmtp_common::NS_IN_SEC)
+                .unwrap();
+            assert_eq!(
+                conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
+                far
             );
         })
     }

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -142,8 +142,13 @@ pub trait QueryTasks {
         expires_at_ns: i64,
     ) -> Result<Task, StorageError>;
 
-    /// Nudge the KP maintenance task to run at `at` — only when it is NOT mid-backoff
-    /// (attempts == 0). If no KP row exists (a prior seed failed), lazily ensure one.
+    /// Nudge the KP maintenance task to run at `at`. A live, idle row (attempts == 0)
+    /// has its `next_attempt_at_ns` pulled in to `MIN(existing, at)`. A live row that is
+    /// legitimately mid-backoff (attempts > 0 and not dead) is left alone so a flood of
+    /// nudges can't trample an upload-outage schedule. A DEAD row (`expires_at_ns < now`
+    /// OR `attempts >= max_attempts`) is not backing off — it's stuck — so it is
+    /// deleted+reseeded to unstick maintenance. If no KP row exists (a prior seed
+    /// failed), lazily ensure one.
     fn bump_kp_maintenance_task(&self, at: i64) -> Result<(), StorageError>;
 
     fn update_task(
@@ -391,25 +396,44 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
         self.raw_query(|conn| {
             conn.transaction(|conn| {
                 // Find the singleton KP row by its constant data_hash. Read its
-                // current (id, attempts, next_attempt_at_ns) so we can decide
-                // whether to pull the deadline in, all inside this txn so a
-                // concurrent backoff write can't slip between read and write.
-                let existing: Option<(i32, i32, i64)> = tasks::table
+                // current (id, attempts, next_attempt_at_ns, expires_at_ns,
+                // max_attempts) so we can decide whether to pull the deadline in,
+                // leave a legitimate backoff alone, or unstick a dead row — all
+                // inside this txn so a concurrent backoff write can't slip between
+                // read and write.
+                let existing: Option<(i32, i32, i64, i64, i32)> = tasks::table
                     .filter(tasks::data_hash.eq(&data_hash))
-                    .select((tasks::id, tasks::attempts, tasks::next_attempt_at_ns))
-                    .first::<(i32, i32, i64)>(conn)
+                    .select((
+                        tasks::id,
+                        tasks::attempts,
+                        tasks::next_attempt_at_ns,
+                        tasks::expires_at_ns,
+                        tasks::max_attempts,
+                    ))
+                    .first::<(i32, i32, i64, i64, i32)>(conn)
                     .optional()?;
                 match existing {
                     // Live row, idle: pull next_attempt in to MIN(existing, at).
                     // We never push it OUT, so a sooner deadline is preserved.
-                    Some((id, 0, next)) => {
+                    Some((id, 0, next, _expires, _max)) => {
                         diesel::update(tasks::table.filter(tasks::id.eq(id)))
                             .set(tasks::next_attempt_at_ns.eq(next.min(at)))
                             .execute(conn)?;
                     }
-                    // Row exists but is mid-backoff (attempts > 0): no-op, so a
+                    // DEAD row (expired or attempts-exhausted): NOT legitimately
+                    // backing off — it's stuck. Delete and re-seed (same as the
+                    // None arm) so a nudge can unstick maintenance.
+                    Some((id, attempts, _next, expires, max))
+                        if expires < now || attempts >= max =>
+                    {
+                        diesel::delete(tasks::table.filter(tasks::id.eq(id))).execute(conn)?;
+                        diesel::insert_or_ignore_into(tasks::table)
+                            .values(&seed)
+                            .execute(conn)?;
+                    }
+                    // Alive but mid-backoff (attempts > 0 and not dead): no-op, so a
                     // flood of welcomes can't trample an upload-outage schedule.
-                    Some((_id, _attempts, _next)) => {}
+                    Some(_) => {}
                     // Missing (a prior startup seed failed): lazily insert a fresh
                     // singleton scheduled at `at`. Inlined here (not via
                     // ensure_kp_maintenance_task) to avoid nesting a second
@@ -772,14 +796,58 @@ pub(crate) mod tests {
             // attempts == 0 -> pulls next_attempt in to <= at.
             let t = conn.get_next_task().unwrap().unwrap();
             assert!(t.next_attempt_at_ns <= at);
-            // Mid-backoff (attempts > 0, far next) -> bump is a no-op.
+
+            // Mid-backoff (attempts > 0, far next) but ALIVE (future expiry) ->
+            // bump is a no-op so a flood of nudges can't trample the backoff.
             let far = now_ns() + xmtp_common::NS_IN_DAY;
             conn.update_task(t.id, 3, now_ns(), far).unwrap();
+            // Belt-and-suspenders: ensure the row's expiry is in the FUTURE so the
+            // dead-row reseed branch does NOT fire here (otherwise the no-op below
+            // would not hold).
+            conn.raw_query(|conn| {
+                diesel::update(tasks::table.filter(tasks::id.eq(t.id)))
+                    .set(tasks::expires_at_ns.eq(now_ns() + xmtp_common::NS_IN_DAY))
+                    .execute(conn)
+            })
+            .unwrap();
             conn.bump_kp_maintenance_task(now_ns() + 5 * xmtp_common::NS_IN_SEC)
                 .unwrap();
             assert_eq!(
                 conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
                 far
+            );
+            assert_eq!(conn.get_tasks().unwrap().len(), 1);
+
+            // DEAD row that is also mid-backoff (attempts > 0 AND expires_at_ns in
+            // the past) is NOT legitimately backing off — it's stuck. A nudge must
+            // delete+reseed it (attempts reset to 0, next_attempt == at), leaving
+            // exactly one row.
+            conn.raw_query(|conn| {
+                diesel::update(tasks::table.filter(tasks::id.eq(t.id)))
+                    .set((
+                        tasks::attempts.eq(5),
+                        tasks::expires_at_ns.eq(now_ns() - 1),
+                        tasks::next_attempt_at_ns.eq(now_ns() + xmtp_common::NS_IN_DAY),
+                    ))
+                    .execute(conn)
+            })
+            .unwrap();
+            let bump_at = now_ns() + 5 * xmtp_common::NS_IN_SEC;
+            conn.bump_kp_maintenance_task(bump_at).unwrap();
+            let tasks = conn.get_tasks().unwrap();
+            assert_eq!(
+                tasks.len(),
+                1,
+                "dead row should be reseeded, not duplicated"
+            );
+            assert_eq!(tasks[0].attempts, 0, "reseeded row resets attempts");
+            assert_eq!(
+                tasks[0].next_attempt_at_ns, bump_at,
+                "reseeded row is scheduled at the nudge time"
+            );
+            assert!(
+                tasks[0].expires_at_ns > now_ns(),
+                "reseeded row has a fresh future expiry"
             );
         })
     }

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -5,7 +5,17 @@ use diesel::prelude::*;
 use prost::Message;
 use xmtp_common::{NS_IN_DAY, NS_IN_SEC, time::now_ns};
 use xmtp_proto::types::GroupId;
-use xmtp_proto::xmtp::mls::database::{Task as TaskProto, task::Task as TaskKind};
+use xmtp_proto::xmtp::mls::database::{KpMaintenance, Task as TaskProto, task::Task as TaskKind};
+
+/// The single constant `KpMaintenance` task payload (an empty message). Because
+/// the payload is constant and empty, its `data_hash` is constant, so the
+/// `UNIQUE(data_hash)` constraint on `tasks` makes insert-or-ignore a natural
+/// singleton seed.
+pub fn kp_maintenance_task_proto() -> TaskProto {
+    TaskProto {
+        task: Some(TaskKind::KpMaintenance(KpMaintenance {})),
+    }
+}
 
 #[derive(Queryable, Identifiable, Debug, Clone)]
 #[diesel(table_name = tasks)]
@@ -105,6 +115,14 @@ pub trait QueryTasks {
         task: NewTask,
     ) -> Result<(), StorageError>;
 
+    /// Ensure exactly one live `KpMaintenance` task exists. In one txn: delete any
+    /// DEAD KP row (`expires_at_ns < now` OR `attempts >= max_attempts`), then
+    /// insert-or-ignore a fresh one (`next_attempt_at_ns = now`,
+    /// `expires_at_ns = now + NS_IN_DAY`). The constant empty payload's constant
+    /// `data_hash` plus `UNIQUE(data_hash)` makes this a self-healing singleton
+    /// seed: a live row is left untouched (dedup), a dead row is cleared+replaced.
+    fn ensure_kp_maintenance_task(&self) -> Result<(), StorageError>;
+
     fn update_task(
         &self,
         id: i32,
@@ -135,6 +153,10 @@ impl<T: QueryTasks> QueryTasks for &'_ T {
         task: NewTask,
     ) -> Result<(), StorageError> {
         (**self).upsert_pending_self_remove_task(group_id, task)
+    }
+
+    fn ensure_kp_maintenance_task(&self) -> Result<(), StorageError> {
+        (**self).ensure_kp_maintenance_task()
     }
 
     fn update_task(
@@ -209,6 +231,50 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
                     );
                     let is_dead = expires_at_ns < now || attempts >= max_attempts;
                     if is_self_remove && is_dead {
+                        diesel::delete(tasks::table.filter(tasks::id.eq(id))).execute(conn)?;
+                    }
+                }
+                diesel::insert_or_ignore_into(tasks::table)
+                    .values(task)
+                    .execute(conn)?;
+                Ok(())
+            })
+        })
+        .map_err(Into::into)
+    }
+
+    fn ensure_kp_maintenance_task(&self) -> Result<(), StorageError> {
+        let now = now_ns();
+        let task = NewTask::builder()
+            .originating_message_sequence_id(0)
+            .originating_message_originator_id(0)
+            .next_attempt_at_ns(now)
+            .expires_at_ns(now + NS_IN_DAY)
+            .build(kp_maintenance_task_proto())?;
+        self.raw_query(|conn| {
+            conn.transaction(|conn| {
+                // Clear only DEAD KpMaintenance rows (expired or attempts
+                // exhausted), then insert-or-ignore a fresh one. A LIVE row is left
+                // untouched so its TaskRunner backoff is never reset out from under
+                // the worker; the constant empty payload shares the same data_hash,
+                // so the unique constraint dedups against a live row, and clearing
+                // dead rows first frees that hash for a fresh retry to take over.
+                let rows: Vec<(i32, i32, i32, i64, Vec<u8>)> = tasks::table
+                    .select((
+                        tasks::id,
+                        tasks::attempts,
+                        tasks::max_attempts,
+                        tasks::expires_at_ns,
+                        tasks::data,
+                    ))
+                    .load(conn)?;
+                for (id, attempts, max_attempts, expires_at_ns, data) in rows {
+                    let is_kp_maintenance = matches!(
+                        TaskProto::decode(data.as_slice()).ok().and_then(|t| t.task),
+                        Some(TaskKind::KpMaintenance(_))
+                    );
+                    let is_dead = expires_at_ns < now || attempts >= max_attempts;
+                    if is_kp_maintenance && is_dead {
                         diesel::delete(tasks::table.filter(tasks::id.eq(id))).execute(conn)?;
                     }
                 }
@@ -428,6 +494,34 @@ pub(crate) mod tests {
             // 15. Verify delete returns false for non-existent task
             let deleted_again = conn.delete_task(task1_id).unwrap();
             assert!(!deleted_again);
+        })
+    }
+
+    #[xmtp_common::test]
+    fn ensure_kp_maintenance_task_is_singleton_and_self_heals() {
+        use crate::test_utils::with_connection;
+        with_connection(|conn| {
+            conn.ensure_kp_maintenance_task().unwrap();
+            conn.ensure_kp_maintenance_task().unwrap();
+            assert_eq!(conn.get_tasks().unwrap().len(), 1); // idempotent singleton
+
+            // Self-heal: force the single live row to be DEAD by expiring it in the
+            // past, then re-ensure. The dead row must be cleared+replaced (not
+            // ignored), leaving exactly one fresh, live row.
+            conn.raw_query(|conn| {
+                diesel::update(tasks::table)
+                    .set(tasks::expires_at_ns.eq(now_ns() - 1))
+                    .execute(conn)
+            })
+            .unwrap();
+
+            conn.ensure_kp_maintenance_task().unwrap();
+            let tasks = conn.get_tasks().unwrap();
+            assert_eq!(tasks.len(), 1);
+            assert!(
+                tasks[0].expires_at_ns > now_ns(),
+                "dead row should have been replaced by a fresh live one"
+            );
         })
     }
 

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -123,6 +123,18 @@ pub trait QueryTasks {
     /// seed: a live row is left untouched (dedup), a dead row is cleared+replaced.
     fn ensure_kp_maintenance_task(&self) -> Result<(), StorageError>;
 
+    /// Re-arm the recurring KP task ATOMICALLY: in ONE transaction, re-read the live
+    /// KP deadline (MIN of identity.next_key_package_rotation_ns and
+    /// MIN(key_package_history.delete_at_ns)) and write
+    /// next_attempt_at_ns = MIN(fallback_next_ns, fresh), plus attempts = 0 and
+    /// renewed expires_at_ns. Closes the read->write lost-rotation race.
+    fn reschedule_kp_task(
+        &self,
+        id: i32,
+        fallback_next_ns: i64,
+        expires_at_ns: i64,
+    ) -> Result<Task, StorageError>;
+
     fn update_task(
         &self,
         id: i32,
@@ -157,6 +169,15 @@ impl<T: QueryTasks> QueryTasks for &'_ T {
 
     fn ensure_kp_maintenance_task(&self) -> Result<(), StorageError> {
         (**self).ensure_kp_maintenance_task()
+    }
+
+    fn reschedule_kp_task(
+        &self,
+        id: i32,
+        fallback_next_ns: i64,
+        expires_at_ns: i64,
+    ) -> Result<Task, StorageError> {
+        (**self).reschedule_kp_task(id, fallback_next_ns, expires_at_ns)
     }
 
     fn update_task(
@@ -282,6 +303,60 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
                     .values(task)
                     .execute(conn)?;
                 Ok(())
+            })
+        })
+        .map_err(Into::into)
+    }
+
+    fn reschedule_kp_task(
+        &self,
+        id: i32,
+        fallback_next_ns: i64,
+        expires_at_ns: i64,
+    ) -> Result<Task, StorageError> {
+        let now = now_ns();
+        self.raw_query(|conn| {
+            conn.transaction(|conn| {
+                // Re-read the LIVE KP deadline INSIDE the same txn as the write.
+                // We deliberately use inline diesel against this txn's `conn`
+                // rather than the public readers (next_key_package_rotation_ns /
+                // min_key_package_delete_at_ns): those re-enter `raw_query` and
+                // grab a SECOND pooled connection, which would deadlock and read
+                // outside this transaction's isolation. Doing the read here means
+                // a rotation queued just before this txn is included in `fresh`
+                // and cannot be clobbered to the far fallback deadline.
+                use crate::schema::identity::dsl as id_dsl;
+                use crate::schema::key_package_history::dsl as kph_dsl;
+                use diesel::dsl::min;
+
+                // The identity table may have zero rows in some states; `.optional()`
+                // maps the empty-table NotFound to Ok(None) and `.flatten()` collapses
+                // a present-but-NULL column, so `rotation` is None (never an error).
+                let rotation: Option<i64> = id_dsl::identity
+                    .select(id_dsl::next_key_package_rotation_ns)
+                    .first::<Option<i64>>(conn)
+                    .optional()?
+                    .flatten();
+                let delete: Option<i64> = kph_dsl::key_package_history
+                    .filter(kph_dsl::delete_at_ns.is_not_null())
+                    .select(min(kph_dsl::delete_at_ns))
+                    .first::<Option<i64>>(conn)?;
+
+                let fresh = [rotation, delete]
+                    .into_iter()
+                    .flatten()
+                    .min()
+                    .unwrap_or(fallback_next_ns);
+                let next = fallback_next_ns.min(fresh);
+
+                diesel::update(tasks::table.filter(tasks::id.eq(id)))
+                    .set((
+                        tasks::attempts.eq(0),
+                        tasks::last_attempted_at_ns.eq(now),
+                        tasks::expires_at_ns.eq(expires_at_ns),
+                        tasks::next_attempt_at_ns.eq(next),
+                    ))
+                    .get_result::<Task>(conn)
             })
         })
         .map_err(Into::into)
@@ -521,6 +596,101 @@ pub(crate) mod tests {
             assert!(
                 tasks[0].expires_at_ns > now_ns(),
                 "dead row should have been replaced by a fresh live one"
+            );
+        })
+    }
+
+    #[xmtp_common::test]
+    fn reschedule_kp_task_floors_to_in_txn_deadline() {
+        use crate::Store;
+        use crate::identity::QueryIdentity;
+        use crate::key_package_history::QueryKeyPackageHistory;
+        use crate::test_utils::with_connection;
+        use xmtp_common::time::now_ns;
+
+        with_connection(|conn| {
+            conn.ensure_kp_maintenance_task().unwrap();
+            let id = conn.get_next_task().unwrap().unwrap().id;
+            let now = now_ns();
+            let far = now + 30 * xmtp_common::NS_IN_DAY;
+
+            // (i) nothing pending -> stored next_attempt == far (advances).
+            // There is no identity row and nothing queued for deletion, so the
+            // live deadline is empty and `next` falls back to `far`. This proves
+            // the re-arm ADVANCES instead of getting stuck on a past value.
+            conn.reschedule_kp_task(id, far, far + xmtp_common::NS_IN_DAY)
+                .unwrap();
+            assert_eq!(
+                conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
+                far
+            );
+
+            // (ii) rotation pending sooner -> stored == near rotation (MIN(far, near)).
+            // Seed the identity row exactly as `next_key_package_rotation_ns_reads_queue`
+            // does (far-future deadline), then queue a rotation so the in-txn read
+            // sees a NEAR deadline. The reschedule must floor to it.
+            let near = now + xmtp_common::NS_IN_DAY; // sooner than `far`
+            crate::identity::StoredIdentity::builder()
+                .inbox_id(String::new())
+                .installation_keys(xmtp_common::rand_vec::<24>())
+                .credential_bytes(xmtp_common::rand_vec::<24>())
+                .next_key_package_rotation_ns(Some(near))
+                .build()
+                .unwrap()
+                .store(conn)
+                .unwrap();
+            assert_eq!(
+                conn.next_key_package_rotation_ns().unwrap(),
+                Some(near),
+                "sanity: identity row seeded with near rotation deadline"
+            );
+
+            let task = conn
+                .reschedule_kp_task(id, far, far + xmtp_common::NS_IN_DAY)
+                .unwrap();
+            assert_eq!(
+                task.next_attempt_at_ns, near,
+                "reschedule must floor to the live rotation deadline read in-txn"
+            );
+            assert_ne!(
+                task.next_attempt_at_ns, far,
+                "must NOT store the far fallback when a sooner rotation is live"
+            );
+            // attempts reset + expires renewed.
+            assert_eq!(task.attempts, 0);
+            assert_eq!(task.expires_at_ns, far + xmtp_common::NS_IN_DAY);
+
+            // (iii) delete pending sooner than rotation -> stored == delete_at.
+            // Store key packages and mark them for deletion; their `delete_at_ns`
+            // is ~24h out. Re-seed the rotation deadline far in the future so the
+            // delete deadline is the soonest, and assert the reschedule floors to
+            // exactly that delete deadline.
+            conn.raw_query(|conn| {
+                use crate::schema::identity::dsl;
+                diesel::update(dsl::identity)
+                    .set(dsl::next_key_package_rotation_ns.eq(Some(far)))
+                    .execute(conn)
+            })
+            .unwrap();
+            conn.store_key_package_history_entry(xmtp_common::rand_vec::<24>(), None)
+                .unwrap();
+            conn.store_key_package_history_entry(xmtp_common::rand_vec::<24>(), None)
+                .unwrap();
+            // High id marks all existing entries; sets `delete_at_ns` ~24h out.
+            conn.mark_key_package_before_id_to_be_deleted(i32::MAX)
+                .unwrap();
+            let delete_at = conn.min_key_package_delete_at_ns().unwrap().unwrap();
+            assert!(
+                delete_at < far,
+                "sanity: delete deadline must be sooner than the far fallback/rotation"
+            );
+
+            let task = conn
+                .reschedule_kp_task(id, far, far + xmtp_common::NS_IN_DAY)
+                .unwrap();
+            assert_eq!(
+                task.next_attempt_at_ns, delete_at,
+                "reschedule must floor to the soonest live deadline (the delete deadline)"
             );
         })
     }

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -505,6 +505,8 @@ mock! {
         fn reset_key_package_rotation_queue(&self, rotation_interval: i64) -> Result<(), StorageError>;
 
         fn is_identity_needs_rotation(&self) -> Result<bool, StorageError>;
+
+        fn next_key_package_rotation_ns(&self) -> Result<Option<i64>, StorageError>;
     }
 
     impl QueryIdentityCache for DbQuery {

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -742,6 +742,8 @@ mock! {
 
         fn reschedule_kp_task(&self, id: i32, fallback_next_ns: i64, expires_at_ns: i64) -> Result<crate::tasks::Task, StorageError>;
 
+        fn bump_kp_maintenance_task(&self, at: i64) -> Result<(), StorageError>;
+
         fn update_task(
             &self,
             id: i32,

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -738,6 +738,8 @@ mock! {
 
         fn upsert_pending_self_remove_task(&self, group_id: &GroupId, task: crate::tasks::NewTask) -> Result<(), StorageError>;
 
+        fn ensure_kp_maintenance_task(&self) -> Result<(), StorageError>;
+
         fn update_task(
             &self,
             id: i32,

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -740,6 +740,8 @@ mock! {
 
         fn ensure_kp_maintenance_task(&self) -> Result<(), StorageError>;
 
+        fn reschedule_kp_task(&self, id: i32, fallback_next_ns: i64, expires_at_ns: i64) -> Result<crate::tasks::Task, StorageError>;
+
         fn update_task(
             &self,
             id: i32,

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -547,6 +547,8 @@ mock! {
             &self,
         ) -> Result<Vec<crate::key_package_history::StoredKeyPackageHistoryEntry>, StorageError>;
 
+        fn min_key_package_delete_at_ns(&self) -> Result<Option<i64>, StorageError>;
+
         fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError>;
 
         fn delete_key_package_entry_with_id(&self, id: i32) -> Result<(), StorageError>;

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -9,7 +9,6 @@ use crate::{
     worker::{WorkerRunner, tasks::TaskWorker},
     worker::{
         device_sync::worker::SyncWorker, disappearing_messages::DisappearingMessagesWorker,
-        key_package_cleaner::KeyPackagesCleanerWorker,
     },
 };
 use futures::FutureExt;
@@ -402,12 +401,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                     context.clone(),
                 );
             }
-            if enabled(WorkerKind::KeyPackageCleaner) {
-                workers
-                    .register_new_worker::<KeyPackagesCleanerWorker<ContextParts<ApiClient, S, Db>>, _>(
-                        context.clone(),
-                    );
-            }
             if enabled(WorkerKind::DisappearingMessages) {
                 workers
                     .register_new_worker::<DisappearingMessagesWorker<ContextParts<ApiClient, S, Db>>, _>(
@@ -424,7 +417,11 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                 _,
                 >(context.clone());
             }
-            if enabled(WorkerKind::TaskRunner) {
+            // The recurring KP-maintenance task runs on the TaskRunner now, so the
+            // TaskRunner must be registered if EITHER its own gate or the
+            // KeyPackageCleaner gate is on. Seeding the KP task is gated solely on
+            // KeyPackageCleaner.
+            if enabled(WorkerKind::TaskRunner) || enabled(WorkerKind::KeyPackageCleaner) {
                 workers.register_new_worker::<TaskWorker<ContextParts<ApiClient, S, Db>>, _>(
                     context.clone(),
                 );
@@ -440,6 +437,14 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                     tracing::warn!(
                         "pending-self-remove backfill failed (will rely on next sync): {e}"
                     );
+                }
+                // Seed the recurring KP-maintenance task only when the
+                // KeyPackageCleaner gate is on. Best-effort: if it fails here the
+                // TaskRunner re-seeds it on next start.
+                if enabled(WorkerKind::KeyPackageCleaner)
+                    && let Err(e) = context.db().ensure_kp_maintenance_task()
+                {
+                    tracing::warn!("kp-maintenance task seed failed (will rely on next start): {e}");
                 }
             }
         }
@@ -775,9 +780,12 @@ mod worker_registration_tests {
             !kinds.contains(&WorkerKind::DisappearingMessages),
             "disabled worker must not be registered, got {kinds:?}"
         );
+        // KeyPackage maintenance now runs on the TaskRunner: an enabled
+        // KeyPackageCleaner gate registers the TaskRunner (no standalone
+        // KeyPackageCleaner worker exists anymore).
         assert!(
-            kinds.contains(&WorkerKind::KeyPackageCleaner),
-            "un-disabled worker must still be registered, got {kinds:?}"
+            kinds.contains(&WorkerKind::TaskRunner),
+            "KeyPackageCleaner-enabled must register the TaskRunner, got {kinds:?}"
         );
     }
 }

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -7,9 +7,7 @@ use crate::{
     mutex_registry::MutexRegistry,
     utils::{VersionInfo, cleanup_duplicate_updates},
     worker::{WorkerRunner, tasks::TaskWorker},
-    worker::{
-        device_sync::worker::SyncWorker, disappearing_messages::DisappearingMessagesWorker,
-    },
+    worker::{device_sync::worker::SyncWorker, disappearing_messages::DisappearingMessagesWorker},
 };
 use futures::FutureExt;
 use std::sync::Arc;
@@ -444,7 +442,9 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                 if enabled(WorkerKind::KeyPackageCleaner)
                     && let Err(e) = context.db().ensure_kp_maintenance_task()
                 {
-                    tracing::warn!("kp-maintenance task seed failed (will rely on next start): {e}");
+                    tracing::warn!(
+                        "kp-maintenance task seed failed (will rely on next start): {e}"
+                    );
                 }
             }
         }

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1079,6 +1079,12 @@ where
         self.identity()
             .queue_key_rotation(&self.context.db())
             .await?;
+        // Nudge the recurring KP-maintenance task to run within the PR #2044
+        // debounce window (~5s) rather than waiting for its far deadline.
+        self.context.db().bump_kp_maintenance_task(
+            xmtp_common::time::now_ns() + xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS,
+        )?;
+        self.context.task_channels().wake();
 
         Ok(())
     }

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1079,12 +1079,21 @@ where
         self.identity()
             .queue_key_rotation(&self.context.db())
             .await?;
-        // Nudge the recurring KP-maintenance task to run within the PR #2044
-        // debounce window (~5s) rather than waiting for its far deadline.
-        self.context.db().bump_kp_maintenance_task(
-            xmtp_common::time::now_ns() + xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS,
-        )?;
-        self.context.task_channels().wake();
+        // Only nudge KP maintenance when it's enabled — KeyPackageCleaner is the
+        // logical gate (matches the builder seed in builder.rs). Without this, a
+        // welcome/rotation would seed+run KP maintenance even when disabled.
+        if self
+            .context
+            .worker_config()
+            .worker_enabled(crate::worker::WorkerKind::KeyPackageCleaner)
+        {
+            // Nudge the recurring KP-maintenance task to run within the PR #2044
+            // debounce window (~5s) rather than waiting for its far deadline.
+            self.context.db().bump_kp_maintenance_task(
+                xmtp_common::time::now_ns() + xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS,
+            )?;
+            self.context.task_channels().wake();
+        }
 
         Ok(())
     }

--- a/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
@@ -530,21 +530,28 @@ async fn test_welcome_pointer_task_retry_resolution() {
     xmtp_common::time::sleep(std::time::Duration::from_secs(1)).await;
 
     tracing::info!("Getting tasks for bo");
-    let tasks = bo.context.db().get_tasks().unwrap();
+    // Filter to ProcessWelcomePointer tasks: every client also seeds a recurring
+    // KpMaintenance singleton (key-package maintenance on the TaskRunner), so
+    // get_tasks() returns it alongside the welcome-pointer task.
+    let expected_data = xmtp_proto::xmtp::mls::database::Task {
+        task: Some(
+            xmtp_proto::xmtp::mls::database::task::Task::ProcessWelcomePointer(
+                welcome_pointer.clone(),
+            ),
+        ),
+    }
+    .encode_to_vec();
+    let tasks: Vec<_> = bo
+        .context
+        .db()
+        .get_tasks()
+        .unwrap()
+        .into_iter()
+        .filter(|t| t.data == expected_data)
+        .collect();
     assert_eq!(tasks.len(), 1, "{tasks:#?}");
     let task = tasks.into_iter().next().unwrap();
-    assert_eq!(
-        task.data,
-        xmtp_proto::xmtp::mls::database::Task {
-            task: Some(
-                xmtp_proto::xmtp::mls::database::task::Task::ProcessWelcomePointer(
-                    welcome_pointer.clone()
-                )
-            )
-        }
-        .encode_to_vec()
-    );
-    assert_eq!(task.id, 1);
+    assert_eq!(task.data, expected_data);
     assert_eq!(
         task.originating_message_sequence_id,
         welcome_from_api.sequence_id() as i64

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -164,8 +164,7 @@ where
             // Nudge the recurring KP-maintenance task to run within the PR #2044
             // debounce window (~5s) rather than waiting for its far deadline.
             db.bump_kp_maintenance_task(
-                xmtp_common::time::now_ns()
-                    + xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS,
+                xmtp_common::time::now_ns() + xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS,
             )?;
             self.context.task_channels().wake();
         }

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -161,6 +161,13 @@ where
         // rotation interval.
         if num_envelopes > 0 {
             self.context.identity().queue_key_rotation(&db).await?;
+            // Nudge the recurring KP-maintenance task to run within the PR #2044
+            // debounce window (~5s) rather than waiting for its far deadline.
+            db.bump_kp_maintenance_task(
+                xmtp_common::time::now_ns()
+                    + xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS,
+            )?;
+            self.context.task_channels().wake();
         }
 
         Ok(groups)

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -161,12 +161,21 @@ where
         // rotation interval.
         if num_envelopes > 0 {
             self.context.identity().queue_key_rotation(&db).await?;
-            // Nudge the recurring KP-maintenance task to run within the PR #2044
-            // debounce window (~5s) rather than waiting for its far deadline.
-            db.bump_kp_maintenance_task(
-                xmtp_common::time::now_ns() + xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS,
-            )?;
-            self.context.task_channels().wake();
+            // Only nudge KP maintenance when it's enabled — KeyPackageCleaner is the
+            // logical gate (matches the builder seed in builder.rs). Without this, a
+            // welcome/rotation would seed+run KP maintenance even when disabled.
+            if self
+                .context
+                .worker_config()
+                .worker_enabled(crate::worker::WorkerKind::KeyPackageCleaner)
+            {
+                // Nudge the recurring KP-maintenance task to run within the PR #2044
+                // debounce window (~5s) rather than waiting for its far deadline.
+                db.bump_kp_maintenance_task(
+                    xmtp_common::time::now_ns() + xmtp_configuration::KEY_PACKAGE_QUEUE_INTERVAL_NS,
+                )?;
+                self.context.task_channels().wake();
+            }
         }
 
         Ok(groups)

--- a/crates/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/crates/xmtp_mls/src/utils/test/tester_utils.rs
@@ -1,10 +1,7 @@
 #![allow(unused)]
 
 use super::FullXmtpClient;
-use crate::worker::{
-    device_sync::{ArchiveOptions, BackupElementSelection, worker::SyncMetric},
-    key_package_cleaner::KeyPackagesCleanerWorker,
-};
+use crate::worker::device_sync::{ArchiveOptions, BackupElementSelection, worker::SyncMetric};
 use crate::{
     Client, MlsContext,
     builder::{ClientBuilder, DeviceSyncMode, ForkRecoveryOpts, ForkRecoveryPolicy},

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -1,6 +1,7 @@
 pub mod device_sync;
 pub mod disappearing_messages;
 pub mod key_package_cleaner;
+pub mod key_package_maintenance;
 pub mod metrics;
 pub mod tasks;
 

--- a/crates/xmtp_mls/src/worker/key_package_cleaner.rs
+++ b/crates/xmtp_mls/src/worker/key_package_cleaner.rs
@@ -1,48 +1,13 @@
 use crate::context::XmtpSharedContext;
 use crate::identity::IdentityError;
 use crate::identity::pq_key_package_references_key;
-use crate::worker::BoxedWorker;
 use crate::worker::NeedsDbReconnect;
-use crate::worker::WorkerResult;
-use crate::worker::{Worker, WorkerFactory, WorkerKind};
-use futures::StreamExt;
-use futures::TryFutureExt;
 use openmls_traits::storage::StorageProvider;
-use std::time::Duration;
 use thiserror::Error;
-use xmtp_configuration::CREATE_PQ_KEY_PACKAGE_EXTENSION;
-use xmtp_db::prelude::*;
 use xmtp_db::{
-    MlsProviderExt, StorageError,
+    MlsProviderExt, StorageError, XmtpMlsStorageProvider,
     sql_key_store::{KEY_PACKAGE_REFERENCES, KEY_PACKAGE_WRAPPER_PRIVATE_KEY},
 };
-
-/// Interval at which the KeyPackagesCleanerWorker runs to delete expired messages.
-pub const INTERVAL_DURATION: Duration = Duration::from_secs(5);
-
-#[derive(Clone)]
-pub struct Factory<Context> {
-    context: Context,
-}
-
-impl<Context> WorkerFactory for Factory<Context>
-where
-    Context: XmtpSharedContext + 'static,
-{
-    fn kind(&self) -> WorkerKind {
-        WorkerKind::KeyPackageCleaner
-    }
-
-    fn create(
-        &self,
-        metrics: Option<crate::worker::DynMetrics>,
-    ) -> (BoxedWorker, Option<crate::worker::DynMetrics>) {
-        (
-            Box::new(KeyPackagesCleanerWorker::new(self.context.clone())) as Box<_>,
-            metrics,
-        )
-    }
-}
 
 #[derive(Debug, Error)]
 pub enum KeyPackagesCleanerError {
@@ -76,28 +41,11 @@ impl NeedsDbReconnect for KeyPackagesCleanerError {
     }
 }
 
-#[xmtp_common::async_trait]
-impl<Context> Worker for KeyPackagesCleanerWorker<Context>
-where
-    Context: XmtpSharedContext + 'static,
-{
-    fn kind(&self) -> WorkerKind {
-        WorkerKind::KeyPackageCleaner
-    }
-
-    async fn run_tasks(&mut self) -> WorkerResult<()> {
-        self.run().map_err(|e| Box::new(e) as Box<_>).await
-    }
-
-    fn factory<C>(context: C) -> impl WorkerFactory + 'static
-    where
-        Self: Sized,
-        C: XmtpSharedContext + 'static,
-    {
-        Factory { context }
-    }
-}
-
+/// Holds the local key-package deletion helper used outside the (now removed)
+/// polling worker loop. The recurring delete/rotate maintenance runs on the
+/// TaskRunner via [`KeyPackageMaintenance`](super::key_package_maintenance);
+/// this struct survives only for [`Self::delete_key_package`], which is used by
+/// a test in `identity.rs`.
 pub struct KeyPackagesCleanerWorker<Context> {
     context: Context,
 }
@@ -108,29 +56,6 @@ where
 {
     pub fn new(context: Context) -> Self {
         Self { context }
-    }
-}
-
-impl<Context> KeyPackagesCleanerWorker<Context>
-where
-    Context: XmtpSharedContext + 'static,
-{
-    async fn run(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        let (base, jitter) = self
-            .context
-            .worker_interval(WorkerKind::KeyPackageCleaner, INTERVAL_DURATION);
-        let mut intervals = xmtp_common::time::jittered_interval_stream(base, jitter);
-        while (intervals.next().await).is_some() {
-            self.tick().await?;
-        }
-        Ok(())
-    }
-
-    #[tracing::instrument(skip_all, fields(worker = ?self.kind(), operation = "worker_turn"))]
-    async fn tick(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        self.delete_expired_key_packages()?;
-        self.rotate_last_key_package_if_needed().await?;
-        Ok(())
     }
 
     /// Delete a key package from the local database.
@@ -151,68 +76,6 @@ where
                 pq_key_package_references_key(&pq_pub_key)?.as_slice(),
             )?;
             key_store.delete(KEY_PACKAGE_WRAPPER_PRIVATE_KEY, &hash_ref)?;
-        }
-
-        Ok(())
-    }
-
-    /// Delete all the expired keys
-    fn delete_expired_key_packages(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        let conn = self.context.db();
-
-        // Propagate (don't swallow): a swallowed fetch error never triggered the supervisor's
-        // reconnect path, so a pool outage retried silently every 5s.
-        let expired_kps = conn
-            .get_expired_key_packages()
-            .map_err(KeyPackagesCleanerError::Fetch)?;
-        if expired_kps.is_empty() {
-            return Ok(());
-        }
-
-        tracing::info!("Deleting {} expired key packages", expired_kps.len());
-        // Delete from local db
-        for kp in &expired_kps {
-            self.delete_key_package(
-                kp.key_package_hash_ref.clone(),
-                kp.post_quantum_public_key.clone(),
-            )
-            .map_err(KeyPackagesCleanerError::DeleteKeyPackage)?;
-        }
-
-        // Delete from database using the max expired ID
-        if let Some(max_id) = expired_kps.iter().map(|kp| kp.id).max() {
-            conn.delete_key_package_history_up_to_id(max_id)
-                .map_err(KeyPackagesCleanerError::Deletion)?;
-            tracing::info!(
-                "Deleted {} expired key packages (up to ID {}) from local DB and state",
-                expired_kps.len(),
-                max_id
-            );
-        }
-
-        Ok(())
-    }
-
-    /// Check if we need to rotate the keys and upload new keypackage if the las one rotate in has passed
-    async fn rotate_last_key_package_if_needed(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        let conn = self.context.db();
-
-        if conn
-            .is_identity_needs_rotation()
-            .map_err(KeyPackagesCleanerError::Metadata)?
-        {
-            tracing::info!("Rotating key package");
-            self.context
-                .identity()
-                .rotate_and_upload_key_package(
-                    self.context.api(),
-                    self.context.mls_storage(),
-                    CREATE_PQ_KEY_PACKAGE_EXTENSION,
-                )
-                .await
-                .map_err(KeyPackagesCleanerError::Rotation)?;
-            tracing::info!("Key package rotation successful");
-            return Ok(());
         }
 
         Ok(())

--- a/crates/xmtp_mls/src/worker/key_package_cleaner.rs
+++ b/crates/xmtp_mls/src/worker/key_package_cleaner.rs
@@ -1,13 +1,7 @@
-use crate::context::XmtpSharedContext;
 use crate::identity::IdentityError;
-use crate::identity::pq_key_package_references_key;
 use crate::worker::NeedsDbReconnect;
-use openmls_traits::storage::StorageProvider;
 use thiserror::Error;
-use xmtp_db::{
-    MlsProviderExt, StorageError, XmtpMlsStorageProvider,
-    sql_key_store::{KEY_PACKAGE_REFERENCES, KEY_PACKAGE_WRAPPER_PRIVATE_KEY},
-};
+use xmtp_db::StorageError;
 
 #[derive(Debug, Error)]
 pub enum KeyPackagesCleanerError {
@@ -45,11 +39,23 @@ impl NeedsDbReconnect for KeyPackagesCleanerError {
 /// polling worker loop. The recurring delete/rotate maintenance runs on the
 /// TaskRunner via [`KeyPackageMaintenance`](super::key_package_maintenance);
 /// this struct survives only for [`Self::delete_key_package`], which is used by
-/// a test in `identity.rs`.
+/// a test in `identity.rs` — hence `#[cfg(test)]`.
+#[cfg(test)]
+use crate::{context::XmtpSharedContext, identity::pq_key_package_references_key};
+#[cfg(test)]
+use openmls_traits::storage::StorageProvider;
+#[cfg(test)]
+use xmtp_db::{
+    MlsProviderExt, XmtpMlsStorageProvider,
+    sql_key_store::{KEY_PACKAGE_REFERENCES, KEY_PACKAGE_WRAPPER_PRIVATE_KEY},
+};
+
+#[cfg(test)]
 pub struct KeyPackagesCleanerWorker<Context> {
     context: Context,
 }
 
+#[cfg(test)]
 impl<Context> KeyPackagesCleanerWorker<Context>
 where
     Context: XmtpSharedContext + 'static,

--- a/crates/xmtp_mls/src/worker/key_package_maintenance.rs
+++ b/crates/xmtp_mls/src/worker/key_package_maintenance.rs
@@ -1,0 +1,167 @@
+//! Reusable key-package maintenance helpers (delete expired / rotate / next deadline).
+//!
+//! This module lifts the delete + rotate logic out of the polling
+//! [`KeyPackagesCleanerWorker`](super::key_package_cleaner) so it can be driven by the
+//! TaskRunner instead. The old worker still exists in this tree; it is removed in a later
+//! task. Both temporarily contain similar logic by design.
+
+use crate::context::XmtpSharedContext;
+use crate::identity::IdentityError;
+use crate::identity::pq_key_package_references_key;
+use crate::worker::key_package_cleaner::KeyPackagesCleanerError;
+use openmls_traits::storage::StorageProvider;
+use xmtp_configuration::CREATE_PQ_KEY_PACKAGE_EXTENSION;
+use xmtp_db::prelude::*;
+use xmtp_db::{
+    MlsProviderExt,
+    sql_key_store::{KEY_PACKAGE_REFERENCES, KEY_PACKAGE_WRAPPER_PRIVATE_KEY},
+};
+
+/// Soonest of the rotation/deletion deadlines, or `now + NS_IN_DAY` if neither is set.
+pub(crate) fn next_deadline_from(rotation: Option<i64>, delete: Option<i64>, now: i64) -> i64 {
+    [rotation, delete]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(now + xmtp_common::NS_IN_DAY)
+}
+
+/// Reusable, context-driven key-package maintenance operations.
+///
+/// These are the delete/rotate operations lifted from the polling
+/// `KeyPackagesCleanerWorker` so the TaskRunner can call them directly via
+/// `KeyPackageMaintenance::delete_expired(context)` etc.
+pub(crate) struct KeyPackageMaintenance;
+
+impl KeyPackageMaintenance {
+    /// Delete a single key package (and its PQ references) from the local key store.
+    fn delete_key_package<Context>(
+        context: &Context,
+        hash_ref: Vec<u8>,
+        pq_pub_key: Option<Vec<u8>>,
+    ) -> Result<(), IdentityError>
+    where
+        Context: XmtpSharedContext,
+    {
+        let openmls_hash_ref = crate::identity::deserialize_key_package_hash_ref(&hash_ref)?;
+        let mls_provider = context.mls_provider();
+        let key_store = mls_provider.key_store();
+
+        key_store.delete_key_package(&openmls_hash_ref)?;
+
+        if let Some(pq_pub_key) = pq_pub_key {
+            key_store.delete(
+                KEY_PACKAGE_REFERENCES,
+                pq_key_package_references_key(&pq_pub_key)?.as_slice(),
+            )?;
+            key_store.delete(KEY_PACKAGE_WRAPPER_PRIVATE_KEY, &hash_ref)?;
+        }
+
+        Ok(())
+    }
+
+    /// Delete all expired key packages from the local DB and key store.
+    pub(crate) fn delete_expired<Context>(
+        context: &Context,
+    ) -> Result<(), KeyPackagesCleanerError>
+    where
+        Context: XmtpSharedContext,
+    {
+        let conn = context.db();
+
+        // Propagate (don't swallow): a swallowed fetch error never triggered the supervisor's
+        // reconnect path, so a pool outage retried silently every 5s.
+        let expired_kps = conn
+            .get_expired_key_packages()
+            .map_err(KeyPackagesCleanerError::Fetch)?;
+        if expired_kps.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!("Deleting {} expired key packages", expired_kps.len());
+        // Delete from local db
+        for kp in &expired_kps {
+            Self::delete_key_package(
+                context,
+                kp.key_package_hash_ref.clone(),
+                kp.post_quantum_public_key.clone(),
+            )
+            .map_err(KeyPackagesCleanerError::DeleteKeyPackage)?;
+        }
+
+        // Delete from database using the max expired ID
+        if let Some(max_id) = expired_kps.iter().map(|kp| kp.id).max() {
+            conn.delete_key_package_history_up_to_id(max_id)
+                .map_err(KeyPackagesCleanerError::Deletion)?;
+            tracing::info!(
+                "Deleted {} expired key packages (up to ID {}) from local DB and state",
+                expired_kps.len(),
+                max_id
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Rotate and upload a new key package if the identity is due for rotation.
+    pub(crate) async fn rotate_if_needed<Context>(
+        context: &Context,
+    ) -> Result<(), KeyPackagesCleanerError>
+    where
+        Context: XmtpSharedContext,
+    {
+        let conn = context.db();
+
+        if conn
+            .is_identity_needs_rotation()
+            .map_err(KeyPackagesCleanerError::Metadata)?
+        {
+            tracing::info!("Rotating key package");
+            context
+                .identity()
+                .rotate_and_upload_key_package(
+                    context.api(),
+                    context.mls_storage(),
+                    CREATE_PQ_KEY_PACKAGE_EXTENSION,
+                )
+                .await
+                .map_err(KeyPackagesCleanerError::Rotation)?;
+            tracing::info!("Key package rotation successful");
+        }
+
+        Ok(())
+    }
+
+    /// Soonest of the next rotation / pending-deletion deadlines, or `now + NS_IN_DAY`.
+    pub(crate) fn next_deadline<Context>(context: &Context) -> Result<i64, KeyPackagesCleanerError>
+    where
+        Context: XmtpSharedContext,
+    {
+        let conn = context.db();
+        let rotation = conn
+            .next_key_package_rotation_ns()
+            .map_err(KeyPackagesCleanerError::Metadata)?;
+        let delete = conn
+            .min_key_package_delete_at_ns()
+            .map_err(KeyPackagesCleanerError::Metadata)?;
+        Ok(next_deadline_from(
+            rotation,
+            delete,
+            xmtp_common::time::now_ns(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[xmtp_common::test]
+    fn next_deadline_picks_soonest_or_falls_back() {
+        use super::next_deadline_from;
+        let now = 1_000i64;
+        let day = xmtp_common::NS_IN_DAY;
+        assert_eq!(next_deadline_from(None, None, now), now + day); // both absent -> fallback
+        assert_eq!(next_deadline_from(Some(now + 50), None, now), now + 50); // rotation only
+        assert_eq!(next_deadline_from(Some(now + 50), Some(now + 20), now), now + 20); // delete sooner
+        assert_eq!(next_deadline_from(None, Some(now + 20), now), now + 20); // delete only
+    }
+}

--- a/crates/xmtp_mls/src/worker/key_package_maintenance.rs
+++ b/crates/xmtp_mls/src/worker/key_package_maintenance.rs
@@ -61,9 +61,7 @@ impl KeyPackageMaintenance {
     }
 
     /// Delete all expired key packages from the local DB and key store.
-    pub(crate) fn delete_expired<Context>(
-        context: &Context,
-    ) -> Result<(), KeyPackagesCleanerError>
+    pub(crate) fn delete_expired<Context>(context: &Context) -> Result<(), KeyPackagesCleanerError>
     where
         Context: XmtpSharedContext,
     {
@@ -161,7 +159,68 @@ mod tests {
         let day = xmtp_common::NS_IN_DAY;
         assert_eq!(next_deadline_from(None, None, now), now + day); // both absent -> fallback
         assert_eq!(next_deadline_from(Some(now + 50), None, now), now + 50); // rotation only
-        assert_eq!(next_deadline_from(Some(now + 50), Some(now + 20), now), now + 20); // delete sooner
+        assert_eq!(
+            next_deadline_from(Some(now + 50), Some(now + 20), now),
+            now + 20
+        ); // delete sooner
         assert_eq!(next_deadline_from(None, Some(now + 20), now), now + 20); // delete only
+    }
+
+    /// Requires a live XMTP node. End-to-end behavior guard for the TaskRunner-driven
+    /// KP maintenance: `client.queue_key_rotation()` marks the identity for rotation
+    /// AND nudges the recurring KpMaintenance task (PR #2044 ~5s debounce). The
+    /// TaskRunner then wakes, rotates, and uploads a fresh key package — so the
+    /// on-network init key must change within the poll window.
+    ///
+    /// WASM-SAFE: the poll is iteration-counted with `xmtp_common::time::sleep`,
+    /// never `std::time::Instant` (which panics on wasm).
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn queue_key_rotation_wakes_taskrunner_and_rotates() {
+        use crate::tester;
+
+        // Default `tester!` builds with workers (the TaskRunner) enabled — required
+        // so the queued rotation is actually driven to completion.
+        tester!(client);
+
+        let installation_id = client.installation_public_key().to_vec();
+
+        // Snapshot the current on-network init key.
+        // `VerifiedKeyPackageV2::hpke_init_key()` returns an owned Vec<u8>.
+        let before = {
+            let mut map = client
+                .get_key_packages_for_installation_ids(vec![installation_id.clone()])
+                .await?;
+            let entry = map
+                .remove(&installation_id)
+                .expect("installation not found in response")?;
+            entry.hpke_init_key()
+        };
+
+        // Queue a rotation: marks the identity AND nudges the KpMaintenance task.
+        client.queue_key_rotation().await?;
+
+        // Poll up to 12 s (60 × 200 ms) for the on-network key to change.
+        // Uses `xmtp_common::time::sleep` so the test compiles for wasm too
+        // (std::time::Instant panics on wasm).
+        let mut after = None;
+        for _ in 0..60u32 {
+            xmtp_common::time::sleep(std::time::Duration::from_millis(200)).await;
+            let mut map = client
+                .get_key_packages_for_installation_ids(vec![installation_id.clone()])
+                .await?;
+            let entry = map
+                .remove(&installation_id)
+                .expect("installation not found in response")?;
+            let key = entry.hpke_init_key();
+            if key != before {
+                after = Some(key);
+                break;
+            }
+        }
+
+        assert!(
+            after.is_some(),
+            "key package did not rotate after queue_key_rotation + TaskRunner wake"
+        );
     }
 }

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -3,6 +3,7 @@ use crate::{
     worker::{
         NeedsDbReconnect, Worker, WorkerFactory, WorkerKind,
         device_sync::{ArchiveOptions, DeviceSyncClient, DeviceSyncError},
+        key_package_maintenance::KeyPackageMaintenance,
     },
 };
 use prost::Message;
@@ -15,6 +16,21 @@ use xmtp_proto::{
     types::{WelcomeMessage, WelcomeMessageType},
     xmtp::mls::database::Task as TaskProto,
 };
+
+/// What `run_task` decided should happen to the task row after it ran.
+///
+/// One-shot tasks resolve to [`TaskOutcome::Done`] (the row is deleted).
+/// The recurring `KpMaintenance` singleton resolves to
+/// [`TaskOutcome::Reschedule`], carrying the fallback next-deadline so the
+/// caller can atomically re-arm the row instead of deleting it.
+#[derive(Debug)]
+enum TaskOutcome {
+    /// The task is finished; delete its row.
+    Done,
+    /// The task is recurring; re-arm its row. The `i64` is the fallback next
+    /// deadline (ns) used if a fresher in-txn deadline isn't found.
+    Reschedule(i64),
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum TaskWorkerError {
@@ -40,6 +56,8 @@ pub enum TaskWorkerError {
     MissingMetrics,
     #[error(transparent)]
     Conversion(#[from] xmtp_proto::ConversionError),
+    #[error("key package maintenance error: {0}")]
+    KeyPackageMaintenance(#[from] crate::worker::key_package_cleaner::KeyPackagesCleanerError),
 }
 
 impl NeedsDbReconnect for TaskWorkerError {
@@ -58,8 +76,25 @@ impl NeedsDbReconnect for TaskWorkerError {
             TaskWorkerError::ReceiverLocked => false,
             TaskWorkerError::MissingMetrics => false,
             TaskWorkerError::Conversion(_) => false,
+            // Forward through KeyPackagesCleanerError's own classifier so a
+            // dropped pool surfacing during delete/rotate restarts the worker.
+            TaskWorkerError::KeyPackageMaintenance(e) => e.needs_db_reconnect(),
         }
     }
+}
+
+/// Is this a recurring task (the `KpMaintenance` singleton)? Recurring tasks are
+/// never reaped — they are re-armed in place instead of deleted. Returns false
+/// on a decode error (treat an undecodable row as a one-shot so it can be reaped).
+fn task_is_recurring(task: &DbTask) -> bool {
+    matches!(
+        TaskProto::decode(task.data.as_slice())
+            .ok()
+            .and_then(|t| t.task),
+        Some(xmtp_proto::xmtp::mls::database::task::Task::KpMaintenance(
+            _
+        ))
+    )
 }
 
 /// Message to the TaskRunner loop.
@@ -200,9 +235,29 @@ where
         context: &Context,
     ) -> Result<(), TaskWorkerError> {
         let now = xmtp_common::time::now_ns();
+        let recurring = task_is_recurring(&task);
+
         if task.expires_at_ns < now || task.attempts >= task.max_attempts {
-            context.db().delete_task(task.id)?;
-            return Ok(());
+            if recurring {
+                // The recurring singleton is NEVER deleted. If it looks dead
+                // (expired or attempts exhausted), renew it in place via the
+                // atomic re-arm, then FALL THROUGH so it still dispatches this
+                // turn. Because the fetched `task` value we keep using below was
+                // already due/dead (next_attempt_at_ns <= now), the
+                // `task.next_attempt_at_ns > now` guard further down won't
+                // early-return, so a dead/overdue recurring task runs now.
+                let fallback = KeyPackageMaintenance::next_deadline(context)?.max(now);
+                context.db().reschedule_kp_task(
+                    task.id,
+                    fallback,
+                    fallback + xmtp_common::NS_IN_DAY,
+                )?;
+                // fall through to dispatch
+            } else {
+                // one-shot: reap it
+                context.db().delete_task(task.id)?;
+                return Ok(());
+            }
         }
         if task.next_attempt_at_ns > now {
             // This will get called again
@@ -214,11 +269,29 @@ where
             return Ok(());
         }
         match Self::run_task(&task, context).await {
-            Ok(()) => {
+            Ok(TaskOutcome::Done) => {
                 context.db().delete_task(task.id)?;
             }
+            Ok(TaskOutcome::Reschedule(fallback)) => {
+                // Atomic floor-re-read closes the nudge race: reschedule_kp_task
+                // re-reads the live KP deadline inside the same txn and writes
+                // MIN(fallback, fresh), so a rotation queued during the run is
+                // never clobbered to the far fallback deadline.
+                context.db().reschedule_kp_task(
+                    task.id,
+                    fallback,
+                    fallback + xmtp_common::NS_IN_DAY,
+                )?;
+            }
             Err(error) => {
-                let attempts = task.attempts + 1;
+                // Cap a recurring task's attempts strictly below max_attempts so
+                // the reaper (attempts >= max_attempts) can never delete the
+                // singleton. One-shot tasks keep the plain +1 so they can age out.
+                let attempts = if recurring {
+                    (task.attempts + 1).min(task.max_attempts - 1)
+                } else {
+                    task.attempts + 1
+                };
                 let attempt_scaling_factor = (task.backoff_scaling_factor as f64).powi(attempts);
                 let next_attempt_duration = (((task.initial_backoff_duration_ns as f64)
                     * attempt_scaling_factor) as i64)
@@ -242,7 +315,7 @@ where
         }
         Ok(())
     }
-    async fn run_task(task: &DbTask, context: &Context) -> Result<(), TaskWorkerError> {
+    async fn run_task(task: &DbTask, context: &Context) -> Result<TaskOutcome, TaskWorkerError> {
         let data_hash = xmtp_common::sha256_bytes(&task.data);
         if task.data_hash != data_hash {
             let expected = hex::encode(&data_hash);
@@ -257,7 +330,7 @@ where
             Err(e) => {
                 context.db().delete_task(task.id)?;
                 tracing::warn!("Task {} data decode error: {}", task.id, e);
-                return Ok(());
+                return Ok(TaskOutcome::Done);
             }
         };
         match task_proto.task {
@@ -276,7 +349,7 @@ where
                     tracing::warn!(
                         "SendSyncArchive task has no archive options. Unable to process."
                     );
-                    return Ok(());
+                    return Ok(TaskOutcome::Done);
                 };
                 let options: ArchiveOptions = proto_options.into();
 
@@ -313,17 +386,20 @@ where
                 Self::process_pending_self_remove(task, pending, context).await?;
             }
             Some(xmtp_proto::xmtp::mls::database::task::Task::KpMaintenance(_)) => {
-                // Key-package maintenance is implemented in the follow-up PR; this
-                // no-op arm only keeps the match exhaustive against the new proto
-                // variant so this PR builds standalone.
-                context.db().delete_task(task.id)?;
+                KeyPackageMaintenance::delete_expired(context)?;
+                KeyPackageMaintenance::rotate_if_needed(context).await?;
+                // next_deadline is read LAST (after the work) so a rotation
+                // queued during this run is reflected; reschedule_kp_task
+                // re-reads it atomically inside the re-arm txn anyway.
+                let fallback = KeyPackageMaintenance::next_deadline(context)?;
+                return Ok(TaskOutcome::Reschedule(fallback));
             }
             None => {
                 tracing::error!("Task {} has no data. Deleting.", task.id);
                 context.db().delete_task(task.id)?;
             }
         }
-        Ok(())
+        Ok(TaskOutcome::Done)
     }
     fn next_wakeup(
         next_attempt_at_ns: Option<i64>,
@@ -404,5 +480,138 @@ where
                 .ok();
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod tests {
+    use super::*;
+    use crate::tester;
+    use xmtp_db::tasks::NewTask as DbNewTask;
+    use xmtp_proto::xmtp::mls::database::{
+        ProcessPendingSelfRemove, Task as TaskProto, task::Task as TaskKind,
+    };
+
+    /// Seed a task row with `proto` payload that is immediately due
+    /// (`next_attempt_at_ns = now`) and pull it back out as a `DbTask`.
+    fn seed_task<C: XmtpSharedContext>(context: &C, proto: TaskProto) -> DbTask {
+        let now = xmtp_common::time::now_ns();
+        let new_task = DbNewTask::builder()
+            .originating_message_sequence_id(0)
+            .originating_message_originator_id(0)
+            .next_attempt_at_ns(now)
+            .expires_at_ns(now + xmtp_common::NS_IN_DAY)
+            .build(proto)
+            .unwrap();
+        context.db().create_task(new_task).unwrap()
+    }
+
+    /// Existing arms keep their behavior: a `ProcessPendingSelfRemove` task with a
+    /// malformed group_id is a drop-case — `run_task` deletes the row and returns
+    /// `Ok(TaskOutcome::Done)`, and `run_and_reschedule_task` reaps it (no row
+    /// left, no reschedule). Only the return-type wrapping changed.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn existing_arms_return_done() {
+        tester!(alix, disable_workers);
+        let context = alix.context.clone();
+
+        // A 3-byte group_id can never convert to a GroupId -> the arm drops it.
+        let proto = TaskProto {
+            task: Some(TaskKind::ProcessPendingSelfRemove(
+                ProcessPendingSelfRemove {
+                    group_id: vec![1, 2, 3],
+                },
+            )),
+        };
+        let task = seed_task(&context, proto);
+        assert!(!task_is_recurring(&task), "self-remove is not recurring");
+
+        let outcome = TaskWorker::run_task(&task, &context).await?;
+        assert!(
+            matches!(outcome, TaskOutcome::Done),
+            "malformed self-remove resolves to Done"
+        );
+        // The drop-arm already deleted the row inside run_task.
+        assert!(
+            !context.db().get_tasks()?.iter().any(|t| t.id == task.id),
+            "malformed self-remove row was deleted by the arm"
+        );
+    }
+
+    /// Load-bearing regression guard: the recurring KpMaintenance singleton is
+    /// NEVER reaped. Forced dead (attempts >= max_attempts), it is re-armed in
+    /// place (still present, attempts reset to 0). A non-recurring task in the
+    /// same dead state IS deleted.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn recurring_task_is_never_reaped() {
+        tester!(alix, disable_workers);
+        let context = alix.context.clone();
+
+        // --- recurring: forced dead, must survive ---
+        context.db().ensure_kp_maintenance_task()?;
+        let kp = context
+            .db()
+            .get_tasks()?
+            .into_iter()
+            .find(task_is_recurring)
+            .expect("ensure_kp_maintenance_task seeded a KP row");
+        assert!(task_is_recurring(&kp));
+
+        // Force it dead: attempts == max_attempts (the reaper's kill condition).
+        let now = xmtp_common::time::now_ns();
+        let dead_kp = context.db().update_task(kp.id, kp.max_attempts, now, now)?;
+        assert!(
+            dead_kp.expires_at_ns < now || dead_kp.attempts >= dead_kp.max_attempts,
+            "KP task is in a dead state before the run"
+        );
+
+        TaskWorker::run_and_reschedule_task(dead_kp, &context).await?;
+
+        let after = context
+            .db()
+            .get_tasks()?
+            .into_iter()
+            .find(task_is_recurring)
+            .expect("recurring KP task must NOT be reaped");
+        assert_eq!(after.attempts, 0, "re-armed KP task has attempts reset");
+
+        // --- non-recurring: same dead state, IS deleted ---
+        let proto = TaskProto {
+            task: Some(TaskKind::ProcessPendingSelfRemove(
+                ProcessPendingSelfRemove {
+                    group_id: vec![9, 9, 9],
+                },
+            )),
+        };
+        let oneshot = seed_task(&context, proto);
+        let dead_oneshot = context
+            .db()
+            .update_task(oneshot.id, oneshot.max_attempts, now, now)?;
+        assert!(!task_is_recurring(&dead_oneshot));
+
+        TaskWorker::run_and_reschedule_task(dead_oneshot, &context).await?;
+        assert!(
+            !context.db().get_tasks()?.iter().any(|t| t.id == oneshot.id),
+            "dead one-shot task was reaped"
+        );
+    }
+
+    /// The KpMaintenance arm runs delete/rotate and resolves to
+    /// `Reschedule(_)` (never `Done`), so the recurring row is re-armed, not
+    /// deleted. A fresh client needs no rotation, so this stays DB-only.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn kp_maintenance_arm_reschedules() {
+        tester!(alix, disable_workers);
+        let context = alix.context.clone();
+
+        let task = seed_task(&context, xmtp_db::tasks::kp_maintenance_task_proto());
+        assert!(task_is_recurring(&task));
+
+        let outcome = TaskWorker::run_task(&task, &context).await?;
+        assert!(
+            matches!(outcome, TaskOutcome::Reschedule(_)),
+            "KpMaintenance arm resolves to Reschedule, got {outcome:?}"
+        );
     }
 }


### PR DESCRIPTION
Stacked on #3794 (proto) — this PR's base is the proto branch, so the diff shown here is ONLY the `xmtp_db`/`xmtp_mls` implementation. Merge #3794 first.

Moves key-package maintenance off the fixed-interval `KeyPackagesCleanerWorker` (~82M `worker_turn` spans/24h, 99.9994% of all worker spans) onto the existing TaskRunner as a single recurring, deadline-driven task. ≤1-day fallback wake; prompt (~5s) rotation after welcome acceptance preserved.

## What changes
- One recurring `KpMaintenance` TaskRunner task: deletes expired key packages, rotates when due, re-arms to the next rotation/deletion deadline.
- `reschedule_kp_task`: atomic re-arm that re-reads the live KP deadline inside the same txn as the write (closes a nudge race that could otherwise delay a queued rotation up to 30 days).
- Recurring task is never reaped (capped backoff + reaper renews-in-place), self-healing singleton seed, backoff-safe 5s nudge on `queue_key_rotation`.
- Old `KeyPackagesCleanerWorker` poll loop removed; `WorkerKind::KeyPackageCleaner` kept as the enable gate (KP-enabled implies TaskRunner registered).

## Tests
- `xmtp_db`: readers, singleton seed, atomic floor-re-read (3 cases), backoff-safe nudge.
- `xmtp_mls`: recurring-never-reaped, KpMaintenance arm, wasm-safe rotation behavior test; deletion-timing guard preserved.
- wasm test-compile + clippy `-D warnings` clean. Live-node tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZTNgPeSH4WtQfN5qB33QF

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace key-package poll loop with TaskRunner-driven recurring maintenance
> - Removes the standalone `KeyPackagesCleanerWorker` poll loop; key-package deletion and rotation now run as a recurring `KpMaintenance` task on the `TaskRunner`.
> - Adds `ensure_kp_maintenance_task`, `reschedule_kp_task`, and `bump_kp_maintenance_task` to the `QueryTasks` trait so the singleton task can be atomically seeded, rescheduled, and nudged based on live deadlines from the DB.
> - Adds `next_key_package_rotation_ns` to `QueryIdentity` and `min_key_package_delete_at_ns` to `QueryKeyPackageHistory` to support scheduling decisions inside transactions.
> - `queue_key_rotation` and `process_new_welcome` now call `bump_kp_maintenance_task` to pull in the next maintenance run and wake the TaskRunner channel.
> - Introduces `TaskOutcome::Reschedule(i64)` so the TaskRunner can re-arm recurring tasks in place instead of deleting them after completion.
> - Risk: the KP maintenance singleton is now a persistent DB row; clients upgrading from the poll-loop model will have the old worker silently dropped and a new singleton seeded on startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cd35452. 10 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->