### PR TITLE
feat(xmtp_mls): generic recurring tasks + PullInDeadline nudge in the TaskRunner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -87,8 +87,26 @@ impl NewTaskBuilder {
 
 // impl_store_or_ignore!(Task, tasks);
 
+/// A task row's identity: sha256 of the prost-encoded payload, exactly as
+/// `NewTaskBuilder::build` computes it.
+pub fn data_hash_for(task: &TaskProto) -> Vec<u8> {
+    xmtp_common::sha256_bytes(&task.encode_to_vec())
+}
+
 pub trait QueryTasks {
     fn create_task(&self, task: NewTask) -> Result<Task, StorageError>;
+
+    /// Idempotent enqueue: a payload-identical duplicate is a no-op (the existing
+    /// row wins; OR IGNORE swallows any constraint hit, not just data_hash UNIQUE).
+    fn create_or_ignore_task(&self, task: NewTask) -> Result<(), StorageError>;
+
+    /// Lower a task's `next_attempt_at_ns` to `MIN(current, at_ns)` — never raises;
+    /// missing target is a no-op. TaskWorker dispatch thread only (sole rescheduler).
+    fn pull_in_task_deadline(
+        &self,
+        target_data_hash: &[u8],
+        at_ns: i64,
+    ) -> Result<(), StorageError>;
 
     fn get_tasks(&self) -> Result<Vec<Task>, StorageError>;
 
@@ -119,6 +137,18 @@ pub trait QueryTasks {
 impl<T: QueryTasks> QueryTasks for &'_ T {
     fn create_task(&self, task: NewTask) -> Result<Task, StorageError> {
         (**self).create_task(task)
+    }
+
+    fn create_or_ignore_task(&self, task: NewTask) -> Result<(), StorageError> {
+        (**self).create_or_ignore_task(task)
+    }
+
+    fn pull_in_task_deadline(
+        &self,
+        target_data_hash: &[u8],
+        at_ns: i64,
+    ) -> Result<(), StorageError> {
+        (**self).pull_in_task_deadline(target_data_hash, at_ns)
     }
 
     fn get_tasks(&self) -> Result<Vec<Task>, StorageError> {
@@ -160,6 +190,35 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
                 .get_result::<Task>(conn)
         })
         .map_err(Into::into)
+    }
+
+    fn create_or_ignore_task(&self, task: NewTask) -> Result<(), StorageError> {
+        // A single INSERT OR IGNORE is atomic; no explicit transaction needed.
+        self.raw_query(|conn| {
+            diesel::insert_or_ignore_into(tasks::table)
+                .values(task)
+                .execute(conn)
+        })?;
+        Ok(())
+    }
+
+    fn pull_in_task_deadline(
+        &self,
+        target_data_hash: &[u8],
+        at_ns: i64,
+    ) -> Result<(), StorageError> {
+        use diesel::dsl::sql;
+        use diesel::sql_types::BigInt;
+        self.raw_query(|conn| {
+            diesel::update(tasks::table.filter(tasks::data_hash.eq(target_data_hash)))
+                .set(
+                    tasks::next_attempt_at_ns.eq(sql::<BigInt>("MIN(next_attempt_at_ns, ")
+                        .bind::<BigInt, _>(at_ns)
+                        .sql(")")),
+                )
+                .execute(conn)
+        })?;
+        Ok(())
     }
 
     fn get_tasks(&self) -> Result<Vec<Task>, StorageError> {
@@ -428,6 +487,73 @@ pub(crate) mod tests {
             // 15. Verify delete returns false for non-existent task
             let deleted_again = conn.delete_task(task1_id).unwrap();
             assert!(!deleted_again);
+        })
+    }
+
+    #[xmtp_common::test]
+    fn data_hash_for_matches_builder() {
+        let proto = gen_task_data();
+        let task = NewTask::builder()
+            .originating_message_sequence_id(0)
+            .originating_message_originator_id(0)
+            .build(proto.clone())
+            .unwrap();
+        assert_eq!(task.data_hash, data_hash_for(&proto));
+    }
+
+    #[xmtp_common::test]
+    fn create_or_ignore_task_is_idempotent() {
+        with_connection(|conn| {
+            let proto = gen_task_data();
+            let mk = || {
+                NewTask::builder()
+                    .originating_message_sequence_id(0)
+                    .originating_message_originator_id(0)
+                    .build(proto.clone())
+                    .unwrap()
+            };
+            conn.create_or_ignore_task(mk()).unwrap();
+            // Second byte-identical insert must be a silent no-op, NOT a
+            // unique-constraint error (plain create_task would error here).
+            conn.create_or_ignore_task(mk()).unwrap();
+            assert_eq!(conn.get_tasks().unwrap().len(), 1);
+        })
+    }
+
+    #[xmtp_common::test]
+    fn pull_in_lowers_deadline() {
+        with_connection(|conn| {
+            let proto = gen_task_data();
+            let now = now_ns();
+            let task = NewTask::builder()
+                .originating_message_sequence_id(0)
+                .originating_message_originator_id(0)
+                .next_attempt_at_ns(now + NS_IN_DAY)
+                .build(proto.clone())
+                .unwrap();
+            conn.create_or_ignore_task(task).unwrap();
+            let hash = data_hash_for(&proto);
+
+            // Lowers a far-out deadline.
+            conn.pull_in_task_deadline(&hash, now + 5).unwrap();
+            assert_eq!(
+                conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
+                now + 5
+            );
+
+            // Never raises (MIN): a later ceiling is a no-op.
+            conn.pull_in_task_deadline(&hash, now + NS_IN_DAY).unwrap();
+            assert_eq!(
+                conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
+                now + 5
+            );
+
+            // Missing target: silent no-op, no error.
+            conn.pull_in_task_deadline(b"no-such-hash", now).unwrap();
+            assert_eq!(
+                conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
+                now + 5
+            );
         })
     }
 

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -100,13 +100,14 @@ pub trait QueryTasks {
     /// row wins; OR IGNORE swallows any constraint hit, not just data_hash UNIQUE).
     fn create_or_ignore_task(&self, task: NewTask) -> Result<(), StorageError>;
 
-    /// Lower a task's `next_attempt_at_ns` to `MIN(current, at_ns)` — never raises;
-    /// missing target is a no-op. TaskWorker dispatch thread only (sole rescheduler).
+    /// Lower a task's `next_attempt_at_ns` to `MIN(current, at_ns)` — never raises.
+    /// Returns whether a row matched; a missing target is a no-op (`false`).
+    /// TaskWorker dispatch thread only (sole rescheduler).
     fn pull_in_task_deadline(
         &self,
         target_data_hash: &[u8],
         at_ns: i64,
-    ) -> Result<(), StorageError>;
+    ) -> Result<bool, StorageError>;
 
     fn get_tasks(&self) -> Result<Vec<Task>, StorageError>;
 
