### PR TITLE
fix(wasm): return error instead of silently ignoring encryption_key

### DIFF
--- a/bindings/wasm/src/client.rs
+++ b/bindings/wasm/src/client.rs
@@ -364,7 +364,7 @@ pub(crate) async fn build_store(
   };
 
   if encryption_key.is_some() {
-    tracing::warn!("encryption_key is not supported in WASM and will be ignored");
+    return Err(JsError::new("encryption_key is not supported in WASM builds"));
   }
 
   let db = WasmDb::new(&storage_option).await?;


### PR DESCRIPTION
Closes #3797

    When encryption_key is provided in WASM builds, return a JsError
    instead of logging a warning and creating an unencrypted database.
    The previous behavior silently exposed sensitive message data in
    plaintext without the caller's knowledge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return error when `encryption_key` is provided in WASM builds
> Previously, `build_store` in the WASM client silently ignored `encryption_key` with a warning log. It now returns a `JsError` immediately, making the unsupported option visible to callers. Behavioral Change: any WASM code that passes `encryption_key` will now receive an error instead of proceeding silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52a721d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->