### PR TITLE
feat(xmtp_api_d14n): bidi silence watchdog + transport suspend/resume

### DIFF
--- a/crates/xmtp_api_d14n/src/queries/bidi.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi.rs
@@ -4,7 +4,10 @@
 //! bidi stream end-to-end and is the **sole writer** of the request half. It
 //! auto-answers server `Ping`s, correlates client liveness probes, multiplexes
 //! caller commands onto the wire, and surfaces only real subscription events —
-//! keepalive never reaches the consumer.
+//! keepalive never reaches the consumer. It also polices liveness on its own:
+//! a wire with no inbound frames for the silence budget gets one watchdog ping,
+//! and if that too goes unanswered the actor tears down — so a half-open link
+//! surfaces as end-of-events instead of a stream that hangs forever.
 //!
 //! Everything backend-specific (wire types, frame construction, and turning an
 //! inbound frame into consumer events — including d14n's `OriginatorEnvelope`
@@ -43,7 +46,15 @@ pub(crate) const DEFAULT_KEEPALIVE_MS: u32 = 30_000;
 /// is this many keepalive intervals — generous enough not to false-positive a
 /// slow-but-live link. Latency-sensitive callers (e.g. a notification handler)
 /// pass a much smaller bound to [`Connection::probe_within`].
+///
+/// It is also the actor's total silence budget: after `N - 1` intervals with no
+/// inbound frame the actor sends a watchdog ping, and after the full `N` it
+/// tears down (see [`watchdog_deadline`]).
 pub(crate) const PROBE_TIMEOUT_MULTIPLIER: u32 = 3;
+/// Nonce for the actor's own watchdog pings. Client probe nonces count up from
+/// 1, so they can never collide with this — and the watchdog doesn't correlate
+/// the pong anyway: *any* inbound frame proves the link and resets the window.
+const WATCHDOG_NONCE: u64 = u64::MAX;
 /// Hard cap on the outbound backlog. Past this, the wire has been wedged long
 /// enough that buffering more is pointless — the transport isn't draining the
 /// request half, so the link is effectively dead — and the actor gives up,
@@ -371,12 +382,16 @@ impl<B: BidiBinding> Connection<B> {
     }
 
     /// Next event, in wire order. `None` means the connection ended (server
-    /// close, network death, or reap) — resume from durable cursors on a fresh
-    /// connection.
+    /// close, network death, watchdog teardown, or reap) — resume from durable
+    /// cursors on a fresh connection.
     ///
-    /// Only resolves on an event or end-of-stream: a server that goes quiet
-    /// without closing (a half-open link) leaves this pending. Detect that gap
-    /// out of band with [`Self::probe`] plus a timeout, never by waiting here.
+    /// Only resolves on an event or end-of-stream, but a half-open link cannot
+    /// leave it pending forever: the actor's silence watchdog tears the
+    /// connection down after [`PROBE_TIMEOUT_MULTIPLIER`] keepalive intervals
+    /// with no inbound frame (one watchdog ping in between), and that teardown
+    /// surfaces here as `None`. [`Self::probe`] remains for callers that need
+    /// an answer *faster* than the watchdog budget — e.g. a notification
+    /// handler deciding within seconds whether to reuse the connection.
     pub async fn next(&mut self) -> Option<Event<B::GroupMessage, B::WelcomeMessage>> {
         let event = self.events.recv().await;
         // Record the server's cadence as `Started` passes through, so a probe
@@ -400,6 +415,24 @@ impl<B: BidiBinding> Drop for Connection<B> {
         // request and tearing the stream down in both directions.
         self.actor.end();
     }
+}
+
+/// When the silence watchdog next fires: after `N - 1` keepalive intervals
+/// without an inbound frame it probes, and a probed connection gets the one
+/// remaining interval — the full `N ×` budget of [`PROBE_TIMEOUT_MULTIPLIER`] —
+/// before teardown. Recomputed every `select!` iteration, so any inbound frame
+/// pushes both deadlines out.
+fn watchdog_deadline(
+    last_inbound: tokio::time::Instant,
+    keepalive: Duration,
+    probed: bool,
+) -> tokio::time::Instant {
+    let intervals = if probed {
+        PROBE_TIMEOUT_MULTIPLIER
+    } else {
+        PROBE_TIMEOUT_MULTIPLIER - 1
+    };
+    last_inbound + keepalive * intervals
 }
 
 /// Hand `frame` to the wire if it has room right now, else queue it for the
@@ -458,7 +491,10 @@ fn enqueue<R>(wire_out: &mpsc::Sender<R>, pending: &mut VecDeque<R>, frame: R) -
 /// (so `next` ends), and any outstanding probe acks (so pending `probe`s see
 /// `Closed`). One place, every teardown. It also gives up the same way if the
 /// outbound backlog blows past [`MAX_PENDING_FRAMES`] — a wedged wire that will
