### PR TITLE
feat(xmtp_mls,bindings): expose proposals_enabled read on node and wasm

### DIFF
--- a/bindings/node/src/conversation/metadata.rs
+++ b/bindings/node/src/conversation/metadata.rs
@@ -97,6 +97,17 @@ impl Conversation {
       .map_err(|e| ErrorWrapper::from(e).into())
   }
 
+  /// Whether this group has migrated to AppData-proposal-based
+  /// metadata updates (the `AppDataDictionary` group-context
+  /// extension is present). `false` means the group is still on
+  /// the legacy GroupContextExtensions path.
+  #[napi]
+  #[xmtp_common::err_span]
+  pub fn proposals_enabled(&self) -> Result<bool> {
+    let group = self.create_mls_group();
+    Ok(group.is_proposals_enabled().map_err(ErrorWrapper::from)?)
+  }
+
   #[napi]
   #[xmtp_common::err_span]
   pub fn group_description(&self) -> Result<String> {

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -691,6 +691,16 @@ impl Conversation {
       .map_err(ErrorWrapper::js)
   }
 
+  /// Whether this group has migrated to AppData-proposal-based
+  /// metadata updates (the `AppDataDictionary` group-context
+  /// extension is present). `false` means the group is still on
+  /// the legacy GroupContextExtensions path.
+  #[wasm_bindgen(js_name = proposalsEnabled)]
+  pub fn proposals_enabled(&self) -> Result<bool, JsError> {
+    let group = self.to_mls_group();
+    group.is_proposals_enabled().map_err(ErrorWrapper::js)
+  }
+
   #[wasm_bindgen(js_name = groupName)]
   pub fn group_name(&self) -> Result<String, JsError> {
     let group = self.to_mls_group();

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -799,6 +799,15 @@ where
         check_proposals_enabled(mls_group.extensions())
     }
 
+    /// Like [`Self::proposals_enabled`], but loads the group from storage
+    /// instead of taking a caller-held `OpenMlsGroup`. The convenience
+    /// shape bindings need for a plain "is this group migrated?" read.
+    pub fn is_proposals_enabled(&self) -> Result<bool, GroupError> {
+        self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
+            Ok(self.proposals_enabled(&mls_group))
+        })
+    }
+
     /// Enable proposals on this group (proposal-by-reference flow).
     ///
     /// Runs the bootstrap commit that migrates the group's state out

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -135,14 +135,8 @@ async fn test_proposals_enabled_default_false() {
         .create_group_with_members(&[bo.inbox_id()], None, None)
         .await?;
 
-    let proposals_enabled = alix_group
-        .load_mls_group_with_lock_async(async |mls_group| {
-            Ok::<bool, crate::groups::GroupError>(alix_group.proposals_enabled(&mls_group))
-        })
-        .await?;
-
     assert!(
-        !proposals_enabled,
+        !alix_group.is_proposals_enabled()?,
         "Proposals should not be enabled by default"
     );
 }
@@ -181,6 +175,7 @@ async fn test_e2e_propose_add_member_flow() {
     alix_group
         .enable_proposals(EnableProposalsOptions::test_default())
         .await?;
+    assert!(alix_group.is_proposals_enabled()?);
     bo_group.sync().await?;
 
     // 2. Alix proposes to add caro


### PR DESCRIPTION
## Summary

Adds `MlsGroup::is_proposals_enabled()` — the load-from-storage convenience form of the existing `proposals_enabled(&OpenMlsGroup)` — and exposes it as `conversation.proposalsEnabled()` in the **node** and **wasm** bindings.

## Why

Server-side JS consumers (herald) need a cheap per-group "is this group migrated to AppData proposals?" boolean to emit migration-progress telemetry during the rollout. `membershipCapabilities()` answers eligibility but is a heavyweight network-touching debug surface; the migrated-or-not bit is a local extensions read. Swift/Kotlin can already derive this; node/wasm had no surface for it.

## Changes

- `xmtp_mls`: `MlsGroup::is_proposals_enabled()` — reads under the group lock via `load_mls_group_with_lock`, wraps the existing `check_proposals_enabled` extensions check.
- `bindings_node`: `proposalsEnabled(): boolean` on Conversation (sync, next to `enableProposals`).
- `bindings_wasm`: `proposalsEnabled(): boolean` on Conversation.
- Tests: `test_proposals_enabled_default_false` now exercises the new getter; `test_e2e_propose_add_member_flow` asserts it flips true after `enable_proposals`.

Both touched tests pass locally against the dev docker backend; `cargo check` clean for `xmtp_mls` (lib+tests), `bindings_node`, and `bindings_wasm` (wasm32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `proposals_enabled` on MLS groups in Node and WASM bindings
> - Adds `Group.is_proposals_enabled()` in [mod.rs](https://github.com/xmtp/libxmtp/pull/3815/files#diff-c27dd00cf700fd888b75fdbd19738462c2549fdc881dad70f8e61c979d440966) as a convenience method that loads the MLS group from storage and returns its `proposals_enabled` status.
> - Exposes this as `Conversation.proposals_enabled()` in the Node binding ([metadata.rs](https://github.com/xmtp/libxmtp/pull/3815/files#diff-3ada3b6dfc7c6089e2528c0823a058c967f88435da5f8c6a9ad79aae96d006c7)) and `Conversation.proposalsEnabled()` in the WASM binding ([conversation.rs](https://github.com/xmtp/libxmtp/pull/3815/files#diff-35aeb79801a6cf0400cf956eb71fc0cbad1420701406c6992d70ddf543739e6e)).
> - Updates tests in [test_proposals.rs](https://github.com/xmtp/libxmtp/pull/3815/files#diff-fb8ffb096fea904de9f05e2ad66734c897c3a9ceb42099e25f894c256f1f5f8e) to use the new method directly instead of manually loading the MLS group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 595532b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->