### PR TITLE
Add Murmur config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,7 @@ docs/plans
 # Claude Code
 .claude/scheduled_tasks.lock
 /target-linux-amd64
+
+# Murmur local config (per-developer, not checked in)
+.murmur/murmur.local.yaml
+.murmur/murmur.*.local.yaml

--- a/.murmur/murmur.yaml
+++ b/.murmur/murmur.yaml
@@ -1,0 +1,9 @@
+# Shared team configuration — check this file into version control.
+#
+# Per-developer settings (encrypted profile, SSH keys, username) belong
+# in murmur.local.yaml, which is gitignored and written by `murmur setup`.
+
+tenant:
+  provider: github_app
+  org: DojoAreas
+workspace: dojoareas-murmur


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add shared Murmur configuration for the DojoAreas organization
Adds [.murmur/murmur.yaml](https://github.com/xmtp/libxmtp/pull/3818/files#diff-c22a1ded466e9c0908f2cf9c79353cb33478faca06914e4e5147737ddffe3c57) with shared team settings, specifying `github_app` as the tenant provider, `DojoAreas` as the organization, and `dojoareas-murmur` as the workspace. Updates [.gitignore](https://github.com/xmtp/libxmtp/pull/3818/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) to exclude per-developer local overrides matching `.murmur/murmur.local.yaml` and `.murmur/murmur.*.local.yaml`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 182e65d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->