-/// never drain, so we tear down and let the consumer re-open.
+/// never drain, so we tear down and let the consumer re-open — or if the wire
+/// goes silent past the watchdog budget (see [`watchdog_deadline`]): a
+/// conformant server keeps pinging, so sustained silence, with one watchdog
+/// ping of grace, means a half-open link that will never speak again.
 async fn run_actor<B, S, E>(
     mut inbound: S,
     wire_out: mpsc::Sender<B::Request>,
@@ -480,6 +516,13 @@ async fn run_actor<B, S, E>(
     // rather than tear everything down. Distinguishes a deliberate half-close
     // from the wire/handle-gone breaks, which fall straight through to teardown.
     let mut finished = false;
+    // Silence-watchdog state. A conformant server pings at `keepalive` cadence,
+    // so a healthy wire always shows *some* inbound frame well inside the
+    // budget; sustained silence is a half-open link. The cadence starts at the
+    // XIP-83 fallback and updates when `Started` advertises the real one.
+    let mut keepalive = Duration::from_millis(DEFAULT_KEEPALIVE_MS.into());
+    let mut last_inbound = tokio::time::Instant::now();
+    let mut watchdog_probed = false;
 
     loop {
         tokio::select! {
@@ -576,10 +619,47 @@ async fn run_actor<B, S, E>(
                     // Consumer-facing frames. The same emit path feeds the live loop
                     // and the post-`finish` drain, so their event semantics match.
                     instruction => {
+                        // Adopt the server's advertised cadence for the watchdog as
+                        // `Started` passes through (0 keeps the fallback).
+                        if let Inbound::Emit(Event::Started {
+                            keepalive_interval_ms,
+                            ..
+                        }) = &instruction
+                            && *keepalive_interval_ms > 0
+                        {
+                            keepalive = Duration::from_millis((*keepalive_interval_ms).into());
+                        }
                         if emit_instruction(&events, instruction).await {
                             break;
                         }
                     }
+                }
+                // Stamp *after* the frame is fully handled, not on receipt: the
+                // emit above can park on consumer backpressure for a long time,
+                // and that stall is the consumer's, not the wire's — inbound
+                // frames may be sitting unread behind it. Restarting the window
+                // when we resume listening keeps a slow consumer from reading
+                // as wire silence and tearing down a healthy link.
+                last_inbound = tokio::time::Instant::now();
+                watchdog_probed = false;
+            }
+            // The silence watchdog. Fires only while the arms above are idle —
+            // exactly the "nothing inbound" condition it exists to detect. One
+            // unanswered ping stands between silence and teardown, so a quiet
+            // but live link (a server between keepalives) is never reaped: any
+            // inbound frame — the pong included — resets the window above.
+            _ = tokio::time::sleep_until(watchdog_deadline(last_inbound, keepalive, watchdog_probed)) => {
+                if watchdog_probed {
+                    tracing::warn!(
+                        silent_for_ms = last_inbound.elapsed().as_millis() as u64,
+                        "bidi wire silent past the watchdog budget (probe unanswered); \
+                         tearing down so the consumer re-opens from cursors"
+                    );
+                    break;
+                }
+                watchdog_probed = true;
+                if !enqueue(&wire_out, &mut pending, B::ping_frame(WATCHDOG_NONCE)) {
+                    break;
                 }
             }
         }
@@ -816,6 +896,186 @@ mod tests {
             wire_rx.recv().await,
             None,
             "the request half must close even when the flush budget expires"
+        );
+    }
+
+    /// Binding for the watchdog tests. A frame under `100_000` is a `Started`
+    /// advertising that many milliseconds of keepalive — so each test picks a
+    /// cadence fast enough to run in real time. [`MSG_FRAME`] delivers one
+    /// group message (to park the actor on consumer backpressure); anything
+    /// else is a no-op frame that still counts as inbound activity.
+    struct WatchdogBinding;
+    const MSG_FRAME: u64 = 1_000_000;
+    const ACTIVITY_FRAME: u64 = 2_000_000;
+    /// Generous ceiling for CI scheduling noise; every wait in these tests
+    /// resolves in well under a second on a healthy run.
+    const WAIT: Duration = Duration::from_secs(5);
+
+    impl BidiBinding for WatchdogBinding {
+        type Request = u64;
+        type Response = u64;
+        type Mutate = u64;
+        type GroupMessage = ();
+        type WelcomeMessage = ();
+
+        fn mutate_frame(mutate: u64) -> u64 {
+            mutate
+        }
+        fn ping_frame(nonce: u64) -> u64 {
+            nonce
+        }
+        fn pong_frame(nonce: u64) -> u64 {
+            nonce
+        }
+        fn handle(response: u64) -> Inbound<(), ()> {
+            match response {
+                ms if ms < 100_000 => Inbound::Emit(Event::Started {
+                    keepalive_interval_ms: ms as u32,
+                    capabilities: vec![],
+                }),
+                MSG_FRAME => Inbound::Messages {
+                    group: vec![()],
+                    welcome: vec![],
+                },
+                _ => Inbound::Skip,
+            }
+        }
+    }
+
+    struct ActorHarness {
+        inbound: mpsc::Sender<Result<u64, BidiError>>,
+        wire: mpsc::Receiver<u64>,
+        events: mpsc::Receiver<Event<(), ()>>,
+        _commands: mpsc::Sender<Command<WatchdogBinding>>,
+    }
+
+    /// Spawn `run_actor` over harness-controlled channels, mirroring
+    /// [`Connection::start`]'s wiring (`poll_fn` stream + `Box::pin`).
+    fn spawn_actor() -> ActorHarness {
+        let (inbound_tx, mut inbound_rx) = mpsc::channel::<Result<u64, BidiError>>(2048);
+        let (wire_out, wire_rx) = mpsc::channel::<u64>(WIRE_BUFFER);
+        let (commands_tx, commands_rx) = mpsc::channel::<Command<WatchdogBinding>>(COMMAND_BUFFER);
+        let (events_tx, events_rx) = mpsc::channel::<Event<(), ()>>(EVENT_BUFFER);
+        let inbound = futures::stream::poll_fn(move |cx| inbound_rx.poll_recv(cx));
+        xmtp_common::spawn(
+            None,
+            run_actor::<WatchdogBinding, _, _>(Box::pin(inbound), wire_out, commands_rx, events_tx),
+        );
+        ActorHarness {
+            inbound: inbound_tx,
+            wire: wire_rx,
+            events: events_rx,
+            _commands: commands_tx,
+        }
+    }
+
+    /// Total silence earns exactly one watchdog ping, then teardown: the
+    /// half-open link surfaces as end-of-events instead of hanging forever.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn watchdog_probes_then_tears_down_a_silent_wire() {
+        let mut actor = spawn_actor();
+        actor.inbound.send(Ok(150)).await?; // Started: 150ms keepalive
+        assert!(matches!(
+            tokio::time::timeout(WAIT, actor.events.recv()).await?,
+            Some(Event::Started { .. })
+        ));
+
+        let ping = tokio::time::timeout(WAIT, actor.wire.recv()).await?;
+        assert_eq!(
+            ping,
+            Some(WATCHDOG_NONCE),
+            "the watchdog must probe before giving up"
+        );
+        assert_eq!(
+            tokio::time::timeout(WAIT, actor.events.recv()).await?,
+            None,
+            "an unanswered watchdog ping must tear the connection down"
+        );
+    }
+
+    /// A quiet-but-live link is never reaped: any inbound frame — a pong or
+    /// otherwise — answers the watchdog ping and resets the window.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn an_answered_watchdog_probe_keeps_the_wire_alive() {
+        let mut actor = spawn_actor();
+        actor.inbound.send(Ok(150)).await?;
+        tokio::time::timeout(WAIT, actor.events.recv()).await?;
+
+        // Ride out three whole silence windows, answering each probe.
+        for _ in 0..3 {
+            let ping = tokio::time::timeout(WAIT, actor.wire.recv()).await?;
+            assert_eq!(ping, Some(WATCHDOG_NONCE));
+            actor.inbound.send(Ok(ACTIVITY_FRAME)).await?;
+        }
+        assert!(
+            matches!(
+                actor.events.try_recv(),
+                Err(mpsc::error::TryRecvError::Empty)
+            ),
+            "an answered probe must keep the connection alive"
+        );
+
+        // Stop answering: the next unanswered ping tears it down.
+        assert_eq!(tokio::time::timeout(WAIT, actor.events.recv()).await?, None);
+    }
+
+    /// A steady trickle of frames well inside the probe threshold never
+    /// triggers a probe at all.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn inbound_activity_resets_the_watchdog() {
+        let mut actor = spawn_actor();
+        actor.inbound.send(Ok(200)).await?; // probe would fire at 400ms silent
+        tokio::time::timeout(WAIT, actor.events.recv()).await?;
+
+        for _ in 0..20 {
+            actor.inbound.send(Ok(ACTIVITY_FRAME)).await?;
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            matches!(actor.wire.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+            "no watchdog ping may fire while frames keep arriving"
+        );
+        assert!(matches!(
+            actor.events.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    /// Consumer backpressure must not read as wire silence: while the actor is
+    /// parked emitting into a full event channel, inbound frames sit unread
+    /// behind it — the stall is the consumer's, not the wire's. The silence
+    /// window restarts when the actor resumes listening, so a slow consumer
+    /// never gets a healthy link torn down.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn consumer_backpressure_is_not_wire_silence() {
+        let mut actor = spawn_actor();
+        actor.inbound.send(Ok(200)).await?; // probe at 400ms, teardown at 600ms
+        tokio::time::timeout(WAIT, actor.events.recv()).await?;
+
+        // Fill the event buffer plus one: the actor parks mid-emit.
+        for _ in 0..(EVENT_BUFFER + 1) {
+            actor.inbound.send(Ok(MSG_FRAME)).await?;
+        }
+        // Hold the park well past the full teardown budget, draining nothing.
+        tokio::time::sleep(Duration::from_millis(800)).await;
+
+        // Drain; the actor unparks with a fresh silence window. If the park
+        // had counted as silence, both watchdog deadlines are long past and
+        // teardown would be immediate.
+        let mut delivered = 0;
+        while delivered < EVENT_BUFFER + 1 {
+            match tokio::time::timeout(WAIT, actor.events.recv()).await? {
+                Some(Event::GroupMessages(_)) => delivered += 1,
+                other => panic!("unexpected event while draining: {other:?}"),
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            matches!(
+                actor.events.try_recv(),
+                Err(mpsc::error::TryRecvError::Empty)
+            ),
+            "a consumer stall must not be read as wire silence"
         );
     }
 }

--- a/crates/xmtp_api_d14n/src/queries/bidi.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi.rs
@@ -51,10 +51,23 @@ pub(crate) const DEFAULT_KEEPALIVE_MS: u32 = 30_000;
 /// inbound frame the actor sends a watchdog ping, and after the full `N` it
 /// tears down (see [`watchdog_deadline`]).
 pub(crate) const PROBE_TIMEOUT_MULTIPLIER: u32 = 3;
-/// Nonce for the actor's own watchdog pings. Client probe nonces count up from
-/// 1, so they can never collide with this — and the watchdog doesn't correlate
-/// the pong anyway: *any* inbound frame proves the link and resets the window.
+/// Nonce for the actor's own watchdog pings. Client probes mint their nonces
+/// via [`next_probe_nonce`], which skips this value, so they can never collide
+/// with it — and the watchdog doesn't correlate the pong anyway: *any* inbound
+/// frame proves the link and resets the window.
 const WATCHDOG_NONCE: u64 = u64::MAX;
+
+/// Mint a client probe nonce: counts up from 1, skipping `0` and the reserved
+/// [`WATCHDOG_NONCE`] when the counter wraps. The loop settles within three
+/// steps — there are only two reserved values.
+fn next_probe_nonce(counter: &AtomicU64) -> u64 {
+    loop {
+        let nonce = counter.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+        if nonce != WATCHDOG_NONCE && nonce != 0 {
+            return nonce;
+        }
+    }
+}
 /// Hard cap on the outbound backlog. Past this, the wire has been wedged long
 /// enough that buffering more is pointless — the transport isn't draining the
 /// request half, so the link is effectively dead — and the actor gives up,
@@ -361,10 +374,7 @@ impl<B: BidiBinding> Connection<B> {
         if self.finished.load(Ordering::Acquire) {
             return Err(BidiError::Closed);
         }
-        let nonce = self
-            .probe_nonce
-            .fetch_add(1, Ordering::Relaxed)
-            .wrapping_add(1);
+        let nonce = next_probe_nonce(&self.probe_nonce);
         let (ack, ack_rx) = oneshot::channel();
         self.commands
             .send(Command::Probe { nonce, ack })
@@ -832,6 +842,15 @@ mod tests {
         fn handle(_response: u64) -> Inbound<(), ()> {
             Inbound::Skip
         }
+    }
+
+    /// Probe nonces skip the reserved values across the wrap: the counter
+    /// steps over [`WATCHDOG_NONCE`] and `0`, then resumes counting from 1.
+    #[xmtp_common::test]
+    fn probe_nonces_never_mint_the_watchdog_nonce() {
+        let counter = AtomicU64::new(u64::MAX - 2);
+        let minted: Vec<u64> = (0..4).map(|_| next_probe_nonce(&counter)).collect();
+        assert_eq!(minted, vec![u64::MAX - 1, 1, 2, 3]);
     }
 
     /// `finish` is a half-close, not an abort: frames the caller already had

--- a/crates/xmtp_api_d14n/src/queries/bidi.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi.rs
@@ -536,6 +536,13 @@ async fn run_actor<B, S, E>(
 
     loop {
         tokio::select! {
+            // Polled in order, so teardown is truly last-resort: the watchdog
+            // arm at the bottom is only reached when no flush, command, or
+            // inbound frame is ready — a pong landing in the same poll as the
+            // deadline always wins the tie and restamps the window. (A command
+            // flood can starve the deadline check, but a silent wire under a
+            // command flood hits `enqueue`'s give-up cap and tears down there.)
+            biased;
             // Hand one queued frame to the wire the moment it has capacity,
             // concurrently with everything else. This is what keeps a busy wire
             // from blocking the loop. Gated on a non-empty queue so we only
@@ -653,8 +660,9 @@ async fn run_actor<B, S, E>(
                 last_inbound = tokio::time::Instant::now();
                 watchdog_probed = false;
             }
-            // The silence watchdog. Fires only while the arms above are idle —
-            // exactly the "nothing inbound" condition it exists to detect. One
+            // The silence watchdog. Fires only while the arms above are idle
+            // (enforced by `biased`) — exactly the "nothing inbound" condition
+            // it exists to detect. One
             // unanswered ping stands between silence and teardown, so a quiet
             // but live link (a server between keepalives) is never reaped: any
             // inbound frame — the pong included — resets the window above.

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -978,6 +978,11 @@ async fn run_ledger<B: TransportBinding>(
                 settle_idle_waiters(&mut ledger, &mut resume_notify);
             }
             Step::Cmd(Some(Cmd::Suspend { reply })) => {
+                tracing::info!(
+                    leases = ledger.leases.len(),
+                    had_wire = conn.is_some(),
+                    "bidi transport: suspending — going off the network"
+                );
                 suspended = true;
                 outbox.clear();
                 if let Some(wire) = conn.take() {
@@ -994,6 +999,10 @@ async fn run_ledger<B: TransportBinding>(
                 let _ = reply.send(());
             }
             Step::Cmd(Some(Cmd::Resume { reply })) => {
+                tracing::info!(
+                    leases = ledger.leases.len(),
+                    "bidi transport: resuming — catch up, then done"
+                );
                 suspended = false;
                 if let Some(notify) =
                     ledger
@@ -2190,6 +2199,43 @@ mod tests {
             }
             _ => panic!("the lease must survive suspend/resume invisibly"),
         }
+    }
+
+    /// Two concurrent `resume()` callers join the same in-flight catch-up:
+    /// one wire, one resume wave, and both resolve at its `CatchUpComplete`.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn concurrent_resumes_join_one_catch_up_wave() {
+        let (transport, servers) = transport();
+        let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        server.send(catchup_complete(first.mutate_id));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+
+        transport.suspend().await?;
+        server.request_stream_ended().await;
+
+        let resume_a = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+        let resume_b = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+
+        let mut second = wait_for_server(&servers).await;
+        let resume = second.next_mutate().await;
+        second.send(catchup_complete(resume.mutate_id));
+        tokio::time::timeout(WAIT, resume_a).await?.unwrap()?;
+        tokio::time::timeout(WAIT, resume_b).await?.unwrap()?;
+        assert!(
+            servers.lock().unwrap().is_empty(),
+            "the second resume must join the wave, not dial a second wire"
+        );
     }
 
     /// While suspended the transport stays off the network — no reconnect

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -827,7 +827,7 @@ where
 /// only runs when there is no wire, hence no events to drain).
 async fn run_ledger<B: TransportBinding>(
     opener: Opener<B>,
-    mut cmds: mpsc::UnboundedReceiver<Cmd<B>>,
+    cmds: mpsc::UnboundedReceiver<Cmd<B>>,
     // For minting lease handles. Weak, so the task's own copy never keeps the
     // command channel (and therefore itself) alive.
     lease_cmds: mpsc::WeakUnboundedSender<Cmd<B>>,
@@ -835,263 +835,475 @@ async fn run_ledger<B: TransportBinding>(
     B::GroupMessage: Clone,
     B::WelcomeMessage: Clone,
 {
-    let mut ledger = Ledger::<B>::default();
-    let mut conn: Option<Connection<B>> = None;
-    let mut reconnect_delay = RECONNECT_INITIAL_DELAY;
-    // When the next reconnect attempt is due. A fixed deadline, set when the
-    // wire dies and pushed out only by a failed attempt — recreating the
-    // sleep from `reconnect_delay` each loop iteration would let a steady
-    // stream of commands postpone the reconnect forever.
-    let mut reconnect_at = tokio::time::Instant::now();
-    // `suspend()`ed: the wire stays down on purpose — no lazy open for new
-    // leases, no reconnect backoff — until `resume()` clears it.
-    let mut suspended = false;
-    // `resume()` callers awaiting a resume wave that hasn't been sent yet
-    // (the open failed, or hasn't happened). [`reopen`] moves them onto the
-    // wave it sends; until then they park here across backoff retries.
-    let mut resume_notify: Vec<oneshot::Sender<()>> = Vec::new();
-    // Waves accepted but not yet on the wire, in issue order. Invariant:
-    // non-empty only while `conn` is `Some` — cleared on every wire close
-    // (stale waves are meaningless to a fresh wire; the resume wave re-seeds).
-    let mut outbox: Outbox<B::Mutate> = Outbox::default();
-    // Commands absorbed while a dial was in flight (see [`open_preemptibly`]),
-    // replayed in order before the channel is read again.
-    let mut deferred: std::collections::VecDeque<Cmd<B>> = std::collections::VecDeque::new();
+    LedgerTask {
+        opener,
+        cmds,
+        lease_cmds,
+        ledger: Ledger::default(),
+        conn: None,
+        reconnect_delay: RECONNECT_INITIAL_DELAY,
+        reconnect_at: tokio::time::Instant::now(),
+        suspended: false,
+        resume_notify: Vec::new(),
+        outbox: Outbox::default(),
+        deferred: std::collections::VecDeque::new(),
+    }
+    .run()
+    .await
+}
 
-    loop {
-        // Opportunistic flush: capacity frees when the actor makes progress,
-        // and the actor's progress is what wakes this loop.
-        if let Some(wire) = conn.as_ref() {
-            flush_outbox(wire, &mut outbox);
-        }
+/// How the ledger loop proceeds after handling a [`Step`].
+enum Flow {
+    Continue,
+    /// Every handle and lease is gone — the task ends.
+    Shutdown,
+}
 
-        let step = if let Some(cmd) = deferred.pop_front() {
-            Step::Cmd(Some(cmd))
-        } else {
-            match conn.as_mut() {
-                Some(wire) => tokio::select! {
-                    cmd = cmds.recv() => Step::Cmd(cmd),
-                    event = wire.next() => Step::Wire(event),
-                    // Backstop for the rare quiet-wire case: the command buffer
-                    // was momentarily full and no event arrives to wake us.
-                    _ = tokio::time::sleep(OUTBOX_RETRY_INTERVAL), if !outbox.is_empty() => Step::Retry,
-                },
-                // A dead wire with live leases reconnects once the backoff
-                // elapses, still absorbing commands meanwhile (which must not
-                // move the deadline) — unless suspended, where staying off the
-                // network is the whole point.
-                None if !ledger.leases.is_empty() && !suspended => tokio::select! {
-                    cmd = cmds.recv() => Step::Cmd(cmd),
-                    _ = tokio::time::sleep_until(reconnect_at) => Step::Reconnect,
-                },
-                // No wire and either nothing leased or suspended: dormant until
-                // the next command.
-                None => Step::Cmd(cmds.recv().await),
-            }
-        };
+/// The ledger task's working state. Each [`Step`] the loop wakes up for is
+/// handled by the same-named method; [`LedgerTask::run`] itself is only the
+/// select-and-dispatch skeleton.
+struct LedgerTask<B: TransportBinding>
+where
+    B::GroupMessage: Clone,
+    B::WelcomeMessage: Clone,
+{
+    opener: Opener<B>,
+    cmds: mpsc::UnboundedReceiver<Cmd<B>>,
+    /// For minting lease handles. Weak, so the task's own copy never keeps
+    /// the command channel (and therefore itself) alive.
+    lease_cmds: mpsc::WeakUnboundedSender<Cmd<B>>,
+    ledger: Ledger<B>,
+    conn: Option<Connection<B>>,
+    reconnect_delay: std::time::Duration,
+    /// When the next reconnect attempt is due. A fixed deadline, set when the
+    /// wire dies and pushed out only by a failed attempt — recreating the
+    /// sleep from `reconnect_delay` each loop iteration would let a steady
+    /// stream of commands postpone the reconnect forever.
+    reconnect_at: tokio::time::Instant,
+    /// `suspend()`ed: the wire stays down on purpose — no lazy open for new
+    /// leases, no reconnect backoff — until `resume()` clears it.
+    suspended: bool,
+    /// `resume()` callers awaiting a resume wave that hasn't been sent yet
+    /// (the open failed, or hasn't happened). [`Self::reopen`] moves them
+    /// onto the wave it sends; until then they park here across backoff
+    /// retries.
+    resume_notify: Vec<oneshot::Sender<()>>,
+    /// Waves accepted but not yet on the wire, in issue order. Invariant:
+    /// non-empty only while `conn` is `Some` — cleared on every wire close
+    /// (stale waves are meaningless to a fresh wire; the resume wave
+    /// re-seeds).
+    outbox: Outbox<B::Mutate>,
+    /// Commands absorbed while a dial was in flight (see
+    /// [`Self::open_preemptibly`]), replayed in order before the channel is
+    /// read again.
+    deferred: std::collections::VecDeque<Cmd<B>>,
+}
 
-        match step {
-            // Loop back to the flush at the top.
-            Step::Retry => {}
-            // Every handle and lease is gone — close up shop.
-            Step::Cmd(None) => {
-                outbox.clear();
-                if let Some(wire) = conn.take() {
-                    close_gracefully(wire);
+impl<B: TransportBinding> LedgerTask<B>
+where
+    B::GroupMessage: Clone,
+    B::WelcomeMessage: Clone,
+{
+    async fn run(mut self) {
+        loop {
+            // Opportunistic flush: capacity frees when the actor makes
+            // progress, and the actor's progress is what wakes this loop.
+            self.flush_outbox();
+            let flow = match self.next_step().await {
+                // Loop back to the flush at the top.
+                Step::Retry => Flow::Continue,
+                Step::Cmd(None) => self.shutdown(),
+                Step::Cmd(Some(Cmd::Lease { subs, depth, reply })) => {
+                    self.lease(subs, depth, reply).await
                 }
+                Step::Cmd(Some(Cmd::Deref(id))) => self.deref(id),
+                Step::Cmd(Some(Cmd::Suspend { reply })) => self.suspend(reply),
+                Step::Cmd(Some(Cmd::Resume { reply })) => self.resume(reply).await,
+                Step::Wire(Some(event)) => self.wire_event(event),
+                Step::Wire(None) => self.wire_died(),
+                Step::Reconnect => self.reconnect().await,
+            };
+            if let Flow::Shutdown = flow {
                 return;
             }
-            Step::Cmd(Some(Cmd::Lease { subs, depth, reply })) => {
-                let wave = ledger.next_wave_id();
-                let topics: Vec<Topic> = subs.iter().map(|(topic, _)| topic.clone()).collect();
-                let floors: HashMap<Topic, B::Cursor> = subs
-                    .iter()
-                    .map(|(topic, cursor)| (topic.clone(), *cursor))
-                    .collect();
-                let mutate = B::build_mutate(subs, None, wave.0);
-                let mut queued = None;
-                if conn.is_none() && ledger.leases.is_empty() && !suspended {
-                    // Cold open, seeded with this lease's adds. The dial is
-                    // preemptible: commands keep flowing while it runs, and a
-                    // Suspend drops it. The failure is this caller's to see —
-                    // nobody else is waiting on the wire.
-                    match open_preemptibly(&opener, mutate, &mut cmds, &mut deferred).await {
-                        OpenOutcome::Opened(wire) => {
-                            conn = Some(wire);
-                            reconnect_delay = RECONNECT_INITIAL_DELAY;
-                        }
-                        OpenOutcome::Failed(e) => {
-                            let _ = reply.send(Err(TransportError::Open(e)));
-                            continue;
-                        }
-                        OpenOutcome::Suspended(ack) => {
-                            // The dial is gone; the lease still registers
-                            // below and rides the resume open, exactly like
-                            // any lease taken while suspended.
-                            suspended = true;
-                            park_deferred_resumes(&mut deferred, &mut resume_notify);
-                            let _ = ack.send(());
-                        }
-                        OpenOutcome::Shutdown => return,
-                    }
-                } else if conn.is_some() {
-                    queued = Some(mutate);
-                }
-                // else: the wire is down (mid-backoff or suspended) — the
-                // next resume wave (reconnect arm or `resume()`) covers this
-                // lease too, so its mutate is deliberately dropped here.
+        }
+    }
 
-                // Registered for routing immediately, NOT at CatchUpComplete:
-                // the lease's own replay arrives *before* its CatchUpComplete
-                // and must reach it. That in-flight deliveries for an
-                // already-live topic also land right away is the documented
-                // non-monotonic delivery contract (see module docs) —
-                // consumers identity-dedup until they are caught up.
-                let (tx, events) = mpsc::channel(depth.max(1));
-                let id = ledger.register(topics.clone(), floors, tx);
-                ledger.pending_waves.insert(wave, WaveOwner::Lease(id));
-                if let Some(mutate) = queued {
-                    // Tagged with the lease so a deref can purge it if it never
-                    // reaches the wire.
-                    outbox.push(Some(id), mutate);
+    /// What this iteration wakes up for: a command deferred during a dial
+    /// first, then whatever the wire state makes relevant.
+    async fn next_step(&mut self) -> Step<B> {
+        if let Some(cmd) = self.deferred.pop_front() {
+            return Step::Cmd(Some(cmd));
+        }
+        match self.conn.as_mut() {
+            Some(wire) => tokio::select! {
+                cmd = self.cmds.recv() => Step::Cmd(cmd),
+                event = wire.next() => Step::Wire(event),
+                // Backstop for the rare quiet-wire case: the command buffer
+                // was momentarily full and no event arrives to wake us.
+                _ = tokio::time::sleep(OUTBOX_RETRY_INTERVAL), if !self.outbox.is_empty() => Step::Retry,
+            },
+            // A dead wire with live leases reconnects once the backoff
+            // elapses, still absorbing commands meanwhile (which must not
+            // move the deadline) — unless suspended, where staying off the
+            // network is the whole point.
+            None if !self.ledger.leases.is_empty() && !self.suspended => tokio::select! {
+                cmd = self.cmds.recv() => Step::Cmd(cmd),
+                _ = tokio::time::sleep_until(self.reconnect_at) => Step::Reconnect,
+            },
+            // No wire and either nothing leased or suspended: dormant until
+            // the next command.
+            None => Step::Cmd(self.cmds.recv().await),
+        }
+    }
+
+    /// Every handle and lease is gone — close up shop.
+    fn shutdown(&mut self) -> Flow {
+        self.outbox.clear();
+        if let Some(wire) = self.conn.take() {
+            close_gracefully(wire);
+        }
+        Flow::Shutdown
+    }
+
+    /// `Cmd::Lease`: open the wire if this lease is the reason to have one,
+    /// send a cursored (re-)add otherwise, and register the lease for
+    /// routing.
+    async fn lease(
+        &mut self,
+        subs: Vec<(Topic, B::Cursor)>,
+        depth: usize,
+        reply: oneshot::Sender<Result<TopicLease<B>, TransportError>>,
+    ) -> Flow {
+        let wave = self.ledger.next_wave_id();
+        let topics: Vec<Topic> = subs.iter().map(|(topic, _)| topic.clone()).collect();
+        let floors: HashMap<Topic, B::Cursor> = subs
+            .iter()
+            .map(|(topic, cursor)| (topic.clone(), *cursor))
+            .collect();
+        let mutate = B::build_mutate(subs, None, wave.0);
+        let mut queued = None;
+        if self.conn.is_none() && self.ledger.leases.is_empty() && !self.suspended {
+            // Cold open, seeded with this lease's adds. The dial is
+            // preemptible: commands keep flowing while it runs, and a
+            // Suspend drops it. The failure is this caller's to see —
+            // nobody else is waiting on the wire.
+            match self.open_preemptibly(mutate).await {
+                OpenOutcome::Opened(wire) => {
+                    self.conn = Some(wire);
+                    self.reconnect_delay = RECONNECT_INITIAL_DELAY;
                 }
-                let Some(cmds) = lease_cmds.upgrade() else {
-                    // Command channel fully closed while we were opening; the
-                    // loop will see `None` next and shut down.
-                    continue;
-                };
-                let _ = reply.send(Ok(TopicLease {
-                    id,
-                    topics,
-                    events,
-                    cmds,
-                }));
-            }
-            Step::Cmd(Some(Cmd::Deref(id))) => {
-                // A wave the dropped lease never got onto the wire must not be
-                // sent late: it would replay its topics from a cursor nobody
-                // asked for anymore (siblings would receive unrequested
-                // backlog, and the wave's completion would route to nobody).
-                outbox.purge(id);
-                let removes = ledger.deref(id);
-                retire(&mut conn, &mut ledger, &mut outbox, removes);
-                settle_idle_waiters(&mut ledger, &mut resume_notify);
-            }
-            Step::Cmd(Some(Cmd::Suspend { reply })) => {
-                tracing::info!(
-                    leases = ledger.leases.len(),
-                    had_wire = conn.is_some(),
-                    "bidi transport: suspending — going off the network"
-                );
-                suspended = true;
-                outbox.clear();
-                if let Some(wire) = conn.take() {
-                    // Detached on purpose: acknowledging must not await the
-                    // wire's bounded command channel (deadlock discipline
-                    // above), and the drain is bounded and discard-only —
-                    // releasing the wire, not finishing its funeral, is what
-                    // "suspended" means.
-                    close_gracefully(wire);
+                OpenOutcome::Failed(e) => {
+                    let _ = reply.send(Err(TransportError::Open(e)));
+                    return Flow::Continue;
                 }
-                // Pending waves stay: their leases are still owed a
-                // CatchUpComplete, and `reopen` re-homes those obligations
-                // (and any parked resume() waiters) onto the resume wave.
-                let _ = reply.send(());
+                OpenOutcome::Suspended(ack) => {
+                    // The dial is gone; the lease still registers below and
+                    // rides the resume open, exactly like any lease taken
+                    // while suspended.
+                    self.suspend_preempted(ack);
+                }
+                OpenOutcome::Shutdown => return Flow::Shutdown,
             }
-            Step::Cmd(Some(Cmd::Resume { reply })) => {
-                tracing::info!(
-                    leases = ledger.leases.len(),
-                    "bidi transport: resuming — catch up, then done"
-                );
-                suspended = false;
-                if let Some(notify) =
-                    ledger
-                        .pending_waves
-                        .values_mut()
-                        .find_map(|owner| match owner {
-                            WaveOwner::Resume { notify, .. } => Some(notify),
-                            WaveOwner::Lease(_) => None,
-                        })
-                {
-                    // A resume catch-up is already in flight — join it rather
-                    // than race it. If its wire has died meanwhile, hasten the
-                    // reconnect that will re-home this waiter.
-                    notify.push(reply);
-                    if conn.is_none() {
-                        reconnect_delay = RECONNECT_INITIAL_DELAY;
-                        reconnect_at = tokio::time::Instant::now();
+        } else if self.conn.is_some() {
+            queued = Some(mutate);
+        }
+        // else: the wire is down (mid-backoff or suspended) — the next
+        // resume wave (reconnect arm or `resume()`) covers this lease too,
+        // so its mutate is deliberately dropped here.
+
+        // Registered for routing immediately, NOT at CatchUpComplete: the
+        // lease's own replay arrives *before* its CatchUpComplete and must
+        // reach it. That in-flight deliveries for an already-live topic also
+        // land right away is the documented non-monotonic delivery contract
+        // (see module docs) — consumers identity-dedup until they are caught
+        // up.
+        let (tx, events) = mpsc::channel(depth.max(1));
+        let id = self.ledger.register(topics.clone(), floors, tx);
+        self.ledger.pending_waves.insert(wave, WaveOwner::Lease(id));
+        if let Some(mutate) = queued {
+            // Tagged with the lease so a deref can purge it if it never
+            // reaches the wire.
+            self.outbox.push(Some(id), mutate);
+        }
+        let Some(cmds) = self.lease_cmds.upgrade() else {
+            // Command channel fully closed while we were opening; the loop
+            // will see `None` next and shut down.
+            return Flow::Continue;
+        };
+        let _ = reply.send(Ok(TopicLease {
+            id,
+            topics,
+            events,
+            cmds,
+        }));
+        Flow::Continue
+    }
+
+    /// `Cmd::Deref`: a lease handle dropped.
+    fn deref(&mut self, id: LeaseId) -> Flow {
+        // A wave the dropped lease never got onto the wire must not be sent
+        // late: it would replay its topics from a cursor nobody asked for
+        // anymore (siblings would receive unrequested backlog, and the
+        // wave's completion would route to nobody).
+        self.outbox.purge(id);
+        let removes = self.ledger.deref(id);
+        self.retire(removes);
+        self.settle_idle_waiters();
+        Flow::Continue
+    }
+
+    /// `Cmd::Suspend`: release the wire and stay off the network until
+    /// `resume()`.
+    fn suspend(&mut self, reply: oneshot::Sender<()>) -> Flow {
+        tracing::info!(
+            leases = self.ledger.leases.len(),
+            had_wire = self.conn.is_some(),
+            "bidi transport: suspending — going off the network"
+        );
+        self.suspended = true;
+        self.outbox.clear();
+        if let Some(wire) = self.conn.take() {
+            // Detached on purpose: acknowledging must not await the wire's
+            // bounded command channel (deadlock discipline above), and the
+            // drain is bounded and discard-only — releasing the wire, not
+            // finishing its funeral, is what "suspended" means.
+            close_gracefully(wire);
+        }
+        // Pending waves stay: their leases are still owed a CatchUpComplete,
+        // and `reopen` re-homes those obligations (and any parked resume()
+        // waiters) onto the resume wave.
+        let _ = reply.send(());
+        Flow::Continue
+    }
+
+    /// `Cmd::Resume`: back onto the network; the reply resolves once the
+    /// resume wave's catch-up completes ("catch up, then done").
+    async fn resume(&mut self, reply: oneshot::Sender<()>) -> Flow {
+        tracing::info!(
+            leases = self.ledger.leases.len(),
+            "bidi transport: resuming — catch up, then done"
+        );
+        self.suspended = false;
+        if let Some(notify) = self
+            .ledger
+            .pending_waves
+            .values_mut()
+            .find_map(|owner| match owner {
+                WaveOwner::Resume { notify, .. } => Some(notify),
+                WaveOwner::Lease(_) => None,
+            })
+        {
+            // A resume catch-up is already in flight — join it rather than
+            // race it. If its wire has died meanwhile, hasten the reconnect
+            // that will re-home this waiter.
+            notify.push(reply);
+            if self.conn.is_none() {
+                self.reconnect_delay = RECONNECT_INITIAL_DELAY;
+                self.reconnect_at = tokio::time::Instant::now();
+            }
+            Flow::Continue
+        } else if self.conn.is_some() || self.ledger.leases.is_empty() {
+            // A live wire (or nothing leased) has nothing to catch up.
+            let _ = reply.send(());
+            Flow::Continue
+        } else {
+            self.resume_notify.push(reply);
+            self.reconnect_delay = RECONNECT_INITIAL_DELAY;
+            self.reconnect().await
+        }
+    }
+
+    /// A wire event: route it, and drop any lease that failed delivery.
+    fn wire_event(&mut self, event: Event<B::GroupMessage, B::WelcomeMessage>) -> Flow {
+        let mut removes = Vec::new();
+        for lease in self.ledger.route(event) {
+            removes.extend(self.ledger.deref(lease));
+        }
+        self.retire(removes);
+        self.settle_idle_waiters();
+        Flow::Continue
+    }
+
+    /// The wire ended (server close or transport failure). Leases survive:
+    /// the dead-wire select arm reconnects with a resume wave (module docs)
+    /// — no stream ever observes the flap.
+    fn wire_died(&mut self) -> Flow {
+        self.outbox.clear();
+        drop(self.conn.take());
+        self.reconnect_at = tokio::time::Instant::now() + self.reconnect_delay;
+        if !self.ledger.leases.is_empty() {
+            tracing::warn!("bidi transport: wire died; reconnecting from last-seen positions");
+        }
+        self.settle_idle_waiters();
+        Flow::Continue
+    }
+
+    /// One reconnect attempt, absorbing every [`reopen`](Self::reopen)
+    /// outcome: a dial-preempting suspend re-suspends, shutdown propagates.
+    async fn reconnect(&mut self) -> Flow {
+        match self.reopen().await {
+            AfterReopen::Proceed => Flow::Continue,
+            AfterReopen::Suspended(ack) => {
+                self.suspend_preempted(ack);
+                Flow::Continue
+            }
+            AfterReopen::Shutdown => Flow::Shutdown,
+        }
+    }
+
+    /// A `Cmd::Suspend` preempted an in-flight dial: mark the transport
+    /// suspended, outrank any resumes the dial had deferred, and acknowledge.
+    fn suspend_preempted(&mut self, ack: oneshot::Sender<()>) {
+        self.suspended = true;
+        self.park_deferred_resumes();
+        let _ = ack.send(());
+    }
+
+    /// Open a fresh wire seeded with the resume wave — every leased topic
+    /// from its deepest owed position — and re-home every open obligation
+    /// onto that wave: leases still owed a `CatchUpComplete`, `resume()`
+    /// waiters parked in `resume_notify`, and waiters riding resume waves the
+    /// previous wire never completed. On failure the backoff grows and every
+    /// waiter stays parked for the next attempt. The dial is preemptible
+    /// ([`Self::open_preemptibly`]): commands keep flowing while it runs, so
+    /// a `suspend()` never waits on a stuck dial.
+    async fn reopen(&mut self) -> AfterReopen {
+        let Some((adds, pending)) = self.ledger.resume_adds() else {
+            // Nothing leased: there is nothing to catch up on, so any
+            // resume() waiters are already done.
+            for waiter in self.resume_notify.drain(..) {
+                let _ = waiter.send(());
+            }
+            return AfterReopen::Proceed;
+        };
+        let wave = self.ledger.next_wave_id();
+        let mutate = B::build_mutate(adds, None, wave.0);
+        match self.open_preemptibly(mutate).await {
+            OpenOutcome::Opened(wire) => {
+                self.conn = Some(wire);
+                self.reconnect_delay = RECONNECT_INITIAL_DELAY;
+                // Waves from the dead wire can never resolve on this one; the
+                // resume wave owes every still-pending lease its
+                // CatchUpComplete instead, and inherits the resume() waiters
+                // those waves carried.
+                let mut notify = std::mem::take(&mut self.resume_notify);
+                for (_, owner) in self.ledger.pending_waves.drain() {
+                    if let WaveOwner::Resume { notify: parked, .. } = owner {
+                        notify.extend(parked);
                     }
-                } else if conn.is_some() || ledger.leases.is_empty() {
-                    // A live wire (or nothing leased) has nothing to catch up.
-                    let _ = reply.send(());
-                } else {
-                    resume_notify.push(reply);
-                    reconnect_delay = RECONNECT_INITIAL_DELAY;
-                    match reopen(
-                        &opener,
-                        &mut ledger,
-                        &mut conn,
-                        &mut reconnect_delay,
-                        &mut reconnect_at,
-                        &mut resume_notify,
-                        &mut cmds,
-                        &mut deferred,
-                    )
-                    .await
-                    {
-                        AfterReopen::Proceed => {}
-                        AfterReopen::Suspended(ack) => {
-                            suspended = true;
-                            park_deferred_resumes(&mut deferred, &mut resume_notify);
-                            let _ = ack.send(());
-                        }
-                        AfterReopen::Shutdown => return,
-                    }
+                }
+                self.ledger
+                    .pending_waves
+                    .insert(wave, WaveOwner::Resume { pending, notify });
+                AfterReopen::Proceed
+            }
+            OpenOutcome::Failed(e) => {
+                tracing::warn!("bidi transport: reconnect failed ({e}); backing off");
+                self.reconnect_delay = (self.reconnect_delay * 2).min(RECONNECT_MAX_DELAY);
+                self.reconnect_at = tokio::time::Instant::now() + self.reconnect_delay;
+                AfterReopen::Proceed
+            }
+            OpenOutcome::Suspended(ack) => AfterReopen::Suspended(ack),
+            OpenOutcome::Shutdown => AfterReopen::Shutdown,
+        }
+    }
+
+    /// Dial while still absorbing commands. Non-lifecycle commands arriving
+    /// mid-dial are deferred in order (`next_step` drains `deferred` before
+    /// reading the channel again); only `Suspend` — whose whole point is
+    /// leaving the network *now* — and shutdown preempt the dial, dropping
+    /// the in-flight open future.
+    async fn open_preemptibly(&mut self, mutate: B::Mutate) -> OpenOutcome<B> {
+        let open = self.opener.open(mutate);
+        tokio::pin!(open);
+        loop {
+            tokio::select! {
+                result = &mut open => {
+                    return match result {
+                        Ok(wire) => OpenOutcome::Opened(wire),
+                        Err(e) => OpenOutcome::Failed(e),
+                    };
+                }
+                cmd = self.cmds.recv() => match cmd {
+                    Some(Cmd::Suspend { reply }) => return OpenOutcome::Suspended(reply),
+                    Some(cmd) => self.deferred.push_back(cmd),
+                    None => return OpenOutcome::Shutdown,
+                },
+            }
+        }
+    }
+
+    /// A dial-preempting `Suspend` outranks anything it jumped over: a
+    /// `Cmd::Resume` deferred during that dial predates the suspend, and
+    /// replaying it later would flip the transport back onto the network
+    /// against the caller's newest intent. Park those waiters instead — they
+    /// ride to the resume wave a *later* `resume()` completes. (Everything
+    /// else deferred — leases, derefs — replays safely under suspension.)
+    fn park_deferred_resumes(&mut self) {
+        for cmd in std::mem::take(&mut self.deferred) {
+            match cmd {
+                Cmd::Resume { reply } => self.resume_notify.push(reply),
+                other => self.deferred.push_back(other),
+            }
+        }
+    }
+
+    /// With nothing leased there is no catch-up left to await: fire every
+    /// parked `resume()` waiter — both those riding pending resume waves and
+    /// those not yet on a wave — and drop the wave obligations, which can
+    /// never resolve (their wire is gone or going, and nothing will re-open
+    /// it). Called whenever a deref or wire death may have emptied the
+    /// ledger; a no-op while any lease remains.
+    fn settle_idle_waiters(&mut self) {
+        if !self.ledger.leases.is_empty() {
+            return;
+        }
+        for (_, owner) in self.ledger.pending_waves.drain() {
+            if let WaveOwner::Resume { notify, .. } = owner {
+                for waiter in notify {
+                    let _ = waiter.send(());
                 }
             }
-            // The wire ended (server close or transport failure). Leases
-            // survive: the dead-wire select arm reconnects with a resume wave
-            // (module docs) — no stream ever observes the flap.
-            Step::Wire(None) => {
-                outbox.clear();
-                drop(conn.take());
-                reconnect_at = tokio::time::Instant::now() + reconnect_delay;
-                if !ledger.leases.is_empty() {
-                    tracing::warn!(
-                        "bidi transport: wire died; reconnecting from last-seen positions"
-                    );
-                }
-                settle_idle_waiters(&mut ledger, &mut resume_notify);
+        }
+        for waiter in self.resume_notify.drain(..) {
+            let _ = waiter.send(());
+        }
+    }
+
+    /// Take unclaimed topics off the wire; close the wire when no lease is
+    /// left. Never blocks — the removes wave rides the outbox (flushed at
+    /// the top of the next loop iteration).
+    fn retire(&mut self, removes: Vec<Topic>) {
+        if self.ledger.leases.is_empty() {
+            // Unsent waves are for a wire we're closing — nobody needs them.
+            self.outbox.clear();
+            if let Some(wire) = self.conn.take() {
+                close_gracefully(wire);
             }
-            Step::Reconnect => {
-                match reopen(
-                    &opener,
-                    &mut ledger,
-                    &mut conn,
-                    &mut reconnect_delay,
-                    &mut reconnect_at,
-                    &mut resume_notify,
-                    &mut cmds,
-                    &mut deferred,
-                )
-                .await
-                {
-                    AfterReopen::Proceed => {}
-                    AfterReopen::Suspended(ack) => {
-                        suspended = true;
-                        park_deferred_resumes(&mut deferred, &mut resume_notify);
-                        let _ = ack.send(());
-                    }
-                    AfterReopen::Shutdown => return,
+            return;
+        }
+        if removes.is_empty() || self.conn.is_none() {
+            return;
+        }
+        self.outbox.push(None, B::build_mutate(None, removes, 0));
+    }
+
+    /// Push waves onto the wire until it's momentarily full, closed, or the
+    /// outbox is empty. Never blocks; `Full` leaves the wave at the front
+    /// for the next flush, `Closed` is left for the select's `Wire(None)` to
+    /// clean up.
+    fn flush_outbox(&mut self) {
+        let Some(wire) = self.conn.as_ref() else {
+            return;
+        };
+        while let Some((lease, wave)) = self.outbox.waves.pop_front() {
+            match wire.try_mutate(wave) {
+                Ok(()) => {}
+                Err(TryMutateError::Full(wave)) | Err(TryMutateError::Closed(wave)) => {
+                    self.outbox.waves.push_front((lease, wave));
+                    return;
                 }
-            }
-            Step::Wire(Some(event)) => {
-                let mut removes = Vec::new();
-                for lease in ledger.route(event) {
-                    removes.extend(ledger.deref(lease));
-                }
-                retire(&mut conn, &mut ledger, &mut outbox, removes);
-                settle_idle_waiters(&mut ledger, &mut resume_notify);
             }
         }
     }
@@ -1113,85 +1325,7 @@ enum OpenOutcome<B: BidiBinding> {
     Shutdown,
 }
 
-async fn open_preemptibly<B: TransportBinding>(
-    opener: &Opener<B>,
-    mutate: B::Mutate,
-    cmds: &mut mpsc::UnboundedReceiver<Cmd<B>>,
-    deferred: &mut std::collections::VecDeque<Cmd<B>>,
-) -> OpenOutcome<B>
-where
-    B::GroupMessage: Clone,
-    B::WelcomeMessage: Clone,
-{
-    let open = opener.open(mutate);
-    tokio::pin!(open);
-    loop {
-        tokio::select! {
-            result = &mut open => {
-                return match result {
-                    Ok(wire) => OpenOutcome::Opened(wire),
-                    Err(e) => OpenOutcome::Failed(e),
-                };
-            }
-            cmd = cmds.recv() => match cmd {
-                Some(Cmd::Suspend { reply }) => return OpenOutcome::Suspended(reply),
-                Some(cmd) => deferred.push_back(cmd),
-                None => return OpenOutcome::Shutdown,
-            },
-        }
-    }
-}
-
-/// A dial-preempting `Suspend` outranks anything it jumped over: a
-/// `Cmd::Resume` deferred during that dial predates the suspend, and
-/// replaying it later would flip the transport back onto the network against
-/// the caller's newest intent. Park those waiters instead — they ride to the
-/// resume wave a *later* `resume()` completes. (Everything else deferred —
-/// leases, derefs — replays safely under suspension.)
-fn park_deferred_resumes<B: TransportBinding>(
-    deferred: &mut std::collections::VecDeque<Cmd<B>>,
-    resume_notify: &mut Vec<oneshot::Sender<()>>,
-) where
-    B::GroupMessage: Clone,
-    B::WelcomeMessage: Clone,
-{
-    for cmd in std::mem::take(deferred) {
-        match cmd {
-            Cmd::Resume { reply } => resume_notify.push(reply),
-            other => deferred.push_back(other),
-        }
-    }
-}
-
-/// With nothing leased there is no catch-up left to await: fire every parked
-/// `resume()` waiter — both those riding pending resume waves and those not
-/// yet on a wave — and drop the wave obligations, which can never resolve
-/// (their wire is gone or going, and nothing will re-open it). Called
-/// whenever a deref or wire death may have emptied the ledger; a no-op while
-/// any lease remains.
-fn settle_idle_waiters<B: TransportBinding>(
-    ledger: &mut Ledger<B>,
-    resume_notify: &mut Vec<oneshot::Sender<()>>,
-) where
-    B::GroupMessage: Clone,
-    B::WelcomeMessage: Clone,
-{
-    if !ledger.leases.is_empty() {
-        return;
-    }
-    for (_, owner) in ledger.pending_waves.drain() {
-        if let WaveOwner::Resume { notify, .. } = owner {
-            for waiter in notify {
-                let _ = waiter.send(());
-            }
-        }
-    }
-    for waiter in resume_notify.drain(..) {
-        let _ = waiter.send(());
-    }
-}
-
-/// How the ledger loop should proceed after a [`reopen`] attempt.
+/// How the ledger loop should proceed after a [`LedgerTask::reopen`] attempt.
 enum AfterReopen {
     Proceed,
     /// `Cmd::Suspend` preempted the dial: acknowledge once the caller has
@@ -1199,67 +1333,6 @@ enum AfterReopen {
     /// to the resume wave that eventually completes.
     Suspended(oneshot::Sender<()>),
     Shutdown,
-}
-
-/// Open a fresh wire seeded with the resume wave — every leased topic from
-/// its deepest owed position — and re-home every open obligation onto that
-/// wave: leases still owed a `CatchUpComplete`, `resume()` waiters parked in
-/// `notify`, and waiters riding resume waves the previous wire never
-/// completed. On failure the backoff grows and every waiter stays parked for
-/// the next attempt. The dial is preemptible ([`open_preemptibly`]): commands
-/// keep flowing while it runs, so a `suspend()` never waits on a stuck dial.
-#[allow(clippy::too_many_arguments)]
-async fn reopen<B: TransportBinding>(
-    opener: &Opener<B>,
-    ledger: &mut Ledger<B>,
-    conn: &mut Option<Connection<B>>,
-    reconnect_delay: &mut std::time::Duration,
-    reconnect_at: &mut tokio::time::Instant,
-    notify: &mut Vec<oneshot::Sender<()>>,
-    cmds: &mut mpsc::UnboundedReceiver<Cmd<B>>,
-    deferred: &mut std::collections::VecDeque<Cmd<B>>,
-) -> AfterReopen
-where
-    B::GroupMessage: Clone,
-    B::WelcomeMessage: Clone,
-{
-    let Some((adds, pending)) = ledger.resume_adds() else {
-        // Nothing leased: there is nothing to catch up on, so any resume()
-        // waiters are already done.
-        for waiter in notify.drain(..) {
-            let _ = waiter.send(());
-        }
-        return AfterReopen::Proceed;
-    };
-    let wave = ledger.next_wave_id();
-    let mutate = B::build_mutate(adds, None, wave.0);
-    match open_preemptibly(opener, mutate, cmds, deferred).await {
-        OpenOutcome::Opened(wire) => {
-            *conn = Some(wire);
-            *reconnect_delay = RECONNECT_INITIAL_DELAY;
-            // Waves from the dead wire can never resolve on this one; the
-            // resume wave owes every still-pending lease its CatchUpComplete
-            // instead, and inherits the resume() waiters those waves carried.
-            let mut notify = std::mem::take(notify);
-            for (_, owner) in ledger.pending_waves.drain() {
-                if let WaveOwner::Resume { notify: parked, .. } = owner {
-                    notify.extend(parked);
-                }
-            }
-            ledger
-                .pending_waves
-                .insert(wave, WaveOwner::Resume { pending, notify });
-            AfterReopen::Proceed
-        }
-        OpenOutcome::Failed(e) => {
-            tracing::warn!("bidi transport: reconnect failed ({e}); backing off");
-            *reconnect_delay = (*reconnect_delay * 2).min(RECONNECT_MAX_DELAY);
-            *reconnect_at = tokio::time::Instant::now() + *reconnect_delay;
-            AfterReopen::Proceed
-        }
-        OpenOutcome::Suspended(ack) => AfterReopen::Suspended(ack),
-        OpenOutcome::Shutdown => AfterReopen::Shutdown,
-    }
 }
 
 /// Waves accepted but not yet on the wire, in issue order, each tagged with
@@ -1293,51 +1366,6 @@ impl<M> Outbox<M> {
     fn purge(&mut self, lease: LeaseId) {
         self.waves.retain(|(owner, _)| *owner != Some(lease));
     }
-}
-
-/// Push waves onto the wire until it's momentarily full, closed, or the outbox
-/// is empty. Never blocks; `Full` leaves the wave at the front for the next
-/// flush, `Closed` is left for the select's `Wire(None)` to clean up.
-fn flush_outbox<B: TransportBinding>(wire: &Connection<B>, outbox: &mut Outbox<B::Mutate>)
-where
-    B::GroupMessage: Clone,
-    B::WelcomeMessage: Clone,
-{
-    while let Some((lease, wave)) = outbox.waves.pop_front() {
-        match wire.try_mutate(wave) {
-            Ok(()) => {}
-            Err(TryMutateError::Full(wave)) | Err(TryMutateError::Closed(wave)) => {
-                outbox.waves.push_front((lease, wave));
-                return;
-            }
-        }
-    }
-}
-
-/// Take unclaimed topics off the wire; close the wire when no lease is left.
-/// Never blocks — the removes wave rides the outbox (flushed at the top of the
-/// next loop iteration).
-fn retire<B: TransportBinding>(
-    conn: &mut Option<Connection<B>>,
-    ledger: &mut Ledger<B>,
-    outbox: &mut Outbox<B::Mutate>,
-    removes: Vec<Topic>,
-) where
-    B::GroupMessage: Clone,
-    B::WelcomeMessage: Clone,
-{
-    if ledger.leases.is_empty() {
-        // Unsent waves are for a wire we're closing — nobody needs them.
-        outbox.clear();
-        if let Some(wire) = conn.take() {
-            close_gracefully(wire);
-        }
-        return;
-    }
-    if removes.is_empty() || conn.is_none() {
-        return;
-    }
-    outbox.push(None, B::build_mutate(None, removes, 0));
 }
 
 /// Half-close and drain off-task, so the ledger stays responsive; bounded, so

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -70,12 +70,17 @@
 //! flap. `next()` → `None` now means only: this consumer fell behind and was
 //! dropped, or the transport itself shut down.
 //!
+//! ## Liveness
+//!
+//! A *half-open* wire needs no handling here: the connection actor's silence
+//! watchdog (see `bidi.rs`) tears down a wire with no inbound frames for the
+//! probe budget, which lands in the same wire-death path as any other close —
+//! the reconnect above absorbs it. The transport never probes inline; awaiting
+//! a probe from the ledger loop would stop draining events, park the actor on
+//! a full event channel, and starve the very pong it waits for.
+//!
 //! ## Not yet here (later phases)
 //!
-//! - Liveness: a *half-open* wire (the failure probes exist to catch) is not
-//!   detected here yet — nothing probes, so leases on such a wire pend until
-//!   something above notices. Until then the consumer keeps its existing
-//!   watchdog floor.
 //! - `Started` capabilities are logged, not consumed (capability gating phase).
 
 use std::collections::{HashMap, HashSet};
@@ -1130,6 +1135,21 @@ mod tests {
             }
         }
 
+        /// Resolves at the next client `Ping`, panicking on anything else.
+        async fn next_ping(&mut self) -> u64 {
+            let frame = tokio::time::timeout(WAIT, self.from_client.recv())
+                .await
+                .expect("timed out waiting for a client frame")
+                .expect("client closed the request stream");
+            let Some(subscribe_request::Version::V1(v1)) = frame.version else {
+                panic!("client sent unknown request version");
+            };
+            match v1.request.expect("client sent empty request") {
+                subscribe_request::v1::Request::Ping(ping) => ping.nonce,
+                other => panic!("expected a Ping, got {other:?}"),
+            }
+        }
+
         /// Resolves once the client half-closes its request stream.
         async fn request_stream_ended(&mut self) {
             loop {
@@ -1736,6 +1756,51 @@ mod tests {
         }
     }
 
+    /// A *half-open* wire — silent but never closed — is caught by the
+    /// connection actor's watchdog and lands in the same transparent-reconnect
+    /// path as an outright close: one probe goes out on the dying wire, the
+    /// actor tears down, the transport re-opens, and the lease never notices.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn half_open_wire_is_reaped_and_reconnected() {
+        let (transport, servers) = transport();
+        let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        // Advertise a fast keepalive so the watchdog runs at test speed, then
+        // catch the lease up and go silent — without ever closing the wire.
+        server.send(started(150));
+        server.send(messages(vec![group_msg(1, b"g1")], vec![]));
+        server.send(catchup_complete(first.mutate_id));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::GroupMessages(_))
+        ));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+
+        // The watchdog probes the silent wire first; nothing answers. Keep
+        // `server` alive throughout — dropping it would close the wire and
+        // exercise the ordinary flap path instead of the half-open one.
+        server.next_ping().await;
+
+        // The actor gives up and the transport re-opens on its own, resuming
+        // from the last-seen position.
+        let mut second = wait_for_server(&servers).await;
+        let resume = second.next_mutate().await;
+        assert_eq!(resume.adds.len(), 1);
+        assert_eq!(resume.adds[0].id_cursor, 1);
+
+        // The lease rides straight onto the new wire.
+        second.send(messages(vec![group_msg(2, b"g1")], vec![]));
+        match recv(&mut alpha).await {
+            Some(LeaseEvent::GroupMessages(got)) => {
+                assert_eq!(got, vec![group_msg(2, b"g1")])
+            }
+            _ => panic!("the lease must survive a half-open wire invisibly"),
+        }
+    }
     /// A lease still catching up when the wire dies is re-owed its replay:
     /// the resume cursor is held down to its floor, and the resume wave's
     /// CatchUpComplete resolves its pending marker.

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -70,6 +70,18 @@
 //! flap. `next()` → `None` now means only: this consumer fell behind and was
 //! dropped, or the transport itself shut down.
 //!
+//! ## Suspend / resume (the app-lifecycle touchpoint)
+//!
+//! [`BidiTransport::suspend`] half-closes the wire and parks: leases and wire
+//! positions are kept, new leases register without touching the network, and
+//! nothing reconnects until [`BidiTransport::resume`] — which re-opens with
+//! the same resume wave a wire flap uses and resolves at that wave's
+//! `CatchUpComplete`: "catch up, then done", the background-fetch primitive.
+//! An unpaired `resume()` (live wire, or nothing leased) resolves
+//! immediately; a process thawed *without* suspending doesn't need one — the
+//! connection's watchdog detects the stale wire and the reconnect above
+//! absorbs it.
+//!
 //! ## Liveness
 //!
 //! A *half-open* wire needs no handling here: the connection actor's silence
@@ -85,8 +97,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use futures::future::BoxFuture;
 use tokio::sync::{mpsc, oneshot};
+use xmtp_common::{BoxDynFuture, MaybeSend, MaybeSync};
 use xmtp_proto::types::Topic;
 
 use super::bidi::{BidiBinding, Connection, Event, TryMutateError};
@@ -290,11 +302,15 @@ where
     /// business — see the module docs on endpoint keying.
     pub fn new<O, Fut>(opener: O) -> Self
     where
-        O: Fn(B::Mutate) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<Connection<B>, OpenError>> + Send + 'static,
+        O: Fn(B::Mutate) -> Fut + MaybeSend + MaybeSync + 'static,
+        Fut: Future<Output = Result<Connection<B>, OpenError>> + MaybeSend + 'static,
     {
         let (cmds, cmds_rx) = mpsc::unbounded_channel();
-        let opener: Opener<B> = Box::new(move |initial| Box::pin(opener(initial)));
+        let opener: Opener<B> = Box::new(
+            move |initial| -> BoxDynFuture<'static, Result<Connection<B>, OpenError>> {
+                Box::pin(opener(initial))
+            },
+        );
         // Not detached-and-forgotten: the task exits when `cmds` fully closes,
         // which happens exactly when every handle and lease is dropped.
         xmtp_common::spawn(
@@ -309,13 +325,14 @@ where
     /// [`DEFAULT_LEASE_DEPTH`]).
     ///
     /// Resolves once the lease is registered and its cursored-add wave is
-    /// queued for the wire, opening the wire first if this is the first lease.
-    /// Waves reach the wire in issue order. A wire death at any point is
-    /// invisible here: the transport reconnects and a resume wave re-covers
-    /// this lease (module docs), so `next()` → `None` means only that this
-    /// consumer fell behind and was dropped, or the transport shut down. A
-    /// lease whose adds the server has definitely processed is signaled by
-    /// its [`LeaseEvent::CatchUpComplete`].
+    /// queued for the wire, opening the wire first if this is the first lease
+    /// (unless suspended — then the lease registers and waits for
+    /// [`Self::resume`]). Waves reach the wire in issue order. A wire death at
+    /// any point is invisible here: the transport reconnects and a resume wave
+    /// re-covers this lease (module docs), so `next()` → `None` means only
+    /// that this consumer fell behind and was dropped, or the transport shut
+    /// down. A lease whose adds the server has definitely processed is
+    /// signaled by its [`LeaseEvent::CatchUpComplete`].
     pub async fn lease(
         &self,
         subs: Vec<(Topic, B::Cursor)>,
@@ -332,6 +349,39 @@ where
             .map_err(|_| TransportError::Closed)?;
         response.await.map_err(|_| TransportError::Closed)?
     }
+
+    /// Take the transport off the network — the app-backgrounding half of the
+    /// lifecycle pair. The wire goes down as a graceful half-close; every
+    /// lease and wire position is kept, new leases register without touching
+    /// the network, and nothing reconnects until [`Self::resume`]. Idempotent,
+    /// and a no-op on a wire that is already down (or was never opened).
+    /// Resolves once the wire is down.
+    pub async fn suspend(&self) -> Result<(), TransportError> {
+        let (reply, response) = oneshot::channel();
+        self.cmds
+            .send(Cmd::Suspend { reply })
+            .map_err(|_| TransportError::Closed)?;
+        response.await.map_err(|_| TransportError::Closed)
+    }
+
+    /// Come back onto the network after [`Self::suspend`]: re-opens with the
+    /// same resume wave a wire flap uses (every leased topic from its kept
+    /// position) and resolves at that wave's `CatchUpComplete` — "catch up,
+    /// then done", the background-fetch primitive. With nothing leased, or a
+    /// wire that never went down, it resolves immediately. An open failure
+    /// does not fail this call: the transport keeps retrying on its backoff
+    /// and the resolution rides to the resume wave that eventually completes.
+    ///
+    /// A process thawed *without* having suspended doesn't need this: the
+    /// connection's own watchdog detects the stale wire and the transport
+    /// reconnects transparently.
+    pub async fn resume(&self) -> Result<(), TransportError> {
+        let (reply, response) = oneshot::channel();
+        self.cmds
+            .send(Cmd::Resume { reply })
+            .map_err(|_| TransportError::Closed)?;
+        response.await.map_err(|_| TransportError::Closed)
+    }
 }
 
 /// Submitted by handles/leases, performed by the ledger task.
@@ -346,12 +396,37 @@ where
         reply: oneshot::Sender<Result<TopicLease<B>, TransportError>>,
     },
     Deref(LeaseId),
+    Suspend {
+        reply: oneshot::Sender<()>,
+    },
+    Resume {
+        reply: oneshot::Sender<()>,
+    },
 }
 
-type Opener<B> = Box<
-    dyn Fn(<B as BidiBinding>::Mutate) -> BoxFuture<'static, Result<Connection<B>, OpenError>>
-        + Send,
->;
+/// The wire opener: the initial `Mutate` (a first lease's adds, or a resume
+/// wave) in, a fresh [`Connection`] out. Expressed as a trait with a blanket
+/// impl — rather than `cfg`-gated `Box<dyn Fn .. + Send + Sync>` aliases — so
+/// the split lives entirely in [`MaybeSend`]/[`MaybeSync`] (native-only
+/// today, but the shape ports). `MaybeSync` because the ledger task holds a
+/// shared reference across the open await (in [`reopen`]); it is only ever
+/// *called* from that one task.
+trait OpenWire<B: BidiBinding>: MaybeSend + MaybeSync {
+    fn open(&self, initial: B::Mutate) -> BoxDynFuture<'static, Result<Connection<B>, OpenError>>;
+}
+
+impl<B: BidiBinding, F> OpenWire<B> for F
+where
+    F: Fn(B::Mutate) -> BoxDynFuture<'static, Result<Connection<B>, OpenError>>
+        + MaybeSend
+        + MaybeSync,
+{
+    fn open(&self, initial: B::Mutate) -> BoxDynFuture<'static, Result<Connection<B>, OpenError>> {
+        self(initial)
+    }
+}
+
+type Opener<B> = Box<dyn OpenWire<B>>;
 
 /// What a resume wave restores: every leased topic with its resume cursor,
 /// plus the leases whose `CatchUpComplete` the wave now owes.
@@ -363,8 +438,12 @@ enum WaveOwner {
     Lease(LeaseId),
     /// A reconnect's resume wave: resolves every lease that was still
     /// catching up when the previous wire died (their own waves can never
-    /// complete on the new wire).
-    Resume { pending: Vec<LeaseId> },
+    /// complete on the new wire), plus any [`BidiTransport::resume`] callers
+    /// awaiting "caught up, then done".
+    Resume {
+        pending: Vec<LeaseId>,
+        notify: Vec<oneshot::Sender<()>>,
+    },
 }
 
 /// The topic ledger: which lease holds which topics, and where each in-flight
@@ -492,7 +571,7 @@ where
         };
         self.pending_waves.retain(|_, owner| match owner {
             WaveOwner::Lease(lease) => *lease != id,
-            WaveOwner::Resume { pending } => {
+            WaveOwner::Resume { pending, .. } => {
                 pending.retain(|lease| *lease != id);
                 true
             }
@@ -611,9 +690,14 @@ where
             Event::CatchUpComplete { mutate_id } => {
                 match self.pending_waves.remove(&WaveId(mutate_id)) {
                     Some(WaveOwner::Lease(lease)) => self.complete(lease, &mut dropped),
-                    Some(WaveOwner::Resume { pending }) => {
+                    Some(WaveOwner::Resume { pending, notify }) => {
                         for lease in pending {
                             self.complete(lease, &mut dropped);
+                        }
+                        // "Caught up, then done": the resume() callers resolve
+                        // exactly here, at the resume wave's completion.
+                        for waiter in notify {
+                            let _ = waiter.send(());
                         }
                     }
                     None => {}
@@ -753,6 +837,13 @@ async fn run_ledger<B: TransportBinding>(
     // sleep from `reconnect_delay` each loop iteration would let a steady
     // stream of commands postpone the reconnect forever.
     let mut reconnect_at = tokio::time::Instant::now();
+    // `suspend()`ed: the wire stays down on purpose — no lazy open for new
+    // leases, no reconnect backoff — until `resume()` clears it.
+    let mut suspended = false;
+    // `resume()` callers awaiting a resume wave that hasn't been sent yet
+    // (the open failed, or hasn't happened). [`reopen`] moves them onto the
+    // wave it sends; until then they park here across backoff retries.
+    let mut resume_notify: Vec<oneshot::Sender<()>> = Vec::new();
     // Waves accepted but not yet on the wire, in issue order. Invariant:
     // non-empty only while `conn` is `Some` — cleared on every wire close
     // (stale waves are meaningless to a fresh wire; the resume wave re-seeds).
@@ -775,12 +866,14 @@ async fn run_ledger<B: TransportBinding>(
             },
             // A dead wire with live leases reconnects once the backoff
             // elapses, still absorbing commands meanwhile (which must not
-            // move the deadline).
-            None if !ledger.leases.is_empty() => tokio::select! {
+            // move the deadline) — unless suspended, where staying off the
+            // network is the whole point.
+            None if !ledger.leases.is_empty() && !suspended => tokio::select! {
                 cmd = cmds.recv() => Step::Cmd(cmd),
                 _ = tokio::time::sleep_until(reconnect_at) => Step::Reconnect,
             },
-            // No wire, no leases: dormant until the next command.
+            // No wire and either nothing leased or suspended: dormant until
+            // the next command.
             None => Step::Cmd(cmds.recv().await),
         };
 
@@ -804,12 +897,12 @@ async fn run_ledger<B: TransportBinding>(
                     .collect();
                 let mutate = B::build_mutate(subs, None, wave.0);
                 let mut queued = None;
-                if conn.is_none() && ledger.leases.is_empty() {
+                if conn.is_none() && ledger.leases.is_empty() && !suspended {
                     // Cold open, seeded with this lease's adds. Awaiting here
                     // is safe: with no wire there are no events to drain. The
                     // failure is this caller's to see — nobody else is
                     // waiting on the wire.
-                    match opener(mutate).await {
+                    match opener.open(mutate).await {
                         Ok(wire) => {
                             conn = Some(wire);
                             reconnect_delay = RECONNECT_INITIAL_DELAY;
@@ -822,8 +915,8 @@ async fn run_ledger<B: TransportBinding>(
                 } else if conn.is_some() {
                     queued = Some(mutate);
                 }
-                // else: the wire is down but other leases exist — the
-                // reconnect arm re-opens with a resume wave covering this
+                // else: the wire is down (mid-backoff or suspended) — the
+                // next resume wave (reconnect arm or `resume()`) covers this
                 // lease too, so its mutate is deliberately dropped here.
 
                 // Registered for routing immediately, NOT at CatchUpComplete:
@@ -861,6 +954,53 @@ async fn run_ledger<B: TransportBinding>(
                 let removes = ledger.deref(id);
                 retire(&mut conn, &mut ledger, &mut outbox, removes);
             }
+            Step::Cmd(Some(Cmd::Suspend { reply })) => {
+                suspended = true;
+                outbox.clear();
+                if let Some(wire) = conn.take() {
+                    close_gracefully(wire);
+                }
+                // Pending waves stay: their leases are still owed a
+                // CatchUpComplete, and `reopen` re-homes those obligations
+                // (and any parked resume() waiters) onto the resume wave.
+                let _ = reply.send(());
+            }
+            Step::Cmd(Some(Cmd::Resume { reply })) => {
+                suspended = false;
+                if let Some(notify) =
+                    ledger
+                        .pending_waves
+                        .values_mut()
+                        .find_map(|owner| match owner {
+                            WaveOwner::Resume { notify, .. } => Some(notify),
+                            WaveOwner::Lease(_) => None,
+                        })
+                {
+                    // A resume catch-up is already in flight — join it rather
+                    // than race it. If its wire has died meanwhile, hasten the
+                    // reconnect that will re-home this waiter.
+                    notify.push(reply);
+                    if conn.is_none() {
+                        reconnect_delay = RECONNECT_INITIAL_DELAY;
+                        reconnect_at = tokio::time::Instant::now();
+                    }
+                } else if conn.is_some() || ledger.leases.is_empty() {
+                    // A live wire (or nothing leased) has nothing to catch up.
+                    let _ = reply.send(());
+                } else {
+                    resume_notify.push(reply);
+                    reconnect_delay = RECONNECT_INITIAL_DELAY;
+                    reopen(
+                        &opener,
+                        &mut ledger,
+                        &mut conn,
+                        &mut reconnect_delay,
+                        &mut reconnect_at,
+                        &mut resume_notify,
+                    )
+                    .await;
+                }
+            }
             // The wire ended (server close or transport failure). Leases
             // survive: the dead-wire select arm reconnects with a resume wave
             // (module docs) — no stream ever observes the flap.
@@ -875,30 +1015,15 @@ async fn run_ledger<B: TransportBinding>(
                 }
             }
             Step::Reconnect => {
-                let Some((adds, pending)) = ledger.resume_adds() else {
-                    continue;
-                };
-                let wave = ledger.next_wave_id();
-                let mutate = B::build_mutate(adds, None, wave.0);
-                // Awaiting is safe: with no wire there are no events to drain.
-                match opener(mutate).await {
-                    Ok(wire) => {
-                        conn = Some(wire);
-                        reconnect_delay = RECONNECT_INITIAL_DELAY;
-                        // Waves from the dead wire can never resolve on this
-                        // one; the resume wave owes every still-pending lease
-                        // its CatchUpComplete instead.
-                        ledger.pending_waves.clear();
-                        ledger
-                            .pending_waves
-                            .insert(wave, WaveOwner::Resume { pending });
-                    }
-                    Err(e) => {
-                        tracing::warn!("bidi transport: reconnect failed ({e}); backing off");
-                        reconnect_delay = (reconnect_delay * 2).min(RECONNECT_MAX_DELAY);
-                        reconnect_at = tokio::time::Instant::now() + reconnect_delay;
-                    }
-                }
+                reopen(
+                    &opener,
+                    &mut ledger,
+                    &mut conn,
+                    &mut reconnect_delay,
+                    &mut reconnect_at,
+                    &mut resume_notify,
+                )
+                .await;
             }
             Step::Wire(Some(event)) => {
                 let mut removes = Vec::new();
@@ -907,6 +1032,59 @@ async fn run_ledger<B: TransportBinding>(
                 }
                 retire(&mut conn, &mut ledger, &mut outbox, removes);
             }
+        }
+    }
+}
+
+/// Open a fresh wire seeded with the resume wave — every leased topic from
+/// its deepest owed position — and re-home every open obligation onto that
+/// wave: leases still owed a `CatchUpComplete`, `resume()` waiters parked in
+/// `notify`, and waiters riding resume waves the previous wire never
+/// completed. On failure the backoff grows and every waiter stays parked for
+/// the next attempt. Awaiting the opener is safe here for the same reason as
+/// the cold open: with no wire there are no events to drain.
+async fn reopen<B: TransportBinding>(
+    opener: &Opener<B>,
+    ledger: &mut Ledger<B>,
+    conn: &mut Option<Connection<B>>,
+    reconnect_delay: &mut std::time::Duration,
+    reconnect_at: &mut tokio::time::Instant,
+    notify: &mut Vec<oneshot::Sender<()>>,
+) where
+    B::GroupMessage: Clone,
+    B::WelcomeMessage: Clone,
+{
+    let Some((adds, pending)) = ledger.resume_adds() else {
+        // Nothing leased: there is nothing to catch up on, so any resume()
+        // waiters are already done.
+        for waiter in notify.drain(..) {
+            let _ = waiter.send(());
+        }
+        return;
+    };
+    let wave = ledger.next_wave_id();
+    let mutate = B::build_mutate(adds, None, wave.0);
+    match opener.open(mutate).await {
+        Ok(wire) => {
+            *conn = Some(wire);
+            *reconnect_delay = RECONNECT_INITIAL_DELAY;
+            // Waves from the dead wire can never resolve on this one; the
+            // resume wave owes every still-pending lease its CatchUpComplete
+            // instead, and inherits the resume() waiters those waves carried.
+            let mut notify = std::mem::take(notify);
+            for (_, owner) in ledger.pending_waves.drain() {
+                if let WaveOwner::Resume { notify: parked, .. } = owner {
+                    notify.extend(parked);
+                }
+            }
+            ledger
+                .pending_waves
+                .insert(wave, WaveOwner::Resume { pending, notify });
+        }
+        Err(e) => {
+            tracing::warn!("bidi transport: reconnect failed ({e}); backing off");
+            *reconnect_delay = (*reconnect_delay * 2).min(RECONNECT_MAX_DELAY);
+            *reconnect_at = tokio::time::Instant::now() + *reconnect_delay;
         }
     }
 }
@@ -1801,6 +1979,137 @@ mod tests {
             _ => panic!("the lease must survive a half-open wire invisibly"),
         }
     }
+
+    /// `suspend()` takes the wire down as a graceful half-close and keeps the
+    /// ledger; `resume()` re-opens from the kept positions and resolves at
+    /// the resume wave's `CatchUpComplete` — catch up, then done.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn suspend_half_closes_and_resume_completes_at_catch_up() {
+        let (transport, servers) = transport();
+        let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        server.send(messages(vec![group_msg(1, b"g1")], vec![]));
+        server.send(catchup_complete(first.mutate_id));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::GroupMessages(_))
+        ));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+
+        transport.suspend().await?;
+        // The wire goes down as a half-close, not an abort.
+        server.request_stream_ended().await;
+
+        let resumed = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+        let mut second = wait_for_server(&servers).await;
+        let resume = second.next_mutate().await;
+        assert_eq!(resume.adds.len(), 1);
+        assert_eq!(
+            resume.adds[0].id_cursor, 1,
+            "resume from the kept wire position"
+        );
+        second.send(catchup_complete(resume.mutate_id));
+        tokio::time::timeout(WAIT, resumed).await?.unwrap()?;
+
+        // The lease rode through the whole background/foreground cycle.
+        second.send(messages(vec![group_msg(2, b"g1")], vec![]));
+        match recv(&mut alpha).await {
+            Some(LeaseEvent::GroupMessages(got)) => {
+                assert_eq!(got, vec![group_msg(2, b"g1")])
+            }
+            _ => panic!("the lease must survive suspend/resume invisibly"),
+        }
+    }
+
+    /// While suspended the transport stays off the network — no reconnect
+    /// backoff, no lazy open for new leases — and `resume()` covers both the
+    /// kept lease and the one taken while suspended with one wave.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn suspended_transport_stays_off_the_network() {
+        let (transport, servers) = transport();
+        let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        server.send(catchup_complete(first.mutate_id));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+
+        transport.suspend().await?;
+        server.request_stream_ended().await;
+
+        // A lease taken while suspended registers but must not open a wire.
+        let mut beta = transport.lease(vec![(group_topic(b"g2"), 0)], 8).await?;
+
+        // Well past several reconnect backoffs: still nothing on the network.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert!(
+            servers.lock().unwrap().is_empty(),
+            "suspended must mean off the network"
+        );
+
+        let resumed = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+        let mut second = wait_for_server(&servers).await;
+        let resume = second.next_mutate().await;
+        let mut got: Vec<_> = resume.adds.iter().map(|add| add.topic.clone()).collect();
+        got.sort();
+        let mut want = vec![
+            group_topic(b"g1").cloned_vec(),
+            group_topic(b"g2").cloned_vec(),
+        ];
+        want.sort();
+        assert_eq!(got, want, "one resume wave covers both leases");
+        second.send(catchup_complete(resume.mutate_id));
+        tokio::time::timeout(WAIT, resumed).await?.unwrap()?;
+
+        // The suspended-time lease was owed its catch-up by the resume wave.
+        assert!(matches!(
+            recv(&mut beta).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+    }
+
+    /// `resume()` with nothing to catch up on — nothing leased, or a wire
+    /// that never went down — resolves immediately and opens nothing.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn resume_with_nothing_to_do_resolves_immediately() {
+        let (transport, servers) = transport();
+        transport.suspend().await?;
+        tokio::time::timeout(WAIT, transport.resume()).await??;
+
+        let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        server.send(catchup_complete(first.mutate_id));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+
+        // On a live wire resume is a no-op that disturbs nothing.
+        tokio::time::timeout(WAIT, transport.resume()).await??;
+        server.send(messages(vec![group_msg(1, b"g1")], vec![]));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::GroupMessages(_))
+        ));
+        assert!(
+            servers.lock().unwrap().is_empty(),
+            "resume on a live wire must not open a second one"
+        );
+    }
+
     /// A lease still catching up when the wire dies is re-owed its replay:
     /// the resume cursor is held down to its floor, and the resume wave's
     /// CatchUpComplete resolves its pending marker.

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -1202,6 +1202,11 @@ where
                 tracing::warn!("bidi transport: reconnect failed ({e}); backing off");
                 self.reconnect_delay = (self.reconnect_delay * 2).min(RECONNECT_MAX_DELAY);
                 self.reconnect_at = tokio::time::Instant::now() + self.reconnect_delay;
+                // Resumes deferred mid-dial were concurrent with this attempt
+                // and it failed for all of them: park their waiters on the
+                // scheduled retry. Replaying them would grant each the
+                // immediate-dial privilege reserved for a *fresh* resume().
+                self.park_deferred_resumes();
                 AfterReopen::Proceed
             }
             OpenOutcome::Suspended(ack) => AfterReopen::Suspended(ack),
@@ -1234,12 +1239,13 @@ where
         }
     }
 
-    /// A dial-preempting `Suspend` outranks anything it jumped over: a
-    /// `Cmd::Resume` deferred during that dial predates the suspend, and
-    /// replaying it later would flip the transport back onto the network
-    /// against the caller's newest intent. Park those waiters instead — they
-    /// ride to the resume wave a *later* `resume()` completes. (Everything
-    /// else deferred — leases, derefs — replays safely under suspension.)
+    /// A `Cmd::Resume` deferred during a dial must not replay as a fresh
+    /// command. After a dial-preempting `Suspend`, replaying it would flip
+    /// the transport back onto the network against the caller's newest
+    /// intent; after a failed dial, replaying it would grant an immediate
+    /// redial per deferred resume, stampeding the opener past its backoff.
+    /// Park those waiters instead — they ride the next reopen's resume wave.
+    /// (Everything else deferred — leases, derefs — replays safely.)
     fn park_deferred_resumes(&mut self) {
         for cmd in std::mem::take(&mut self.deferred) {
             match cmd {
@@ -2474,6 +2480,104 @@ mod tests {
         assert!(matches!(
             recv(&mut alpha).await,
             Some(LeaseEvent::CatchUpComplete)
+        ));
+    }
+
+    /// A burst of `resume()` calls during an outage collapses into ONE dial.
+    /// The first resume earns the immediate attempt; resumes deferred while
+    /// that dial is in flight rode it and lost with it — replaying each as a
+    /// fresh dial would stampede the opener past its backoff. Their waiters
+    /// park and ride the scheduled retry instead.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn a_resume_burst_during_an_outage_dials_once() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        let servers: Servers = Arc::default();
+        let dials = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let network_down = Arc::new(AtomicBool::new(true));
+        let transport: BidiTransport<V3Binding> = {
+            let sink = servers.clone();
+            let dials = dials.clone();
+            let gate = gate.clone();
+            let network_down = network_down.clone();
+            BidiTransport::new(move |initial| {
+                let n = dials.fetch_add(1, Ordering::SeqCst);
+                let sink = sink.clone();
+                let gate = gate.clone();
+                let network_down = network_down.clone();
+                async move {
+                    // Dial 1 holds until released, then fails — the window
+                    // for the rest of the burst to arrive mid-dial. Later
+                    // dials fail fast until the network comes back.
+                    if n == 1 {
+                        gate.notified().await;
+                        return Err(Box::new(std::io::Error::other("down")) as OpenError);
+                    }
+                    if n >= 2 && network_down.load(Ordering::SeqCst) {
+                        return Err(Box::new(std::io::Error::other("down")) as OpenError);
+                    }
+                    let (api, server) = mock_pair();
+                    sink.lock().unwrap().push(server);
+                    BidiConnection::open(&api, initial)
+                        .await
+                        .map_err(|e| Box::new(e) as OpenError)
+                }
+            })
+        };
+
+        let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        server.send(catchup_complete(first.mutate_id));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+        tokio::time::timeout(WAIT, transport.suspend()).await??;
+
+        // The burst: the first resume dials immediately; two more land while
+        // that dial is in flight and are deferred.
+        let resumes: Vec<_> = (0..3)
+            .map(|i| {
+                let transport = transport.clone();
+                tokio::spawn(async move {
+                    if i > 0 {
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                    }
+                    transport.resume().await
+                })
+            })
+            .collect();
+        while dials.load(Ordering::SeqCst) < 2 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        network_down.store(false, Ordering::SeqCst);
+        gate.notify_one();
+
+        // Inside the backoff window (retry is scheduled at +200ms): the
+        // deferred resumes must not have re-dialed on their own.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            dials.load(Ordering::SeqCst),
+            2,
+            "resumes deferred by the failed dial must park, not re-dial"
+        );
+
+        // The scheduled retry carries every parked waiter to catch-up.
+        let mut server = wait_for_server(&servers).await;
+        let resume = server.next_mutate().await;
+        server.send(catchup_complete(resume.mutate_id));
+        for handle in resumes {
+            tokio::time::timeout(WAIT, handle).await?.unwrap()?;
+        }
+        assert_eq!(dials.load(Ordering::SeqCst), 3, "exactly one retry dial");
+
+        // And the lease is live on the new wire.
+        server.send(messages(vec![group_msg(1, b"g1")], vec![]));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::GroupMessages(_))
         ));
     }
 

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -355,7 +355,13 @@ where
     /// lease and wire position is kept, new leases register without touching
     /// the network, and nothing reconnects until [`Self::resume`]. Idempotent,
     /// and a no-op on a wire that is already down (or was never opened).
-    /// Resolves once the wire is down.
+    ///
+    /// Resolves once the transport has **released** the wire: no new work
+    /// will touch it, and a bounded, discard-only half-close drain finishes
+    /// in the background (deliberately not awaited — see the ledger's
+    /// deadlock discipline). A `resume()` right after may briefly overlap
+    /// that dying drain with the fresh wire; the resume wave re-serves
+    /// anything the drain discarded, so nothing is lost.
     pub async fn suspend(&self) -> Result<(), TransportError> {
         let (reply, response) = oneshot::channel();
         self.cmds
@@ -848,6 +854,9 @@ async fn run_ledger<B: TransportBinding>(
     // non-empty only while `conn` is `Some` — cleared on every wire close
     // (stale waves are meaningless to a fresh wire; the resume wave re-seeds).
     let mut outbox: Outbox<B::Mutate> = Outbox::default();
+    // Commands absorbed while a dial was in flight (see [`open_preemptibly`]),
+    // replayed in order before the channel is read again.
+    let mut deferred: std::collections::VecDeque<Cmd<B>> = std::collections::VecDeque::new();
 
     loop {
         // Opportunistic flush: capacity frees when the actor makes progress,
@@ -856,25 +865,29 @@ async fn run_ledger<B: TransportBinding>(
             flush_outbox(wire, &mut outbox);
         }
 
-        let step = match conn.as_mut() {
-            Some(wire) => tokio::select! {
-                cmd = cmds.recv() => Step::Cmd(cmd),
-                event = wire.next() => Step::Wire(event),
-                // Backstop for the rare quiet-wire case: the command buffer
-                // was momentarily full and no event arrives to wake us.
-                _ = tokio::time::sleep(OUTBOX_RETRY_INTERVAL), if !outbox.is_empty() => Step::Retry,
-            },
-            // A dead wire with live leases reconnects once the backoff
-            // elapses, still absorbing commands meanwhile (which must not
-            // move the deadline) — unless suspended, where staying off the
-            // network is the whole point.
-            None if !ledger.leases.is_empty() && !suspended => tokio::select! {
-                cmd = cmds.recv() => Step::Cmd(cmd),
-                _ = tokio::time::sleep_until(reconnect_at) => Step::Reconnect,
-            },
-            // No wire and either nothing leased or suspended: dormant until
-            // the next command.
-            None => Step::Cmd(cmds.recv().await),
+        let step = if let Some(cmd) = deferred.pop_front() {
+            Step::Cmd(Some(cmd))
+        } else {
+            match conn.as_mut() {
+                Some(wire) => tokio::select! {
+                    cmd = cmds.recv() => Step::Cmd(cmd),
+                    event = wire.next() => Step::Wire(event),
+                    // Backstop for the rare quiet-wire case: the command buffer
+                    // was momentarily full and no event arrives to wake us.
+                    _ = tokio::time::sleep(OUTBOX_RETRY_INTERVAL), if !outbox.is_empty() => Step::Retry,
+                },
+                // A dead wire with live leases reconnects once the backoff
+                // elapses, still absorbing commands meanwhile (which must not
+                // move the deadline) — unless suspended, where staying off the
+                // network is the whole point.
+                None if !ledger.leases.is_empty() && !suspended => tokio::select! {
+                    cmd = cmds.recv() => Step::Cmd(cmd),
+                    _ = tokio::time::sleep_until(reconnect_at) => Step::Reconnect,
+                },
+                // No wire and either nothing leased or suspended: dormant until
+                // the next command.
+                None => Step::Cmd(cmds.recv().await),
+            }
         };
 
         match step {
@@ -898,19 +911,28 @@ async fn run_ledger<B: TransportBinding>(
                 let mutate = B::build_mutate(subs, None, wave.0);
                 let mut queued = None;
                 if conn.is_none() && ledger.leases.is_empty() && !suspended {
-                    // Cold open, seeded with this lease's adds. Awaiting here
-                    // is safe: with no wire there are no events to drain. The
-                    // failure is this caller's to see — nobody else is
-                    // waiting on the wire.
-                    match opener.open(mutate).await {
-                        Ok(wire) => {
+                    // Cold open, seeded with this lease's adds. The dial is
+                    // preemptible: commands keep flowing while it runs, and a
+                    // Suspend drops it. The failure is this caller's to see —
+                    // nobody else is waiting on the wire.
+                    match open_preemptibly(&opener, mutate, &mut cmds, &mut deferred).await {
+                        OpenOutcome::Opened(wire) => {
                             conn = Some(wire);
                             reconnect_delay = RECONNECT_INITIAL_DELAY;
                         }
-                        Err(e) => {
+                        OpenOutcome::Failed(e) => {
                             let _ = reply.send(Err(TransportError::Open(e)));
                             continue;
                         }
+                        OpenOutcome::Suspended(ack) => {
+                            // The dial is gone; the lease still registers
+                            // below and rides the resume open, exactly like
+                            // any lease taken while suspended.
+                            suspended = true;
+                            park_deferred_resumes(&mut deferred, &mut resume_notify);
+                            let _ = ack.send(());
+                        }
+                        OpenOutcome::Shutdown => return,
                     }
                 } else if conn.is_some() {
                     queued = Some(mutate);
@@ -953,11 +975,17 @@ async fn run_ledger<B: TransportBinding>(
                 outbox.purge(id);
                 let removes = ledger.deref(id);
                 retire(&mut conn, &mut ledger, &mut outbox, removes);
+                settle_idle_waiters(&mut ledger, &mut resume_notify);
             }
             Step::Cmd(Some(Cmd::Suspend { reply })) => {
                 suspended = true;
                 outbox.clear();
                 if let Some(wire) = conn.take() {
+                    // Detached on purpose: acknowledging must not await the
+                    // wire's bounded command channel (deadlock discipline
+                    // above), and the drain is bounded and discard-only —
+                    // releasing the wire, not finishing its funeral, is what
+                    // "suspended" means.
                     close_gracefully(wire);
                 }
                 // Pending waves stay: their leases are still owed a
@@ -990,15 +1018,26 @@ async fn run_ledger<B: TransportBinding>(
                 } else {
                     resume_notify.push(reply);
                     reconnect_delay = RECONNECT_INITIAL_DELAY;
-                    reopen(
+                    match reopen(
                         &opener,
                         &mut ledger,
                         &mut conn,
                         &mut reconnect_delay,
                         &mut reconnect_at,
                         &mut resume_notify,
+                        &mut cmds,
+                        &mut deferred,
                     )
-                    .await;
+                    .await
+                    {
+                        AfterReopen::Proceed => {}
+                        AfterReopen::Suspended(ack) => {
+                            suspended = true;
+                            park_deferred_resumes(&mut deferred, &mut resume_notify);
+                            let _ = ack.send(());
+                        }
+                        AfterReopen::Shutdown => return,
+                    }
                 }
             }
             // The wire ended (server close or transport failure). Leases
@@ -1013,17 +1052,29 @@ async fn run_ledger<B: TransportBinding>(
                         "bidi transport: wire died; reconnecting from last-seen positions"
                     );
                 }
+                settle_idle_waiters(&mut ledger, &mut resume_notify);
             }
             Step::Reconnect => {
-                reopen(
+                match reopen(
                     &opener,
                     &mut ledger,
                     &mut conn,
                     &mut reconnect_delay,
                     &mut reconnect_at,
                     &mut resume_notify,
+                    &mut cmds,
+                    &mut deferred,
                 )
-                .await;
+                .await
+                {
+                    AfterReopen::Proceed => {}
+                    AfterReopen::Suspended(ack) => {
+                        suspended = true;
+                        park_deferred_resumes(&mut deferred, &mut resume_notify);
+                        let _ = ack.send(());
+                    }
+                    AfterReopen::Shutdown => return,
+                }
             }
             Step::Wire(Some(event)) => {
                 let mut removes = Vec::new();
@@ -1031,9 +1082,114 @@ async fn run_ledger<B: TransportBinding>(
                     removes.extend(ledger.deref(lease));
                 }
                 retire(&mut conn, &mut ledger, &mut outbox, removes);
+                settle_idle_waiters(&mut ledger, &mut resume_notify);
             }
         }
     }
+}
+
+/// What racing a dial against the command channel produced. Non-lifecycle
+/// commands arriving mid-dial are deferred in order (the ledger loop drains
+/// `deferred` before reading the channel again); only `Suspend` — whose whole
+/// point is leaving the network *now* — and shutdown preempt the dial,
+/// dropping the in-flight open future.
+enum OpenOutcome<B: BidiBinding> {
+    Opened(Connection<B>),
+    Failed(OpenError),
+    /// A `Cmd::Suspend` arrived mid-dial and the dial was dropped. Carries
+    /// the suspend reply for the caller to acknowledge once it has marked
+    /// the transport suspended.
+    Suspended(oneshot::Sender<()>),
+    /// Every handle is gone; the ledger should shut down.
+    Shutdown,
+}
+
+async fn open_preemptibly<B: TransportBinding>(
+    opener: &Opener<B>,
+    mutate: B::Mutate,
+    cmds: &mut mpsc::UnboundedReceiver<Cmd<B>>,
+    deferred: &mut std::collections::VecDeque<Cmd<B>>,
+) -> OpenOutcome<B>
+where
+    B::GroupMessage: Clone,
+    B::WelcomeMessage: Clone,
+{
+    let open = opener.open(mutate);
+    tokio::pin!(open);
+    loop {
+        tokio::select! {
+            result = &mut open => {
+                return match result {
+                    Ok(wire) => OpenOutcome::Opened(wire),
+                    Err(e) => OpenOutcome::Failed(e),
+                };
+            }
+            cmd = cmds.recv() => match cmd {
+                Some(Cmd::Suspend { reply }) => return OpenOutcome::Suspended(reply),
+                Some(cmd) => deferred.push_back(cmd),
+                None => return OpenOutcome::Shutdown,
+            },
+        }
+    }
+}
+
+/// A dial-preempting `Suspend` outranks anything it jumped over: a
+/// `Cmd::Resume` deferred during that dial predates the suspend, and
+/// replaying it later would flip the transport back onto the network against
+/// the caller's newest intent. Park those waiters instead — they ride to the
+/// resume wave a *later* `resume()` completes. (Everything else deferred —
+/// leases, derefs — replays safely under suspension.)
+fn park_deferred_resumes<B: TransportBinding>(
+    deferred: &mut std::collections::VecDeque<Cmd<B>>,
+    resume_notify: &mut Vec<oneshot::Sender<()>>,
+) where
+    B::GroupMessage: Clone,
+    B::WelcomeMessage: Clone,
+{
+    for cmd in std::mem::take(deferred) {
+        match cmd {
+            Cmd::Resume { reply } => resume_notify.push(reply),
+            other => deferred.push_back(other),
+        }
+    }
+}
+
+/// With nothing leased there is no catch-up left to await: fire every parked
+/// `resume()` waiter — both those riding pending resume waves and those not
+/// yet on a wave — and drop the wave obligations, which can never resolve
+/// (their wire is gone or going, and nothing will re-open it). Called
+/// whenever a deref or wire death may have emptied the ledger; a no-op while
+/// any lease remains.
+fn settle_idle_waiters<B: TransportBinding>(
+    ledger: &mut Ledger<B>,
+    resume_notify: &mut Vec<oneshot::Sender<()>>,
+) where
+    B::GroupMessage: Clone,
+    B::WelcomeMessage: Clone,
+{
+    if !ledger.leases.is_empty() {
+        return;
+    }
+    for (_, owner) in ledger.pending_waves.drain() {
+        if let WaveOwner::Resume { notify, .. } = owner {
+            for waiter in notify {
+                let _ = waiter.send(());
+            }
+        }
+    }
+    for waiter in resume_notify.drain(..) {
+        let _ = waiter.send(());
+    }
+}
+
+/// How the ledger loop should proceed after a [`reopen`] attempt.
+enum AfterReopen {
+    Proceed,
+    /// `Cmd::Suspend` preempted the dial: acknowledge once the caller has
+    /// marked the transport suspended. Parked waiters stay parked and ride
+    /// to the resume wave that eventually completes.
+    Suspended(oneshot::Sender<()>),
+    Shutdown,
 }
 
 /// Open a fresh wire seeded with the resume wave — every leased topic from
@@ -1041,8 +1197,9 @@ async fn run_ledger<B: TransportBinding>(
 /// wave: leases still owed a `CatchUpComplete`, `resume()` waiters parked in
 /// `notify`, and waiters riding resume waves the previous wire never
 /// completed. On failure the backoff grows and every waiter stays parked for
-/// the next attempt. Awaiting the opener is safe here for the same reason as
-/// the cold open: with no wire there are no events to drain.
+/// the next attempt. The dial is preemptible ([`open_preemptibly`]): commands
+/// keep flowing while it runs, so a `suspend()` never waits on a stuck dial.
+#[allow(clippy::too_many_arguments)]
 async fn reopen<B: TransportBinding>(
     opener: &Opener<B>,
     ledger: &mut Ledger<B>,
@@ -1050,7 +1207,10 @@ async fn reopen<B: TransportBinding>(
     reconnect_delay: &mut std::time::Duration,
     reconnect_at: &mut tokio::time::Instant,
     notify: &mut Vec<oneshot::Sender<()>>,
-) where
+    cmds: &mut mpsc::UnboundedReceiver<Cmd<B>>,
+    deferred: &mut std::collections::VecDeque<Cmd<B>>,
+) -> AfterReopen
+where
     B::GroupMessage: Clone,
     B::WelcomeMessage: Clone,
 {
@@ -1060,12 +1220,12 @@ async fn reopen<B: TransportBinding>(
         for waiter in notify.drain(..) {
             let _ = waiter.send(());
         }
-        return;
+        return AfterReopen::Proceed;
     };
     let wave = ledger.next_wave_id();
     let mutate = B::build_mutate(adds, None, wave.0);
-    match opener.open(mutate).await {
-        Ok(wire) => {
+    match open_preemptibly(opener, mutate, cmds, deferred).await {
+        OpenOutcome::Opened(wire) => {
             *conn = Some(wire);
             *reconnect_delay = RECONNECT_INITIAL_DELAY;
             // Waves from the dead wire can never resolve on this one; the
@@ -1080,12 +1240,16 @@ async fn reopen<B: TransportBinding>(
             ledger
                 .pending_waves
                 .insert(wave, WaveOwner::Resume { pending, notify });
+            AfterReopen::Proceed
         }
-        Err(e) => {
+        OpenOutcome::Failed(e) => {
             tracing::warn!("bidi transport: reconnect failed ({e}); backing off");
             *reconnect_delay = (*reconnect_delay * 2).min(RECONNECT_MAX_DELAY);
             *reconnect_at = tokio::time::Instant::now() + *reconnect_delay;
+            AfterReopen::Proceed
         }
+        OpenOutcome::Suspended(ack) => AfterReopen::Suspended(ack),
+        OpenOutcome::Shutdown => AfterReopen::Shutdown,
     }
 }
 
@@ -2076,6 +2240,165 @@ mod tests {
         // The suspended-time lease was owed its catch-up by the resume wave.
         assert!(matches!(
             recv(&mut beta).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+    }
+
+    /// A `resume()` waiter whose last lease disappears mid-catch-up must
+    /// resolve — with nothing leased there is nothing left to await.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn dropping_the_last_lease_settles_resume_waiters() {
+        let (transport, servers) = transport();
+        let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        server.send(catchup_complete(first.mutate_id));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+
+        transport.suspend().await?;
+        server.request_stream_ended().await;
+
+        // resume() re-opens and parks awaiting the resume wave's catch-up...
+        let resumed = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+        let mut second = wait_for_server(&servers).await;
+        let _resume = second.next_mutate().await;
+        // ...but the last lease goes away before the server answers.
+        drop(alpha);
+        tokio::time::timeout(WAIT, resumed).await?.unwrap()?;
+    }
+
+    /// `suspend()` must preempt a stuck dial: backgrounding during a network
+    /// outage is exactly when dials hang, and leaving the network cannot
+    /// wait on one.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn suspend_preempts_a_stuck_dial() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        // The first dial hangs forever; later dials get a scripted session.
+        let servers: Servers = Arc::default();
+        let dials = Arc::new(AtomicUsize::new(0));
+        let transport: BidiTransport<V3Binding> = {
+            let sink = servers.clone();
+            let dials = dials.clone();
+            BidiTransport::new(move |initial| {
+                let n = dials.fetch_add(1, Ordering::SeqCst);
+                let sink = sink.clone();
+                async move {
+                    if n == 0 {
+                        std::future::pending::<()>().await;
+                        unreachable!("the hung dial never resolves");
+                    }
+                    let (api, server) = mock_pair();
+                    sink.lock().unwrap().push(server);
+                    BidiConnection::open(&api, initial)
+                        .await
+                        .map_err(|e| Box::new(e) as OpenError)
+                }
+            })
+        };
+
+        // The cold open hangs; drive it from a task and wait for the dial
+        // to actually be in flight.
+        let leased = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.lease(vec![(group_topic(b"g1"), 0)], 8).await }
+        });
+        while dials.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // Suspend preempts the stuck dial promptly...
+        tokio::time::timeout(WAIT, transport.suspend()).await??;
+        // ...and the lease registered anyway, parked for the resume open.
+        let mut alpha = tokio::time::timeout(WAIT, leased).await?.unwrap()?;
+
+        let resumed = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+        let mut server = wait_for_server(&servers).await;
+        let resume = server.next_mutate().await;
+        server.send(catchup_complete(resume.mutate_id));
+        tokio::time::timeout(WAIT, resumed).await?.unwrap()?;
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+    }
+
+    /// A `resume()` deferred while a dial is in flight predates the
+    /// `suspend()` that preempts the dial — replaying it afterwards must not
+    /// put the transport back on the network. Its waiter parks and rides the
+    /// next explicit resume instead.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn a_preempting_suspend_outranks_a_deferred_resume() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let servers: Servers = Arc::default();
+        let dials = Arc::new(AtomicUsize::new(0));
+        let transport: BidiTransport<V3Binding> = {
+            let sink = servers.clone();
+            let dials = dials.clone();
+            BidiTransport::new(move |initial| {
+                let n = dials.fetch_add(1, Ordering::SeqCst);
+                let sink = sink.clone();
+                async move {
+                    if n == 0 {
+                        std::future::pending::<()>().await;
+                        unreachable!("the hung dial never resolves");
+                    }
+                    let (api, server) = mock_pair();
+                    sink.lock().unwrap().push(server);
+                    BidiConnection::open(&api, initial)
+                        .await
+                        .map_err(|e| Box::new(e) as OpenError)
+                }
+            })
+        };
+
+        let leased = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.lease(vec![(group_topic(b"g1"), 0)], 8).await }
+        });
+        while dials.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // FIFO on the command channel: this resume is deferred mid-dial,
+        // then the suspend preempts the dial.
+        let first_resume = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        tokio::time::timeout(WAIT, transport.suspend()).await??;
+        let mut alpha = tokio::time::timeout(WAIT, leased).await?.unwrap()?;
+
+        // The stale resume must not resurrect the network.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert_eq!(
+            dials.load(Ordering::SeqCst),
+            1,
+            "a resume deferred before the suspend must not redial"
+        );
+
+        // A later, explicit resume brings everything back — including the
+        // parked waiter from before the suspend.
+        let second_resume = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+        let mut server = wait_for_server(&servers).await;
+        let resume = server.next_mutate().await;
+        server.send(catchup_complete(resume.mutate_id));
+        tokio::time::timeout(WAIT, second_resume).await?.unwrap()?;
+        tokio::time::timeout(WAIT, first_resume).await?.unwrap()?;
+        assert!(matches!(
+            recv(&mut alpha).await,
             Some(LeaseEvent::CatchUpComplete)
         ));
     }


### PR DESCRIPTION
Phase E of the XIP-83 client integration, part 2 of 2 — **stacked on #3828**. Liveness moves into the connection actor, and the transport gains the mobile app-lifecycle touchpoint.

## Commit 1 — bidi actor silence watchdog

A half-open wire (silent but never closed) previously left `Connection::next()` pending forever; detection was deferred to callers via `probe()`. The actor now polices this itself — it is the sole inbound reader, so silence detection there cannot deadlock (an inline `probe()` await from the transport's ledger loop would stop draining events, park the actor on a full event channel, and starve the very pong it waits for).

- Every inbound frame stamps activity; cadence comes from the server's `Started` (30s XIP-83 fallback until then).
- At `(N−1)×keepalive` of silence: one watchdog ping. At `N×` (`PROBE_TIMEOUT_MULTIPLIER` = 3): teardown.
- Emitting to a backpressured consumer restarts the window — a slow consumer must never read as wire silence (frames may sit unread behind the parked emit).

Teardown surfaces as end-of-events → the transport's existing `Wire(None)` → resume-wave path (previous PR) absorbs it. `probe()` remains for callers needing an answer faster than the watchdog budget (e.g. notification handlers).

## Commit 2 — transport `suspend()` / `resume()`

The single FFI lifecycle touchpoint for mobile backgrounding (`didEnterBackground` / `willEnterForeground`):

- `suspend()`: graceful half-close; leases and wire positions kept; new leases register without touching the network; nothing reconnects until resume. Idempotent.
- `resume()`: re-opens with the same resume wave a wire flap uses and resolves at that wave's `CatchUpComplete` — "catch up, then done", the background-fetch primitive. Waiters ride open-failure backoff and re-home onto the next resume wave if the wire dies mid-catch-up; a second `resume()` joins the in-flight one. A live wire (or nothing leased) resolves immediately — a process thawed *without* suspending is instead caught by the watchdog above.

Also converts the wire opener to the `MaybeSend`/`MaybeSync` trait-object pattern (per `watchdog.rs` precedent) — the ledger holds a shared reference across the open await, and the Maybe* form keeps the bound wasm-portable even though this module is native-only today.

## Review-round fixes

- Watchdog teardown yields to ready work (`biased` select ordering); suspend/resume transitions log at info; the watchdog nonce is reserved so client probes can never mint it.
- Resumes deferred by a failed dial park instead of re-dialing (macroscope finding): an explicit `resume()` deliberately dials immediately, but resumes arriving *mid-dial* rode that attempt and lost with it — replaying each as a fresh dial would stampede the opener past its backoff. They now park (the suspend-preempt rule) and ride the scheduled retry; only a resume arriving between attempts earns a new immediate dial.

## Tests

Nine new tests: watchdog probe-then-teardown, answered-probe survival, activity reset, consumer-backpressure-is-not-silence, cross-layer half-open-wire-reaped-and-reconnected, suspend/resume round-trip resolving at catch-up, suspended-stays-off-the-network (including a lease taken while suspended riding the one resume wave), resume-with-nothing-to-do, resume-burst-during-an-outage-dials-once. 37/37 across the bidi + transport modules; `just lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add silence watchdog and suspend/resume lifecycle to bidi transport
> - Adds a silence watchdog to the bidi connection actor in [bidi.rs](https://github.com/xmtp/libxmtp/pull/3829/files#diff-c49e1661d673a984b586cc256686366332160bc09d8324aff059ff2d9753879f): after `PROBE_TIMEOUT_MULTIPLIER - 1` keepalive intervals with no inbound frame, the actor sends a watchdog ping; after the full budget with no response, it tears down the connection so consumers see end-of-stream rather than a hang.
> - Introduces a reserved `WATCHDOG_NONCE` (`u64::MAX`) so watchdog pings are distinguishable from client probes, and updates `next_probe_nonce` to skip both `0` and `WATCHDOG_NONCE`.
> - Adds `suspend()` and `resume()` methods to `BidiTransport` in [bidi_transport.rs](https://github.com/xmtp/libxmtp/pull/3829/files#diff-d4217bbd27403da346b2451dab35cab51079f0ccb533baa2a2248a7fa3dbe458): suspend half-closes the wire and stops reconnects; resume reopens with a catch-up wave and resolves at `CatchUpComplete`. Leases registered while suspended are covered by the next resume wave without touching the network.
> - Rewrites the monolithic `run_ledger` loop into a `LedgerTask` state machine supporting preemptible dialing, suspend preempting a hung dial, consolidated resume waiters, and immediate settlement when no leases remain.
> - Risk: the watchdog teardown timing is relative to consumer backpressure — stalls due to a full event channel no longer count as wire silence, which changes when teardown can fire.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #3829 opened
>
> - Modified `queries::bidi_transport` reconnect handler to park deferred resume requests after failed dial attempts [b95b78b]
> - Added test case validating single dial behavior during outage with multiple resume requests [b95b78b]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized febca30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
