### PR TITLE
feat(xmtp_mls,bindings): route callback streams over bidi behind XMTP_BIDI_STREAMS_ENABLED

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -77,6 +77,7 @@ use xmtp_mls::mls_common::group::GroupMetadataOptions;
 use xmtp_mls::mls_common::group_metadata::GroupMetadata;
 use xmtp_mls::mls_common::group_mutable_metadata::MessageDisappearingSettings;
 use xmtp_mls::mls_common::group_mutable_metadata::MetadataField;
+use xmtp_mls::subscriptions::router_callbacks::bidi_streams_enabled;
 use xmtp_mls::{
     client::Client as MlsClient,
     groups::{
@@ -1615,6 +1616,45 @@ impl From<&FfiMetadataField> for MetadataField {
     }
 }
 
+impl FfiConversations {
+    /// One seam for every conversation stream: route over the shared bidi
+    /// wire when `XMTP_BIDI_STREAMS_ENABLED` is set, legacy otherwise. Lives
+    /// outside the exported impl (uniffi must not see the rust-only types).
+    fn stream_conversations_dispatch(
+        &self,
+        conversation_type: Option<ConversationType>,
+        callback: Arc<dyn FfiConversationCallback>,
+    ) -> FfiStreamCloser {
+        let client = self.inner_client.clone();
+        let close_cb = callback.clone();
+        if bidi_streams_enabled() {
+            // Interim bidi scope — locally-created conversations do not
+            // surface on this stream yet: see the entry point's docs.
+            FfiStreamCloser::new(RustXmtpClient::stream_conversations_with_callback_bidi(
+                client,
+                conversation_type,
+                false,
+                move |convo| match convo {
+                    Ok(c) => callback.on_conversation(Arc::new(c.into())),
+                    Err(e) => callback.on_error(e.into()),
+                },
+                move || close_cb.on_close(),
+            ))
+        } else {
+            FfiStreamCloser::new(RustXmtpClient::stream_conversations_with_callback(
+                client,
+                conversation_type,
+                move |convo| match convo {
+                    Ok(c) => callback.on_conversation(Arc::new(c.into())),
+                    Err(e) => callback.on_error(e.into()),
+                },
+                move || close_cb.on_close(),
+                false,
+            ))
+        }
+    }
+}
+
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiConversations {
     #[tracing::instrument(level = "debug", skip_all)]
@@ -1849,55 +1889,16 @@ impl FfiConversations {
         &self,
         callback: Arc<dyn FfiConversationCallback>,
     ) -> FfiStreamCloser {
-        let client = self.inner_client.clone();
-        let close_cb = callback.clone();
-        let handle = RustXmtpClient::stream_conversations_with_callback(
-            client.clone(),
-            Some(ConversationType::Group),
-            move |convo| match convo {
-                Ok(c) => callback.on_conversation(Arc::new(c.into())),
-                Err(e) => callback.on_error(e.into()),
-            },
-            move || close_cb.on_close(),
-            false,
-        );
-
-        FfiStreamCloser::new(handle)
+        self.stream_conversations_dispatch(Some(ConversationType::Group), callback)
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream_dms(&self, callback: Arc<dyn FfiConversationCallback>) -> FfiStreamCloser {
-        let client = self.inner_client.clone();
-        let close_cb = callback.clone();
-        let handle = RustXmtpClient::stream_conversations_with_callback(
-            client.clone(),
-            Some(ConversationType::Dm),
-            move |convo| match convo {
-                Ok(c) => callback.on_conversation(Arc::new(c.into())),
-                Err(e) => callback.on_error(e.into()),
-            },
-            move || close_cb.on_close(),
-            false,
-        );
-
-        FfiStreamCloser::new(handle)
+        self.stream_conversations_dispatch(Some(ConversationType::Dm), callback)
     }
 
     pub async fn stream(&self, callback: Arc<dyn FfiConversationCallback>) -> FfiStreamCloser {
-        let client = self.inner_client.clone();
-        let close_cb = callback.clone();
-        let handle = RustXmtpClient::stream_conversations_with_callback(
-            client.clone(),
-            None,
-            move |convo| match convo {
-                Ok(c) => callback.on_conversation(Arc::new(c.into())),
-                Err(e) => callback.on_error(e.into()),
-            },
-            move || close_cb.on_close(),
-            false,
-        );
-
-        FfiStreamCloser::new(handle)
+        self.stream_conversations_dispatch(None, callback)
     }
 
     pub async fn stream_all_group_messages(
@@ -1944,18 +1945,31 @@ impl FfiConversations {
         let consents: Option<Vec<ConsentState>> =
             consent_states.map(|states| states.into_iter().map(|state| state.into()).collect());
         let close_cb = message_callback.clone();
-        let handle = RustXmtpClient::stream_all_messages_with_callback(
-            self.inner_client.context.clone(),
-            conversation_type.map(Into::into),
-            consents,
-            move |msg| match msg {
-                Ok(m) => message_callback.on_message(m.into()),
-                Err(e) => message_callback.on_error(e.into()),
-            },
-            move || close_cb.on_close(),
-        );
-
-        FfiStreamCloser::new(handle)
+        if bidi_streams_enabled() {
+            // Interim bidi scope — covers the groups known at subscribe time:
+            // see the entry point's docs.
+            FfiStreamCloser::new(RustXmtpClient::stream_all_messages_with_callback_bidi(
+                self.inner_client.clone(),
+                conversation_type.map(Into::into),
+                consents,
+                move |msg| match msg {
+                    Ok(m) => message_callback.on_message(m.into()),
+                    Err(e) => message_callback.on_error(e.into()),
+                },
+                move || close_cb.on_close(),
+            ))
+        } else {
+            FfiStreamCloser::new(RustXmtpClient::stream_all_messages_with_callback(
+                self.inner_client.context.clone(),
+                conversation_type.map(Into::into),
+                consents,
+                move |msg| match msg {
+                    Ok(m) => message_callback.on_message(m.into()),
+                    Err(e) => message_callback.on_error(e.into()),
+                },
+                move || close_cb.on_close(),
+            ))
+        }
     }
 
     /// Get notified when there is a new consent update either locally or is synced from another device

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -77,7 +77,9 @@ use xmtp_mls::mls_common::group::GroupMetadataOptions;
 use xmtp_mls::mls_common::group_metadata::GroupMetadata;
 use xmtp_mls::mls_common::group_mutable_metadata::MessageDisappearingSettings;
 use xmtp_mls::mls_common::group_mutable_metadata::MetadataField;
-use xmtp_mls::subscriptions::router_callbacks::bidi_streams_enabled;
+use xmtp_mls::subscriptions::router_callbacks::{
+    bidi_streams_enabled, stream_conversation_messages_with_callback_bidi,
+};
 use xmtp_mls::{
     client::Client as MlsClient,
     groups::{
@@ -3057,17 +3059,29 @@ impl FfiConversation {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream(&self, message_callback: Arc<dyn FfiMessageCallback>) -> FfiStreamCloser {
         let close_cb = message_callback.clone();
-        let handle = MlsGroup::stream_with_callback(
-            self.inner.context.clone(),
-            self.inner.group_id,
-            move |message| match message {
-                Ok(m) => message_callback.on_message(m.into()),
-                Err(e) => message_callback.on_error(e.into()),
-            },
-            move || close_cb.on_close(),
-        );
-
-        FfiStreamCloser::new(handle)
+        if bidi_streams_enabled() {
+            let handle = stream_conversation_messages_with_callback_bidi(
+                self.inner.context.clone(),
+                self.inner.group_id,
+                move |message| match message {
+                    Ok(m) => message_callback.on_message(m.into()),
+                    Err(e) => message_callback.on_error(e.into()),
+                },
+                move || close_cb.on_close(),
+            );
+            FfiStreamCloser::new(handle)
+        } else {
+            let handle = MlsGroup::stream_with_callback(
+                self.inner.context.clone(),
+                self.inner.group_id,
+                move |message| match message {
+                    Ok(m) => message_callback.on_message(m.into()),
+                    Err(e) => message_callback.on_error(e.into()),
+                },
+                move || close_cb.on_close(),
+            );
+            FfiStreamCloser::new(handle)
+        }
     }
 
     pub fn created_at_ns(&self) -> i64 {

--- a/bindings/node/src/conversation/streams.rs
+++ b/bindings/node/src/conversation/streams.rs
@@ -5,6 +5,9 @@ use napi::{
 };
 use napi_derive::napi;
 use xmtp_mls::groups::MlsGroup;
+use xmtp_mls::subscriptions::router_callbacks::{
+  bidi_streams_enabled, stream_conversation_messages_with_callback_bidi,
+};
 
 #[napi]
 impl Conversation {
@@ -16,10 +19,8 @@ impl Conversation {
     on_close: ThreadsafeFunction<(), ()>,
   ) -> Result<StreamCloser> {
     let group = self.create_mls_group();
-    let stream_closer = MlsGroup::stream_with_callback(
-      group.context.clone(),
-      group.group_id,
-      move |message| {
+    let on_message =
+      move |message: std::result::Result<_, xmtp_mls::subscriptions::SubscribeError>| {
         let status = callback.call(
           message
             .map(Message::from)
@@ -28,12 +29,23 @@ impl Conversation {
           ThreadsafeFunctionCallMode::Blocking,
         );
         tracing::info!("Stream status: {:?}", status);
-      },
-      move || {
-        on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
-      },
-    );
+      };
+    let on_close = move || {
+      on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
+    };
 
-    Ok(StreamCloser::new(stream_closer))
+    if bidi_streams_enabled() {
+      let handle = stream_conversation_messages_with_callback_bidi(
+        group.context.clone(),
+        group.group_id,
+        on_message,
+        on_close,
+      );
+      Ok(StreamCloser::new(handle))
+    } else {
+      let handle =
+        MlsGroup::stream_with_callback(group.context.clone(), group.group_id, on_message, on_close);
+      Ok(StreamCloser::new(handle))
+    }
   }
 }

--- a/bindings/node/src/conversations/streams.rs
+++ b/bindings/node/src/conversations/streams.rs
@@ -9,6 +9,7 @@ use napi::bindgen_prelude::{Error, Result, Uint8Array};
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 use xmtp_db::consent_record::ConsentState as XmtpConsentState;
+use xmtp_mls::subscriptions::router_callbacks::bidi_streams_enabled;
 use xmtp_mls::worker::device_sync::preference_sync::PreferenceUpdate as XmtpUserPreferenceUpdate;
 
 #[napi(discriminant = "type")]
@@ -38,10 +39,8 @@ impl Conversations {
     on_close: ThreadsafeFunction<(), ()>,
     conversation_type: Option<ConversationType>,
   ) -> Result<StreamCloser> {
-    let stream_closer = RustXmtpClient::stream_conversations_with_callback(
-      self.inner_client.clone(),
-      conversation_type.map(|ct| ct.into()),
-      move |convo| {
+    let on_conversation =
+      move |convo: std::result::Result<_, xmtp_mls::subscriptions::SubscribeError>| {
         let status = callback.call(
           convo
             .map(Conversation::from)
@@ -50,14 +49,32 @@ impl Conversations {
           ThreadsafeFunctionCallMode::Blocking,
         );
         tracing::info!("Stream status: {:?}", status);
-      },
-      move || {
-        on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
-      },
-      false,
-    );
+      };
+    let on_close = move || {
+      on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
+    };
 
-    Ok(StreamCloser::new(stream_closer))
+    if bidi_streams_enabled() {
+      // Interim bidi scope — locally-created conversations do not surface on
+      // this stream yet: see `stream_conversations_with_callback_bidi`'s docs.
+      let handle = RustXmtpClient::stream_conversations_with_callback_bidi(
+        self.inner_client.clone(),
+        conversation_type.map(|ct| ct.into()),
+        false,
+        on_conversation,
+        on_close,
+      );
+      Ok(StreamCloser::new(handle))
+    } else {
+      let handle = RustXmtpClient::stream_conversations_with_callback(
+        self.inner_client.clone(),
+        conversation_type.map(|ct| ct.into()),
+        on_conversation,
+        on_close,
+        false,
+      );
+      Ok(StreamCloser::new(handle))
+    }
   }
 
   #[napi]
@@ -82,11 +99,8 @@ impl Conversations {
         .collect()
     });
 
-    let stream_closer = RustXmtpClient::stream_all_messages_with_callback(
-      self.inner_client.context.clone(),
-      conversation_type.map(Into::into),
-      consents,
-      move |message| {
+    let on_message =
+      move |message: std::result::Result<_, xmtp_mls::subscriptions::SubscribeError>| {
         tracing::trace!(
             inbox_id,
             conversation_type = ?conversation_type,
@@ -127,13 +141,32 @@ impl Conversations {
             );
           }
         }
-      },
-      move || {
-        on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
-      },
-    );
+      };
+    let on_close = move || {
+      on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
+    };
 
-    Ok(StreamCloser::new(stream_closer))
+    if bidi_streams_enabled() {
+      // Interim bidi scope — covers the groups known at subscribe time: see
+      // `stream_all_messages_with_callback_bidi`'s docs.
+      let handle = RustXmtpClient::stream_all_messages_with_callback_bidi(
+        self.inner_client.clone(),
+        conversation_type.map(Into::into),
+        consents,
+        on_message,
+        on_close,
+      );
+      Ok(StreamCloser::new(handle))
+    } else {
+      let handle = RustXmtpClient::stream_all_messages_with_callback(
+        self.inner_client.context.clone(),
+        conversation_type.map(Into::into),
+        consents,
+        on_message,
+        on_close,
+      );
+      Ok(StreamCloser::new(handle))
+    }
   }
 
   #[napi]

--- a/crates/xmtp_api_d14n/src/protocol/traits/full_api.rs
+++ b/crates/xmtp_api_d14n/src/protocol/traits/full_api.rs
@@ -6,6 +6,31 @@ use xmtp_proto::{
     prelude::{XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams},
 };
 
+// The XIP-83 bidi requirement, folded into the full API only where it can
+// exist: `Send`-style Maybe* bridge — on native the full API must speak
+// bidi (with the boxed stream, so it stays `dyn`-compatible); on wasm the
+// bound is vacuous (gRPC-Web cannot full-duplex).
+xmtp_common::if_native! {
+    pub trait MaybeBidiStreams<Err>:
+        xmtp_proto::api_client::XmtpMlsBidiStreams<
+            Error = Err,
+            SubscribeStream = xmtp_proto::api_client::BoxedSubscribeS<Err>,
+        >
+    {
+    }
+    impl<T, Err> MaybeBidiStreams<Err> for T where
+        T: xmtp_proto::api_client::XmtpMlsBidiStreams<
+                Error = Err,
+                SubscribeStream = xmtp_proto::api_client::BoxedSubscribeS<Err>,
+            > + ?Sized
+    {
+    }
+}
+xmtp_common::if_wasm! {
+    pub trait MaybeBidiStreams<Err> {}
+    impl<T, Err> MaybeBidiStreams<Err> for T where T: ?Sized {}
+}
+
 use crate::protocol::XmtpQuery;
 
 /// A type-erased version of the Xmtp Api in a [`Box`]
@@ -32,6 +57,7 @@ where
             GroupMessageStream = BoxedGroupS<Err>,
         > + IsConnectedCheck
         + XmtpQuery<Error = Err>
+        + MaybeBidiStreams<Err>
         + 'static,
 {
 }
@@ -45,6 +71,7 @@ impl<T, Err> FullXmtpApiT<Err> for T where
             GroupMessageStream = BoxedGroupS<Err>,
         > + IsConnectedCheck
         + XmtpQuery<Error = Err>
+        + MaybeBidiStreams<Err>
         + ?Sized
         + 'static
 {

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -193,6 +193,18 @@ pub enum TransportError {
     Empty,
 }
 
+impl xmtp_common::RetryableError for TransportError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            // The next `lease()` attempts a fresh open.
+            Self::Open(_) => true,
+            // The transport is gone for good; an empty lease is a caller bug
+            // no retry fixes.
+            Self::Closed | Self::Empty => false,
+        }
+    }
+}
+
 /// Raw wire deliveries for one lease's topics, in wire order. Message payloads
 /// are still encrypted wire shapes — decoding is the consumer's job.
 pub enum LeaseEvent<B: TransportBinding>

--- a/crates/xmtp_api_d14n/src/queries/boxed_streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/boxed_streams.rs
@@ -142,6 +142,29 @@ where
     }
 }
 
+xmtp_common::if_native! {
+    // Same erasure for the XIP-83 bidi stream (native-only, like the trait):
+    // pin the concrete subscribe stream behind `BoxedSubscribeS` so the
+    // boxed client can flow into `dyn` full-API objects.
+    #[xmtp_common::async_trait]
+    impl<C> xmtp_proto::api_client::XmtpMlsBidiStreams for BoxedStreamsClient<C>
+    where
+        C: xmtp_proto::api_client::XmtpMlsBidiStreams,
+        C::SubscribeStream: 'static,
+    {
+        type SubscribeStream = xmtp_proto::api_client::BoxedSubscribeS<Self::Error>;
+        type Error = <C as xmtp_proto::api_client::XmtpMlsBidiStreams>::Error;
+
+        async fn subscribe_bidi(
+            &self,
+            requests: futures::stream::BoxStream<'static, xmtp_proto::mls_v1::SubscribeRequest>,
+        ) -> Result<Self::SubscribeStream, Self::Error> {
+            let s = self.inner.subscribe_bidi(requests).await?;
+            Ok(Box::pin(s) as Pin<Box<_>>)
+        }
+    }
+}
+
 #[xmtp_common::async_trait]
 impl<C> XmtpMlsStreams for BoxedStreamsClient<C>
 where

--- a/crates/xmtp_api_d14n/src/queries/combined/streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/streams.rs
@@ -51,3 +51,31 @@ where
             .await?)
     }
 }
