### PR TITLE
feat(bindings): error-case tracing for every exported FFI fn (mobile + node)

### DIFF
--- a/bindings/mobile/src/crypto.rs
+++ b/bindings/mobile/src/crypto.rs
@@ -28,6 +28,7 @@ impl From<ethereum::EthereumCryptoError> for FfiCryptoError {
 ///    Returns **65-byte uncompressed** (0x04 || X || Y)
 ///    Private key is automatically zeroized after use for security
 #[uniffi::export]
+#[xmtp_common::err_span]
 fn ethereum_generate_public_key(private_key32: Vec<u8>) -> Result<Vec<u8>, FfiCryptoError> {
     let zeroizing_key = ethereum::zeroizing_private_key(&private_key32)?;
     let public_key = ethereum::public_key_uncompressed(zeroizing_key)?;
@@ -42,6 +43,7 @@ fn ethereum_generate_public_key(private_key32: Vec<u8>) -> Result<Vec<u8>, FfiCr
 ///    - If `hashing == false`: `msg` must be a **32-byte** prehash (e.g., keccak256/EIP-712 digest).
 ///    - Private key is automatically zeroized after signing for security
 #[uniffi::export]
+#[xmtp_common::err_span]
 fn ethereum_sign_recoverable(
     msg: Vec<u8>,
     private_key32: Vec<u8>,
@@ -55,6 +57,7 @@ fn ethereum_sign_recoverable(
 
 /// 3) Ethereum address from public key (accepts 65-byte 0x04||XY or 64-byte XY).
 #[uniffi::export]
+#[xmtp_common::err_span]
 fn ethereum_address_from_pubkey(pubkey: Vec<u8>) -> Result<String, FfiCryptoError> {
     let address = ethereum::address_from_pubkey(&pubkey)?;
     Ok(address)
@@ -62,6 +65,7 @@ fn ethereum_address_from_pubkey(pubkey: Vec<u8>) -> Result<String, FfiCryptoErro
 
 /// 4) EIP-191 personal message hash: keccak256("\x19Ethereum Signed Message:\n{len}" || message)
 #[uniffi::export]
+#[xmtp_common::err_span]
 fn ethereum_hash_personal(message: String) -> Result<Vec<u8>, FfiCryptoError> {
     Ok(ethereum::hash_personal(&message).to_vec()) // 32 bytes
 }

--- a/bindings/mobile/src/identity.rs
+++ b/bindings/mobile/src/identity.rs
@@ -34,6 +34,7 @@ impl Display for FfiIdentifier {
 
 #[allow(unused)]
 #[uniffi::export]
+#[xmtp_common::err_span]
 pub fn generate_inbox_id(
     account_identifier: FfiIdentifier,
     nonce: u64,

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -120,6 +120,7 @@ impl From<xmtp_logging::Error> for crate::GenericError {
 /// i.e "libxmtp-v1.6.0.abc123.main.12345.log.2025-04-02"
 /// A maximum of 'max_files' log files are kept.
 #[uniffi::export]
+#[xmtp_common::err_span]
 pub fn enter_debug_writer(
     directory: String,
     log_level: FfiLogLevel,
@@ -135,6 +136,7 @@ pub fn enter_debug_writer(
 /// i.e "libxmtp-v1.6.0.abc123.notif.67890.log.2025-04-02"
 /// A maximum of 'max_files' log files are kept.
 #[uniffi::export]
+#[xmtp_common::err_span]
 pub fn enter_debug_writer_with_level(
     directory: String,
     rotation: FfiLogRotation,
@@ -166,6 +168,7 @@ pub fn enter_debug_writer_with_level(
 /// This should be called before the program exits, to ensure all the logs in memory have been
 /// written. this ends the writer thread.
 #[uniffi::export]
+#[xmtp_common::err_span]
 pub fn exit_debug_writer() -> Result<(), FfiError> {
     if let Some(h) = handle() {
         h.disable_file()?;
@@ -178,6 +181,7 @@ pub fn exit_debug_writer() -> Result<(), FfiError> {
 /// Activity spans are emitted as os_signpost on iOS — set to `Trace` to see span
 /// activity in Console.app / Instruments. No-op on non-mobile builds.
 #[uniffi::export]
+#[xmtp_common::err_span]
 pub fn set_native_log_level(log_level: FfiLogLevel) -> Result<(), FfiError> {
     if let Some(h) = handle() {
         h.set_native_level(log_level.into())?;

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1114,6 +1114,7 @@ impl FfiXmtpClient {
     ///
     /// `options` controls the quorum, timeout, and polling interval.
     /// Pass `None` to use the defaults (50% quorum, 30s timeout, 500ms interval).
+    #[xmtp_common::err_span]
     pub async fn wait_for_registration_visible(
         &self,
         options: Option<FfiVisibilityConfirmationOptions>,
@@ -2956,10 +2957,12 @@ impl FfiConversation {
         self.inner.created_at_ns
     }
 
+    #[xmtp_common::err_span]
     pub fn is_active(&self) -> Result<bool, FfiError> {
         self.inner.is_active().map_err(Into::into)
     }
 
+    #[xmtp_common::err_span]
     pub fn paused_for_version(&self) -> Result<Option<String>, FfiError> {
         self.inner.paused_for_version().map_err(Into::into)
     }
@@ -2979,6 +2982,7 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[xmtp_common::err_span]
     pub fn added_by_inbox_id(&self) -> Result<String, FfiError> {
         self.inner.added_by_inbox_id().map_err(Into::into)
     }
@@ -3027,6 +3031,7 @@ impl FfiConversation {
         Ok(hmac_map)
     }
 
+    #[xmtp_common::err_span]
     pub async fn conversation_debug_info(&self) -> Result<FfiConversationDebugInfo, FfiError> {
         let debug_info = self.inner.debug_info().await?;
         Ok(debug_info.into())
@@ -3761,6 +3766,7 @@ pub struct FfiGroupPermissions {
 
 #[uniffi::export]
 impl FfiGroupPermissions {
+    #[xmtp_common::err_span]
     pub fn policy_type(&self) -> Result<FfiGroupPermissionsOptions, FfiError> {
         if let Ok(preconfigured_policy) = self.inner.preconfigured_policy() {
             Ok(preconfigured_policy.into())
@@ -3769,6 +3775,7 @@ impl FfiGroupPermissions {
         }
     }
 
+    #[xmtp_common::err_span]
     pub fn policy_set(&self) -> Result<FfiPermissionPolicySet, FfiError> {
         let policy_set = &self.inner.policies;
         let metadata_policy_map = &policy_set.update_metadata_policy;

--- a/bindings/mobile/src/mls/device_sync/mod.rs
+++ b/bindings/mobile/src/mls/device_sync/mod.rs
@@ -15,6 +15,7 @@ use xmtp_proto::xmtp::device_sync::BackupElementSelection as BackupElementSelect
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiXmtpClient {
     /// Manually trigger a device sync request to sync records from another active device on this account.
+    #[xmtp_common::err_span]
     pub async fn send_sync_request(
         &self,
         options: FfiArchiveOptions,
@@ -29,6 +30,7 @@ impl FfiXmtpClient {
 
     /// Manually send a sync archive to the sync group.
     /// The pin will be later used as a reference when importing.
+    #[xmtp_common::err_span]
     pub async fn send_sync_archive(
         &self,
         options: FfiArchiveOptions,
@@ -44,6 +46,7 @@ impl FfiXmtpClient {
 
     /// Manually process a sync archive that matches the pin given.
     /// If no pin is given, then it will process the last archive sent.
+    #[xmtp_common::err_span]
     pub async fn process_sync_archive(&self, archive_pin: Option<String>) -> Result<(), FfiError> {
         self.inner_client
             .device_sync_client()
@@ -55,6 +58,7 @@ impl FfiXmtpClient {
     /// List the archives available for import in the sync group.
     /// You may need to manually sync the sync group before calling
     /// this function to see recently uploaded archives.
+    #[xmtp_common::err_span]
     pub fn list_available_archives(
         &self,
         days_cutoff: i64,
@@ -68,6 +72,7 @@ impl FfiXmtpClient {
     }
 
     /// Archive application elements to file for later restoration.
+    #[xmtp_common::err_span]
     pub async fn create_archive(
         &self,
         path: String,
@@ -84,6 +89,7 @@ impl FfiXmtpClient {
     }
 
     /// Import a previous archive from file.
+    #[xmtp_common::err_span]
     pub async fn import_archive(&self, path: String, key: Vec<u8>) -> Result<(), FfiError> {
         let mut importer = ArchiveImporter::from_file(path, &check_key(key)?)
             .await
@@ -95,6 +101,7 @@ impl FfiXmtpClient {
 
     /// Load the metadata for an archive to see what it contains.
     /// Reads only the metadata without loading the entire file, so this function is quick.
+    #[xmtp_common::err_span]
     pub async fn archive_metadata(
         &self,
         path: String,
@@ -107,6 +114,7 @@ impl FfiXmtpClient {
     }
 
     /// Manually sync all device sync groups.
+    #[xmtp_common::err_span]
     pub async fn sync_all_device_sync_groups(&self) -> Result<FfiGroupSyncSummary, FfiError> {
         self.inner_client.sync_welcomes().await?;
         let summary = self.inner_client.sync_all_device_sync_groups().await?;

--- a/bindings/mobile/src/mls/gateway_auth.rs
+++ b/bindings/mobile/src/mls/gateway_auth.rs
@@ -24,6 +24,7 @@ impl FfiAuthHandle {
             handle: AuthHandle::new(),
         }
     }
+    #[xmtp_common::err_span]
     pub async fn set(&self, credential: FfiCredential) -> Result<(), FfiError> {
         let credential = credential.try_into()?;
         self.handle.set(credential).await;

--- a/bindings/mobile/src/worker.rs
+++ b/bindings/mobile/src/worker.rs
@@ -8,6 +8,7 @@ pub struct FfiSyncWorker {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiSyncWorker {
+    #[xmtp_common::err_span]
     pub async fn wait(&self, metric: FfiSyncMetric, count: u64) -> Result<(), FfiError> {
         let Some(handle) = self.handle.clone() else {
             tracing::warn!("Tried to wait on a worker without a handle.");

--- a/bindings/node/src/client/backend.rs
+++ b/bindings/node/src/client/backend.rs
@@ -42,6 +42,7 @@ impl BackendBuilder {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn build(&self) -> Result<Backend> {
     {
       let mut consumed = self

--- a/bindings/node/src/client/consent_state.rs
+++ b/bindings/node/src/client/consent_state.rs
@@ -9,6 +9,7 @@ use xmtp_db::consent_record::StoredConsentRecord;
 #[napi]
 impl Client {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn set_consent_states(&self, records: Vec<Consent>) -> Result<()> {
     let stored_records: Vec<StoredConsentRecord> =
       records.into_iter().map(StoredConsentRecord::from).collect();
@@ -23,6 +24,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn get_consent_state(
     &self,
     entity_type: ConsentEntityType,

--- a/bindings/node/src/client/create_client.rs
+++ b/bindings/node/src/client/create_client.rs
@@ -100,6 +100,7 @@ fn init_logging(options: LogOptions) -> Result<()> {
 ///
 /// `async` is load-bearing: it runs on napi's Tokio runtime so the OTLP tonic exporter build has a reactor (a sync `#[napi] pub fn` runs reactor-less on the JS thread and panics).
 #[napi(js_name = "initLogging")]
+#[xmtp_common::err_span]
 pub async fn init_logging_export(options: Option<LogOptions>) -> Result<()> {
   init_logging(options.unwrap_or_default())
 }
@@ -269,6 +270,7 @@ async fn create_client_inner(
  */
 #[allow(clippy::too_many_arguments)]
 #[napi]
+#[xmtp_common::err_span]
 pub async fn create_client(
   v3_host: String,
   gateway_host: Option<String>,
@@ -324,6 +326,7 @@ pub async fn create_client(
 /// This function only needs identity and database configuration.
 #[allow(clippy::too_many_arguments)]
 #[napi]
+#[xmtp_common::err_span]
 pub async fn create_client_with_backend(
   backend: &Backend,
   db: DbOptions,

--- a/bindings/node/src/client/gateway_auth.rs
+++ b/bindings/node/src/client/gateway_auth.rs
@@ -51,6 +51,7 @@ impl AuthHandle {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn set(&self, credential: Credential) -> Result<(), super::Error> {
     self.handle.set(credential.try_into()?).await;
     Ok(())

--- a/bindings/node/src/client/identity.rs
+++ b/bindings/node/src/client/identity.rs
@@ -35,6 +35,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn register_identity(
     &self,
     signature_request: &SignatureRequestHandle,
@@ -67,6 +68,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn get_inbox_id_by_identity(&self, identifier: Identifier) -> Result<Option<String>> {
     let conn = self.inner_client().context.store().db();
 

--- a/bindings/node/src/client/inbox_state.rs
+++ b/bindings/node/src/client/inbox_state.rs
@@ -9,6 +9,7 @@ use xmtp_id::InboxId;
 #[napi]
 impl Client {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn fetch_inbox_states_by_inbox_ids(
     &self,
     inbox_ids: Vec<String>,
@@ -32,6 +33,7 @@ impl Client {
    * Otherwise, the state will be read from the local database.
    */
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn inbox_state(&self, refresh_from_network: bool) -> Result<InboxState> {
     let state = self
       .inner_client()
@@ -42,6 +44,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn fetch_inbox_updates_count(
     &self,
     inbox_ids: Vec<String>,
@@ -57,6 +60,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn fetch_own_inbox_updates_count(&self, refresh_from_network: bool) -> Result<u32> {
     let res = self
       .inner_client()
@@ -72,6 +76,7 @@ impl Client {
    * Returns a JavaScript Object mapping installation ID strings to KeyPackageStatus objects.
    */
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn fetch_key_package_statuses_by_installation_ids(
     &self,
     installation_ids: Vec<String>,

--- a/bindings/node/src/client/mod.rs
+++ b/bindings/node/src/client/mod.rs
@@ -49,6 +49,7 @@ impl Client {
 
   #[napi]
   /// The resulting vec will be the same length as the input and should be zipped for the results.
+  #[xmtp_common::err_span]
   pub async fn can_message(
     &self,
     account_identities: Vec<Identifier>,
@@ -79,6 +80,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn release_db_connection(&self) -> Result<()> {
     self
       .inner_client
@@ -88,6 +90,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn db_reconnect(&self) -> Result<()> {
     self
       .inner_client
@@ -103,6 +106,7 @@ impl Client {
   /// reference to avoid late log spew from detached workers/streams firing
   /// against a dead DB.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn close(&self) -> Result<()> {
     self
       .inner_client

--- a/bindings/node/src/client/registration_visible.rs
+++ b/bindings/node/src/client/registration_visible.rs
@@ -38,6 +38,7 @@ impl From<VisibilityConfirmationOptions>
 #[napi]
 impl Client {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn wait_for_registration_visible(
     &self,
     options: Option<VisibilityConfirmationOptions>,

--- a/bindings/node/src/client/signatures.rs
+++ b/bindings/node/src/client/signatures.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 #[napi]
 impl Client {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn create_inbox_signature_request(&self) -> Result<Option<SignatureRequestHandle>> {
     let Some(signature_request) = self.inner_client().identity().signature_request() else {
       return Ok(None);
@@ -22,6 +23,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn add_identifier_signature_request(
     &self,
     new_identifier: Identifier,
@@ -42,6 +44,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn revoke_identifier_signature_request(
     &self,
     identifier: Identifier,
@@ -64,6 +67,7 @@ impl Client {
   // Returns Some SignatureRequestHandle if we have installations to revoke.
   // If we have no other installations to revoke, returns None.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn revoke_all_other_installations_signature_request(
     &self,
   ) -> Result<Option<SignatureRequestHandle>> {
@@ -99,6 +103,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn revoke_installations_signature_request(
     &self,
     installation_ids: Vec<Uint8Array>,
@@ -122,6 +127,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn change_recovery_identifier_signature_request(
     &self,
     new_recovery_identifier: Identifier,
@@ -140,6 +146,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn apply_signature_request(
     &self,
     signature_request: &SignatureRequestHandle,
@@ -157,6 +164,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn sign_with_installation_key(&self, signature_text: String) -> Result<Uint8Array> {
     let result = self
       .inner_client()
@@ -168,6 +176,7 @@ impl Client {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn verify_signed_with_installation_key(
     &self,
     signature_text: String,

--- a/bindings/node/src/content_types/actions.rs
+++ b/bindings/node/src/content_types/actions.rs
@@ -155,6 +155,7 @@ pub fn content_type_actions() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_actions(actions: Actions) -> Result<EncodedContent> {
   Ok(
     ActionsCodec::encode(actions.into())

--- a/bindings/node/src/content_types/attachment.rs
+++ b/bindings/node/src/content_types/attachment.rs
@@ -47,6 +47,7 @@ pub fn content_type_attachment() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_attachment(attachment: Attachment) -> Result<EncodedContent> {
   Ok(
     AttachmentCodec::encode(attachment.into())

--- a/bindings/node/src/content_types/intent.rs
+++ b/bindings/node/src/content_types/intent.rs
@@ -41,6 +41,7 @@ pub fn content_type_intent() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_intent(intent: Intent) -> Result<EncodedContent> {
   Ok(
     IntentCodec::encode(intent.into())

--- a/bindings/node/src/content_types/markdown.rs
+++ b/bindings/node/src/content_types/markdown.rs
@@ -10,6 +10,7 @@ pub fn content_type_markdown() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_markdown(text: String) -> Result<EncodedContent> {
   Ok(
     MarkdownCodec::encode(text)

--- a/bindings/node/src/content_types/multi_remote_attachment.rs
+++ b/bindings/node/src/content_types/multi_remote_attachment.rs
@@ -43,6 +43,7 @@ pub fn content_type_multi_remote_attachment() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_multi_remote_attachment(
   multi_remote_attachment: MultiRemoteAttachment,
 ) -> Result<EncodedContent> {

--- a/bindings/node/src/content_types/reaction.rs
+++ b/bindings/node/src/content_types/reaction.rs
@@ -48,6 +48,7 @@ pub fn content_type_reaction() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_reaction(reaction: Reaction) -> Result<EncodedContent> {
   let reaction_v2: ReactionV2 = reaction.into();
   Ok(

--- a/bindings/node/src/content_types/read_receipt.rs
+++ b/bindings/node/src/content_types/read_receipt.rs
@@ -26,6 +26,7 @@ pub fn content_type_read_receipt() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_read_receipt(read_receipt: ReadReceipt) -> Result<EncodedContent> {
   Ok(
     ReadReceiptCodec::encode(read_receipt.into())

--- a/bindings/node/src/content_types/remote_attachment.rs
+++ b/bindings/node/src/content_types/remote_attachment.rs
@@ -74,6 +74,7 @@ pub fn content_type_remote_attachment() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_remote_attachment(remote_attachment: RemoteAttachment) -> Result<EncodedContent> {
   Ok(
     RemoteAttachmentCodec::encode(remote_attachment.into())
@@ -131,6 +132,7 @@ impl From<xmtp_content_types::remote_attachment::EncryptedAttachment> for Encryp
 
 /// Encrypts an attachment for storage as a remote attachment.
 #[napi]
+#[xmtp_common::err_span]
 pub fn encrypt_attachment(attachment: Attachment) -> Result<EncryptedAttachment> {
   Ok(
     xmtp_encrypt_attachment(attachment.into())
@@ -141,6 +143,7 @@ pub fn encrypt_attachment(attachment: Attachment) -> Result<EncryptedAttachment>
 
 /// Decrypts an encrypted payload from a remote attachment.
 #[napi]
+#[xmtp_common::err_span]
 pub fn decrypt_attachment(
   encrypted_bytes: Uint8Array,
   remote_attachment: RemoteAttachment,

--- a/bindings/node/src/content_types/reply.rs
+++ b/bindings/node/src/content_types/reply.rs
@@ -23,11 +23,13 @@ impl EnrichedReply {
   }
 
   #[napi(getter)]
+  #[xmtp_common::err_span]
   pub fn content(&self) -> Result<DecodedMessageContent> {
     self.content.as_ref().clone().try_into()
   }
 
   #[napi(getter)]
+  #[xmtp_common::err_span]
   pub fn in_reply_to(&self) -> Result<Option<DecodedMessage>> {
     self
       .in_reply_to

--- a/bindings/node/src/content_types/text.rs
+++ b/bindings/node/src/content_types/text.rs
@@ -10,6 +10,7 @@ pub fn content_type_text() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_text(text: String) -> Result<EncodedContent> {
   Ok(TextCodec::encode(text).map_err(ErrorWrapper::from)?.into())
 }

--- a/bindings/node/src/content_types/transaction_reference.rs
+++ b/bindings/node/src/content_types/transaction_reference.rs
@@ -82,6 +82,7 @@ pub fn content_type_transaction_reference() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_transaction_reference(
   transaction_reference: TransactionReference,
 ) -> Result<EncodedContent> {

--- a/bindings/node/src/content_types/wallet_send_calls.rs
+++ b/bindings/node/src/content_types/wallet_send_calls.rs
@@ -105,6 +105,7 @@ pub fn content_type_wallet_send_calls() -> ContentTypeId {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn encode_wallet_send_calls(wallet_send_calls: WalletSendCalls) -> Result<EncodedContent> {
   let wsc = wallet_send_calls.try_into()?;
   Ok(

--- a/bindings/node/src/conversation/consent_state.rs
+++ b/bindings/node/src/conversation/consent_state.rs
@@ -5,6 +5,7 @@ use napi_derive::napi;
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub fn consent_state(&self) -> Result<ConsentState> {
     let group = self.create_mls_group();
 
@@ -14,6 +15,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn update_consent_state(&self, state: ConsentState) -> Result<()> {
     let group = self.create_mls_group();
 

--- a/bindings/node/src/conversation/content_types.rs
+++ b/bindings/node/src/conversation/content_types.rs
@@ -43,6 +43,7 @@ impl SendMessageOpts {
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_text(&self, text: String, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = TextCodec::encode(text).map_err(ErrorWrapper::from)?;
     let opts = SendMessageOpts::from_send_opts(TextCodec::should_push(), opts);
@@ -50,6 +51,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_markdown(&self, markdown: String, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = MarkdownCodec::encode(markdown).map_err(ErrorWrapper::from)?;
     let opts = SendMessageOpts::from_send_opts(MarkdownCodec::should_push(), opts);
@@ -57,6 +59,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_reaction(&self, reaction: Reaction, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = ReactionCodec::encode(reaction.into()).map_err(ErrorWrapper::from)?;
     let opts = SendMessageOpts::from_send_opts(ReactionCodec::should_push(), opts);
@@ -64,6 +67,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_reply(&self, reply: Reply, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = ReplyCodec::encode(reply.into()).map_err(ErrorWrapper::from)?;
     let opts = SendMessageOpts::from_send_opts(ReplyCodec::should_push(), opts);
@@ -71,6 +75,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_read_receipt(&self, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = ReadReceiptCodec::encode(ReadReceipt {}).map_err(ErrorWrapper::from)?;
     let opts = SendMessageOpts::from_send_opts(ReadReceiptCodec::should_push(), opts);
@@ -78,6 +83,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_attachment(
     &self,
     attachment: Attachment,
@@ -89,6 +95,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_remote_attachment(
     &self,
     remote_attachment: RemoteAttachment,
@@ -101,6 +108,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_multi_remote_attachment(
     &self,
     multi_remote_attachment: MultiRemoteAttachment,
@@ -113,6 +121,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_transaction_reference(
     &self,
     transaction_reference: TransactionReference,
@@ -125,6 +134,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_wallet_send_calls(
     &self,
     wallet_send_calls: WalletSendCalls,
@@ -137,6 +147,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_actions(&self, actions: Actions, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = ActionsCodec::encode(actions.into()).map_err(ErrorWrapper::from)?;
     let opts = SendMessageOpts::from_send_opts(ActionsCodec::should_push(), opts);
@@ -144,6 +155,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_intent(&self, intent: Intent, opts: Option<SendOpts>) -> Result<String> {
     let encoded_content = IntentCodec::encode(intent.into()).map_err(ErrorWrapper::from)?;
     let opts = SendMessageOpts::from_send_opts(IntentCodec::should_push(), opts);

--- a/bindings/node/src/conversation/debug.rs
+++ b/bindings/node/src/conversation/debug.rs
@@ -48,6 +48,7 @@ impl From<XmtpConversationDebugInfo> for ConversationDebugInfo {
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn debug_info(&self) -> Result<ConversationDebugInfo> {
     let group = self.create_mls_group();
 

--- a/bindings/node/src/conversation/disappearing_messages.rs
+++ b/bindings/node/src/conversation/disappearing_messages.rs
@@ -31,6 +31,7 @@ impl From<XmtpMessageDisappearingSettings> for MessageDisappearingSettings {
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn update_message_disappearing_settings(
     &self,
     settings: MessageDisappearingSettings,
@@ -45,6 +46,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn remove_message_disappearing_settings(&self) -> Result<()> {
     let group = self.create_mls_group();
 
@@ -57,6 +59,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn message_disappearing_settings(&self) -> Result<Option<MessageDisappearingSettings>> {
     let settings = self
       .create_mls_group()
@@ -70,6 +73,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn is_message_disappearing_enabled(&self) -> Result<bool> {
     self.message_disappearing_settings().map(|settings| {
       settings

--- a/bindings/node/src/conversation/dm.rs
+++ b/bindings/node/src/conversation/dm.rs
@@ -6,6 +6,7 @@ use xmtp_db::group::DmIdExt;
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub fn dm_peer_inbox_id(&self) -> Result<String> {
     let group = self.create_mls_group();
     let inbox_id = group.context.inbox_id();
@@ -17,6 +18,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn duplicate_dms(&self) -> Result<Vec<Conversation>> {
     let group = self.create_mls_group();
     let dms = group.find_duplicate_dms().map_err(ErrorWrapper::from)?;

--- a/bindings/node/src/conversation/hmac_key.rs
+++ b/bindings/node/src/conversation/hmac_key.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub fn hmac_keys(&self) -> Result<HashMap<String, Vec<HmacKey>>> {
     let group = self.create_mls_group();
 

--- a/bindings/node/src/conversation/membership.rs
+++ b/bindings/node/src/conversation/membership.rs
@@ -71,6 +71,7 @@ impl GroupMember {
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn list_members(&self) -> Result<Vec<GroupMember>> {
     let group = self.create_mls_group();
 
@@ -104,6 +105,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn membership_state(&self) -> Result<GroupMembershipState> {
     let group = self.create_mls_group();
     let state = group.membership_state().map_err(ErrorWrapper::from)?;
@@ -111,6 +113,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn list_admins(&self) -> Result<Vec<String>> {
     let group = self.create_mls_group();
 
@@ -120,6 +123,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn list_super_admins(&self) -> Result<Vec<String>> {
     let group = self.create_mls_group();
 
@@ -129,18 +133,21 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn is_admin(&self, inbox_id: String) -> Result<bool> {
     let admin_list = self.list_admins()?;
     Ok(admin_list.contains(&inbox_id))
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn is_super_admin(&self, inbox_id: String) -> Result<bool> {
     let super_admin_list = self.list_super_admins()?;
     Ok(super_admin_list.contains(&inbox_id))
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn add_members_by_identity(&self, account_identities: Vec<Identifier>) -> Result<()> {
     let group = self.create_mls_group();
 
@@ -153,6 +160,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn add_admin(&self, inbox_id: String) -> Result<()> {
     let group = self.create_mls_group();
     group
@@ -164,6 +172,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn remove_admin(&self, inbox_id: String) -> Result<()> {
     let group = self.create_mls_group();
     group
@@ -175,6 +184,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn add_super_admin(&self, inbox_id: String) -> Result<()> {
     let group = self.create_mls_group();
     group
@@ -186,6 +196,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn remove_super_admin(&self, inbox_id: String) -> Result<()> {
     let group = self.create_mls_group();
     group
@@ -197,6 +208,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn group_permissions(&self) -> Result<GroupPermissions> {
     let group = self.create_mls_group();
 
@@ -206,6 +218,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn add_members(&self, inbox_ids: Vec<String>) -> Result<()> {
     let group = self.create_mls_group();
 
@@ -218,6 +231,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn remove_members_by_identity(
     &self,
     account_identities: Vec<Identifier>,
@@ -233,6 +247,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn remove_members(&self, inbox_ids: Vec<String>) -> Result<()> {
     let group = self.create_mls_group();
 
@@ -251,6 +266,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn added_by_inbox_id(&self) -> Result<String> {
     let group = self.create_mls_group();
 
@@ -258,6 +274,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn leave_group(&self) -> Result<()> {
     let group = self.create_mls_group();
     group.leave_group().await.map_err(ErrorWrapper::from)?;

--- a/bindings/node/src/conversation/messages.rs
+++ b/bindings/node/src/conversation/messages.rs
@@ -45,6 +45,7 @@ impl From<SendMessageOpts> for xmtp_mls::groups::send_message_opts::SendMessageO
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send(
     &self,
     encoded_content: EncodedContent,
@@ -67,6 +68,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn publish_messages(&self) -> Result<()> {
     let group = self.create_mls_group();
     group.publish_messages().await.map_err(ErrorWrapper::from)?;
@@ -74,6 +76,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn list_messages(&self, opts: Option<ListMessagesOptions>) -> Result<Vec<Message>> {
     let opts = opts.unwrap_or_default();
     let group = self.create_mls_group();
@@ -89,6 +92,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn count_messages(&self, opts: Option<ListMessagesOptions>) -> Result<i64> {
     let opts = opts.unwrap_or_default();
     let group = self.create_mls_group();
@@ -101,6 +105,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn process_streamed_group_message(
     &self,
     envelope_bytes: Uint8Array,
@@ -116,6 +121,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn list_enriched_messages(
     &self,
     opts: Option<ListMessagesOptions>,
@@ -133,6 +139,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn last_read_times(&self) -> Result<HashMap<String, i64>> {
     let group = self.create_mls_group();
     let times = group.get_last_read_times().map_err(ErrorWrapper::from)?;
@@ -142,6 +149,7 @@ impl Conversation {
   /// Prepare a message for later publishing.
   /// Stores the message locally without publishing. Returns the message ID.
   #[napi]
+  #[xmtp_common::err_span]
   pub fn prepare_message(
     &self,
     encoded_content: EncodedContent,
@@ -162,6 +170,7 @@ impl Conversation {
 
   /// Publish a previously prepared message by ID.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn publish_stored_message(&self, message_id: String) -> Result<()> {
     let group = self.create_mls_group();
     let message_id_bytes = hex::decode(&message_id).map_err(ErrorWrapper::from)?;

--- a/bindings/node/src/conversation/metadata.rs
+++ b/bindings/node/src/conversation/metadata.rs
@@ -50,6 +50,7 @@ impl GroupMetadata {
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn group_metadata(&self) -> Result<GroupMetadata> {
     let group = self.create_mls_group();
     let metadata = group.metadata().await.map_err(ErrorWrapper::from)?;
@@ -58,6 +59,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn group_name(&self) -> Result<String> {
     let group = self.create_mls_group();
     let group_name = group.group_name().map_err(ErrorWrapper::from)?;
@@ -66,6 +68,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn update_group_name(&self, group_name: String) -> Result<()> {
     let group = self.create_mls_group();
 
@@ -85,6 +88,7 @@ impl Conversation {
   /// package doesn't advertise `ProposalType::AppDataUpdate`. One-
   /// way: migrated groups cannot return to the legacy path.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn enable_proposals(&self, options: EnableProposalsOptions) -> Result<()> {
     let group = self.create_mls_group();
     group
@@ -94,6 +98,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn group_description(&self) -> Result<String> {
     let group = self.create_mls_group();
     let group_description = group.group_description().map_err(ErrorWrapper::from)?;
@@ -102,6 +107,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn update_group_description(&self, group_description: String) -> Result<()> {
     let group = self.create_mls_group();
 
@@ -114,6 +120,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn group_image_url_square(&self) -> Result<String> {
     let group = self.create_mls_group();
 
@@ -123,6 +130,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn update_group_image_url_square(&self, group_image_url_square: String) -> Result<()> {
     let group = self.create_mls_group();
 
@@ -135,6 +143,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn app_data(&self) -> Result<String> {
     let group = self.create_mls_group();
     let app_data = group.app_data().map_err(ErrorWrapper::from)?;
@@ -143,6 +152,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn update_app_data(&self, app_data: String) -> Result<()> {
     let group = self.create_mls_group();
 

--- a/bindings/node/src/conversation/mod.rs
+++ b/bindings/node/src/conversation/mod.rs
@@ -74,6 +74,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn is_active(&self) -> Result<bool> {
     let group = self.create_mls_group();
 
@@ -81,6 +82,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn paused_for_version(&self) -> napi::Result<Option<String>> {
     let group = self.create_mls_group();
 
@@ -88,6 +90,7 @@ impl Conversation {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn sync(&self) -> Result<()> {
     let group = self.create_mls_group();
     group.sync().await.map_err(ErrorWrapper::from)?;

--- a/bindings/node/src/conversation/permissions.rs
+++ b/bindings/node/src/conversation/permissions.rs
@@ -13,6 +13,7 @@ use xmtp_mls::{
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn update_permission_policy(
     &self,
     permission_update_type: PermissionUpdateType,

--- a/bindings/node/src/conversation/streams.rs
+++ b/bindings/node/src/conversation/streams.rs
@@ -9,6 +9,7 @@ use xmtp_mls::groups::MlsGroup;
 #[napi]
 impl Conversation {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn stream(
     &self,
     callback: ThreadsafeFunction<Message, ()>,

--- a/bindings/node/src/conversations/dm.rs
+++ b/bindings/node/src/conversations/dm.rs
@@ -26,6 +26,7 @@ impl CreateDMOptions {
 #[napi]
 impl Conversations {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn create_dm_by_identity(
     &self,
     account_identity: Identifier,
@@ -44,6 +45,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn create_dm(
     &self,
     inbox_id: String,
@@ -59,6 +61,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn get_dm_by_inbox_id(&self, inbox_id: String) -> Result<Conversation> {
     let convo = self
       .inner_client

--- a/bindings/node/src/conversations/group.rs
+++ b/bindings/node/src/conversations/group.rs
@@ -38,6 +38,7 @@ impl CreateGroupOptions {
 #[napi]
 impl Conversations {
   #[napi]
+  #[xmtp_common::err_span]
   pub fn create_group_optimistic(
     &self,
     options: Option<CreateGroupOptions>,
@@ -90,6 +91,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn create_group_by_identity(
     &self,
     account_identities: Vec<Identifier>,
@@ -107,6 +109,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn create_group(
     &self,
     inbox_ids: Vec<String>,

--- a/bindings/node/src/conversations/hmac_key.rs
+++ b/bindings/node/src/conversations/hmac_key.rs
@@ -9,6 +9,7 @@ use xmtp_db::group::GroupQueryArgs;
 #[napi]
 impl Conversations {
   #[napi]
+  #[xmtp_common::err_span]
   pub fn hmac_keys(&self) -> Result<HashMap<String, Vec<HmacKey>>> {
     let inner = self.inner_client.as_ref();
     let conversations = inner

--- a/bindings/node/src/conversations/messages.rs
+++ b/bindings/node/src/conversations/messages.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 #[napi]
 impl Conversations {
   #[napi]
+  #[xmtp_common::err_span]
   pub fn get_message_by_id(&self, message_id: String) -> Result<Message> {
     let message_id = hex::decode(message_id).map_err(ErrorWrapper::from)?;
 
@@ -22,6 +23,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn get_enriched_message_by_id(&self, message_id: String) -> Result<DecodedMessage> {
     let message_id = hex::decode(message_id).map_err(ErrorWrapper::from)?;
 
@@ -34,6 +36,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn delete_message_by_id(&self, message_id: String) -> Result<u32> {
     let message_id = hex::decode(message_id).map_err(ErrorWrapper::from)?;
 
@@ -46,6 +49,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn process_streamed_welcome_message(
     &self,
     envelope_bytes: Uint8Array,

--- a/bindings/node/src/conversations/mod.rs
+++ b/bindings/node/src/conversations/mod.rs
@@ -148,6 +148,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn get_conversation_by_id(&self, group_id: String) -> Result<Conversation> {
     let group_id = hex::decode(group_id).map_err(ErrorWrapper::from)?;
     let group_id = xmtp_proto::types::GroupId::try_from(group_id).map_err(ErrorWrapper::from)?;
@@ -161,6 +162,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn sync(&self) -> Result<()> {
     self
       .inner_client
@@ -171,6 +173,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn sync_all(
     &self,
     consent_states: Option<Vec<ConsentState>>,
@@ -188,6 +191,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn sync_preferences(&self) -> Result<GroupSyncSummary> {
     let inner = self.inner_client.as_ref();
 
@@ -200,6 +204,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn list(&self, opts: Option<ListConversationsOptions>) -> Result<Vec<ConversationListItem>> {
     let convo_list: Vec<ConversationListItem> = self
       .inner_client

--- a/bindings/node/src/conversations/streams.rs
+++ b/bindings/node/src/conversations/streams.rs
@@ -31,6 +31,7 @@ impl From<XmtpUserPreferenceUpdate> for UserPreferenceUpdate {
 #[napi]
 impl Conversations {
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn stream(
     &self,
     callback: ThreadsafeFunction<Conversation, ()>,
@@ -60,6 +61,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn stream_all_messages(
     &self,
     callback: ThreadsafeFunction<Message, ()>,
@@ -135,6 +137,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn stream_consent(
     &self,
     callback: ThreadsafeFunction<Vec<Consent>, ()>,
@@ -170,6 +173,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn stream_preferences(
     &self,
     callback: ThreadsafeFunction<Vec<UserPreferenceUpdate>, ()>,
@@ -209,6 +213,7 @@ impl Conversations {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn stream_message_deletions(
     &self,
     callback: ThreadsafeFunction<DecodedMessage, ()>,

--- a/bindings/node/src/device_sync.rs
+++ b/bindings/node/src/device_sync.rs
@@ -159,6 +159,7 @@ impl DeviceSync {
 
   /// Manually trigger a device sync request to sync records from another active device on this account.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_sync_request(&self, options: ArchiveOptions, server_url: String) -> Result<()> {
     self
       .inner_client
@@ -173,6 +174,7 @@ impl DeviceSync {
   /// Manually send a sync archive to the sync group.
   /// The pin is used for reference when importing.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn send_sync_archive(
     &self,
     options: ArchiveOptions,
@@ -191,6 +193,7 @@ impl DeviceSync {
   /// Manually process a sync archive that matches the pin given.
   /// If no pin is given, then it will process the last archive sent.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn process_sync_archive(&self, archive_pin: Option<String>) -> Result<()> {
     self
       .inner_client
@@ -205,6 +208,7 @@ impl DeviceSync {
   /// You may need to manually sync the sync group before calling
   /// this function to see recently uploaded archives.
   #[napi]
+  #[xmtp_common::err_span]
   pub fn list_available_archives(&self, days_cutoff: i64) -> Result<Vec<AvailableArchiveInfo>> {
     let available = self
       .inner_client
@@ -217,6 +221,7 @@ impl DeviceSync {
 
   /// Archive application elements to file for later restoration.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn create_archive(
     &self,
     path: String,
@@ -234,6 +239,7 @@ impl DeviceSync {
 
   /// Import a previous archive from a file.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn import_archive(&self, path: String, key: Uint8Array) -> Result<()> {
     let key = check_key(&key)?;
     let mut importer = ArchiveImporter::from_file(path, &key)
@@ -251,6 +257,7 @@ impl DeviceSync {
   /// Load the metadata for an archive to see what it contains.
   /// Reads only the metadata without loading the entire file, so this function is quick.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn archive_metadata(&self, path: String, key: Uint8Array) -> Result<ArchiveMetadata> {
     let key = check_key(&key)?;
     let importer = ArchiveImporter::from_file(path, &key)
@@ -263,6 +270,7 @@ impl DeviceSync {
 
   /// Manually sync all device sync groups.
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn sync_all_device_sync_groups(&self) -> Result<GroupSyncSummary> {
     self
       .inner_client

--- a/bindings/node/src/inbox_id.rs
+++ b/bindings/node/src/inbox_id.rs
@@ -10,6 +10,7 @@ use xmtp_id::associations::MemberIdentifier;
 use xmtp_proto::types::ApiIdentifier;
 
 #[napi]
+#[xmtp_common::err_span]
 pub async fn get_inbox_id_by_identity(
   backend: &Backend,
   identifier: Identifier,
@@ -30,6 +31,7 @@ pub async fn get_inbox_id_by_identity(
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn generate_inbox_id(account_ident: Identifier, nonce: Option<BigInt>) -> Result<String> {
   let nonce = match nonce {
     Some(n) => {
@@ -49,6 +51,7 @@ pub fn generate_inbox_id(account_ident: Identifier, nonce: Option<BigInt>) -> Re
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub async fn is_installation_authorized(
   backend: &Backend,
   inbox_id: String,
@@ -63,6 +66,7 @@ pub async fn is_installation_authorized(
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub async fn is_address_authorized(
   backend: &Backend,
   inbox_id: String,

--- a/bindings/node/src/inbox_state.rs
+++ b/bindings/node/src/inbox_state.rs
@@ -84,6 +84,7 @@ impl From<VerifiedKeyPackageV2> for KeyPackageStatus {
 
 #[allow(dead_code)]
 #[napi]
+#[xmtp_common::err_span]
 pub async fn fetch_inbox_states_by_inbox_ids(
   backend: &Backend,
   inbox_ids: Vec<String>,

--- a/bindings/node/src/messages/decoded_message.rs
+++ b/bindings/node/src/messages/decoded_message.rs
@@ -36,6 +36,7 @@ impl DecodedMessage {
   }
 
   #[napi(getter)]
+  #[xmtp_common::err_span]
   pub fn reactions(&self) -> Result<Vec<DecodedMessage>> {
     self
       .inner
@@ -51,6 +52,7 @@ impl DecodedMessage {
   }
 
   #[napi(getter)]
+  #[xmtp_common::err_span]
   pub fn content(&self) -> Result<DecodedMessageContent> {
     self.inner.content.clone().try_into()
   }

--- a/bindings/node/src/permissions.rs
+++ b/bindings/node/src/permissions.rs
@@ -189,6 +189,7 @@ impl GroupPermissions {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn policy_type(&self) -> Result<GroupPermissionsOptions> {
     if let Ok(preconfigured_policy) = self.inner.preconfigured_policy() {
       Ok(preconfigured_policy.into())
@@ -198,6 +199,7 @@ impl GroupPermissions {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub fn policy_set(&self) -> Result<PermissionPolicySet> {
     let policy_set = &self.inner.policies;
     let metadata_policy_map = &policy_set.update_metadata_policy;

--- a/bindings/node/src/signatures.rs
+++ b/bindings/node/src/signatures.rs
@@ -24,6 +24,7 @@ pub struct SignatureRequestHandle {
 }
 
 #[napi]
+#[xmtp_common::err_span]
 pub fn verify_signed_with_public_key(
   signature_text: String,
   signature_bytes: Uint8Array,
@@ -47,6 +48,7 @@ pub fn verify_signed_with_public_key(
 
 #[allow(dead_code)]
 #[napi]
+#[xmtp_common::err_span]
 pub async fn revoke_installations_signature_request(
   backend: &Backend,
   recovery_identifier: Identifier,
@@ -73,6 +75,7 @@ pub async fn revoke_installations_signature_request(
 
 #[allow(dead_code)]
 #[napi]
+#[xmtp_common::err_span]
 pub async fn apply_signature_request(
   backend: &Backend,
   signature_request: &SignatureRequestHandle,
@@ -109,11 +112,13 @@ impl SignatureRequestHandle {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn signature_text(&self) -> Result<String> {
     Ok(self.inner.lock().await.signature_text())
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn add_ecdsa_signature(&self, signature_bytes: Uint8Array) -> Result<()> {
     let signature = UnverifiedSignature::new_recoverable_ecdsa(signature_bytes.to_vec());
     let mut inner = self.inner.lock().await;
@@ -127,6 +132,7 @@ impl SignatureRequestHandle {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn add_passkey_signature(&self, signature: PasskeySignature) -> Result<()> {
     let new_signature = UnverifiedSignature::new_passkey(
       signature.public_key,
@@ -146,6 +152,7 @@ impl SignatureRequestHandle {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn add_scw_signature(
     &self,
     account_identifier: Identifier,

--- a/bindings/node/src/streams.rs
+++ b/bindings/node/src/streams.rs
@@ -40,6 +40,7 @@ impl StreamCloser {
   /// Returns the `Result` of the task.
   /// End the stream and asynchronously wait for it to shutdown
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn end_and_wait(&self) -> Result<(), Error> {
     use StreamHandleError::*;
     if self.abort.is_finished() {
@@ -63,6 +64,7 @@ impl StreamCloser {
   }
 
   #[napi]
+  #[xmtp_common::err_span]
   pub async fn wait_for_ready(&self) -> Result<(), Error> {
     let mut stream_handle = self.handle.lock().await;
     futures::future::OptionFuture::from((*stream_handle).as_mut().map(|s| s.wait_for_ready()))

--- a/crates/xmtp_common/src/lib.rs
+++ b/crates/xmtp_common/src/lib.rs
@@ -50,6 +50,7 @@ pub use xmtp_cryptography::hash::*;
 pub use xmtp_cryptography::rand::*;
 
 pub use xmtp_macro::db_span;
+pub use xmtp_macro::err_span;
 pub use xmtp_macro::log_event;
 pub use xmtp_macro::mls_span;
 pub use xmtp_macro::parser;

--- a/crates/xmtp_macro/src/lib.rs
+++ b/crates/xmtp_macro/src/lib.rs
@@ -285,3 +285,30 @@ pub fn span(
 ) -> proc_macro::TokenStream {
     span_macro::span(attr, body)
 }
+
+/// Error-case-only tracing for an FFI-exported fn:
+/// `#[tracing::instrument(level = "trace", skip_all, err)]`.
+///
+/// The span is `trace`-level, so under normal filters the success path emits
+/// nothing; `err` fires an ERROR event only when the fn returns `Err`, and
+/// `skip_all` keeps arguments (keys, pins, paths) off the span.
+///
+/// Unlike [`span`], this is napi-safe: napi-rs clones every method attribute
+/// onto the `extern "C"` wrapper it generates (which returns a raw
+/// `napi_value`, not `Result`), so a bare `#[tracing::instrument(err)]` on an
+/// exported method fails to compile. This macro detects the wrapper by its
+/// `extern` ABI and passes it through untouched, instrumenting only the real
+/// method.
+///
+/// ```ignore
+/// #[napi]
+/// #[xmtp_common::err_span]
+/// pub async fn sync(&self) -> Result<()> { .. }
+/// ```
+#[proc_macro_attribute]
+pub fn err_span(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    span_macro::err_span(attr, body)
+}

--- a/crates/xmtp_macro/src/span_macro.rs
+++ b/crates/xmtp_macro/src/span_macro.rs
@@ -68,6 +68,25 @@ pub fn span(
     expand_with_prefix(&args.prefix, input_fn).into()
 }
 
+/// `#[err_span]` → `#[tracing::instrument(level = "trace", skip_all, err)]`,
+/// except on `extern`-ABI fns, which pass through untouched: napi-rs clones
+/// method attributes onto the raw-`napi_value`-returning `extern "C"` wrapper
+/// it generates, where `err` would not compile.
+pub fn err_span(
+    _attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let input_fn = parse_macro_input!(body as syn::ItemFn);
+    if input_fn.sig.abi.is_some() {
+        return quote! { #input_fn }.into();
+    }
+    quote! {
+        #[tracing::instrument(level = "trace", skip_all, err)]
+        #input_fn
+    }
+    .into()
+}
+
 /// Parses the `prefix = "..."` argument of `#[span(...)]`.
 struct SpanArgs {
     prefix: String,

--- a/crates/xmtp_mls/src/worker/device_sync/mod.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/mod.rs
@@ -181,9 +181,11 @@ pub enum DeviceSyncError {
     MissingField(MissingField, String),
     /// Missing payload.
     ///
-    /// Sync payload not found for PIN. Retryable.
-    #[error("Could not find payload with pin {0:?}")]
-    MissingPayload(Option<String>),
+    /// Sync payload not found for PIN. Retryable. The PIN itself is a secret
+    /// archive reference token and must never appear in the error (it is
+    /// logged on the FFI error path), only whether one was provided.
+    #[error("Could not find payload (pin provided: {0})")]
+    MissingPayload(bool),
 }
 
 #[derive(Debug)]

--- a/crates/xmtp_mls/src/worker/device_sync/worker.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/worker.rs
@@ -588,7 +588,7 @@ where
             }
         }
 
-        Err(DeviceSyncError::MissingPayload(pin.map(str::to_string)))
+        Err(DeviceSyncError::MissingPayload(pin.is_some()))
     }
 
     pub fn list_available_archives(


### PR DESCRIPTION
# Summary

Audit of every exported FFI fn in **`bindings/mobile`** (uniffi) and **`bindings/node`** (napi) for tracing instrumentation:

- **Already instrumented** (`#[tracing::instrument(...)]`) → left untouched.
- **Uninstrumented + returns `Result`** → added `#[xmtp_common::err_span]`, which expands to `#[tracing::instrument(level = "trace", skip_all, err)]`. The span is `trace`-level, so under normal filters the success path emits nothing; `err` fires an ERROR event only when the fn returns `Err` — instrumentation strictly for the error case. `skip_all` keeps every argument out of the span (no key material, pins, ids, or paths can leak).
- **Uninstrumented + infallible** (getters, stream constructors, statistics accessors) → no error case exists, so nothing added.
- **Foreign-implemented callback traits** (uniffi `with_foreign`) → not Rust FFI fns; skipped.

## The `#[err_span]` macro (`xmtp_macro`)

A bare `#[tracing::instrument(err)]` cannot be used on napi methods: napi-rs clones every method attribute onto the `extern "C"` wrapper it generates, and that wrapper returns a raw `napi_value` (not `Result`), so `err` fails to compile there. `#[err_span]` passes `extern`-ABI fns through untouched and instruments only the real method.

**Verification**: temporarily made the macro emit `compile_error!` on its instrument path — exactly **153 node + 26 mobile** sites expand it (the wrapper copies pass through silently), then compiled clean with the real expansion.

## Instrumented sites

- `bindings/mobile`: 26 fns — crypto (4), identity (1), logger (4), worker (1), mls.rs (7), device_sync (8), gateway_auth (1)
- `bindings/node`: 153 fns across 47 files — every fallible `#[napi]` export (client, conversations, conversation, content_types, device_sync, signatures, streams, permissions, inbox_id, messages)

## Review feedback addressed

`DeviceSyncError::MissingPayload(Option<String>)` displayed the caller-supplied archive PIN (`Could not find payload with pin {0:?}`), and the new `err` instrumentation would have logged it. The PIN is a secret archive reference token: the variant now carries only `bool` (whether a pin was provided), so the value can no longer reach logs via `Display` or `Debug`.

## Test plan

- `cargo check -p xmtpv3 -p bindings_node -p xmtp_common -p xmtp_macro` — clean
- `just lint` (rust + config) — clean; markdown recipe fails on pre-existing `sdks/js` files untouched here
- `just node lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSkt9HsAxLkY48W47XE4xy


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add error-only tracing to all exported FFI functions in mobile and node bindings
> - Introduces a new `#[xmtp_common::err_span]` proc-macro attribute in [xmtp_macro/src/span_macro.rs](https://github.com/xmtp/libxmtp/pull/3807/files#diff-cea3c5a1b2dd8d137d886a09cca5e90c3835c5a0681ff6c7fed5c20bc4a446a5) that wraps functions with `#[tracing::instrument(level = "trace", skip_all, err)]`, skipping extern ABI functions to stay compatible with napi-rs wrappers.
> - Applies `#[xmtp_common::err_span]` to every exported FFI function across the mobile ([bindings/mobile/src/](https://github.com/xmtp/libxmtp/pull/3807/files#diff-5d08bb1e6a0f40d6a6c79c52406f7d91f61f83e40a470ace5e445acab7294064)) and node ([bindings/node/src/](https://github.com/xmtp/libxmtp/pull/3807/files#diff-daec7d74b41add1a6a019d6a4705261691a4ca607c1101b2678f624e1209410c)) bindings, covering client, conversation, messaging, device sync, permissions, and signature operations.
> - Changes `DeviceSyncError::MissingPayload` in [device_sync/mod.rs](https://github.com/xmtp/libxmtp/pull/3807/files#diff-3551b5963cf2c5a05aeb3cd6d1105e82fedae4160d4258bec732cdbb5f382f15) to carry a `bool` (pin provided: yes/no) instead of the raw `Option<String>` pin value, so the actual PIN is no longer included in error messages.
> - Behavioral Change: archive-not-found errors no longer log the PIN value, only whether one was provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31af42f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->