@@ -147,7 +148,7 @@ impl<T: QueryTasks> QueryTasks for &'_ T {
         &self,
         target_data_hash: &[u8],
         at_ns: i64,
-    ) -> Result<(), StorageError> {
+    ) -> Result<bool, StorageError> {
         (**self).pull_in_task_deadline(target_data_hash, at_ns)
     }
 
@@ -206,10 +207,10 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
         &self,
         target_data_hash: &[u8],
         at_ns: i64,
-    ) -> Result<(), StorageError> {
+    ) -> Result<bool, StorageError> {
         use diesel::dsl::sql;
         use diesel::sql_types::BigInt;
-        self.raw_query(|conn| {
+        let matched = self.raw_query(|conn| {
             diesel::update(tasks::table.filter(tasks::data_hash.eq(target_data_hash)))
                 .set(
                     tasks::next_attempt_at_ns.eq(sql::<BigInt>("MIN(next_attempt_at_ns, ")
@@ -218,7 +219,7 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
                 )
                 .execute(conn)
         })?;
-        Ok(())
+        Ok(matched > 0)
     }
 
     fn get_tasks(&self) -> Result<Vec<Task>, StorageError> {
@@ -535,21 +536,21 @@ pub(crate) mod tests {
             let hash = data_hash_for(&proto);
 
             // Lowers a far-out deadline.
-            conn.pull_in_task_deadline(&hash, now + 5).unwrap();
+            assert!(conn.pull_in_task_deadline(&hash, now + 5).unwrap());
             assert_eq!(
                 conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
                 now + 5
             );
 
-            // Never raises (MIN): a later ceiling is a no-op.
-            conn.pull_in_task_deadline(&hash, now + NS_IN_DAY).unwrap();
+            // Never raises (MIN): a later ceiling keeps the row but not the value.
+            assert!(conn.pull_in_task_deadline(&hash, now + NS_IN_DAY).unwrap());
             assert_eq!(
                 conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
                 now + 5
             );
 
-            // Missing target: silent no-op, no error.
-            conn.pull_in_task_deadline(b"no-such-hash", now).unwrap();
+            // Missing target: no-op reported as false, no error.
+            assert!(!conn.pull_in_task_deadline(b"no-such-hash", now).unwrap());
             assert_eq!(
                 conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
                 now + 5

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -59,7 +59,7 @@ impl NewTaskBuilder {
         use derive_builder::UninitializedFieldError;
         let err = |s: &'static str| UninitializedFieldError::new(s);
         let data = task.encode_to_vec();
-        let data_hash = xmtp_common::sha256_bytes(&data);
+        let data_hash = xmtp_common::sha256_array(&data).to_vec();
         let new_task = NewTask {
             originating_message_sequence_id: self
                 .originating_message_sequence_id
@@ -87,10 +87,48 @@ impl NewTaskBuilder {
 
 // impl_store_or_ignore!(Task, tasks);
 
-/// A task row's identity: sha256 of the prost-encoded payload, exactly as
-/// `NewTaskBuilder::build` computes it.
-pub fn data_hash_for(task: &TaskProto) -> Vec<u8> {
-    xmtp_common::sha256_bytes(&task.encode_to_vec())
+/// A task row's identity: sha256 over the prost-encoded payload. Payload
+/// encodings must stay canonical — never add protobuf map fields to task
+/// messages (map entry order is nondeterministic); see the pinned-encoding test.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct TaskDataHash([u8; 32]);
+
+impl TaskDataHash {
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl AsRef<[u8]> for TaskDataHash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for TaskDataHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TaskDataHash({})", hex::encode(self.0))
+    }
+}
+
+impl TryFrom<&[u8]> for TaskDataHash {
+    type Error = std::array::TryFromSliceError;
+    fn try_from(v: &[u8]) -> Result<Self, Self::Error> {
+        Ok(Self(v.try_into()?))
+    }
+}
+
+/// Compute a task payload's `data_hash` exactly as `NewTaskBuilder::build` does.
+pub fn data_hash_for(task: &TaskProto) -> TaskDataHash {
+    let bytes = task.encode_to_vec();
+    // Hash-as-identity requires deterministic encoding; a map field in any task
+    // payload would break this (HashMap iteration order varies per process).
+    debug_assert_eq!(
+        bytes,
+        task.encode_to_vec(),
+        "task payload encoding is nondeterministic — hashes cannot identify rows"
+    );
+    TaskDataHash(xmtp_common::sha256_array(&bytes))
 }
 
 pub trait QueryTasks {
@@ -105,7 +143,7 @@ pub trait QueryTasks {
     /// TaskWorker dispatch thread only (sole rescheduler).
     fn pull_in_task_deadline(
         &self,
-        target_data_hash: &[u8],
+        target_data_hash: &TaskDataHash,
         at_ns: i64,
     ) -> Result<bool, StorageError>;
 
@@ -146,7 +184,7 @@ impl<T: QueryTasks> QueryTasks for &'_ T {
 
     fn pull_in_task_deadline(
         &self,
-        target_data_hash: &[u8],
+        target_data_hash: &TaskDataHash,
         at_ns: i64,
     ) -> Result<bool, StorageError> {
         (**self).pull_in_task_deadline(target_data_hash, at_ns)
@@ -205,13 +243,13 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
 
     fn pull_in_task_deadline(
         &self,
-        target_data_hash: &[u8],
+        target_data_hash: &TaskDataHash,
         at_ns: i64,
     ) -> Result<bool, StorageError> {
         use diesel::dsl::sql;
         use diesel::sql_types::BigInt;
         let matched = self.raw_query(|conn| {
-            diesel::update(tasks::table.filter(tasks::data_hash.eq(target_data_hash)))
+            diesel::update(tasks::table.filter(tasks::data_hash.eq(target_data_hash.as_ref())))
                 .set(
                     tasks::next_attempt_at_ns.eq(sql::<BigInt>("MIN(next_attempt_at_ns, ")
                         .bind::<BigInt, _>(at_ns)
@@ -499,7 +537,51 @@ pub(crate) mod tests {
             .originating_message_originator_id(0)
             .build(proto.clone())
             .unwrap();
-        assert_eq!(task.data_hash, data_hash_for(&proto));
+        assert_eq!(task.data_hash, data_hash_for(&proto).as_ref());
+    }
+
+    /// data_hash values live in persisted rows and must match across app
+    /// upgrades. If this test fails, prost's encoding of these payloads drifted:
+    /// that ORPHANS every existing recurring/pull-in row. Do NOT update the
+    /// constants without a row-migration story.
+    #[xmtp_common::test]
+    fn data_hash_encoding_is_pinned() {
+        use xmtp_proto::xmtp::mls::database::{KpDeletion, KpRotation, PullInDeadline};
+        let rotation = TaskProto {
+            task: Some(TaskKind::KpRotation(KpRotation {})),
+        };
+        let deletion = TaskProto {
+            task: Some(TaskKind::KpDeletion(KpDeletion {})),
+        };
+        // Empty singleton payloads: one tag byte + zero length.
+        assert_eq!(rotation.encode_to_vec(), [0x2a, 0x00]);
+        assert_eq!(deletion.encode_to_vec(), [0x32, 0x00]);
+        assert_eq!(
+            hex::encode(data_hash_for(&rotation)),
+            "17d5f5a33ab5f6aed0395d2bc0a4e5df61d92441ea8d77b0952c01bc8aa8bde0"
+        );
+        assert_eq!(
+            hex::encode(data_hash_for(&deletion)),
+            "913da1f8df6f8fd47593840d533ba0458cc9873996bf310460abb495b34c232a"
+        );
+        // Non-empty payload sample (bytes + i64 fields).
+        let pull_in = TaskProto {
+            task: Some(TaskKind::PullInDeadline(PullInDeadline {
+                target_data_hash: vec![0x11; 32],
+                not_later_than_ns: 1_234_567_890,
+            })),
+        };
+        assert_eq!(
+            hex::encode(data_hash_for(&pull_in)),
+            "16b424873a34096e5157ab9f0a31e80dff1d23ebd8b1aab2b948a4732abfc849"
+        );
+        // Determinism under repetition and a decode round-trip.
+        let bytes = pull_in.encode_to_vec();
+        for _ in 0..100 {
+            assert_eq!(pull_in.encode_to_vec(), bytes);
+        }
+        let decoded = TaskProto::decode(bytes.as_slice()).unwrap();
+        assert_eq!(decoded.encode_to_vec(), bytes);
     }
 
     #[xmtp_common::test]
@@ -550,7 +632,8 @@ pub(crate) mod tests {
             );
 
             // Missing target: no-op reported as false, no error.
-            assert!(!conn.pull_in_task_deadline(b"no-such-hash", now).unwrap());
+            let absent = TaskDataHash::try_from([0xAAu8; 32].as_slice()).unwrap();
+            assert!(!conn.pull_in_task_deadline(&absent, now).unwrap());
             assert_eq!(
                 conn.get_next_task().unwrap().unwrap().next_attempt_at_ns,
                 now + 5

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -728,6 +728,10 @@ mock! {
     impl QueryTasks for DbQuery {
         fn create_task(&self, task: crate::tasks::NewTask) -> Result<crate::tasks::Task, StorageError>;
 
+        fn create_or_ignore_task(&self, task: crate::tasks::NewTask) -> Result<(), StorageError>;
+
+        fn pull_in_task_deadline(&self, target_data_hash: &[u8], at_ns: i64) -> Result<(), StorageError>;
+
         fn get_tasks(&self) -> Result<Vec<crate::tasks::Task>, StorageError>;
 
         fn get_next_task(&self) -> Result<Option<crate::tasks::Task>, StorageError>;

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -730,7 +730,7 @@ mock! {
 
         fn create_or_ignore_task(&self, task: crate::tasks::NewTask) -> Result<(), StorageError>;
 
-        fn pull_in_task_deadline(&self, target_data_hash: &[u8], at_ns: i64) -> Result<(), StorageError>;
+        fn pull_in_task_deadline(&self, target_data_hash: &[u8], at_ns: i64) -> Result<bool, StorageError>;
 
         fn get_tasks(&self) -> Result<Vec<crate::tasks::Task>, StorageError>;
 

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -730,7 +730,7 @@ mock! {
 
         fn create_or_ignore_task(&self, task: crate::tasks::NewTask) -> Result<(), StorageError>;
 
-        fn pull_in_task_deadline(&self, target_data_hash: &[u8], at_ns: i64) -> Result<bool, StorageError>;
+        fn pull_in_task_deadline(&self, target_data_hash: &crate::tasks::TaskDataHash, at_ns: i64) -> Result<bool, StorageError>;
 
         fn get_tasks(&self) -> Result<Vec<crate::tasks::Task>, StorageError>;
 

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -16,6 +16,26 @@ use xmtp_proto::{
     xmtp::mls::database::Task as TaskProto,
 };
 
+/// `Done` = one-shot, row deleted. `RescheduleAt(ns)` = recurring, row kept and
+/// advanced to that absolute deadline.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum TaskOutcome {
+    Done,
+    // Constructed only by the cfg(test) hook until the first real recurring
+    // task variant lands; without the allow, the non-test lib build flags
+    // dead_code and `just lint` (-Dwarnings) fails.
+    #[allow(dead_code)]
+    RescheduleAt(i64),
+}
+
+#[cfg(test)]
+pub(crate) mod test_hooks {
+    use std::sync::Mutex;
+    /// `(target_data_hash, deadline)` → `run_task` returns `RescheduleAt(deadline)`
+    /// for the matching task. Reset to `None` at test end (shared wasm process).
+    pub(crate) static RESCHEDULE_OVERRIDE: Mutex<Option<(Vec<u8>, i64)>> = Mutex::new(None);
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum TaskWorkerError {
     #[error("generic storage error: {0}")]
@@ -195,7 +215,7 @@ where
         }
     }
     #[tracing::instrument(skip_all, fields(worker = "TaskRunner", operation = "worker_turn"))]
-    async fn run_and_reschedule_task(
+    pub(crate) async fn run_and_reschedule_task(
         task: DbTask,
         context: &Context,
     ) -> Result<(), TaskWorkerError> {
@@ -214,8 +234,19 @@ where
             return Ok(());
         }
         match Self::run_task(&task, context).await {
-            Ok(()) => {
+            Ok(TaskOutcome::Done) => {
                 context.db().delete_task(task.id)?;
+            }
+            Ok(TaskOutcome::RescheduleAt(t)) => {
+                // Plain advance + attempts=0. A MIN floor here would pin a just-run
+                // (past-due) row and hot-loop it.
+                match context.db().update_task(task.id, 0, now, t) {
+                    Ok(_) => {}
+                    Err(StorageError::DieselResult(diesel::result::Error::NotFound)) => {
+                        tracing::debug!("Task {} vanished before reschedule; skipping", task.id);
+                    }
+                    Err(e) => return Err(e.into()),
+                }
             }
             Err(error) => {
                 let attempts = task.attempts + 1;
@@ -242,7 +273,13 @@ where
         }
         Ok(())
     }
-    async fn run_task(task: &DbTask, context: &Context) -> Result<(), TaskWorkerError> {
+    async fn run_task(task: &DbTask, context: &Context) -> Result<TaskOutcome, TaskWorkerError> {
+        #[cfg(test)]
+        if let Some((hash, t)) = test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap().clone()
+            && task.data_hash == hash
+        {
+            return Ok(TaskOutcome::RescheduleAt(t));
+        }
         let data_hash = xmtp_common::sha256_bytes(&task.data);
         if task.data_hash != data_hash {
             let expected = hex::encode(&data_hash);
@@ -257,7 +294,7 @@ where
             Err(e) => {
                 context.db().delete_task(task.id)?;
                 tracing::warn!("Task {} data decode error: {}", task.id, e);
-                return Ok(());
+                return Ok(TaskOutcome::Done);
             }
         };
         match task_proto.task {
@@ -276,7 +313,7 @@ where
                     tracing::warn!(
                         "SendSyncArchive task has no archive options. Unable to process."
                     );
-                    return Ok(());
+                    return Ok(TaskOutcome::Done);
                 };
                 let options: ArchiveOptions = proto_options.into();
 
@@ -313,15 +350,11 @@ where
                 Self::process_pending_self_remove(task, pending, context).await?;
             }
             Some(xmtp_proto::xmtp::mls::database::task::Task::PullInDeadline(p)) => {
-                // Minimal arm so this proto-only change compiles standalone; the
-                // real handler lands with the recurrence implementation. An
-                // unapplied pull-in is advisory, so dropping it is safe.
-                tracing::warn!(
-                    target_data_hash = hex::encode(&p.target_data_hash),
-                    "PullInDeadline task {} received before handler landed; dropping",
-                    task.id
-                );
-                context.db().delete_task(task.id)?;
+                // Runs on the worker thread — the sole writer of task scheduling
+                // state — so no transaction is needed (see the recurrence design).
+                context
+                    .db()
+                    .pull_in_task_deadline(&p.target_data_hash, p.not_later_than_ns)?;
             }
             Some(xmtp_proto::xmtp::mls::database::task::Task::KpRotation(_))
             | Some(xmtp_proto::xmtp::mls::database::task::Task::KpDeletion(_)) => {
@@ -338,7 +371,7 @@ where
                 context.db().delete_task(task.id)?;
             }
         }
-        Ok(())
+        Ok(TaskOutcome::Done)
     }
     fn next_wakeup(
         next_attempt_at_ns: Option<i64>,
@@ -419,5 +452,134 @@ where
                 .ok();
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tester;
+    use crate::worker::{WorkerConfig, WorkerKind};
+    use xmtp_db::tasks::{NewTask, data_hash_for};
+    use xmtp_proto::xmtp::mls::database::{Task as TaskProto, task::Task as TaskKind};
+
+    /// A unique one-shot payload: a PullInDeadline aimed at a random, nonexistent
+    /// target. Applying it is a no-op; its data_hash is unique per call.
+    fn unique_proto() -> TaskProto {
+        TaskProto {
+            task: Some(TaskKind::PullInDeadline(
+                xmtp_proto::xmtp::mls::database::PullInDeadline {
+                    target_data_hash: xmtp_common::rand_vec::<32>(),
+                    not_later_than_ns: 0,
+                },
+            )),
+        }
+    }
+
+    fn no_runner_cfg() -> WorkerConfig {
+        let mut cfg = WorkerConfig::default();
+        cfg.enabled.insert(WorkerKind::TaskRunner, false);
+        cfg
+    }
+
+    /// Insert a task row and return the stored row (found by its data_hash).
+    fn seed(
+        db: &impl QueryTasks,
+        proto: TaskProto,
+        next: i64,
+        expires: i64,
+        attempts: i32,
+        max: i32,
+    ) -> xmtp_db::tasks::Task {
+        let hash = data_hash_for(&proto);
+        let task = NewTask::builder()
+            .originating_message_sequence_id(0)
+            .originating_message_originator_id(0)
+            .next_attempt_at_ns(next)
+            .expires_at_ns(expires)
+            .attempts(attempts)
+            .max_attempts(max)
+            .build(proto)
+            .unwrap();
+        db.create_or_ignore_task(task).unwrap();
+        db.get_tasks()
+            .unwrap()
+            .into_iter()
+            .find(|t| t.data_hash == hash)
+            .unwrap()
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn done_deletes() {
+        tester!(alix, worker_config: no_runner_cfg());
+        let db = alix.context.db();
+        let now = xmtp_common::time::now_ns();
+        let row = seed(&db, unique_proto(), now - 1, i64::MAX, 0, i32::MAX);
+        TaskWorker::run_and_reschedule_task(row, &alix.context).await?;
+        assert!(db.get_tasks()?.is_empty(), "Done task must be deleted");
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn recurring_task_advances_and_does_not_hot_loop() {
+        tester!(alix, worker_config: no_runner_cfg());
+        let db = alix.context.db();
+        let now = xmtp_common::time::now_ns();
+        let proto = unique_proto();
+        let row = seed(&db, proto.clone(), now - 1, i64::MAX, 5, i32::MAX);
+        let target = now + xmtp_common::NS_IN_DAY;
+        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() = Some((data_hash_for(&proto), target));
+
+        TaskWorker::run_and_reschedule_task(row, &alix.context).await?;
+
+        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() = None;
+        let after = db.get_tasks()?.pop().expect("recurring row must survive");
+        assert_eq!(
+            after.next_attempt_at_ns, target,
+            "deadline must ADVANCE, not stay past-due"
+        );
+        assert_eq!(after.attempts, 0, "success resets the backoff counter");
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn never_expire_seed_survives_reaper() {
+        tester!(alix, worker_config: no_runner_cfg());
+        let db = alix.context.db();
+        let now = xmtp_common::time::now_ns();
+        let proto = unique_proto();
+        // High attempts + past-due: only the i64::MAX/i32::MAX seed keeps the
+        // reaper (expires < now || attempts >= max) from deleting it.
+        let row = seed(&db, proto.clone(), now - 1, i64::MAX, 1_000_000, i32::MAX);
+        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() =
+            Some((data_hash_for(&proto), now + xmtp_common::NS_IN_DAY));
+
+        TaskWorker::run_and_reschedule_task(row, &alix.context).await?;
+
+        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() = None;
+        assert_eq!(
+            db.get_tasks()?.len(),
+            1,
+            "never-expire seed must not be reaped"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn not_yet_due_task_is_not_run_early() {
+        tester!(alix, worker_config: no_runner_cfg());
+        let db = alix.context.db();
+        let now = xmtp_common::time::now_ns();
+        let proto = unique_proto();
+        let far = now + 30 * xmtp_common::NS_IN_DAY;
+        let row = seed(&db, proto.clone(), far, i64::MAX, 0, i32::MAX);
+        // If the guard failed and the task ran, the hook would rewrite next_attempt.
+        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() = Some((data_hash_for(&proto), now));
+
+        TaskWorker::run_and_reschedule_task(row, &alix.context).await?;
+
+        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() = None;
+        let after = db.get_tasks()?.pop().unwrap();
+        assert_eq!(
+            after.next_attempt_at_ns, far,
+            "not-yet-due task must not run on a 1-day-cap wake"
+        );
     }
 }

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -22,9 +22,10 @@ use xmtp_proto::{
 pub(crate) enum TaskOutcome {
     Done,
     // Constructed only by the cfg(test) hook until the first real recurring
-    // task variant lands; without the allow, the non-test lib build flags
-    // dead_code and `just lint` (-Dwarnings) fails.
-    #[allow(dead_code)]
+    // task variant lands. cfg_attr(expect) self-cleans: when non-test code
+    // first constructs RescheduleAt, the unfulfilled expectation becomes a
+    // compiler warning that forces removal of this attribute.
+    #[cfg_attr(not(test), expect(dead_code))]
     RescheduleAt(i64),
 }
 
@@ -32,7 +33,7 @@ pub(crate) enum TaskOutcome {
 pub(crate) mod test_hooks {
     use std::sync::Mutex;
     /// `(target_data_hash, deadline)` → `run_task` returns `RescheduleAt(deadline)`
-    /// for the matching task. Reset to `None` at test end (shared wasm process).
+    /// for the matching task. Reset at test end; assumes process-per-test isolation.
     pub(crate) static RESCHEDULE_OVERRIDE: Mutex<Option<(Vec<u8>, i64)>> = Mutex::new(None);
 }
 
@@ -124,6 +125,39 @@ impl TaskWorkerChannels {
             .send(TaskMessage::Wake)
             .expect("Task receiver is owned by same struct");
     }
+}
+
+/// Durably enqueue a `PullInDeadline` for `target_data_hash`, then wake the loop.
+/// Row is committed before the wake; duplicates coalesce on data_hash. Lifetime is
+/// bounded by `expires_at_ns` alone (pass `i64::MAX` for delivery-critical nudges).
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "KP-consumer plan adds production callers")
+)]
+pub(crate) fn enqueue_pull_in<Context: XmtpSharedContext>(
+    context: &Context,
+    target_data_hash: Vec<u8>,
+    not_later_than_ns: i64,
+    expires_at_ns: i64,
+) -> Result<(), xmtp_db::StorageError> {
+    let now = xmtp_common::time::now_ns();
+    let task = xmtp_db::tasks::NewTask::builder()
+        .originating_message_sequence_id(0)
+        .originating_message_originator_id(0)
+        .next_attempt_at_ns(now) // the pull-in itself is due immediately
+        .expires_at_ns(expires_at_ns)
+        .max_attempts(i32::MAX) // lifetime bounded by expires_at_ns, not retries
+        .build(xmtp_proto::xmtp::mls::database::Task {
+            task: Some(xmtp_proto::xmtp::mls::database::task::Task::PullInDeadline(
+                xmtp_proto::xmtp::mls::database::PullInDeadline {
+                    target_data_hash,
+                    not_later_than_ns,
+                },
+            )),
+        })?;
+    context.db().create_or_ignore_task(task)?;
+    context.task_channels().wake();
+    Ok(())
 }
 
 pub struct Factory<Context> {
@@ -350,8 +384,10 @@ where
                 Self::process_pending_self_remove(task, pending, context).await?;
             }
             Some(xmtp_proto::xmtp::mls::database::task::Task::PullInDeadline(p)) => {
-                // Runs on the worker thread — the sole writer of task scheduling
-                // state — so no transaction is needed (see the recurrence design).
+                // Runs on the worker thread — the sole rescheduler of existing
+                // rows' deadlines — so no transaction is needed (inserts happen
+                // off-thread; the precise invariant is over `next_attempt_at_ns`
+                // mutation; see the recurrence design).
                 context
                     .db()
                     .pull_in_task_deadline(&p.target_data_hash, p.not_later_than_ns)?;
@@ -555,10 +591,12 @@ mod tests {
         TaskWorker::run_and_reschedule_task(row, &alix.context).await?;
 
         *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() = None;
+        let after = db.get_tasks()?;
+        assert_eq!(after.len(), 1, "never-expire seed must not be reaped");
         assert_eq!(
-            db.get_tasks()?.len(),
-            1,
-            "never-expire seed must not be reaped"
+            after[0].next_attempt_at_ns,
+            now + xmtp_common::NS_IN_DAY,
+            "seed must have been rescheduled to the target deadline"
         );
     }
 
@@ -580,6 +618,83 @@ mod tests {
         assert_eq!(
             after.next_attempt_at_ns, far,
             "not-yet-due task must not run on a 1-day-cap wake"
+        );
+        assert_eq!(
+            after.attempts, 0,
+            "not-yet-due task must not have its attempts incremented"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn pull_in_arm_lowers_existing_target() {
+        tester!(alix, worker_config: no_runner_cfg());
+        let db = alix.context.db();
+        let now = xmtp_common::time::now_ns();
+        // Far-future recurring target.
+        let target_proto = unique_proto();
+        let target_hash = data_hash_for(&target_proto);
+        let far = now + 30 * xmtp_common::NS_IN_DAY;
+        seed(&db, target_proto, far, i64::MAX, 0, i32::MAX);
+        // Due pull-in aimed at it.
+        enqueue_pull_in(&alix.context, target_hash.clone(), now + 1_000, i64::MAX)?;
+        let pull_in_row = db
+            .get_tasks()?
+            .into_iter()
+            .find(|t| t.data_hash != target_hash)
+            .expect("pull-in row exists");
+
+        TaskWorker::run_and_reschedule_task(pull_in_row, &alix.context).await?;
+
+        let rows = db.get_tasks()?;
+        let target = rows
+            .iter()
+            .find(|t| t.data_hash == target_hash)
+            .expect("target survives");
+        assert_eq!(
+            target.next_attempt_at_ns,
+            now + 1_000,
+            "arm must lower the target to the ceiling"
+        );
+        assert_eq!(rows.len(), 1, "applied pull-in must self-delete");
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn pull_in_task_runs_and_pulls_in() {
+        tester!(alix); // live TaskRunner
+        let db = alix.context.db();
+        let now = xmtp_common::time::now_ns();
+        let proto = unique_proto();
+        // Ceiling 1 day out: the exact-equality assert below proves lowering
+        // regardless of magnitude, and a generous ceiling means the target can't
+        // become due (and get dispatched/deleted) even on a pathologically slow
+        // CI runner — only constraints are "> test wall time" and "!= far".
+        let ceiling = now + xmtp_common::NS_IN_DAY;
+        let far = now + 30 * xmtp_common::NS_IN_DAY;
+        seed(&db, proto.clone(), far, i64::MAX, 0, i32::MAX);
+        let hash = data_hash_for(&proto);
+
+        enqueue_pull_in(&alix.context, hash.clone(), ceiling, i64::MAX)?;
+
+        // Poll up to ~10s (wasm-safe): the worker dispatches the due pull-in,
+        // which lowers the target and self-deletes.
+        let mut pulled = false;
+        for _ in 0..50u32 {
+            xmtp_common::time::sleep(std::time::Duration::from_millis(200)).await;
+            let rows = db.get_tasks()?;
+            let target_ok = rows
+                .iter()
+                .any(|t| t.data_hash == hash && t.next_attempt_at_ns == ceiling);
+            let pull_in_gone = !rows.iter().any(|t| {
+                t.data_hash != hash && t.next_attempt_at_ns <= xmtp_common::time::now_ns()
+            });
+            if target_ok && pull_in_gone {
+                pulled = true;
+                break;
+            }
+        }
+        assert!(
+            pulled,
+            "worker must apply the pull-in and lower the target deadline"
         );
     }
 }

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -130,6 +130,9 @@ impl TaskWorkerChannels {
 /// Durably enqueue a `PullInDeadline` for `target_data_hash`, then wake the loop.
 /// Row is committed before the wake; duplicates coalesce on data_hash. Lifetime is
 /// bounded by `expires_at_ns` alone (pass `i64::MAX` for delivery-critical nudges).
+/// Callers must commit the target row FIRST: a pull-in never waits for its target —
+/// a miss is dropped (debug-logged), since a missing target is normally a completed
+/// one-shot and retrying would spin forever on never-expiring nudges.
 #[cfg_attr(
     not(test),
     expect(dead_code, reason = "KP-consumer plan adds production callers")
@@ -385,12 +388,23 @@ where
             }
             Some(xmtp_proto::xmtp::mls::database::task::Task::PullInDeadline(p)) => {
                 // Runs on the worker thread — the sole rescheduler of existing
-                // rows' deadlines — so no transaction is needed (inserts happen
-                // off-thread; the precise invariant is over `next_attempt_at_ns`
-                // mutation; see the recurrence design).
-                context
+                // rows' `next_attempt_at_ns` — so no transaction is needed
+                // (inserts happen off-thread; only deadline mutation is guarded).
+                let matched = context
                     .db()
                     .pull_in_task_deadline(&p.target_data_hash, p.not_later_than_ns)?;
+                if !matched {
+                    // Completed one-shot target, or a producer broke the
+                    // commit-target-first contract. Drop either way (retrying
+                    // would spin forever on never-expiring nudges). warn: every
+                    // in-tree pull-in targets a never-deleted singleton, so a
+                    // miss is always anomalous today.
+                    tracing::warn!(
+                        target_data_hash = hex::encode(&p.target_data_hash),
+                        "pull-in target missing; dropping nudge for task {}",
+                        task.id
+                    );
+                }
             }
             Some(xmtp_proto::xmtp::mls::database::task::Task::KpRotation(_))
             | Some(xmtp_proto::xmtp::mls::database::task::Task::KpDeletion(_)) => {

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -8,7 +8,7 @@ use crate::{
 use prost::Message;
 use std::sync::Arc;
 use xmtp_common::Event;
-use xmtp_db::tasks::{NewTask as DbNewTask, QueryTasks, Task as DbTask};
+use xmtp_db::tasks::{NewTask as DbNewTask, QueryTasks, Task as DbTask, TaskDataHash};
 use xmtp_db::{StorageError, diesel};
 use xmtp_macro::log_event;
 use xmtp_proto::{
@@ -139,7 +139,7 @@ impl TaskWorkerChannels {
 )]
 pub(crate) fn enqueue_pull_in<Context: XmtpSharedContext>(
     context: &Context,
-    target_data_hash: Vec<u8>,
+    target_data_hash: TaskDataHash,
     not_later_than_ns: i64,
     expires_at_ns: i64,
 ) -> Result<(), xmtp_db::StorageError> {
@@ -153,7 +153,7 @@ pub(crate) fn enqueue_pull_in<Context: XmtpSharedContext>(
         .build(xmtp_proto::xmtp::mls::database::Task {
             task: Some(xmtp_proto::xmtp::mls::database::task::Task::PullInDeadline(
                 xmtp_proto::xmtp::mls::database::PullInDeadline {
-                    target_data_hash,
+                    target_data_hash: target_data_hash.to_vec(),
                     not_later_than_ns,
                 },
             )),
@@ -390,9 +390,12 @@ where
                 // Runs on the worker thread — the sole rescheduler of existing
                 // rows' `next_attempt_at_ns` — so no transaction is needed
                 // (inserts happen off-thread; only deadline mutation is guarded).
-                let matched = context
-                    .db()
-                    .pull_in_task_deadline(&p.target_data_hash, p.not_later_than_ns)?;
+                let matched = match TaskDataHash::try_from(p.target_data_hash.as_slice()) {
+                    Ok(h) => context
+                        .db()
+                        .pull_in_task_deadline(&h, p.not_later_than_ns)?,
+                    Err(_) => false, // malformed length: fall through to the miss log
+                };
                 if !matched {
                     // Completed one-shot target, or a producer broke the
                     // commit-target-first contract. Drop either way (retrying
@@ -555,7 +558,7 @@ mod tests {
         db.get_tasks()
             .unwrap()
             .into_iter()
-            .find(|t| t.data_hash == hash)
+            .find(|t| t.data_hash == hash.as_ref())
             .unwrap()
     }
 
@@ -577,7 +580,8 @@ mod tests {
         let proto = unique_proto();
         let row = seed(&db, proto.clone(), now - 1, i64::MAX, 5, i32::MAX);
         let target = now + xmtp_common::NS_IN_DAY;
-        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() = Some((data_hash_for(&proto), target));
+        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() =
+            Some((data_hash_for(&proto).to_vec(), target));
 
         TaskWorker::run_and_reschedule_task(row, &alix.context).await?;
 
@@ -600,7 +604,7 @@ mod tests {
         // reaper (expires < now || attempts >= max) from deleting it.
         let row = seed(&db, proto.clone(), now - 1, i64::MAX, 1_000_000, i32::MAX);
         *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() =
-            Some((data_hash_for(&proto), now + xmtp_common::NS_IN_DAY));
+            Some((data_hash_for(&proto).to_vec(), now + xmtp_common::NS_IN_DAY));
 
         TaskWorker::run_and_reschedule_task(row, &alix.context).await?;
 
@@ -623,7 +627,8 @@ mod tests {
         let far = now + 30 * xmtp_common::NS_IN_DAY;
         let row = seed(&db, proto.clone(), far, i64::MAX, 0, i32::MAX);
         // If the guard failed and the task ran, the hook would rewrite next_attempt.
-        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() = Some((data_hash_for(&proto), now));
+        *test_hooks::RESCHEDULE_OVERRIDE.lock().unwrap() =
+            Some((data_hash_for(&proto).to_vec(), now));
 
         TaskWorker::run_and_reschedule_task(row, &alix.context).await?;
 
@@ -650,11 +655,11 @@ mod tests {
         let far = now + 30 * xmtp_common::NS_IN_DAY;
         seed(&db, target_proto, far, i64::MAX, 0, i32::MAX);
         // Due pull-in aimed at it.
-        enqueue_pull_in(&alix.context, target_hash.clone(), now + 1_000, i64::MAX)?;
+        enqueue_pull_in(&alix.context, target_hash, now + 1_000, i64::MAX)?;
         let pull_in_row = db
             .get_tasks()?
             .into_iter()
-            .find(|t| t.data_hash != target_hash)
+            .find(|t| t.data_hash != target_hash.as_ref())
             .expect("pull-in row exists");
 
         TaskWorker::run_and_reschedule_task(pull_in_row, &alix.context).await?;
@@ -662,7 +667,7 @@ mod tests {
         let rows = db.get_tasks()?;
         let target = rows
             .iter()
-            .find(|t| t.data_hash == target_hash)
+            .find(|t| t.data_hash == target_hash.as_ref())
             .expect("target survives");
         assert_eq!(
             target.next_attempt_at_ns,
@@ -687,7 +692,7 @@ mod tests {
         seed(&db, proto.clone(), far, i64::MAX, 0, i32::MAX);
         let hash = data_hash_for(&proto);
 
-        enqueue_pull_in(&alix.context, hash.clone(), ceiling, i64::MAX)?;
+        enqueue_pull_in(&alix.context, hash, ceiling, i64::MAX)?;
 
         // Poll up to ~10s (wasm-safe): the worker dispatches the due pull-in,
         // which lowers the target and self-deletes.
@@ -697,9 +702,9 @@ mod tests {
             let rows = db.get_tasks()?;
             let target_ok = rows
                 .iter()
-                .any(|t| t.data_hash == hash && t.next_attempt_at_ns == ceiling);
+                .any(|t| t.data_hash == hash.as_ref() && t.next_attempt_at_ns == ceiling);
             let pull_in_gone = !rows.iter().any(|t| {
-                t.data_hash != hash && t.next_attempt_at_ns <= xmtp_common::time::now_ns()
+                t.data_hash != hash.as_ref() && t.next_attempt_at_ns <= xmtp_common::time::now_ns()
             });
             if target_ok && pull_in_gone {
                 pulled = true;


### PR DESCRIPTION
**Draft** — PR 2 of 2 (generic layer implementation). Stacked on the `PullInDeadline` proto PR.

## What

First-class **recurring tasks** in the TaskRunner, plus a durable, race-free "run sooner" nudge — entirely key-package-agnostic:

- **`TaskOutcome { Done, RescheduleAt(i64) }`** — `run_task` returns an outcome. One-shot tasks return `Done` (deleted on success, exactly today's behavior). A recurring task returns `RescheduleAt(t)`: the row is kept, its deadline advances to `t` (plain write), and `attempts` resets to 0.
- **Never-reaped recurring seeds** — recurring singletons are seeded with `expires_at_ns = i64::MAX` / `max_attempts = i32::MAX`, so the existing reaper check never fires for them. **Zero reaper changes.**
- **`PullInDeadline` handler + `enqueue_pull_in`** — a pull-in is itself a durable one-shot task (`create_or_ignore_task`: insert-or-ignore on the `data_hash` UNIQUE + `wake()`). The worker applies it on its own dispatch thread — making the TaskWorker the sole rescheduler of existing rows' deadlines, so no cross-thread transactions or floor-reads are needed anywhere.
- **`xmtp_db` primitives** — `create_or_ignore_task` (durable idempotent enqueue), `pull_in_task_deadline` (single-statement `MIN` lower, never raises), `data_hash_for` (canonical payload hash so callers target rows exactly as seeded).

## Design notes

- **Why plain `RescheduleAt` (no MIN floor):** a just-run row's deadline is past-due by definition; flooring would pin it past-due and hot-loop the task. Serialization comes from the single worker loop: a pull-in and a reschedule can never interleave. Running two clients against one DB is unsupported.
- **Nudge durability:** pull-ins are DB rows committed before the wake — they survive restart. `expires_at_ns` is caller-controlled so delivery-critical nudges outlive the 3-day builder default.

## Tests

9 new tests: hash-parity, idempotent enqueue, MIN lower/no-raise/missing-target (xmtp_db); Done-deletes, advance-not-hot-loop, never-expire-reaper-survival, not-yet-due guard, direct-drive pull-in wiring, live worker end-to-end pull-in (xmtp_mls).

## Follow-up

Key-package rotation/deletion as two recurring consumer tasks (`KpRotation`/`KpDeletion`) land in a separate stack on top of this; that stack supersedes #3791/#3794/#3795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZTNgPeSH4WtQfN5qB33QF


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add generic recurring tasks and `PullInDeadline` nudge handling to the MLS task runner
> - Adds a `TaskOutcome` enum (`Done`/`RescheduleAt`) so tasks can signal recurrence; on `RescheduleAt` the worker resets attempts to 0 and updates `next_attempt_at_ns` in place instead of deleting the row.
> - Adds a `PullInDeadline` task type: when processed, it atomically lowers the target task's `next_attempt_at_ns` to `MIN(current, requested)` via a new `pull_in_task_deadline` DB method, then self-deletes.
> - Adds `enqueue_pull_in` to idempotently insert a `PullInDeadline` task and wake the task loop.
> - Extends the `QueryTasks` trait with `create_or_ignore_task` (idempotent insert) and `pull_in_task_deadline` (atomic deadline lowering that reports whether a row was matched).
> - Risk: `RescheduleAt` resets `attempts` to 0, which bypasses normal backoff/max-attempts accounting for recurring tasks.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #3806 opened
>
> - Implemented generic recurring tasks infrastructure in the `xmtp_mls` package [aed898a]
> - Added `PullInDeadline` nudge mechanism to the `TaskRunner` [aed898a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da945c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->