### PR TITLE
refactor(xmtp_mls): extract shared message-processing pipeline

### DIFF
--- a/crates/xmtp_mls/src/subscriptions/process_message.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message.rs
@@ -94,6 +94,64 @@ where
     }
 }
 
+/// Outcome of running a single raw group message through the processing pipeline,
+/// independent of any stream/poll machinery.
+///
+/// Dedup (skipping already-seen cursors) and cursor bookkeeping are intentionally
+/// **not** handled here — they are the caller's responsibility, because different
+/// consumers track them differently. The live [`super::stream_messages`] stream uses
+/// a per-stream `GroupList`; the XIP-83 bidi multiplexing manager keeps central
+/// per-topic high-water marks plus per-subscriber in-flight cursors. This seam is
+/// only the decode half (DB fast-path, then decrypt/store + recovery-sync), so both
+/// consumers decode identically.
+#[derive(Debug)]
+pub struct Processed {
+    /// The decrypted message to deliver, if this envelope produced one. `None` means
+    /// the envelope was processed but surfaced nothing (e.g. a commit); the caller
+    /// should still advance its cursor to `next_cursor`.
+    pub message: Option<StoredGroupMessage>,
+    /// The group this envelope belongs to.
+    pub group_id: Vec<u8>,
+    /// The cursor the caller should advance this group to after handling the result.
+    pub next_cursor: Cursor,
+    /// The cursor of the envelope we attempted to process (for tracking/logging).
+    pub tried: Cursor,
+}
+
+/// Run a single raw group message through the shared processing pipeline.
+///
+/// 1. **Fast path:** if the message is already stored locally (e.g. a replayed
+///    envelope after a cursor'd re-add — see XIP-83 client integration), return it
+///    without decrypting.
+/// 2. Otherwise run the full decrypt/store pipeline (which may trigger a recovery
+///    sync for out-of-order / commit-dependent messages) and surface whatever it
+///    produced.
+///
+/// The caller owns dedup and cursor advancement (see [`Processed`]). This mirrors the
+/// orchestration in [`super::stream_messages`]'s `on_waiting`/`resolve_futures`, lifted
+/// out of the poll state-machine so the bidi manager can reuse it from an async task.
+pub async fn process_one<'a>(
+    factory: &impl ProcessFutureFactory<'a>,
+    msg: xmtp_proto::types::GroupMessage,
+) -> Result<Processed> {
+    // Fast path: already stored locally — no decrypt, advance to the message's cursor.
+    if let Some(stored) = factory.retrieve(&msg)? {
+        return Ok(Processed {
+            message: Some(stored),
+            group_id: msg.group_id.to_vec(),
+            next_cursor: msg.cursor,
+            tried: msg.cursor,
+        });
+    }
+    let processed = factory.create(msg).await?;
+    Ok(Processed {
+        message: processed.message,
+        group_id: processed.group_id,
+        next_cursor: processed.next_message,
+        tried: processed.tried_to_process,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use crate::groups::mls_sync::GroupMessageProcessingError;
@@ -293,5 +351,90 @@ mod tests {
         if message.is_some() {
             assert!(processed.unwrap().message.is_some())
         }
+    }
+
+    // A minimal in-test [`ProcessFutureFactory`] so we can drive `process_one` without
+    // a real client: `retrieve` returns a canned DB hit/miss, `create` returns a canned
+    // `ProcessedMessage` (and asserts it is only reached on a fast-path miss).
+    struct StubFactory {
+        retrieve: Option<StoredGroupMessage>,
+        create_message: Option<StoredGroupMessage>,
+        create_group: Vec<u8>,
+        create_next: Cursor,
+        create_tried: Cursor,
+        allow_create: bool,
+    }
+
+    impl<'a> ProcessFutureFactory<'a> for StubFactory {
+        fn create(
+            &self,
+            _msg: xmtp_proto::types::GroupMessage,
+        ) -> xmtp_common::BoxDynFuture<'a, Result<ProcessedMessage>> {
+            assert!(
+                self.allow_create,
+                "process_one called create() on a DB fast-path hit"
+            );
+            let processed = ProcessedMessage {
+                message: self.create_message.clone(),
+                group_id: self.create_group.clone(),
+                next_message: self.create_next,
+                tried_to_process: self.create_tried,
+            };
+            Box::pin(async move { Ok(processed) })
+        }
+
+        fn retrieve(
+            &self,
+            _msg: &xmtp_proto::types::GroupMessage,
+        ) -> Result<Option<StoredGroupMessage>> {
+            Ok(self.retrieve.clone())
+        }
+    }
+
+    /// A locally-stored message is returned without decrypting, and `create()` is
+    /// never reached. The cursor advances to the message's own cursor.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn process_one_uses_db_fast_path_without_decrypting() {
+        use xmtp_common::Generate as _;
+        let gid = GroupId::generate();
+        let msg = generate_message(55, &gid);
+        let oid = msg.originator_id();
+        let factory = StubFactory {
+            retrieve: Some(generate_stored_msg(Cursor::new(55, oid), gid.clone())),
+            create_message: None,
+            create_group: gid.to_vec(),
+            create_next: Cursor::new(0, oid),
+            create_tried: Cursor::new(0, oid),
+            allow_create: false,
+        };
+        let processed = process_one(&factory, msg.clone()).await?;
+        assert!(processed.message.is_some());
+        assert_eq!(processed.next_cursor, msg.cursor);
+        assert_eq!(processed.tried, msg.cursor);
+        assert_eq!(processed.group_id, gid.to_vec());
+    }
+
+    /// On a fast-path miss, `process_one` runs the full pipeline and surfaces the
+    /// processed message and its post-processing cursor.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn process_one_runs_pipeline_on_fast_path_miss() {
+        use xmtp_common::Generate as _;
+        let gid = GroupId::generate();
+        let msg = generate_message(10, &gid);
+        let oid = msg.originator_id();
+        let next = Cursor::new(11, oid);
+        let factory = StubFactory {
+            retrieve: None,
+            create_message: Some(generate_stored_msg(next, gid.clone())),
+            create_group: gid.to_vec(),
+            create_next: next,
+            create_tried: msg.cursor,
+            allow_create: true,
+        };
+        let processed = process_one(&factory, msg.clone()).await?;
+        assert!(processed.message.is_some());
+        assert_eq!(processed.next_cursor, next);
+        assert_eq!(processed.tried, msg.cursor);
+        assert_eq!(processed.group_id, gid.to_vec());
     }
 }

