### PR TITLE
fix(db): fix batch_read_from_cache pairwise filter broken into cross product

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/association_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/association_state.rs
@@ -124,15 +124,16 @@ impl<C: ConnectionExt> QueryAssociationStateCache for DbConnection<C> {
             return Ok(vec![]);
         }
 
-        let (inbox_ids, sequence_ids): (Vec<String>, Vec<i64>) = identifiers.into_iter().unzip();
-
-        let query = dsl::association_state
+        let mut query = dsl::association_state
             .select((dsl::inbox_id, dsl::sequence_id, dsl::state))
-            .filter(
-                dsl::inbox_id
-                    .eq_any(inbox_ids)
-                    .and(dsl::sequence_id.eq_any(sequence_ids)),
-            );
+            .into_boxed();
+
+        for (inbox_id, sequence_id) in &identifiers {
+            let predicate = dsl::inbox_id
+                .eq(inbox_id.clone())
+                .and(dsl::sequence_id.eq(*sequence_id));
+            query = query.or_filter(predicate);
+        }
 
         let association_states =
             self.raw_query(|query_conn| query.load::<StoredAssociationState>(query_conn))?;


### PR DESCRIPTION
 Closes #3800

    Replace the unzip + eq_any approach with into_boxed() + or_filter()
    to ensure each (inbox_id, sequence_id) pair is matched individually
    instead of producing a cross-product (inbox_id IN list) AND (sequence_id IN list).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `batch_read_from_cache` returning cross-product matches instead of exact pairs
> The previous implementation filtered by `inbox_id IN (...)` AND `sequence_id IN (...)` separately, causing a cross-product of all input inbox IDs and sequence IDs to be returned instead of only the exact `(inbox_id, sequence_id)` pairs requested.
>
> The fix in [`association_state.rs`](https://github.com/xmtp/libxmtp/pull/3802/files#diff-581d80a6e674bed695f641d46fdc06c7a810f0f66a113d191daec50a5fab2a60) replaces the two-vector approach with iterative `or_filter` calls, each matching one exact `(inbox_id, sequence_id)` pair using a boxed query.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e1128c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->