### PR TITLE
fix(ios): correct remote attachment contentLength (CON-436)

### DIFF
--- a/sdks/ios/Sources/XMTPiOS/Codecs/MultiRemoteAttachmentCodec.swift
+++ b/sdks/ios/Sources/XMTPiOS/Codecs/MultiRemoteAttachmentCodec.swift
@@ -80,7 +80,7 @@ public struct MultiRemoteAttachment {
 			return RemoteAttachmentInfo(
 				url: url.absoluteString,
 				filename: encryptedEncodedContent.filename ?? "",
-				contentLength: encryptedEncodedContent.contentLength ?? 0,
+				contentLength: encryptedEncodedContent.contentLength ?? UInt32(encryptedEncodedContent.payload.count),
 				contentDigest: encryptedEncodedContent.digest,
 				nonce: encryptedEncodedContent.nonce,
 				scheme: url.scheme ?? "https",

--- a/sdks/ios/Sources/XMTPiOS/Codecs/RemoteAttachmentCodec.swift
+++ b/sdks/ios/Sources/XMTPiOS/Codecs/RemoteAttachmentCodec.swift
@@ -92,6 +92,7 @@ public struct RemoteAttachment {
 		secret = encryptedEncodedContent.secret
 		salt = encryptedEncodedContent.salt
 		nonce = encryptedEncodedContent.nonce
+		contentLength = encryptedEncodedContent.payload.count
 
 		scheme = .https
 		fetcher = HTTPFetcher()
@@ -190,15 +191,18 @@ public struct RemoteAttachmentCodec: ContentCodec {
 
 		encodedContent.type = ContentTypeRemoteAttachment
 		encodedContent.content = Data(content.url.utf8)
-		encodedContent.parameters = [
+		var parameters = [
 			"contentDigest": content.contentDigest,
 			"secret": content.secret.toHex,
 			"salt": content.salt.toHex,
 			"nonce": content.nonce.toHex,
 			"scheme": "https",
-			"contentLength": String(content.contentLength ?? -1),
 			"filename": content.filename ?? "",
 		]
+		if let contentLength = content.contentLength {
+			parameters["contentLength"] = String(contentLength)
+		}
+		encodedContent.parameters = parameters
 
 		return encodedContent
 	}

--- a/sdks/ios/Tests/XMTPTests/MultiRemoteAttachmentTest.swift
+++ b/sdks/ios/Tests/XMTPTests/MultiRemoteAttachmentTest.swift
@@ -167,4 +167,21 @@ class MultiRemoteAttachmentTests: XCTestCase {
 		XCTAssertEqual(decodedAttachments[0].filename, "test1.txt")
 		XCTAssertEqual(decodedAttachments[1].filename, "test2.txt")
 	}
+
+	func testFromSetsContentLengthFromCiphertext() throws {
+		let payload = Data(repeating: 7, count: 2048)
+		let encrypted = EncryptedEncodedContent(
+			secret: Data(repeating: 1, count: 32),
+			digest: "deadbeef",
+			salt: Data(repeating: 2, count: 32),
+			nonce: Data(repeating: 3, count: 12),
+			payload: payload
+		)
+		let url = try XCTUnwrap(URL(string: "https://example.com/x.bin"))
+		let info = try MultiRemoteAttachment.RemoteAttachmentInfo.from(
+			url: url,
+			encryptedEncodedContent: encrypted
+		)
+		XCTAssertEqual(info.contentLength, UInt32(payload.count))
+	}
 }

--- a/sdks/ios/Tests/XMTPTests/RemoteAttachmentTest.swift
+++ b/sdks/ios/Tests/XMTPTests/RemoteAttachmentTest.swift
@@ -200,4 +200,52 @@ class RemoteAttachmentTests: XCTestCase {
 
 		await fulfillment(of: [expect], timeout: 3)
 	}
+
+	func testEncodeOmitsContentLengthWhenNil() throws {
+		let codec = RemoteAttachmentCodec()
+		let attachment = try RemoteAttachment(
+			url: "https://example.com/x.bin",
+			contentDigest: "deadbeef",
+			secret: Data(repeating: 1, count: 32),
+			salt: Data(repeating: 2, count: 32),
+			nonce: Data(repeating: 3, count: 12),
+			scheme: .https,
+			contentLength: nil,
+			filename: "x.bin"
+		)
+		let encoded = try codec.encode(content: attachment)
+		XCTAssertNil(encoded.parameters["contentLength"])
+		XCTAssertNotEqual(encoded.parameters["contentLength"], "-1")
+	}
+
+	func testEncodeWritesContentLengthWhenPresent() throws {
+		let codec = RemoteAttachmentCodec()
+		var attachment = try RemoteAttachment(
+			url: "https://example.com/x.bin",
+			contentDigest: "deadbeef",
+			secret: Data(repeating: 1, count: 32),
+			salt: Data(repeating: 2, count: 32),
+			nonce: Data(repeating: 3, count: 12),
+			scheme: .https
+		)
+		attachment.contentLength = 1234
+		let encoded = try codec.encode(content: attachment)
+		XCTAssertEqual(encoded.parameters["contentLength"], "1234")
+	}
+
+	func testInitFromEncryptedSetsContentLength() throws {
+		let payload = Data(repeating: 7, count: 4096)
+		let encrypted = EncryptedEncodedContent(
+			secret: Data(repeating: 1, count: 32),
+			digest: "deadbeef",
+			salt: Data(repeating: 2, count: 32),
+			nonce: Data(repeating: 3, count: 12),
+			payload: payload
+		)
+		let attachment = try RemoteAttachment(
+			url: "https://example.com/x.bin",
+			encryptedEncodedContent: encrypted
+		)
+		XCTAssertEqual(attachment.contentLength, payload.count)
+	}
 }


### PR DESCRIPTION
## Problem

The XMTPiOS remote-attachment codecs emit a wrong \`contentLength\` when the size is unknown:

- \`RemoteAttachmentCodec.encode\` wrote \`String(content.contentLength ?? -1)\` — a literal **-1** on the wire when nil. Downstream (convos) renders this as the \`(-1 bytes)\` signal in [CON-436](https://linear.app/convos/issue/CON-436).
- \`RemoteAttachment.init(url:encryptedEncodedContent:)\` never set \`contentLength\`, though the ciphertext was in hand → always nil → -1.
- \`MultiRemoteAttachmentCodec.RemoteAttachmentInfo.from(url:encryptedEncodedContent:)\` used \`encryptedEncodedContent.contentLength ?? 0\`; the encrypt helpers never populate that field, so **every bundle emitted contentLength: 0** (the Agent-Builder / multi-image path).

Per the proto, \`contentLength\` is the **encrypted** content size.

## Fix

- encode: omit the \`contentLength\` parameter entirely when nil (optional in the proto; \`decode\` already tolerates an absent param) instead of writing -1.
- \`init(url:encryptedEncodedContent:)\`: set \`contentLength = encryptedEncodedContent.payload.count\`.
- multi \`.from\`: derive \`contentLength\` from \`payload.count\` when the descriptor field is nil, instead of 0.

## Tests

New pure-codec tests in \`RemoteAttachmentTest.swift\` and \`MultiRemoteAttachmentTest.swift\`: encode omits param when nil; encode writes it when present; encrypted-init sets it from ciphertext; multi \`.from\` derives it from ciphertext. All pass.

> Note: the full SDK suite has pre-existing fixtures/client test failures in this checkout (\`rustPanic: junk data left in buffer ... arg db\` — Swift bindings out of sync with the compiled Rust core); unrelated to this change (reproduced with the fix reverted). The new codec tests are pure and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `contentLength` for remote attachments in iOS to use ciphertext payload size
> - `RemoteAttachment.init(url:encryptedEncodedContent:)` now sets `contentLength` from `encryptedEncodedContent.payload.count` instead of leaving it unset.
> - `MultiRemoteAttachment.RemoteAttachmentInfo.from` defaults `contentLength` to the ciphertext length when the source lacks an explicit value, instead of 0.
> - `RemoteAttachmentCodec.encode` omits the `contentLength` parameter entirely when `contentLength` is nil, rather than writing `"-1"`.
> - Tests are added for all three behaviors in [RemoteAttachmentTest.swift](https://github.com/xmtp/libxmtp/pull/3796/files#diff-5af28171636f9c84a7555c923a88c9b134c73b1519cd009ddc6331f0f5b01628) and [MultiRemoteAttachmentTest.swift](https://github.com/xmtp/libxmtp/pull/3796/files#diff-1b070b2a7863aa1429393bef75e37499323f54f125008bea826b914329b7cc55).
> - Behavioral Change: encoded content previously included `contentLength = "-1"` when nil; it is now omitted entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84645ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->