+
+xmtp_common::if_native! {
+    // The v3-shaped XIP-83 bidi surface (`mls_v1` frames). This client cannot
+    // serve it — the d14n wire speaks its own envelope binding — so it refuses
+    // at runtime with an unretryable error. The dyn full API always *has*
+    // `subscribe_bidi`; support is a runtime property of the backend. There is
+    // no automatic fallback to the legacy streams yet (that latch is follow-on
+    // work), so the opt-in env gate must only be enabled against v3 backends.
+    #[xmtp_common::async_trait]
+    impl<V3, D14n, Store> xmtp_proto::api_client::XmtpMlsBidiStreams for MigrationClient<V3, D14n, Store>
+    where
+        V3: Client,
+        D14n: Client,
+        Store: CursorStore + Clone,
+    {
+        type SubscribeStream = xmtp_proto::api_client::BoxedSubscribeS<ApiClientError>;
+        type Error = ApiClientError;
+
+        async fn subscribe_bidi(
+            &self,
+            _requests: futures::stream::BoxStream<'static, xmtp_proto::mls_v1::SubscribeRequest>,
+        ) -> Result<Self::SubscribeStream, Self::Error> {
+            Err(ApiClientError::OtherUnretryable(
+                "the v3 bidi subscription is not available on this client".into(),
+            ))
+        }
+    }
+}