--- a/crates/xmtp_mls/src/subscriptions/process_message.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message.rs
@@ -1,4 +1,4 @@
-//! he future for processing messages from a stream.
+//! The future for processing messages from a stream.
 //! When we receive a message from a stream, we treat it with special care.
 //! Streams may receive messages out of order. Since we cannot rely on the order of messages
 //! in a stream, we must defer to the 'sync' function whenever we receive a message that
@@ -13,9 +13,9 @@ use crate::groups::summary::MessageIdentifierBuilder;
 use factory::{GroupDatabase, GroupDb, MessageProcessor, Syncer};
 use xmtp_common::BoxDynFuture;
 use xmtp_db::group_message::StoredGroupMessage;
-use xmtp_proto::types::Cursor;
+use xmtp_proto::types::{Cursor, GroupId};
 
-/// Creates a future that processes sa single message
+/// Creates a future that processes a single message
 pub trait ProcessFutureFactory<'a> {
     fn create(
         &self,
@@ -67,7 +67,7 @@ impl<Context: Clone> Clone for ProcessMessageFuture<Context> {
 // The processed message
 pub struct ProcessedMessage {
     pub message: Option<StoredGroupMessage>,
-    pub group_id: Vec<u8>,
+    pub group_id: GroupId,
     pub next_message: Cursor,
     pub tried_to_process: Cursor,
 }
@@ -111,11 +111,55 @@ pub struct Processed {
     /// should still advance its cursor to `next_cursor`.
     pub message: Option<StoredGroupMessage>,
     /// The group this envelope belongs to.
-    pub group_id: Vec<u8>,
+    pub group_id: GroupId,
     /// The cursor the caller should advance this group to after handling the result.
     pub next_cursor: Cursor,
     /// The cursor of the envelope we attempted to process (for tracking/logging).
     pub tried: Cursor,
+}
+
+/// The result of [`prepare`]: the synchronous pre-step of the pipeline. Either the
+/// message was already stored locally (fast path) or it needs the async decrypt/store
+/// pass run on it.
+pub(crate) enum Prepared {
+    /// Fast-path hit — no async work needed. Carries the stored message by value so
+    /// consumers never face a "hit without a message" state.
+    Ready {
+        message: StoredGroupMessage,
+        group_id: GroupId,
+        cursor: Cursor,
+    },
+    /// Needs the async `create()` pass; carries the message to run it on.
+    NeedsProcessing(xmtp_proto::types::GroupMessage),
+}
+
+/// Synchronous pre-step shared by the live stream and the bidi manager: probe the DB
+/// fast path. Returns the stored message on a hit (no decrypt), or the message to run
+/// the async pass on.
+pub(crate) fn prepare<'a>(
+    factory: &impl ProcessFutureFactory<'a>,
+    msg: xmtp_proto::types::GroupMessage,
+) -> Result<Prepared> {
+    // Fast path: already stored locally — no decrypt, advance to the message's cursor.
+    if let Some(stored) = factory.retrieve(&msg)? {
+        return Ok(Prepared::Ready {
+            message: stored,
+            group_id: msg.group_id,
+            cursor: msg.cursor,
+        });
+    }
+    Ok(Prepared::NeedsProcessing(msg))
+}
+
+/// Synchronous post-step shared by the live stream and the bidi manager: map the async
+/// pipeline's [`ProcessedMessage`] into the unified [`Processed`] shape.
+pub(crate) fn finish(processed: ProcessedMessage) -> Processed {
+    Processed {
+        message: processed.message,
+        group_id: processed.group_id,
+        next_cursor: processed.next_message,
+        tried: processed.tried_to_process,
+    }
 }
 
 /// Run a single raw group message through the shared processing pipeline.
@@ -127,29 +171,26 @@ pub struct Processed {
 ///    sync for out-of-order / commit-dependent messages) and surface whatever it
 ///    produced.
 ///
-/// The caller owns dedup and cursor advancement (see [`Processed`]). This mirrors the
-/// orchestration in [`super::stream_messages`]'s `on_waiting`/`resolve_futures`, lifted
-/// out of the poll state-machine so the bidi manager can reuse it from an async task.
+/// The caller owns dedup and cursor advancement (see [`Processed`]). The live
+/// [`super::stream_messages`] stream shares the same [`prepare`]/[`finish`] steps from
+/// its poll state-machine (which cannot `.await` this directly).
 pub async fn process_one<'a>(
     factory: &impl ProcessFutureFactory<'a>,
     msg: xmtp_proto::types::GroupMessage,
 ) -> Result<Processed> {
-    // Fast path: already stored locally — no decrypt, advance to the message's cursor.
-    if let Some(stored) = factory.retrieve(&msg)? {
-        return Ok(Processed {
-            message: Some(stored),
-            group_id: msg.group_id.to_vec(),
-            next_cursor: msg.cursor,
-            tried: msg.cursor,
-        });
+    match prepare(factory, msg)? {
+        Prepared::Ready {
+            message,
+            group_id,
+            cursor,
+        } => Ok(Processed {
+            message: Some(message),
+            group_id,
+            next_cursor: cursor,
+            tried: cursor,
+        }),
+        Prepared::NeedsProcessing(msg) => Ok(finish(factory.create(msg).await?)),
     }
-    let processed = factory.create(msg).await?;
-    Ok(Processed {
-        message: processed.message,
-        group_id: processed.group_id,
-        next_cursor: processed.next_message,
-        tried: processed.tried_to_process,
-    })
 }
 
 #[cfg(test)]
@@ -359,7 +400,7 @@ mod tests {
     struct StubFactory {
         retrieve: Option<StoredGroupMessage>,
         create_message: Option<StoredGroupMessage>,
-        create_group: Vec<u8>,
+        create_group: GroupId,
         create_next: Cursor,
         create_tried: Cursor,
         allow_create: bool,
@@ -376,7 +417,7 @@ mod tests {
             );
             let processed = ProcessedMessage {
                 message: self.create_message.clone(),
-                group_id: self.create_group.clone(),
+                group_id: self.create_group,
                 next_message: self.create_next,
                 tried_to_process: self.create_tried,
             };
@@ -400,9 +441,9 @@ mod tests {
         let msg = generate_message(55, &gid);
         let oid = msg.originator_id();
         let factory = StubFactory {
-            retrieve: Some(generate_stored_msg(Cursor::new(55, oid), gid.clone())),
+            retrieve: Some(generate_stored_msg(Cursor::new(55, oid), gid)),
             create_message: None,
-            create_group: gid.to_vec(),
+            create_group: gid,
             create_next: Cursor::new(0, oid),
             create_tried: Cursor::new(0, oid),
             allow_create: false,
@@ -411,7 +452,7 @@ mod tests {
         assert!(processed.message.is_some());
         assert_eq!(processed.next_cursor, msg.cursor);
         assert_eq!(processed.tried, msg.cursor);
-        assert_eq!(processed.group_id, gid.to_vec());
+        assert_eq!(processed.group_id, gid);
     }
 
     /// On a fast-path miss, `process_one` runs the full pipeline and surfaces the
@@ -425,8 +466,8 @@ mod tests {
         let next = Cursor::new(11, oid);
         let factory = StubFactory {
             retrieve: None,
-            create_message: Some(generate_stored_msg(next, gid.clone())),
-            create_group: gid.to_vec(),
+            create_message: Some(generate_stored_msg(next, gid)),
+            create_group: gid,
             create_next: next,
             create_tried: msg.cursor,
             allow_create: true,
@@ -435,6 +476,6 @@ mod tests {
         assert!(processed.message.is_some());
         assert_eq!(processed.next_cursor, next);
         assert_eq!(processed.tried, msg.cursor);
-        assert_eq!(processed.group_id, gid.to_vec());
+        assert_eq!(processed.group_id, gid);
     }
 }

--- a/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -258,7 +258,9 @@ where
             Ok(ProcessedMessage {
                 message: Some(new_msg.clone()),
                 next_message: delivered_cursor,
-                group_id: new_msg.group_id.to_vec(),
+                // `lookup_stored_from_sync` only returns same-group rows, so
+                // the wire message's typed id is the stored message's group.
+                group_id: msg.group_id,
                 tried_to_process: msg.cursor,
             })
         } else {
@@ -266,7 +268,7 @@ where
             Ok(ProcessedMessage {
                 message: None,
                 next_message: next,
-                group_id: msg.group_id.to_vec(),
+                group_id: msg.group_id,
                 tried_to_process: msg.cursor,
             })
         }

--- a/crates/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -46,6 +46,57 @@ pub enum ProcessWelcomeResult<Context> {
     Ignore,
 }
 
+/// Outcome of running a single raw welcome through the processing pipeline,
+/// independent of any stream/poll machinery — the welcome analog of
+/// [`super::process_message::Processed`].
+///
+/// As with messages, dedup bookkeeping is the caller's job: record `seen` into
+/// whatever known-welcome set the caller owns (the per-stream `known_welcome_ids`
+/// set, or the bidi manager's central set).
+pub struct WelcomeOutcome<Context> {
+    /// The conversation to surface to the subscriber, if this welcome produced one
+    /// that passed the stream's filters.
+    pub group: Option<MlsGroup<Context>>,
+    /// The welcome cursor to record as seen for dedup, if any.
+    pub seen: Option<Cursor>,
+}
+
+impl<Context> ProcessWelcomeResult<Context> {
+    /// Interpret a processing result into a [`WelcomeOutcome`]: which group (if any)
+    /// to surface, and which welcome cursor (if any) to record as seen. This mirrors
+    /// the logic previously inlined in `StreamConversations::filter_welcome`, lifted
+    /// out so both the live conversation stream and the bidi manager interpret results
+    /// identically.
+    pub fn into_outcome(self) -> WelcomeOutcome<Context> {
+        match self {
+            ProcessWelcomeResult::New { group, id } => WelcomeOutcome {
+                group: Some(group),
+                seen: Some(id),
+            },
+            ProcessWelcomeResult::NewStored {
+                group,
+                maybe_sequence_id,
+                maybe_originator,
+            } => WelcomeOutcome {
+                group: Some(group),
+                seen: maybe_sequence_id
+                    .zip(maybe_originator)
+                    .map(|(id, originator)| {
+                        Cursor::new(id as SequenceId, originator as OriginatorId)
+                    }),
+            },
+            ProcessWelcomeResult::IgnoreId { id } => WelcomeOutcome {
+                group: None,
+                seen: Some(id),
+            },
+            ProcessWelcomeResult::Ignore => WelcomeOutcome {
+                group: None,
+                seen: None,
+            },
+        }
+    }
+}
+
 impl<Context> ProcessWelcomeFuture<Context>
 where
     Context: XmtpSharedContext,
@@ -365,5 +416,57 @@ where
             group.conversation_type,
             group.created_at_ns,
         )))
+    }
+}
+
+/// Run a single raw welcome through the shared processing pipeline and interpret the
+/// result. The decode half of the conversation stream, lifted out of the poll machinery
+/// so the XIP-83 bidi multiplexing manager can reuse it from an async task.
+///
+/// The caller owns dedup: pass the current known-welcome set in, and record
+/// [`WelcomeOutcome::seen`] back into it after handling the outcome.
+pub async fn process_welcome_one<Context>(
+    context: Context,
+    known_welcome_ids: HashSet<Cursor>,
+    welcome: WelcomeMessage,
+    conversation_type: Option<ConversationType>,
+    include_duplicate_dms: bool,
+    consent_states: Option<Vec<ConsentState>>,
+) -> Result<WelcomeOutcome<Context>>
+where
+    Context: XmtpSharedContext,
+{
+    let result = ProcessWelcomeFuture::new(
+        known_welcome_ids,
+        context,
+        WelcomeOrGroup::Welcome(welcome),
+        conversation_type,
+        include_duplicate_dms,
+        consent_states,
+    )?
+    .process()
+    .await?;
+    Ok(result.into_outcome())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Ignore` surfaces no group and records nothing for dedup.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn into_outcome_ignore_yields_nothing() {
+        let outcome = ProcessWelcomeResult::<()>::Ignore.into_outcome();
+        assert!(outcome.group.is_none());
+        assert!(outcome.seen.is_none());
+    }
+
+    /// `IgnoreId` surfaces no group but records the welcome cursor for dedup.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn into_outcome_ignore_id_records_seen_without_group() {
+        let cursor = Cursor::new(42, 7u32);
+        let outcome = ProcessWelcomeResult::<()>::IgnoreId { id: cursor }.into_outcome();
+        assert!(outcome.group.is_none());
+        assert_eq!(outcome.seen, Some(cursor));
     }
 }

--- a/crates/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -423,11 +423,19 @@ where
 /// result. The decode half of the conversation stream, lifted out of the poll machinery
 /// so the XIP-83 bidi multiplexing manager can reuse it from an async task.
 ///
-/// The caller owns dedup: pass the current known-welcome set in, and record
-/// [`WelcomeOutcome::seen`] back into it after handling the outcome.
+/// `known_welcome_ids` is borrowed from the caller's authoritative dedup set and
+/// snapshotted for the pipeline (an already-seen cursor short-circuits into an
+/// ignore outcome). The borrow makes the safe pattern the default: a caller
+/// processing welcomes sequentially — check, call, record
+/// [`WelcomeOutcome::seen`] — gets correct dedup by construction, because the
+/// set cannot be mutated while a call borrows it. A caller that wants
+/// concurrent calls must clone the set explicitly, and then owns the
+/// consequence: two in-flight calls for the same cursor will each see it as
+/// unseen and both surface the conversation. Serialize same-cursor decisions
+/// (the XIP-83 router routes from a single task for exactly this reason).
 pub async fn process_welcome_one<Context>(
     context: Context,
-    known_welcome_ids: HashSet<Cursor>,
+    known_welcome_ids: &HashSet<Cursor>,
     welcome: WelcomeMessage,
     conversation_type: Option<ConversationType>,
     include_duplicate_dms: bool,
@@ -437,7 +445,7 @@ where
     Context: XmtpSharedContext,
 {
     let result = ProcessWelcomeFuture::new(
-        known_welcome_ids,
+        known_welcome_ids.clone(),
         context,
         WelcomeOrGroup::Welcome(welcome),
         conversation_type,

--- a/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -21,7 +21,7 @@ use xmtp_common::{BoxDynFuture, Event, MaybeSend};
 use xmtp_db::prelude::*;
 use xmtp_macro::log_event;
 use xmtp_proto::api_client::XmtpMlsStreams;
-use xmtp_proto::types::{Cursor, OriginatorId, SequenceId, WelcomeMessage};
+use xmtp_proto::types::{Cursor, WelcomeMessage};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConversationStreamError {
@@ -385,49 +385,28 @@ where
         welcome: Result<ProcessWelcomeResult<C>>,
     ) -> Option<<Self as Stream>::Item> {
         let this = self.as_mut().project();
-        match welcome {
-            Ok(ProcessWelcomeResult::New {
-                group,
-                id: welcome_id,
-            }) => {
-                tracing::debug!(
-                    group_id = %group.group_id,
-                    "finished processing with group {}",
-                    hex::encode(group.group_id)
-                );
-                this.known_welcome_ids.insert(welcome_id);
-                Some(Ok(group))
-            }
-            // we are ignoring this payload with id
-            Ok(ProcessWelcomeResult::IgnoreId { id }) => {
-                tracing::debug!("ignoring streamed conversation payload with welcome id {id}");
-                this.known_welcome_ids.insert(id);
-                None
-            }
-            Ok(ProcessWelcomeResult::Ignore) => {
-                tracing::debug!("ignoring streamed conversation payload");
-                None
-            }
-            Ok(ProcessWelcomeResult::NewStored {
-                group,
-                maybe_sequence_id,
-                maybe_originator,
-            }) => {
-                tracing::debug!(
-                    group_id = %group.group_id,
-                    "finished processing with group {}",
-                    hex::encode(group.group_id)
-                );
-                if let Some(id) = maybe_sequence_id
-                    && let Some(originator) = maybe_originator
-                {
-                    this.known_welcome_ids
-                        .insert(Cursor::new(id as SequenceId, originator as OriginatorId));
-                }
-                Some(Ok(group))
-            }
-            Err(e) => Some(Err(e)),
+        let result = match welcome {
+            Ok(result) => result,
+            Err(e) => return Some(Err(e)),
+        };
+        // Interpretation (which group to surface, which cursor to record as seen) is
+        // shared with the bidi manager via `ProcessWelcomeResult::into_outcome`.
+        let outcome = result.into_outcome();
+        if let Some(seen) = outcome.seen {
+            this.known_welcome_ids.insert(seen);
         }
+        match (&outcome.group, outcome.seen) {
+            (Some(group), _) => tracing::debug!(
+                group_id = %group.group_id,
+                "finished processing with group {}",
+                hex::encode(group.group_id)
+            ),
+            (None, Some(id)) => {
+                tracing::debug!("ignoring streamed conversation payload with welcome id {id}")
+            }
+            (None, None) => tracing::debug!("ignoring streamed conversation payload"),
+        }
+        outcome.group.map(Ok)
     }
 }
 

--- a/crates/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -13,7 +13,7 @@ use xmtp_macro::log_event;
 
 use super::{
     Result, SubscribeError,
-    process_message::{ProcessFutureFactory, ProcessMessageFuture},
+    process_message::{Prepared, ProcessFutureFactory, ProcessMessageFuture, finish, prepare},
 };
 use crate::{
     context::XmtpSharedContext,
@@ -430,30 +430,39 @@ where
             cx.waker().wake_by_ref();
             return Poll::Pending;
         }
-        if let Some(stored) = self.factory.retrieve(&next_msg)? {
-            tracing::debug!(
-                "msg @cursor[{:?}] for group_id@[{}] is available locally",
-                next_msg.cursor,
-                next_msg.group_id
-            );
-            let this = self.as_mut().project();
-            this.groups.set(next_msg.group_id, next_msg.cursor);
-            return Poll::Ready(Some(Ok(stored)));
+        match prepare(&self.factory, next_msg)? {
+            Prepared::Ready {
+                message,
+                group_id,
+                cursor,
+            } => {
+                // Already stored locally — surface it without decrypting.
+                tracing::debug!(
+                    "msg @cursor[{:?}] for group_id@[{}] is available locally",
+                    cursor,
+                    hex::encode(group_id),
+                );
+                let this = self.as_mut().project();
+                this.groups.set(group_id.as_slice(), cursor);
+                Poll::Ready(Some(Ok(message)))
+            }
+            Prepared::NeedsProcessing(msg) => {
+                tracing::debug!(
+                    "group_id@[{}] encountered newly unprocessed message @cursor=[{}]",
+                    msg.group_id,
+                    msg.cursor
+                );
+                let msg_cursor = msg.cursor;
+                let future = self.factory.create(msg);
+                let mut this = self.as_mut().project();
+                this.state.set(State::Processing {
+                    future,
+                    message: msg_cursor,
+                });
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
         }
-        tracing::debug!(
-            "group_id@[{}] encountered newly unprocessed message @cursor=[{}]",
-            next_msg.group_id,
-            next_msg.cursor
-        );
-        let future = self.factory.create(next_msg.clone());
-        let msg_cursor = next_msg.cursor;
-        let mut this = self.as_mut().project();
-        this.state.set(State::Processing {
-            future,
-            message: msg_cursor,
-        });
-        cx.waker().wake_by_ref();
-        Poll::Pending
     }
 
     /// Add the group to the group list
@@ -537,10 +546,8 @@ where
         if let Processing { future, .. } = self.as_mut().project().state.project() {
             let processed = ready!(future.poll(cx))
                 .inspect_err(|_| self.as_mut().project().state.set(State::Waiting))?;
-            tracing::trace!(
-                "message @cursor=[{}] finished processing",
-                processed.tried_to_process
-            );
+            let processed = finish(processed);
+            tracing::trace!("message @cursor=[{}] finished processing", processed.tried);
             let this = self.as_mut().project();
             if let Some(msg) = processed.message {
                 this.returned.push(Cursor::new(
@@ -548,23 +555,23 @@ where
                     msg.originator_id as OriginatorId,
                 ));
                 self.as_mut()
-                    .set_cursor(msg.group_id.as_slice(), processed.next_message);
+                    .set_cursor(msg.group_id.as_slice(), processed.next_cursor);
                 tracing::trace!(
                     "returning new message for group=[{}] @cursor=[{:?}], total messages={}",
                     xmtp_common::fmt::debug_hex(msg.group_id.as_slice()),
-                    processed.tried_to_process,
+                    processed.tried,
                     self.returned.len()
                 );
                 self.as_mut().project().state.set(State::Waiting);
                 return Poll::Ready(Some(Ok(msg)));
             } else {
                 self.as_mut()
-                    .set_cursor(processed.group_id.as_slice(), processed.next_message);
+                    .set_cursor(processed.group_id.as_slice(), processed.next_cursor);
                 tracing::trace!(
                     "skipping message for group=[{}] @cursor=[{}], setting cursor to [{:?}]",
-                    xmtp_common::fmt::debug_hex(&processed.group_id),
-                    processed.tried_to_process,
-                    processed.next_message
+                    xmtp_common::fmt::debug_hex(processed.group_id),
+                    processed.tried,
+                    processed.next_cursor
                 );
                 self.as_mut().project().state.set(State::Waiting);
                 cx.waker().wake_by_ref();


### PR DESCRIPTION
## Summary

XIP-83 client-integration **Phase A**: extract the message/welcome decode pipeline out of the live-stream poll state-machines into standalone, reusable seams — then route the live streams through those same seams so there is exactly one implementation.

Two commits, best reviewed in order:

1. **`extract reusable message-processing pipeline from StreamGroupMessages`** — adds the seams:
   - `process_one(factory, msg) -> Processed`: DB fast-path (already-stored → forward without re-decrypting), else the full decrypt/store pass (incl. recovery sync). Dedup and cursor bookkeeping deliberately stay **caller-side** — the live stream tracks them per-stream (`GroupList`), while the upcoming XIP-83 multiplexing layer tracks them centrally (per-topic high-water marks).
   - `process_welcome_one(...) -> WelcomeOutcome` + `ProcessWelcomeResult::into_outcome()`: the welcome analog, lifted from `StreamConversations::filter_welcome`.
2. **`route live streams through the shared processing seams`** — proves the extraction is behavior-preserving:
   - `StreamGroupMessages::on_waiting`/`resolve_futures` now share the pipeline via sync `prepare`/`finish` halves (the poll state-machine can't `.await`), instead of duplicating the logic. Also drops a per-message clone on the decrypt path.
   - `filter_welcome` now interprets results via `into_outcome()`; ignore-path debug logs preserved.
   - `Prepared::Ready` carries the stored message **by value**, so a "fast-path hit without a message" state is unrepresentable.

Note for reviewers: `process_one` / `process_welcome_one` have **no non-test callers yet by design** — they are the seams the XIP-83 stream router (next phase) consumes. The live streams already exercise their internals via `prepare`/`finish`/`into_outcome`, so the shared halves are covered by every existing streaming test.

## Test plan

- New unit tests: `process_one` DB fast-path (asserts `create()` is never reached) and fast-path-miss pipeline run, via a `StubFactory`; `into_outcome` ignore/ignore-with-id mappings.
- Existing streaming integration tests cover the rewired live paths.
- `cargo clippy -p xmtp_mls --tests` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract shared message and welcome processing pipeline for XIP-83 Phase A
> - Adds `process_one` in [process_message.rs](https://github.com/xmtp/libxmtp/pull/3823/files#diff-c533e00eddfcecd8eb7fb1e7b5c8984143d191b48d28c44b8fea4dfbb06528d2) — a single-message async API that checks a DB fast-path via `prepare` and falls back to decrypt/store, returning a normalized `Processed` result.
> - Adds `process_welcome_one` and `WelcomeOutcome` in [process_welcome.rs](https://github.com/xmtp/libxmtp/pull/3823/files#diff-6a8fc2f2e683ba89ea325dab846f3caec443d5bbd3bd0b96f5e259300ff94296), giving callers a consistent welcome-processing result outside of stream poll machinery.
> - Refactors `StreamConversations.filter_welcome` and `MessageStream` in the stream files to delegate to the new shared `prepare`/`finish`/`into_outcome` helpers, removing duplicated inline logic.
> - Changes `group_id` field type from `Vec<u8>` to typed `GroupId` across `ProcessedMessage` and related structures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aaec92a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->