### PR TITLE
nix: restore atf cross overlay dropped in #3810

### DIFF
--- a/nix/lib/patches.nix
+++ b/nix/lib/patches.nix
@@ -8,6 +8,56 @@
       };
     }
   )
+  # atf 0.23's configure.ac uses AC_RUN_IFELSE for three probes that
+  # cannot execute a compiled test binary during cross-compilation,
+  # aborting with:
+  #   "configure: error: cannot run test program while cross compiling"
+  #
+  # This breaks the aarch64-apple-darwin cross-build chain:
+  #   atf → libiconv → apple-sdk-14.4 → bindings-node-js-napi-*
+  # See https://github.com/xmtp/libxmtp/issues/3470
+  # and https://github.com/xmtp/libxmtp/issues/3476.
+  #
+  # Upstreamed as https://github.com/NixOS/nixpkgs/pull/510292 (merged,
+  # present in the current pin) — but the upstream seeds are gated on
+  # `!buildPlatform.canExecute hostPlatform`, and our nightly cross is
+  # aarch64-darwin → aarch64-apple-darwin: same arch and kernel, so
+  # canExecute is TRUE and the seeds never apply, while autoconf still
+  # decides cross_compiling=yes from the triple mismatch and aborts
+  # (broke the 2026-07-03 nightly after #3810 dropped this overlay).
+  # Keep this structurally-gated copy until the upstream gate is
+  # `buildPlatform != hostPlatform`; double-applying the seeds when
+  # both gates fire is harmless (same cache values).
+  #
+  # The three AC_RUN_IFELSE cache variables and their justifications:
+  #
+  #   kyua_cv_getopt_plus (m4/module-application.m4)
+  #     Tests whether getopt(3) accepts a leading '+' for POSIX
+  #     behavior. All target platforms (Darwin, glibc, musl) honour '+'.
+  #
+  #   kyua_cv_attribute_noreturn (m4/module-defs.m4)
+  #     Tests whether __attribute__((__noreturn__)) is supported by
+  #     checking GCC version >= 2.5. All modern GCC/Clang satisfy this.
+  #
+  #   kyua_cv_getcwd_works (m4/module-fs.m4)
+  #     Tests whether getcwd(NULL, 0) dynamically allocates. Both
+  #     Darwin and Linux (glibc and musl) support this.
+  #
+  # Pre-seeding all three is safe for every target in this flake.
+  # Gated on cross-compilation so native builds keep pulling from
+  # cache.nixos.org unchanged.
+  (
+    final: prev:
+    prev.lib.optionalAttrs (prev.stdenv.buildPlatform != prev.stdenv.hostPlatform) {
+      atf = prev.atf.overrideAttrs (old: {
+        configureFlags = (old.configureFlags or [ ]) ++ [
+          "kyua_cv_getopt_plus=yes"
+          "kyua_cv_attribute_noreturn=yes"
+          "kyua_cv_getcwd_works=yes"
+        ];
+      });
+    }
+  )
   # tcl 8.6.16 (pinned via nixpkgs 09061f74...) has multiple
   # cross-compile bugs when targeting *-unknown-linux-musl, and the
   # Hydra build farm only caches the x86_64-linux build host (not


### PR DESCRIPTION
## Summary

The 2026-07-03 nightly failed in `release-node-sdk / bindings / build-macos (darwin-arm64)`:

```
atf-aarch64-apple-darwin> configure: error: cannot run test program while cross compiling
error: Cannot build '...libiconv-aarch64-apple-darwin-113.drv' — 1 dependency failed
error: Cannot build '...bindings-node-js-napi-aarch64-apple-darwin-1.11.0-dev.drv'
```

No node-sdk/node-bindings npm nightly has published since `20260630.ac662b3` — and because the nightly watermark is the latest tag of *any* SDK, the successful iOS leg's `20260703` tag makes every subsequent scheduled run log "No new commits since last nightly; skipping", so the node leg never retried.

## Why the upstream fix doesn't cover this

#3810 removed this overlay expecting NixOS/nixpkgs#510292 (merged, present in the pinned nixos-unstable rev `b5aa0fbd`) to cover it. The upstream seeds are gated on `!stdenv.buildPlatform.canExecute stdenv.hostPlatform` — but this build's cross is **aarch64-darwin → aarch64-apple-darwin**: same arch, same kernel, so `canExecute` is true and the seeds never apply, while autoconf still decides `cross_compiling=yes` from the configured-triple mismatch and aborts the `AC_RUN_IFELSE` probes.

This restores the original overlay verbatim (structurally gated on `buildPlatform != hostPlatform`) with the comment updated to record the upstream state and the retirement condition: the upstream gate switching to structural inequality (nixpkgs follow-up incoming). Double-applying the seeds when both gates fire is harmless — same cache values.

Verification: `nix-instantiate --parse` clean; the real proof is the next scheduled nightly (new commit un-skips the watermark) or a manual `Release` dispatch with `node-sdk: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore atf cross-compilation overlay in nix patches
> Restores an overlay in [patches.nix](https://github.com/xmtp/libxmtp/pull/3822/files#diff-a0c603b759efcc01ff44a1cc1d0f7aeb5b28903640bb2354bb0c6b41059a3609) that was dropped in #3810. When `buildPlatform != hostPlatform`, the `atf` derivation is overridden to pre-seed three autoconf cache variables (`kyua_cv_getopt_plus`, `kyua_cv_attribute_noreturn`, `kyua_cv_getcwd_works`) so `AC_RUN_IFELSE` tests are skipped and configuration succeeds during cross-compilation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4005df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->