--- a/crates/xmtp_api_d14n/src/queries/d14n/streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/streams.rs
@@ -116,3 +116,30 @@ where
         Ok(stream::try_extractor(s))
     }
 }
+
+xmtp_common::if_native! {
+    // The v3-shaped XIP-83 bidi surface (`mls_v1` frames). This client cannot
+    // serve it — the d14n wire speaks its own envelope binding — so it refuses
+    // at runtime with an unretryable error. The dyn full API always *has*
+    // `subscribe_bidi`; support is a runtime property of the backend. There is
+    // no automatic fallback to the legacy streams yet (that latch is follow-on
+    // work), so the opt-in env gate must only be enabled against v3 backends.
+    #[xmtp_common::async_trait]
+    impl<C, Store> xmtp_proto::api_client::XmtpMlsBidiStreams for D14nClient<C, Store>
+    where
+        C: Client,
+        Store: CursorStore + Clone,
+    {
+        type SubscribeStream = xmtp_proto::api_client::BoxedSubscribeS<ApiClientError>;
+        type Error = ApiClientError;
+
+        async fn subscribe_bidi(
+            &self,
+            _requests: futures::stream::BoxStream<'static, xmtp_proto::mls_v1::SubscribeRequest>,
+        ) -> Result<Self::SubscribeStream, Self::Error> {
+            Err(ApiClientError::OtherUnretryable(
+                "the v3 bidi subscription is not available on this client".into(),
+            ))
+        }
+    }
+}

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -463,6 +463,8 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             installation_id,
             local_events,
             workers,
+            #[cfg(not(target_arch = "wasm32"))]
+            stream_router: Default::default(),
         };
 
         // Cleanup old unstitched group updated messages.

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -248,6 +248,17 @@ pub struct Client<Context> {
     pub installation_id: InstallationId,
     pub(crate) local_events: broadcast::Sender<LocalEvents>,
     pub(crate) workers: Arc<WorkerRunner>,
+    /// This client's router over the process-shared bidi wire (XIP-83
+    /// streaming path), created on first use. Shared across clones so one
+    /// client never runs two routers.
+    ///
+    /// Lifecycle rides the client's: `close()` ends the streams (their pumps
+    /// watch the cancellation token), after which the router task parks —
+    /// pending on an idle channel, holding no wire state — and exits when
+    /// the last client clone drops this cell.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) stream_router:
+        Arc<tokio::sync::OnceCell<crate::subscriptions::stream_router::StreamRouter<Context>>>,
 }
 
 impl<Context> Drop for Client<Context> {
@@ -269,6 +280,8 @@ impl<Context: Clone> Clone for Client<Context> {
             installation_id: self.installation_id,
             local_events: self.local_events.clone(),
             workers: self.workers.clone(),
+            #[cfg(not(target_arch = "wasm32"))]
+            stream_router: self.stream_router.clone(),
         }
     }
 }

--- a/crates/xmtp_mls/src/groups/subscriptions.rs
+++ b/crates/xmtp_mls/src/groups/subscriptions.rs
@@ -342,6 +342,8 @@ pub(crate) mod tests {
             installation_id,
             local_events,
             workers,
+            #[cfg(not(target_arch = "wasm32"))]
+            stream_router: Default::default(),
         };
 
         let group = client.create_group(None, None).unwrap();
@@ -433,6 +435,8 @@ pub(crate) mod tests {
             installation_id,
             local_events,
             workers,
+            #[cfg(not(target_arch = "wasm32"))]
+            stream_router: Default::default(),
         };
 
         let group = client.create_group(None, None).unwrap();

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -37,6 +37,13 @@ pub mod stream_router;
 // `bidi_tests` above).
 #[cfg(all(test, not(target_arch = "wasm32"), not(feature = "d14n")))]
 mod stream_router_tests;
+// Callback adapters over the router: the process-shared transport, the
+// `XMTP_BIDI_STREAMS_ENABLED` gate, and the pull→push pumps the bindings
+// call (native-only, like the router).
+#[cfg(not(target_arch = "wasm32"))]
+pub mod router_callbacks;
+#[cfg(all(test, not(target_arch = "wasm32"), not(feature = "d14n")))]
+mod router_callbacks_tests;
 pub(crate) mod watchdog;
 
 use crate::messages::enrichment::EnrichMessageError;
@@ -194,6 +201,11 @@ impl StreamMessages for broadcast::Receiver<LocalEvents> {
 
 #[derive(thiserror::Error, Debug, ErrorCode)]
 pub enum SubscribeError {
+    /// Subscribing through the bidi stream router failed. Boxed: RouterError
+    /// itself wraps SubscribeError, so the cycle needs indirection.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error(transparent)]
+    Router(#[from] Box<stream_router::RouterError>),
     /// Group error.
     ///
     /// Group operation failed during subscription. May be retryable.
@@ -283,6 +295,13 @@ impl From<GroupError> for SubscribeError {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl From<stream_router::RouterError> for SubscribeError {
+    fn from(value: stream_router::RouterError) -> Self {
+        SubscribeError::Router(Box::new(value))
+    }
+}
+
 impl From<GroupMessageProcessingError> for SubscribeError {
     fn from(value: GroupMessageProcessingError) -> Self {
         SubscribeError::ReceiveGroup(Box::new(value))
@@ -293,6 +312,14 @@ impl RetryableError for SubscribeError {
     fn is_retryable(&self) -> bool {
         use SubscribeError::*;
         match self {
+            // Re-subscribing recovers from an open failure; a shut-down
+            // router/transport (client teardown) and caller bugs do not.
+            #[cfg(not(target_arch = "wasm32"))]
+            Router(e) => match e.as_ref() {
+                stream_router::RouterError::Closed => false,
+                stream_router::RouterError::Transport(t) => retryable!(t),
+                stream_router::RouterError::Subscribe(inner) => retryable!(inner),
+            },
             Group(e) => retryable!(e),
             GroupMessageNotFound => true,
             ReceiveGroup(e) => retryable!(e),
@@ -321,6 +348,10 @@ impl crate::worker::NeedsDbReconnect for SubscribeError {
             Group(e) => e.needs_db_reconnect(),
             Storage(e) => e.db_needs_connection(),
             Db(c) => c.db_needs_connection(),
+            #[cfg(not(target_arch = "wasm32"))]
+            Router(e) => {
+                matches!(e.as_ref(), stream_router::RouterError::Subscribe(inner) if inner.needs_db_reconnect())
+            }
             GroupMessageNotFound
             | ReceiveGroup(_)
             | Decode(_)

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -114,6 +114,33 @@ where
         .clone()
 }
 
+/// Take the shared bidi wire off the network (the `didEnterBackground` half
+/// of the app-lifecycle pair). Leases and wire positions are kept; nothing
+/// reconnects until [`resume_bidi_streams`]. A no-op when the transport was
+/// never opened (gate off, or nothing ever streamed).
+pub async fn suspend_bidi_streams() -> Result<()> {
+    let Some(transport) = SHARED_TRANSPORT.get() else {
+        return Ok(());
+    };
+    transport
+        .suspend()
+        .await
+        .map_err(|e| super::stream_router::RouterError::Transport(e).into())
+}
+
+/// Bring the shared bidi wire back (`willEnterForeground`), resolving once
+/// its resume wave has caught up — "catch up, then done", the
+/// background-fetch primitive. A no-op when the transport was never opened.
+pub async fn resume_bidi_streams() -> Result<()> {
+    let Some(transport) = SHARED_TRANSPORT.get() else {
+        return Ok(());
+    };
+    transport
+        .resume()
+        .await
+        .map_err(|e| super::stream_router::RouterError::Transport(e).into())
+}
+
 /// Drain a router stream into a callback until it ends or the client shuts
 /// down, then report the close once.
 async fn pump<T>(

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -1,0 +1,281 @@
+//! Callback adapters over the XIP-83 [`StreamRouter`] — the pull→push bridge
+//! the bindings call, plus the pieces that decide *whether* and *where* the
+//! bidi path runs.
+//!
+//! ## One wire per process
+//!
+//! Every client in the process shares ONE [`BidiTransport`]: topics from all
+//! of them multiplex onto a single bidi stream, and the transport's leases
+//! keep them apart (welcome topics are per-installation; a group topic two
+//! clients share is subscribed once and fanned out). One client per process —
+//! mobile — makes this invisible; a process running many clients (agents)
+//! gets O(1) wires instead of O(clients). The first client to stream donates
+//! its api client — connection, auth middleware and all — to the opener,
+//! which assumes one backend and one set of wire credentials per process:
+//! true for mobile, agents, and `nextest`'s process-per-test runs. (Client
+//! *identity* is not wire state — sibling clients' topics multiplex fine —
+//! but a process mixing differently-authenticated api clients would ride
+//! the donor's credentials.)
+//!
+//! ## The gate
+//!
+//! The bidi path is opt-in via [`BIDI_STREAMS_ENABLED_ENV`], read once at
+//! the first stream call: mobile apps set it at process init, agents in
+//! their deploy env. Unset (or anything but a truthy value) keeps the legacy
+//! streams. Dispatch on the gate lives with the bindings; the
+//! `*_with_callback_bidi` entry points here are the bidi arm.
+//!
+//! ## Pump semantics
+//!
+//! Each stream is one spawned task: subscribe (ready fires once the lease is
+//! registered), then drain the router stream into the callback. A subscribe
+//! failure fires `on_close()` and carries the error out through the handle's
+//! result — legacy watchdog semantics, so `end_and_wait()` distinguishes a
+//! startup failure from a clean end. `on_close` fires once
+//! at natural end — the wire-facing lease survives reconnects and suspends
+//! (transport docs), so a natural end means this consumer fell behind and
+//! was dropped, or the client shut down; re-subscribing recovers from
+//! durable cursors. An `end()`ed handle aborts the task without `on_close`,
+//! matching the local-events streams.
+
+use std::sync::{Arc, LazyLock, OnceLock};
+
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use xmtp_api_d14n::{BidiConnection, BidiTransport, OpenError, V3Binding};
+use xmtp_common::{MaybeSend, StreamHandle};
+use xmtp_db::consent_record::ConsentState;
+use xmtp_db::group::{ConversationType, GroupQueryArgs};
+use xmtp_db::group_message::StoredGroupMessage;
+use xmtp_db::prelude::*;
+use xmtp_proto::api_client::XmtpMlsBidiStreams;
+
+use super::stream_router::{DEFAULT_STREAM_DEPTH, RouterStream, StreamRouter};
+use super::{Result, SubscribeError, SyncWorkerEvent};
+use crate::Client;
+use crate::context::XmtpSharedContext;
+use crate::groups::MlsGroup;
+use crate::groups::welcome_sync::WelcomeService;
+
+/// Opt-in env var for the bidi streaming path (`1`/`true`/`yes`/`on`,
+/// case-insensitive). Anything else — including unset — keeps the legacy
+/// per-stream subscriptions.
+pub const BIDI_STREAMS_ENABLED_ENV: &str = "XMTP_BIDI_STREAMS_ENABLED";
+
+/// Whether callback streams should take the bidi path. The environment is
+/// read once, at the first stream call — late enough that a process setting
+/// the variable at init never races client construction, and never again,
+/// since an env lookup scans the whole environ under a lock. Toggling the
+/// variable mid-process has no effect.
+pub fn bidi_streams_enabled() -> bool {
+    static ENABLED: LazyLock<bool> = LazyLock::new(|| {
+        std::env::var(BIDI_STREAMS_ENABLED_ENV)
+            .map(|v| {
+                matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false)
+    });
+    *ENABLED
+}
+
+/// The process-wide transport (see the module docs). `OnceLock` rather than
+/// per-client state: the whole point is that clients share the wire.
+///
+/// Its ledger task is bound to the async runtime alive at first use — the
+/// one-runtime-per-process reality of mobile, node, and agents. A process
+/// that tears its runtime down and starts another (some non-`nextest` test
+/// harnesses) would find the cached transport dead; `nextest`'s
+/// process-per-test model keeps tests clear of that.
+static SHARED_TRANSPORT: OnceLock<BidiTransport<V3Binding>> = OnceLock::new();
+
+fn shared_transport<C>(api: C) -> BidiTransport<V3Binding>
+where
+    C: XmtpMlsBidiStreams + Clone + Send + Sync + 'static,
+    C::SubscribeStream: 'static,
+{
+    SHARED_TRANSPORT
+        .get_or_init(move || {
+            // Whoever streams first donates their api client for the life of
+            // the process — log it, so a mixed-backend accident is findable.
+            tracing::info!("bidi: initializing the process-shared transport");
+            BidiTransport::new(move |initial| {
+                let api = api.clone();
+                async move {
+                    BidiConnection::open(&api, initial)
+                        .await
+                        .map_err(|e| Box::new(e) as OpenError)
+                }
+            })
+        })
+        .clone()
+}
+
+/// Drain a router stream into a callback until it ends or the client shuts
+/// down, then report the close once.
+async fn pump<T>(
+    mut stream: RouterStream<T>,
+    cancel: CancellationToken,
+    mut callback: impl FnMut(Result<T>),
+    on_close: impl FnOnce(),
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            next = stream.next() => match next {
+                Some(item) => callback(item),
+                None => break,
+            }
+        }
+    }
+    on_close();
+}
+
+impl<Context> Client<Context>
+where
+    Context: XmtpSharedContext + 'static,
+    Context::ApiClient: XmtpMlsBidiStreams + Clone + Send + Sync + 'static,
+    <Context::ApiClient as XmtpMlsBidiStreams>::SubscribeStream: 'static,
+{
+    /// This client's router over the process-shared bidi wire, created on
+    /// first use.
+    pub(crate) async fn stream_router(&self) -> &StreamRouter<Context> {
+        self.stream_router
+            .get_or_init(|| async {
+                let api = self.context.api().api_client.clone();
+                StreamRouter::new(self.context.clone(), shared_transport(api))
+            })
+            .await
+    }
+
+    /// Bidi-path counterpart of `stream_all_messages_with_callback`: every
+    /// matching conversation's messages, decoded, over the shared wire.
+    ///
+    /// Interim scope: covers the groups known at subscribe time. A
+    /// conversation joined afterwards reaches this stream on re-subscribe,
+    /// until the welcome auto-subscribe reflex lands.
+    pub fn stream_all_messages_with_callback_bidi(
+        client: Arc<Client<Context>>,
+        conversation_type: Option<ConversationType>,
+        consent_states: Option<Vec<ConsentState>>,
+        mut callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
+        on_close: impl FnOnce() + MaybeSend + 'static,
+    ) -> impl StreamHandle<StreamOutput = Result<()>> {
+        let (tx, rx) = oneshot::channel();
+        xmtp_common::spawn(Some(rx), async move {
+            let cancel = client.context.cancellation_token().clone();
+            let subscribed = async {
+                // Same seeding as the legacy stream: close the welcome gap,
+                // then subscribe every matching group. A conversation joined
+                // after this point reaches the stream on re-subscribe (until
+                // the welcome auto-subscribe reflex lands).
+                WelcomeService::new(&client.context).sync_welcomes().await?;
+                let groups = client.context.db().find_groups(GroupQueryArgs {
+                    conversation_type,
+                    consent_states: consent_states.clone(),
+                    include_duplicate_dms: true,
+                    include_sync_groups: conversation_type
+                        .map(|ct| matches!(ct, ConversationType::Sync))
+                        .unwrap_or(true),
+                    ..Default::default()
+                })?;
+                // Sync groups are subscribed (their traffic nudges the
+                // device-sync worker) but their messages are intercepted
+                // below, exactly like the legacy stream — internal payloads
+                // must not surface as conversation messages.
+                let sync_groups: Vec<Vec<u8>> = groups
+                    .iter()
+                    .filter(|g| matches!(g.conversation_type, ConversationType::Sync))
+                    .map(|g| g.id.to_vec())
+                    .collect();
+                let ids: Vec<GroupId> = groups.into_iter().map(|g| g.id).collect();
+                if ids.is_empty() {
+                    // Nothing matches (fresh account, or an empty filter):
+                    // the transport refuses an empty lease, and legacy stays
+                    // open here — so stay open with nothing subscribed.
+                    // Deliveries begin on re-subscribe (interim scope above).
+                    return Ok::<_, SubscribeError>(None);
+                }
+                let router = client.stream_router().await;
+                let stream = router.stream_messages(ids, DEFAULT_STREAM_DEPTH).await?;
+                Ok(Some((stream, sync_groups)))
+            };
+            let (stream, sync_groups) = match subscribed.await {
+                Ok(Some(subscription)) => subscription,
+                Ok(None) => {
+                    let _ = tx.send(());
+                    cancel.cancelled().await;
+                    on_close();
+                    return Ok(());
+                }
+                Err(e) => {
+                    // The subscribe itself failed: `on_close` fires and the
+                    // handle's result carries the error (legacy watchdog
+                    // semantics); the caller re-subscribes from durable
+                    // cursors.
+                    on_close();
+                    return Err(e);
+                }
+            };
+            let _ = tx.send(());
+            let worker_events = client.context.worker_events().clone();
+            let callback = move |message: Result<StoredGroupMessage>| {
+                if let Ok(m) = &message
+                    && sync_groups
+                        .iter()
+                        .any(|id| id.as_slice() == m.group_id.as_slice())
+                {
+                    let _ = worker_events.send(SyncWorkerEvent::NewSyncGroupMsg);
+                    return;
+                }
+                callback(message);
+            };
+            pump(stream, cancel, callback, on_close).await;
+            tracing::debug!("bidi `stream_all_messages` ended");
+            Ok::<_, SubscribeError>(())
+        })
+    }
+
+    /// Bidi-path counterpart of `stream_conversations_with_callback`: new
+    /// conversations from the welcome topic, over the shared wire.
+    ///
+    /// Interim scope: welcome topic only — a conversation created *locally*
+    /// by this client does not surface here (legacy multiplexes
+    /// `LocalEvents::NewGroup` for that). Parity arrives with the reflex
+    /// work, which fans local new-group events into both stream kinds.
+    pub fn stream_conversations_with_callback_bidi(
+        client: Arc<Client<Context>>,
+        conversation_type: Option<ConversationType>,
+        include_duplicate_dms: bool,
+        callback: impl FnMut(Result<MlsGroup<Context>>) + MaybeSend + 'static,
+        on_close: impl FnOnce() + MaybeSend + 'static,
+    ) -> impl StreamHandle<StreamOutput = Result<()>> {
+        let (tx, rx) = oneshot::channel();
+        xmtp_common::spawn(Some(rx), async move {
+            let cancel = client.context.cancellation_token().clone();
+            let router = client.stream_router().await;
+            let stream = match router
+                .stream_conversations(
+                    conversation_type,
+                    include_duplicate_dms,
+                    None,
+                    DEFAULT_STREAM_DEPTH,
+                )
+                .await
+            {
+                Ok(stream) => stream,
+                Err(e) => {
+                    on_close();
+                    return Err(e.into());
+                }
+            };
+            let _ = tx.send(());
+            pump(stream, cancel, callback, on_close).await;
+            tracing::debug!("bidi `stream_conversations` ended");
+            Ok::<_, SubscribeError>(())
+        })
+    }
+}

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -50,6 +50,7 @@ use xmtp_db::group::{ConversationType, GroupQueryArgs};
 use xmtp_db::group_message::StoredGroupMessage;
 use xmtp_db::prelude::*;
 use xmtp_proto::api_client::XmtpMlsBidiStreams;
+use xmtp_proto::types::GroupId;
 
 use super::stream_router::{DEFAULT_STREAM_DEPTH, RouterStream, StreamRouter};
 use super::{Result, SubscribeError, SyncWorkerEvent};
@@ -305,4 +306,46 @@ where
             Ok::<_, SubscribeError>(())
         })
     }
+}
+
+/// Bidi-path counterpart of [`MlsGroup::stream_with_callback`]: one
+/// conversation's messages, decoded, over the shared wire.
+///
+/// Context-based (a conversation object holds no client), so it cannot reach
+/// the client's cached router; it builds one scoped to this conversation
+/// instead. That is safe by design: router state is per-stream and its task
+/// exits with its last stream, dedup correctness lives in the transport's
+/// per-lease positions, and the wire is the process-shared transport either
+/// way.
+pub fn stream_conversation_messages_with_callback_bidi<Context>(
+    context: Context,
+    group_id: GroupId,
+    callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
+    on_close: impl FnOnce() + MaybeSend + 'static,
+) -> impl StreamHandle<StreamOutput = Result<()>>
+where
+    Context: XmtpSharedContext + 'static,
+    Context::ApiClient: XmtpMlsBidiStreams + Clone + Send + Sync + 'static,
+    <Context::ApiClient as XmtpMlsBidiStreams>::SubscribeStream: 'static,
+{
+    let (tx, rx) = oneshot::channel();
+    xmtp_common::spawn(Some(rx), async move {
+        let cancel = context.cancellation_token().clone();
+        let api = context.api().api_client.clone();
+        let router = StreamRouter::new(context.clone(), shared_transport(api));
+        let stream = match router
+            .stream_messages(vec![group_id], DEFAULT_STREAM_DEPTH)
+            .await
+        {
+            Ok(stream) => stream,
+            Err(e) => {
+                on_close();
+                return Err(e.into());
+            }
+        };
+        let _ = tx.send(());
+        pump(stream, cancel, callback, on_close).await;
+        tracing::debug!("bidi `stream_conversation_messages` ended");
+        Ok::<_, SubscribeError>(())
+    })
 }

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 use xmtp_common::StreamHandle;
 
 use crate::Client;
-use crate::subscriptions::router_callbacks::{resume_bidi_streams, suspend_bidi_streams};
+use crate::subscriptions::router_callbacks::{
+    resume_bidi_streams, stream_conversation_messages_with_callback_bidi, suspend_bidi_streams,
+};
 use crate::tester;
 use crate::utils::MlsGroupExt;
 
@@ -126,6 +128,44 @@ async fn sibling_clients_share_the_process_transport() {
         .expect("timed out waiting for caro's callback")
         .expect("caro callback channel closed")?;
     assert_eq!(to_caro.decrypted_message_bytes, b"for caro");
+}
+
+/// A single-conversation callback stream (the context-based, ephemeral-router
+/// path) delivers that conversation's messages and only those.
+#[xmtp_common::test(unwrap_try = true)]
+async fn single_conversation_callback_is_scoped_to_its_group() {
+    tester!(alix);
+    tester!(bo);
+
+    let streamed = alix.create_group(None, None)?;
+    streamed.invite(&bo).await?;
+    let other = alix.create_group(None, None)?;
+    other.invite(&bo).await?;
+    bo.sync_welcomes().await?;
+    bo.group(&streamed.group_id)?.sync().await?;
+    bo.group(&other.group_id)?.sync().await?;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = stream_conversation_messages_with_callback_bidi(
+        bo.client.context.clone(),
+        bo.group(&streamed.group_id)?.group_id,
+        move |message| {
+            let _ = tx.send(message);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+
+    // The sibling group's message must not leak into this stream; sent first
+    // so a leak would arrive ahead of the expected message.
+    other.send_msg(b"for the other stream").await;
+    streamed.send_msg(b"for this stream").await;
+
+    let delivered = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the callback")
+        .expect("callback channel closed")?;
+    assert_eq!(delivered.decrypted_message_bytes, b"for this stream");
 }
 
 /// The app-lifecycle round trip: a message sent while suspended is replayed

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
@@ -1,0 +1,128 @@
+//! Live integration tests for the bidi callback adapters over a real v3
+//! backend (docker node). Native-only, v3-only — see the module gate.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use xmtp_common::StreamHandle;
+
+use crate::Client;
+use crate::tester;
+use crate::utils::MlsGroupExt;
+
+const WAIT: Duration = Duration::from_secs(20);
+
+/// A message sent after subscribing arrives decoded through the callback.
+#[xmtp_common::test(unwrap_try = true)]
+async fn callback_stream_delivers_live_messages() {
+    tester!(alix);
+    tester!(bo);
+
+    let group = alix.create_group(None, None)?;
+    group.invite(&bo).await?;
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&group.group_id)?;
+    bo_group.sync().await?;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = Client::stream_all_messages_with_callback_bidi(
+        Arc::new(bo.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = tx.send(message);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+
+    group.send_msg(b"over the bidi pump").await;
+    let delivered = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the callback")
+        .expect("callback channel closed")?;
+    assert_eq!(delivered.decrypted_message_bytes, b"over the bidi pump");
+}
+
+/// A new conversation surfaces on the conversations callback.
+#[xmtp_common::test(unwrap_try = true)]
+async fn callback_stream_surfaces_new_conversations() {
+    tester!(alix);
+    tester!(bo);
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = Client::stream_conversations_with_callback_bidi(
+        Arc::new(bo.client.clone()),
+        None,
+        false,
+        move |conversation| {
+            let _ = tx.send(conversation);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+
+    let group = alix.create_group(None, None)?;
+    group.invite(&bo).await?;
+
+    let conversation = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the conversation callback")
+        .expect("callback channel closed")?;
+    assert_eq!(conversation.group_id, group.group_id);
+}
+
+/// Two clients in one process ride the shared transport: each callback
+/// stream still receives exactly its own client's traffic.
+#[xmtp_common::test(unwrap_try = true)]
+async fn sibling_clients_share_the_process_transport() {
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+
+    let bo_group = alix.create_group(None, None)?;
+    bo_group.invite(&bo).await?;
+    bo.sync_welcomes().await?;
+    bo.group(&bo_group.group_id)?.sync().await?;
+    let caro_group = alix.create_group(None, None)?;
+    caro_group.invite(&caro).await?;
+    caro.sync_welcomes().await?;
+    caro.group(&caro_group.group_id)?.sync().await?;
+
+    let (bo_tx, mut bo_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut bo_handle = Client::stream_all_messages_with_callback_bidi(
+        Arc::new(bo.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = bo_tx.send(message);
+        },
+        || {},
+    );
+    let (caro_tx, mut caro_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut caro_handle = Client::stream_all_messages_with_callback_bidi(
+        Arc::new(caro.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = caro_tx.send(message);
+        },
+        || {},
+    );
+    bo_handle.wait_for_ready().await;
+    caro_handle.wait_for_ready().await;
+
+    bo_group.send_msg(b"for bo").await;
+    caro_group.send_msg(b"for caro").await;
+
+    let to_bo = tokio::time::timeout(WAIT, bo_rx.recv())
+        .await
+        .expect("timed out waiting for bo's callback")
+        .expect("bo callback channel closed")?;
+    assert_eq!(to_bo.decrypted_message_bytes, b"for bo");
+    let to_caro = tokio::time::timeout(WAIT, caro_rx.recv())
+        .await
+        .expect("timed out waiting for caro's callback")
+        .expect("caro callback channel closed")?;
+    assert_eq!(to_caro.decrypted_message_bytes, b"for caro");
+}

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use xmtp_common::StreamHandle;
 
 use crate::Client;
+use crate::subscriptions::router_callbacks::{resume_bidi_streams, suspend_bidi_streams};
 use crate::tester;
 use crate::utils::MlsGroupExt;
 
@@ -125,4 +126,158 @@ async fn sibling_clients_share_the_process_transport() {
         .expect("timed out waiting for caro's callback")
         .expect("caro callback channel closed")?;
     assert_eq!(to_caro.decrypted_message_bytes, b"for caro");
+}
+
+/// The app-lifecycle round trip: a message sent while suspended is replayed
+/// by the resume wave and reaches the callback — resume() resolving is the
+/// "catch up, then done" signal.
+#[xmtp_common::test(unwrap_try = true)]
+async fn suspend_resume_replays_what_was_missed() {
+    tester!(alix);
+    tester!(bo);
+
+    let group = alix.create_group(None, None)?;
+    group.invite(&bo).await?;
+    bo.sync_welcomes().await?;
+    bo.group(&group.group_id)?.sync().await?;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = Client::stream_all_messages_with_callback_bidi(
+        Arc::new(bo.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = tx.send(message);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+
+    suspend_bidi_streams().await?;
+    group.send_msg(b"sent while backgrounded").await;
+    resume_bidi_streams().await?;
+
+    let delivered = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the replayed message")
+        .expect("callback channel closed")?;
+    assert_eq!(
+        delivered.decrypted_message_bytes,
+        b"sent while backgrounded"
+    );
+
+    // A second cycle: the resume positions must carry over, so the replay
+    // brings exactly the newly-missed message, not history.
+    suspend_bidi_streams().await?;
+    group.send_msg(b"backgrounded again").await;
+    resume_bidi_streams().await?;
+
+    let delivered = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the second replay")
+        .expect("callback channel closed")?;
+    assert_eq!(delivered.decrypted_message_bytes, b"backgrounded again");
+}
+
+/// The lifecycle helpers are safe to call before anything ever streamed:
+/// with no transport in the process they resolve as no-ops. (Real on
+/// mobile — backgrounding can beat the first subscription.)
+#[xmtp_common::test(unwrap_try = true)]
+async fn lifecycle_helpers_are_noops_without_a_transport() {
+    // Isolation note: this relies on nextest's process-per-test model — no
+    // other test in this process can have initialized the shared transport.
+    suspend_bidi_streams().await?;
+    resume_bidi_streams().await?;
+    suspend_bidi_streams().await?;
+}
+
+/// Sync-group traffic is intercepted, exactly like the legacy stream: it
+/// nudges the device-sync worker instead of surfacing internal payloads as
+/// conversation messages.
+#[xmtp_common::test(unwrap_try = true)]
+async fn sync_group_messages_are_intercepted_not_delivered() {
+    use crate::context::XmtpSharedContext;
+    use crate::subscriptions::SyncWorkerEvent;
+    use xmtp_db::prelude::*;
+    tester!(alix, sync_worker);
+
+    // The device-sync worker creates the sync group in the background.
+    let sync_group = xmtp_common::wait_for_some(|| async {
+        alix.client.context.db().primary_sync_group().ok().flatten()
+    })
+    .await
+    .expect("the sync worker creates a sync group");
+    let group = alix.create_group(None, None)?;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = Client::stream_all_messages_with_callback_bidi(
+        Arc::new(alix.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = tx.send(message);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+    let mut worker_events = alix.client.context.worker_events().subscribe();
+
+    // Into the sync group first — a leak would arrive ahead of the normal
+    // message below.
+    alix.group(&sync_group.id)?
+        .send_msg(b"internal sync payload")
+        .await;
+    group.send_msg(b"a normal message").await;
+
+    let delivered = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the callback")
+        .expect("callback channel closed")?;
+    assert_eq!(delivered.decrypted_message_bytes, b"a normal message");
+
+    // The intercepted message became a worker nudge instead.
+    let nudged = tokio::time::timeout(WAIT, async {
+        loop {
+            match worker_events.recv().await {
+                Ok(SyncWorkerEvent::NewSyncGroupMsg) => break,
+                Ok(_) => continue,
+                Err(e) => panic!("worker events channel closed: {e}"),
+            }
+        }
+    })
+    .await;
+    assert!(nudged.is_ok(), "the sync worker must be nudged");
+}
+
+/// `stream_all_messages` on an account with no matching conversations stays
+/// open instead of error-closing — the transport refuses an empty lease, and
+/// that refusal must not surface to the caller.
+#[xmtp_common::test(unwrap_try = true)]
+async fn stream_all_with_no_conversations_stays_open() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    tester!(bo);
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let closed = Arc::new(AtomicBool::new(false));
+    let on_close = {
+        let closed = closed.clone();
+        move || closed.store(true, Ordering::SeqCst)
+    };
+    let mut handle = Client::stream_all_messages_with_callback_bidi(
+        Arc::new(bo.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = tx.send(message);
+        },
+        on_close,
+    );
+    handle.wait_for_ready().await;
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        !closed.load(Ordering::SeqCst),
+        "an empty subscription must stay open, not error-close"
+    );
+    assert!(rx.try_recv().is_err(), "nothing should have been delivered");
 }

--- a/crates/xmtp_proto/src/api_client.rs
+++ b/crates/xmtp_proto/src/api_client.rs
@@ -45,6 +45,8 @@ pub type ArcedXmtpApi<Error> = Arc<dyn BoxableXmtpApi<Error>>;
 xmtp_common::if_native! {
     pub type BoxedGroupS<Err> = Pin<Box<dyn Stream<Item = Result<GroupMessage, Err>> + Send>>;
     pub type BoxedWelcomeS<Err> = Pin<Box<dyn Stream<Item = Result<WelcomeMessage, Err>> + Send>>;
+    pub type BoxedSubscribeS<Err> =
+        Pin<Box<dyn Stream<Item = Result<crate::mls_v1::SubscribeResponse, Err>> + Send>>;
 }
 
 xmtp_common::if_wasm! {


### PR DESCRIPTION
Phase C of the XIP-83 client integration — **stacked on #3829**. The client callback surface (mobile + node) learns to route its streams over the bidi transport, dark behind `XMTP_BIDI_STREAMS_ENABLED`.

## Commit 1 — pull-to-push adapter (`xmtp_mls`)

`router_callbacks.rs` adapts the `StreamRouter`'s pull streams to the callback shape the FFI bindings consume: spawn, pump, callback per item, `on_close` when the stream ends. The router rides a **process-global shared transport** — one wire per process regardless of client count — and every entry point gates on `bidi_streams_enabled()` (the env var, read per call), so the whole path stays dark until explicitly enabled.

## Commit 2 — mobile dispatch

`FfiConversations::stream` / `stream_all_messages` branch on the gate; the legacy path is untouched. The mobile client holds its API behind a trait object, so `XmtpMlsBidiStreams` is plumbed through the dyn-API surface (`full_api`, boxed streams, combined, d14n) to make the bound satisfiable there.

## Commit 3 — crate-level suspend/resume helpers

`suspend_bidi_streams()` / `resume_bidi_streams()` wrap the shared transport's app-lifecycle pair (#3829) — resume resolves at catch-up, the background-fetch "catch up, then done" primitive — and no-op when bidi was never active. **Crate-level only for now**: exposing them over the FFI boundary is deliberate follow-on work.

## Commit 4 — single-conversation streams

`FfiConversation::stream` was the one callback stream still pinned to the legacy path — a conversation object holds only the context, while the client's cached router hangs off the `Client`. Rather than thread client handles through every conversation construction site, the bidi arm builds an **ephemeral router scoped to the one conversation**: router state is per-stream and its task exits with its last stream, while dedup correctness already lives in the transport's per-lease positions — so a second router beside the client's cached one is safe by design.

## Commit 5 — node dispatch

Mirrors mobile: `conversations.stream`, `conversations.streamAllMessages`, and `conversation.stream` take the bidi path when the env var is truthy. Consent/preference/deletion streams ride the sync topics and stay legacy by design.

## Semantics & rollout notes

- **`on_close` semantics differ from legacy for a wedged consumer** (macroscope flagged): a bidi stream whose callback stops draining is dropped by the transport (protecting the shared wire) and fires `on_close` — the caller re-subscribes from durable cursors. Legacy instead stalls its own dedicated stream indefinitely. Wire flaps do NOT end bidi streams (leases survive reconnects). Whether the adapters should internally re-subscribe on that drop instead of surfacing `on_close` is an open design call — flagged for review.

- **Dark by default.** Nothing changes unless `XMTP_BIDI_STREAMS_ENABLED` is set — intended for dev/agent deploys until the fallback latch lands. There is **no automatic legacy fallback yet** (that latch is follow-on work), so the gate must only be enabled against v3 backends — a `MigrationClient`/`D14nClient` refuses `subscribe_bidi` at runtime.
- **Interim scope (messages)**: bidi `stream_all_messages` covers the groups known at subscribe time; the welcome auto-subscribe reflex is the next phase. Don't flip the env var for always-on agents until that lands.
- **Interim scope (conversations)**: the bidi conversations stream speaks the welcome topic only — a group/DM *created locally by the same client* does not fire its own `conversations.stream` callback (legacy multiplexes `LocalEvents::NewGroup` for that). Documented at the `WelcomeConsumer`; parity arrives with the same reflex work, which fans local new-group events into both stream kinds.

## Review-round fixes

- **Sync-group interception restored** (macroscope, High): the bidi `stream_all_messages` arm subscribed sync groups (same query as legacy) but forwarded their messages to the callback — surfacing internal device-sync payloads to apps. It now mirrors legacy exactly: sync-group traffic nudges the device-sync worker (`NewSyncGroupMsg`) and never reaches the callback. (Macroscope's suggested fix — dropping sync groups from the subscription — would have silently lost that worker nudge.) Pinned by a live test with a real sync group.
- **Empty subscription stays open** (macroscope): `stream_all_messages` on an account with no matching conversations used to hit the transport's empty-lease refusal and error-close immediately; it now stays open with nothing subscribed, matching legacy. Pinned by a live test.
- The false "falls back to legacy streams" comment on the `MigrationClient`/`D14nClient` refusal is corrected — the latch is follow-on work, v3 backends only (also disclosed above).
- The single-auth-identity assumption of the process-shared transport is documented at the module doc, and transport initialization logs at info.
- Interim-scope doc comments added at both bidi entry points.

## Tests

Eight live tests in `router_callbacks_tests.rs`: callback stream delivers live messages, new-conversation surfacing, sibling clients share the process transport, single-conversation scoping (two groups — only the streamed one delivers), suspend → miss → resume → replay E2E across **two** background cycles, lifecycle helpers as no-ops before any transport exists, empty-subscription-stays-open, and sync-group-messages-intercepted-not-delivered. The node vitest stream suites (`Conversations.test.ts` / `Conversation.test.ts`) pass identically with the env var off (8/8) and on (8/8 + 1/1), including conversation-type filters and the new-installation DM case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route MLS callback streams over bidi transport behind `XMTP_BIDI_STREAMS_ENABLED` flag
> - Adds `bidi_streams_enabled()` gate in [router_callbacks.rs](https://github.com/xmtp/libxmtp/pull/3832/files#diff-0c27658258694997d993ae3e2e444204d0c98a70f368560fd306949e8849549d) that reads the `XMTP_BIDI_STREAMS_ENABLED` env var to select between the new bidi path and the legacy streaming path.
> - Implements `stream_all_messages_with_callback_bidi` and `stream_conversations_with_callback_bidi` on `Client`, backed by a process-wide shared `BidiTransport` cached in a `OnceLock`; a free function handles per-conversation streams via an ephemeral router.
> - Updates all mobile and Node binding stream entry points (`stream`, `stream_groups`, `stream_dms`, `stream_messages`) to branch on `bidi_streams_enabled()` and call the appropriate path.
> - Adds `MaybeBidiStreams` trait to `FullXmtpApiT` bounds and stubs out `XmtpMlsBidiStreams` for `BoxedStreamsClient`, `MigrationClient`, and `D14nClient` (the latter two return unretryable errors at runtime).
> - Adds `suspend_bidi_streams()` / `resume_bidi_streams()` lifecycle helpers and integration tests covering delivery, suspend/resume replay, and sync-group interception.
> - Behavioral Change: when `XMTP_BIDI_STREAMS_ENABLED` is set, all subscription callbacks run over the bidi transport; the legacy path is unchanged when the flag is unset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afc96f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->