### PR TITLE
feat(xmtp_mls): bidi streams grow at runtime — welcome reflex + local fan-in

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1948,8 +1948,6 @@ impl FfiConversations {
             consent_states.map(|states| states.into_iter().map(|state| state.into()).collect());
         let close_cb = message_callback.clone();
         if bidi_streams_enabled() {
-            // Interim bidi scope — covers the groups known at subscribe time:
-            // see the entry point's docs.
             FfiStreamCloser::new(RustXmtpClient::stream_all_messages_with_callback_bidi(
                 self.inner_client.clone(),
                 conversation_type.map(Into::into),

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1630,8 +1630,6 @@ impl FfiConversations {
         let client = self.inner_client.clone();
         let close_cb = callback.clone();
         if bidi_streams_enabled() {
-            // Interim bidi scope — locally-created conversations do not
-            // surface on this stream yet: see the entry point's docs.
             FfiStreamCloser::new(RustXmtpClient::stream_conversations_with_callback_bidi(
                 client,
                 conversation_type,

--- a/bindings/node/src/conversations/streams.rs
+++ b/bindings/node/src/conversations/streams.rs
@@ -147,8 +147,6 @@ impl Conversations {
     };
 
     if bidi_streams_enabled() {
-      // Interim bidi scope — covers the groups known at subscribe time: see
-      // `stream_all_messages_with_callback_bidi`'s docs.
       let handle = RustXmtpClient::stream_all_messages_with_callback_bidi(
         self.inner_client.clone(),
         conversation_type.map(Into::into),

--- a/bindings/node/src/conversations/streams.rs
+++ b/bindings/node/src/conversations/streams.rs
@@ -55,8 +55,6 @@ impl Conversations {
     };
 
     if bidi_streams_enabled() {
-      // Interim bidi scope — locally-created conversations do not surface on
-      // this stream yet: see `stream_conversations_with_callback_bidi`'s docs.
       let handle = RustXmtpClient::stream_conversations_with_callback_bidi(
         self.inner_client.clone(),
         conversation_type.map(|ct| ct.into()),

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -127,8 +127,62 @@ const RECONNECT_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(
 const GRACEFUL_CLOSE_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Error type an opener may return; boxed so the transport stays generic over
-/// whichever API-client error the integration layer produces.
-pub type OpenError = Box<dyn std::error::Error + Send + Sync + 'static>;
+/// whichever API-client error the integration layer produces, while carrying
+/// the inner error's retryability across the erasure: a transient dial
+/// failure stays worth redialing, a backend that refuses the bidi surface
+/// outright is not.
+#[derive(Debug)]
+pub struct OpenError {
+    retryable: bool,
+    source: Box<dyn std::error::Error + Send + Sync + 'static>,
+}
+
+impl OpenError {
+    /// Capture `e` along with its own retryability verdict.
+    pub fn new<E>(e: E) -> Self
+    where
+        E: std::error::Error + xmtp_common::RetryableError + Send + Sync + 'static,
+    {
+        Self {
+            retryable: e.is_retryable(),
+            source: Box::new(e),
+        }
+    }
+
+    /// An open failure worth redialing (a transient dial or wire error).
+    pub fn retryable(e: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>) -> Self {
+        Self {
+            retryable: true,
+            source: e.into(),
+        }
+    }
+
+    /// An open failure no redial can fix (the backend refuses the surface).
+    pub fn unretryable(e: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>) -> Self {
+        Self {
+            retryable: false,
+            source: e.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for OpenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(f)
+    }
+}
+
+impl std::error::Error for OpenError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&*self.source)
+    }
+}
+
+impl xmtp_common::RetryableError for OpenError {
+    fn is_retryable(&self) -> bool {
+        self.retryable
+    }
+}
 
 /// What the transport needs from a binding beyond the wire vocabulary in
 /// [`BidiBinding`]: building a `Mutate` wave from topics + resume cursors, and
@@ -182,8 +236,9 @@ pub enum TransportError {
     /// The transport is gone (every handle and lease dropped, or its task died).
     #[error("the bidi transport is closed")]
     Closed,
-    /// Opening the wire failed; the lease was not registered. Retryable — the
-    /// next `lease()` attempts a fresh open.
+    /// Opening the wire failed; the lease was not registered. Whether a
+    /// fresh `lease()` is worth attempting follows the inner error: a
+    /// transient dial failure is, an outright backend refusal is not.
     #[error("opening the bidi wire failed: {0}")]
     Open(#[source] OpenError),
     /// A lease must name at least one topic: an adds-nothing wave yields no
@@ -196,8 +251,8 @@ pub enum TransportError {
 impl xmtp_common::RetryableError for TransportError {
     fn is_retryable(&self) -> bool {
         match self {
-            // The next `lease()` attempts a fresh open.
-            Self::Open(_) => true,
+            // The opener knows whether a fresh `lease()` can succeed.
+            Self::Open(e) => e.is_retryable(),
             // The transport is gone for good; an empty lease is a caller bug
             // no retry fixes.
             Self::Closed | Self::Empty => false,
@@ -1006,6 +1061,10 @@ where
                     self.reconnect_delay = RECONNECT_INITIAL_DELAY;
                 }
                 OpenOutcome::Failed(e) => {
+                    // The failure also travels to the caller, but join
+                    // results are rarely read — the log is the reliable
+                    // trace (the reconnect path warns the same way).
+                    tracing::warn!("bidi cold open failed: {e}");
                     let _ = reply.send(Err(TransportError::Open(e)));
                     return Flow::Continue;
                 }
@@ -1574,7 +1633,7 @@ mod tests {
             async move {
                 BidiConnection::open(&api, initial)
                     .await
-                    .map_err(|e| Box::new(e) as OpenError)
+                    .map_err(OpenError::new)
             }
         });
         (transport, servers)
@@ -2389,7 +2448,7 @@ mod tests {
                     sink.lock().unwrap().push(server);
                     BidiConnection::open(&api, initial)
                         .await
-                        .map_err(|e| Box::new(e) as OpenError)
+                        .map_err(OpenError::new)
                 }
             })
         };
@@ -2447,7 +2506,7 @@ mod tests {
                     sink.lock().unwrap().push(server);
                     BidiConnection::open(&api, initial)
                         .await
-                        .map_err(|e| Box::new(e) as OpenError)
+                        .map_err(OpenError::new)
                 }
             })
         };
@@ -2523,16 +2582,16 @@ mod tests {
                     // dials fail fast until the network comes back.
                     if n == 1 {
                         gate.notified().await;
-                        return Err(Box::new(std::io::Error::other("down")) as OpenError);
+                        return Err(OpenError::retryable(std::io::Error::other("down")));
                     }
                     if n >= 2 && network_down.load(Ordering::SeqCst) {
-                        return Err(Box::new(std::io::Error::other("down")) as OpenError);
+                        return Err(OpenError::retryable(std::io::Error::other("down")));
                     }
                     let (api, server) = mock_pair();
                     sink.lock().unwrap().push(server);
                     BidiConnection::open(&api, initial)
                         .await
-                        .map_err(|e| Box::new(e) as OpenError)
+                        .map_err(OpenError::new)
                 }
             })
         };
@@ -2797,7 +2856,7 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     async fn open_failure_surfaces_and_registers_nothing() {
         let transport = BidiTransport::<V3Binding>::new(|_initial| async {
-            Err(Box::new(Refused) as OpenError)
+            Err(OpenError::unretryable(Refused))
         });
         let denied = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await;
         assert!(matches!(denied, Err(TransportError::Open(_))));

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -98,7 +98,7 @@
 use std::collections::{HashMap, HashSet};
 
 use tokio::sync::{mpsc, oneshot};
-use xmtp_common::{BoxDynFuture, MaybeSend, MaybeSync};
+use xmtp_common::{BoxDynFuture, MaybeSend, MaybeSync, RetryableError};
 use xmtp_proto::types::Topic;
 
 use super::bidi::{BidiBinding, Connection, Event, TryMutateError};
@@ -150,6 +150,9 @@ impl OpenError {
     }
 
     /// An open failure worth redialing (a transient dial or wire error).
+    /// Test-only: production openers use [`Self::new`], whose verdict comes
+    /// from the error itself and cannot contradict it.
+    #[cfg(test)]
     pub fn retryable(e: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>) -> Self {
         Self {
             retryable: true,
@@ -158,6 +161,8 @@ impl OpenError {
     }
 
     /// An open failure no redial can fix (the backend refuses the surface).
+    /// Test-only, like [`Self::retryable`].
+    #[cfg(test)]
     pub fn unretryable(e: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>) -> Self {
         Self {
             retryable: false,
@@ -1270,6 +1275,14 @@ where
                 AfterReopen::Proceed
             }
             OpenOutcome::Failed(e) => {
+                if !e.is_retryable() {
+                    // The backend refuses the surface outright — no redial
+                    // can succeed. Shutting the ledger down ends every lease,
+                    // so consumers see their streams end and the next
+                    // subscribe carries the refusal to the caller.
+                    tracing::error!("bidi transport: reconnect refused ({e}); closing");
+                    return AfterReopen::Shutdown;
+                }
                 tracing::warn!("bidi transport: reconnect failed ({e}); backing off");
                 self.reconnect_delay = (self.reconnect_delay * 2).min(RECONNECT_MAX_DELAY);
                 self.reconnect_at = tokio::time::Instant::now() + self.reconnect_delay;
@@ -2851,6 +2864,12 @@ mod tests {
     #[error("no wire for you")]
     struct Refused;
 
+    impl xmtp_common::RetryableError for Refused {
+        fn is_retryable(&self) -> bool {
+            false
+        }
+    }
+
     /// An opener failure surfaces as `TransportError::Open` and registers
     /// nothing — the transport stays usable for a later attempt.
     #[xmtp_common::test(unwrap_try = true)]
@@ -2864,5 +2883,56 @@ mod tests {
         // same way, proving the ledger task survived the failed open).
         let again = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await;
         assert!(matches!(again, Err(TransportError::Open(_))));
+    }
+
+    /// An unretryable failure on the *reconnect* path closes the transport
+    /// instead of redialing forever: every lease ends (`next()` → `None`),
+    /// and the consumers' re-subscribes carry the refusal to their callers.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn unretryable_reconnect_closes_every_lease() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let servers: Servers = Arc::default();
+        let dials = Arc::new(AtomicUsize::new(0));
+        let transport: BidiTransport<V3Binding> = {
+            let sink = servers.clone();
+            let dials = dials.clone();
+            BidiTransport::new(move |initial| {
+                let n = dials.fetch_add(1, Ordering::SeqCst);
+                let sink = sink.clone();
+                async move {
+                    // The backend accepts the first dial, then refuses the
+                    // surface outright — a server dropping bidi support, not
+                    // a flap.
+                    if n > 0 {
+                        return Err(OpenError::new(Refused));
+                    }
+                    let (api, server) = mock_pair();
+                    sink.lock().unwrap().push(server);
+                    BidiConnection::open(&api, initial)
+                        .await
+                        .map_err(OpenError::new)
+                }
+            })
+        };
+
+        let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        server.send(catchup_complete(first.mutate_id));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+
+        drop(server); // the wire dies; the reconnect dial is refused
+
+        assert!(
+            recv(&mut alpha).await.is_none(),
+            "an unretryable reconnect must end every lease, not redial forever"
+        );
+        assert_eq!(dials.load(Ordering::SeqCst), 2, "no dial after the refusal");
+        // The ledger is gone: a fresh lease reports the transport closed.
+        let denied = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await;
+        assert!(matches!(denied, Err(TransportError::Closed)));
     }
 }

--- a/crates/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -457,6 +457,34 @@ where
     Ok(result.into_outcome())
 }
 
+/// Run a locally-created group (a `LocalEvents::NewGroup` id) through the
+/// same pipeline and filters a welcome takes — the local-event analog of
+/// [`process_welcome_one`]. No welcome cursor is involved: dedup is the
+/// event's own once-per-creation broadcast, exactly what the legacy
+/// conversation stream relies on.
+pub async fn process_local_group_one<Context>(
+    context: Context,
+    group_id: xmtp_proto::types::GroupId,
+    conversation_type: Option<ConversationType>,
+    include_duplicate_dms: bool,
+    consent_states: Option<Vec<ConsentState>>,
+) -> Result<WelcomeOutcome<Context>>
+where
+    Context: XmtpSharedContext,
+{
+    let result = ProcessWelcomeFuture::new(
+        HashSet::new(),
+        context,
+        WelcomeOrGroup::Group(group_id),
+        conversation_type,
+        include_duplicate_dms,
+        consent_states,
+    )?
+    .process()
+    .await?;
+    Ok(result.into_outcome())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -50,9 +50,9 @@ pub enum ProcessWelcomeResult<Context> {
 /// independent of any stream/poll machinery — the welcome analog of
 /// [`super::process_message::Processed`].
 ///
-/// As with messages, dedup bookkeeping is the caller's job: record `seen` into
-/// whatever known-welcome set the caller owns (the per-stream `known_welcome_ids`
-/// set, or the bidi manager's central set).
+/// As with messages, dedup bookkeeping is the caller's job: record `seen`
+/// into whatever known-welcome set the caller owns (every stream keeps its
+/// own).
 pub struct WelcomeOutcome<Context> {
     /// The conversation to surface to the subscriber, if this welcome produced one
     /// that passed the stream's filters.
@@ -417,72 +417,6 @@ where
             group.created_at_ns,
         )))
     }
-}
-
-/// Run a single raw welcome through the shared processing pipeline and interpret the
-/// result. The decode half of the conversation stream, lifted out of the poll machinery
-/// so the XIP-83 bidi multiplexing manager can reuse it from an async task.
-///
-/// `known_welcome_ids` is borrowed from the caller's authoritative dedup set and
-/// snapshotted for the pipeline (an already-seen cursor short-circuits into an
-/// ignore outcome). The borrow makes the safe pattern the default: a caller
-/// processing welcomes sequentially — check, call, record
-/// [`WelcomeOutcome::seen`] — gets correct dedup by construction, because the
-/// set cannot be mutated while a call borrows it. A caller that wants
-/// concurrent calls must clone the set explicitly, and then owns the
-/// consequence: two in-flight calls for the same cursor will each see it as
-/// unseen and both surface the conversation. Serialize same-cursor decisions
-/// (the XIP-83 router routes from a single task for exactly this reason).
-pub async fn process_welcome_one<Context>(
-    context: Context,
-    known_welcome_ids: &HashSet<Cursor>,
-    welcome: WelcomeMessage,
-    conversation_type: Option<ConversationType>,
-    include_duplicate_dms: bool,
-    consent_states: Option<Vec<ConsentState>>,
-) -> Result<WelcomeOutcome<Context>>
-where
-    Context: XmtpSharedContext,
-{
-    let result = ProcessWelcomeFuture::new(
-        known_welcome_ids.clone(),
-        context,
-        WelcomeOrGroup::Welcome(welcome),
-        conversation_type,
-        include_duplicate_dms,
-        consent_states,
-    )?
-    .process()
-    .await?;
-    Ok(result.into_outcome())
-}
-
-/// Run a locally-created group (a `LocalEvents::NewGroup` id) through the
-/// same pipeline and filters a welcome takes — the local-event analog of
-/// [`process_welcome_one`]. No welcome cursor is involved: dedup is the
-/// event's own once-per-creation broadcast, exactly what the legacy
-/// conversation stream relies on.
-pub async fn process_local_group_one<Context>(
-    context: Context,
-    group_id: xmtp_proto::types::GroupId,
-    conversation_type: Option<ConversationType>,
-    include_duplicate_dms: bool,
-    consent_states: Option<Vec<ConsentState>>,
-) -> Result<WelcomeOutcome<Context>>
-where
-    Context: XmtpSharedContext,
-{
-    let result = ProcessWelcomeFuture::new(
-        HashSet::new(),
-        context,
-        WelcomeOrGroup::Group(group_id),
-        conversation_type,
-        include_duplicate_dms,
-        consent_states,
-    )?
-    .process()
-    .await?;
-    Ok(result.into_outcome())
 }
 
 #[cfg(test)]

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -38,7 +38,10 @@
 //! (transport docs), so a natural end means this consumer fell behind and
 //! was dropped, or the client shut down; re-subscribing recovers from
 //! durable cursors. An `end()`ed handle aborts the task without `on_close`,
-//! matching the local-events streams.
+//! matching the local-events streams. The `StreamOpened`/`StreamClosed`
+//! telemetry pair still closes on every ending — including that abort, which
+//! never runs the task's tail but does drop it, so `StreamClosed` rides a
+//! drop guard.
 
 use std::sync::{Arc, LazyLock, OnceLock};
 
@@ -51,12 +54,12 @@ use xmtp_db::consent_record::ConsentState;
 use xmtp_db::group::ConversationType;
 use xmtp_db::group_message::StoredGroupMessage;
 use xmtp_proto::api_client::XmtpMlsBidiStreams;
-use xmtp_proto::types::GroupId;
+use xmtp_proto::types::{GroupId, InstallationId};
 
 use xmtp_common::Event;
 use xmtp_macro::log_event;
 
-use super::stream_router::{DEFAULT_STREAM_DEPTH, RouterStream, StreamRouter};
+use super::stream_router::{DEFAULT_STREAM_DEPTH, RouterError, RouterStream, StreamRouter};
 use super::{Result, StreamKind, SubscribeError};
 use crate::Client;
 use crate::context::XmtpSharedContext;
@@ -169,6 +172,64 @@ async fn pump<T>(
     on_close();
 }
 
+/// Emits the `StreamClosed` telemetry event when dropped. A guard rather
+/// than a tail call: the bindings' closers end these streams by aborting the
+/// task, and an aborted future never runs its tail — but it is dropped, so
+/// the pair-closing event still fires.
+struct StreamClosedGuard {
+    kind: StreamKind,
+    installation: InstallationId,
+}
+
+impl Drop for StreamClosedGuard {
+    fn drop(&mut self) {
+        log_event!(Event::StreamClosed, self.installation, kind = ?self.kind);
+    }
+}
+
+/// One spawned bidi stream: emit `StreamOpened`, subscribe, signal ready,
+/// then pump into the callback until the stream ends or the client shuts
+/// down. Every entry point is this wrapper plus its subscribe future.
+///
+/// `on_close` fires on the subscribe-failure and natural-end paths only (an
+/// aborted task must not invoke it — the caller asked for the end), exactly
+/// like the local-events streams; `StreamClosed` fires on every ending via
+/// the drop guard.
+fn pump_stream<T, S>(
+    kind: StreamKind,
+    installation: InstallationId,
+    cancel: CancellationToken,
+    subscribe: S,
+    callback: impl FnMut(Result<T>) + MaybeSend + 'static,
+    on_close: impl FnOnce() + MaybeSend + 'static,
+) -> impl StreamHandle<StreamOutput = Result<()>>
+where
+    T: MaybeSend + 'static,
+    S: Future<Output = std::result::Result<RouterStream<T>, RouterError>> + MaybeSend + 'static,
+{
+    let (tx, rx) = oneshot::channel();
+    xmtp_common::spawn(Some(rx), async move {
+        log_event!(Event::StreamOpened, installation, kind = ?kind);
+        let _closed = StreamClosedGuard { kind, installation };
+        let stream = match subscribe.await {
+            Ok(stream) => stream,
+            Err(e) => {
+                // The subscribe itself failed: warn (the handle's result
+                // carries the error but is rarely read), fire `on_close`
+                // — legacy watchdog semantics — and the caller
+                // re-subscribes from durable cursors.
+                tracing::warn!("bidi {kind:?} stream failed to subscribe: {e}");
+                on_close();
+                return Err(e.into());
+            }
+        };
+        let _ = tx.send(());
+        pump(stream, cancel, callback, on_close).await;
+        tracing::debug!("bidi {kind:?} stream ended");
+        Ok::<_, SubscribeError>(())
+    })
+}
+
 impl<Context> Client<Context>
 where
     Context: XmtpSharedContext + 'static,
@@ -198,34 +259,22 @@ where
         callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
         on_close: impl FnOnce() + MaybeSend + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
-        let (tx, rx) = oneshot::channel();
-        xmtp_common::spawn(Some(rx), async move {
-            let installation = client.context.installation_id();
-            log_event!(Event::StreamOpened, installation, kind = ?StreamKind::All);
-            let cancel = client.context.cancellation_token().clone();
+        let installation = client.context.installation_id();
+        let cancel = client.context.cancellation_token().clone();
+        let subscribe = async move {
             let router = client.stream_router().await;
-            let stream = match router
+            router
                 .stream_all_messages(conversation_type, consent_states, DEFAULT_STREAM_DEPTH)
                 .await
-            {
-                Ok(stream) => stream,
-                Err(e) => {
-                    // The subscribe itself failed: warn (the handle's result
-                    // carries the error but is rarely read), fire `on_close`
-                    // — legacy watchdog semantics — and the caller
-                    // re-subscribes from durable cursors.
-                    tracing::warn!("bidi `stream_all_messages` failed to subscribe: {e}");
-                    log_event!(Event::StreamClosed, installation, kind = ?StreamKind::All);
-                    on_close();
-                    return Err(e.into());
-                }
-            };
-            let _ = tx.send(());
-            pump(stream, cancel, callback, on_close).await;
-            tracing::debug!("bidi `stream_all_messages` ended");
-            log_event!(Event::StreamClosed, installation, kind = ?StreamKind::All);
-            Ok::<_, SubscribeError>(())
-        })
+        };
+        pump_stream(
+            StreamKind::All,
+            installation,
+            cancel,
+            subscribe,
+            callback,
+            on_close,
+        )
     }
 
     /// Bidi-path counterpart of `stream_conversations_with_callback`: new
@@ -239,13 +288,11 @@ where
         callback: impl FnMut(Result<MlsGroup<Context>>) + MaybeSend + 'static,
         on_close: impl FnOnce() + MaybeSend + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
-        let (tx, rx) = oneshot::channel();
-        xmtp_common::spawn(Some(rx), async move {
-            let installation = client.context.installation_id();
-            log_event!(Event::StreamOpened, installation, kind = ?StreamKind::Conversations);
-            let cancel = client.context.cancellation_token().clone();
+        let installation = client.context.installation_id();
+        let cancel = client.context.cancellation_token().clone();
+        let subscribe = async move {
             let router = client.stream_router().await;
-            let stream = match router
+            router
                 .stream_conversations(
                     conversation_type,
                     include_duplicate_dms,
@@ -253,21 +300,15 @@ where
                     DEFAULT_STREAM_DEPTH,
                 )
                 .await
-            {
-                Ok(stream) => stream,
-                Err(e) => {
-                    tracing::warn!("bidi `stream_conversations` failed to subscribe: {e}");
-                    log_event!(Event::StreamClosed, installation, kind = ?StreamKind::Conversations);
-                    on_close();
-                    return Err(e.into());
-                }
-            };
-            let _ = tx.send(());
-            pump(stream, cancel, callback, on_close).await;
-            tracing::debug!("bidi `stream_conversations` ended");
-            log_event!(Event::StreamClosed, installation, kind = ?StreamKind::Conversations);
-            Ok::<_, SubscribeError>(())
-        })
+        };
+        pump_stream(
+            StreamKind::Conversations,
+            installation,
+            cancel,
+            subscribe,
+            callback,
+            on_close,
+        )
     }
 }
 
@@ -291,29 +332,21 @@ where
     Context::ApiClient: XmtpMlsBidiStreams + Clone + Send + Sync + 'static,
     <Context::ApiClient as XmtpMlsBidiStreams>::SubscribeStream: 'static,
 {
-    let (tx, rx) = oneshot::channel();
-    xmtp_common::spawn(Some(rx), async move {
-        let installation = context.installation_id();
-        log_event!(Event::StreamOpened, installation, kind = ?StreamKind::Messages);
-        let cancel = context.cancellation_token().clone();
+    let installation = context.installation_id();
+    let cancel = context.cancellation_token().clone();
+    let subscribe = async move {
         let api = context.api().api_client.clone();
         let router = StreamRouter::new(context.clone(), shared_transport(api));
-        let stream = match router
+        router
             .stream_messages(vec![group_id], DEFAULT_STREAM_DEPTH)
             .await
-        {
-            Ok(stream) => stream,
-            Err(e) => {
-                tracing::warn!("bidi `stream_conversation_messages` failed to subscribe: {e}");
-                log_event!(Event::StreamClosed, installation, kind = ?StreamKind::Messages);
-                on_close();
-                return Err(e.into());
-            }
-        };
-        let _ = tx.send(());
-        pump(stream, cancel, callback, on_close).await;
-        tracing::debug!("bidi `stream_conversation_messages` ended");
-        log_event!(Event::StreamClosed, installation, kind = ?StreamKind::Messages);
-        Ok::<_, SubscribeError>(())
-    })
+    };
+    pump_stream(
+        StreamKind::Messages,
+        installation,
+        cancel,
+        subscribe,
+        callback,
+        on_close,
+    )
 }

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -106,7 +106,7 @@ where
                 async move {
                     BidiConnection::open(&api, initial)
                         .await
-                        .map_err(|e| Box::new(e) as OpenError)
+                        .map_err(OpenError::new)
                 }
             })
         })

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -180,87 +180,36 @@ where
     }
 
     /// Bidi-path counterpart of `stream_all_messages_with_callback`: every
-    /// matching conversation's messages, decoded, over the shared wire.
-    ///
-    /// Interim scope: covers the groups known at subscribe time. A
-    /// conversation joined afterwards reaches this stream on re-subscribe,
-    /// until the welcome auto-subscribe reflex lands.
+    /// matching conversation's messages, decoded, over the shared wire. The
+    /// stream grows with new conversations — the router's welcome
+    /// auto-subscribe reflex leases each later-joined group's topic as its
+    /// welcome arrives, no re-subscribe needed.
     pub fn stream_all_messages_with_callback_bidi(
         client: Arc<Client<Context>>,
         conversation_type: Option<ConversationType>,
         consent_states: Option<Vec<ConsentState>>,
-        mut callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
+        callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
         on_close: impl FnOnce() + MaybeSend + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
         xmtp_common::spawn(Some(rx), async move {
             let cancel = client.context.cancellation_token().clone();
-            let subscribed = async {
-                // Same seeding as the legacy stream: close the welcome gap,
-                // then subscribe every matching group. A conversation joined
-                // after this point reaches the stream on re-subscribe (until
-                // the welcome auto-subscribe reflex lands).
-                WelcomeService::new(&client.context).sync_welcomes().await?;
-                let groups = client.context.db().find_groups(GroupQueryArgs {
-                    conversation_type,
-                    consent_states: consent_states.clone(),
-                    include_duplicate_dms: true,
-                    include_sync_groups: conversation_type
-                        .map(|ct| matches!(ct, ConversationType::Sync))
-                        .unwrap_or(true),
-                    ..Default::default()
-                })?;
-                // Sync groups are subscribed (their traffic nudges the
-                // device-sync worker) but their messages are intercepted
-                // below, exactly like the legacy stream — internal payloads
-                // must not surface as conversation messages.
-                let sync_groups: Vec<Vec<u8>> = groups
-                    .iter()
-                    .filter(|g| matches!(g.conversation_type, ConversationType::Sync))
-                    .map(|g| g.id.to_vec())
-                    .collect();
-                let ids: Vec<GroupId> = groups.into_iter().map(|g| g.id).collect();
-                if ids.is_empty() {
-                    // Nothing matches (fresh account, or an empty filter):
-                    // the transport refuses an empty lease, and legacy stays
-                    // open here — so stay open with nothing subscribed.
-                    // Deliveries begin on re-subscribe (interim scope above).
-                    return Ok::<_, SubscribeError>(None);
-                }
-                let router = client.stream_router().await;
-                let stream = router.stream_messages(ids, DEFAULT_STREAM_DEPTH).await?;
-                Ok(Some((stream, sync_groups)))
-            };
-            let (stream, sync_groups) = match subscribed.await {
-                Ok(Some(subscription)) => subscription,
-                Ok(None) => {
-                    let _ = tx.send(());
-                    cancel.cancelled().await;
-                    on_close();
-                    return Ok(());
-                }
+            let router = client.stream_router().await;
+            let stream = match router
+                .stream_all_messages(conversation_type, consent_states, DEFAULT_STREAM_DEPTH)
+                .await
+            {
+                Ok(stream) => stream,
                 Err(e) => {
                     // The subscribe itself failed: `on_close` fires and the
                     // handle's result carries the error (legacy watchdog
                     // semantics); the caller re-subscribes from durable
                     // cursors.
                     on_close();
-                    return Err(e);
+                    return Err(e.into());
                 }
             };
             let _ = tx.send(());
-            let worker_events = client.context.worker_events().clone();
-            let callback = move |message: Result<StoredGroupMessage>| {
-                if let Ok(m) = &message
-                    && sync_groups
-                        .iter()
-                        .any(|id| id.as_slice() == m.group_id.as_slice())
-                {
-                    let _ = worker_events.send(SyncWorkerEvent::NewSyncGroupMsg);
-                    return;
-                }
-                callback(message);
-            };
             pump(stream, cancel, callback, on_close).await;
             tracing::debug!("bidi `stream_all_messages` ended");
             Ok::<_, SubscribeError>(())

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -10,12 +10,14 @@
 //! clients share is subscribed once and fanned out). One client per process —
 //! mobile — makes this invisible; a process running many clients (agents)
 //! gets O(1) wires instead of O(clients). The first client to stream donates
-//! its api client — connection, auth middleware and all — to the opener,
-//! which assumes one backend and one set of wire credentials per process:
-//! true for mobile, agents, and `nextest`'s process-per-test runs. (Client
-//! *identity* is not wire state — sibling clients' topics multiplex fine —
-//! but a process mixing differently-authenticated api clients would ride
-//! the donor's credentials.)
+//! its api client to the opener, which assumes one backend per process: true
+//! for mobile, agents, and `nextest`'s process-per-test runs. Auth is not at
+//! stake — the shared wire is receive-only (publishes keep each client's own
+//! api client and whatever authorization it carries), and on v3 the donated
+//! client attaches only version-attribution headers. The hazard of mixing
+//! backends is misrouting: a sibling client pointed elsewhere would lease
+//! its topics on the donor's wire, subscribe successfully, and receive
+//! nothing — hence the init log below.
 //!
 //! ## The gate
 //!
@@ -29,9 +31,9 @@
 //!
 //! Each stream is one spawned task: subscribe (ready fires once the lease is
 //! registered), then drain the router stream into the callback. A subscribe
-//! failure fires `on_close()` and carries the error out through the handle's
-//! result — legacy watchdog semantics, so `end_and_wait()` distinguishes a
-//! startup failure from a clean end. `on_close` fires once
+//! failure warns, fires `on_close()`, and carries the error out through the
+//! handle's result — legacy watchdog semantics; the warn is the reliable
+//! trace, since the bindings' closers rarely read the result. `on_close` fires once
 //! at natural end — the wire-facing lease survives reconnects and suspends
 //! (transport docs), so a natural end means this consumer fell behind and
 //! was dropped, or the client shut down; re-subscribing recovers from
@@ -51,8 +53,11 @@ use xmtp_db::group_message::StoredGroupMessage;
 use xmtp_proto::api_client::XmtpMlsBidiStreams;
 use xmtp_proto::types::GroupId;
 
+use xmtp_common::Event;
+use xmtp_macro::log_event;
+
 use super::stream_router::{DEFAULT_STREAM_DEPTH, RouterStream, StreamRouter};
-use super::{Result, SubscribeError};
+use super::{Result, StreamKind, SubscribeError};
 use crate::Client;
 use crate::context::XmtpSharedContext;
 use crate::groups::MlsGroup;
@@ -128,8 +133,12 @@ pub async fn suspend_bidi_streams() -> Result<()> {
 }
 
 /// Bring the shared bidi wire back (`willEnterForeground`), resolving once
-/// its resume wave has caught up — "catch up, then done", the
-/// background-fetch primitive. A no-op when the transport was never opened.
+/// the wire's resume wave has caught up. That is a wire-level mark: replayed
+/// messages may still be decoding and storing in the stream pipeline behind
+/// it, and the wait is unbounded while the network is down — the FFI
+/// exposure (follow-on) owes callers a processing-drain barrier and a
+/// deadline before this can honestly serve as the background-fetch
+/// primitive. A no-op when the transport was never opened.
 pub async fn resume_bidi_streams() -> Result<()> {
     let Some(transport) = SHARED_TRANSPORT.get() else {
         return Ok(());
@@ -191,6 +200,8 @@ where
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
         xmtp_common::spawn(Some(rx), async move {
+            let installation = client.context.installation_id();
+            log_event!(Event::StreamOpened, installation, kind = ?StreamKind::All);
             let cancel = client.context.cancellation_token().clone();
             let router = client.stream_router().await;
             let stream = match router
@@ -199,10 +210,12 @@ where
             {
                 Ok(stream) => stream,
                 Err(e) => {
-                    // The subscribe itself failed: `on_close` fires and the
-                    // handle's result carries the error (legacy watchdog
-                    // semantics); the caller re-subscribes from durable
-                    // cursors.
+                    // The subscribe itself failed: warn (the handle's result
+                    // carries the error but is rarely read), fire `on_close`
+                    // — legacy watchdog semantics — and the caller
+                    // re-subscribes from durable cursors.
+                    tracing::warn!("bidi `stream_all_messages` failed to subscribe: {e}");
+                    log_event!(Event::StreamClosed, installation, kind = ?StreamKind::All);
                     on_close();
                     return Err(e.into());
                 }
@@ -210,6 +223,7 @@ where
             let _ = tx.send(());
             pump(stream, cancel, callback, on_close).await;
             tracing::debug!("bidi `stream_all_messages` ended");
+            log_event!(Event::StreamClosed, installation, kind = ?StreamKind::All);
             Ok::<_, SubscribeError>(())
         })
     }
@@ -227,6 +241,8 @@ where
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
         xmtp_common::spawn(Some(rx), async move {
+            let installation = client.context.installation_id();
+            log_event!(Event::StreamOpened, installation, kind = ?StreamKind::Conversations);
             let cancel = client.context.cancellation_token().clone();
             let router = client.stream_router().await;
             let stream = match router
@@ -240,6 +256,8 @@ where
             {
                 Ok(stream) => stream,
                 Err(e) => {
+                    tracing::warn!("bidi `stream_conversations` failed to subscribe: {e}");
+                    log_event!(Event::StreamClosed, installation, kind = ?StreamKind::Conversations);
                     on_close();
                     return Err(e.into());
                 }
@@ -247,6 +265,7 @@ where
             let _ = tx.send(());
             pump(stream, cancel, callback, on_close).await;
             tracing::debug!("bidi `stream_conversations` ended");
+            log_event!(Event::StreamClosed, installation, kind = ?StreamKind::Conversations);
             Ok::<_, SubscribeError>(())
         })
     }
@@ -274,6 +293,8 @@ where
 {
     let (tx, rx) = oneshot::channel();
     xmtp_common::spawn(Some(rx), async move {
+        let installation = context.installation_id();
+        log_event!(Event::StreamOpened, installation, kind = ?StreamKind::Messages);
         let cancel = context.cancellation_token().clone();
         let api = context.api().api_client.clone();
         let router = StreamRouter::new(context.clone(), shared_transport(api));
@@ -283,6 +304,8 @@ where
         {
             Ok(stream) => stream,
             Err(e) => {
+                tracing::warn!("bidi `stream_conversation_messages` failed to subscribe: {e}");
+                log_event!(Event::StreamClosed, installation, kind = ?StreamKind::Messages);
                 on_close();
                 return Err(e.into());
             }
@@ -290,6 +313,7 @@ where
         let _ = tx.send(());
         pump(stream, cancel, callback, on_close).await;
         tracing::debug!("bidi `stream_conversation_messages` ended");
+        log_event!(Event::StreamClosed, installation, kind = ?StreamKind::Messages);
         Ok::<_, SubscribeError>(())
     })
 }

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -46,18 +46,16 @@ use tokio_util::sync::CancellationToken;
 use xmtp_api_d14n::{BidiConnection, BidiTransport, OpenError, V3Binding};
 use xmtp_common::{MaybeSend, StreamHandle};
 use xmtp_db::consent_record::ConsentState;
-use xmtp_db::group::{ConversationType, GroupQueryArgs};
+use xmtp_db::group::ConversationType;
 use xmtp_db::group_message::StoredGroupMessage;
-use xmtp_db::prelude::*;
 use xmtp_proto::api_client::XmtpMlsBidiStreams;
 use xmtp_proto::types::GroupId;
 
 use super::stream_router::{DEFAULT_STREAM_DEPTH, RouterStream, StreamRouter};
-use super::{Result, SubscribeError, SyncWorkerEvent};
+use super::{Result, SubscribeError};
 use crate::Client;
 use crate::context::XmtpSharedContext;
 use crate::groups::MlsGroup;
-use crate::groups::welcome_sync::WelcomeService;
 
 /// Opt-in env var for the bidi streaming path (`1`/`true`/`yes`/`on`,
 /// case-insensitive). Anything else — including unset — keeps the legacy
@@ -217,12 +215,9 @@ where
     }
 
     /// Bidi-path counterpart of `stream_conversations_with_callback`: new
-    /// conversations from the welcome topic, over the shared wire.
-    ///
-    /// Interim scope: welcome topic only — a conversation created *locally*
-    /// by this client does not surface here (legacy multiplexes
-    /// `LocalEvents::NewGroup` for that). Parity arrives with the reflex
-    /// work, which fans local new-group events into both stream kinds.
+    /// conversations — welcomes from the shared wire, plus this client's own
+    /// locally-created groups via the `LocalEvents` broadcast (legacy
+    /// parity).
     pub fn stream_conversations_with_callback_bidi(
         client: Arc<Client<Context>>,
         conversation_type: Option<ConversationType>,

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
@@ -372,6 +372,8 @@ async fn sync_group_messages_are_intercepted_not_delivered() {
             match worker_events.recv().await {
                 Ok(SyncWorkerEvent::NewSyncGroupMsg) => break,
                 Ok(_) => continue,
+                // Lagged is recoverable — keep draining for the nudge.
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                 Err(e) => panic!("worker events channel closed: {e}"),
             }
         }

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
@@ -49,6 +49,63 @@ async fn welcomed_group_joins_the_live_stream() {
     assert_eq!(delivered.decrypted_message_bytes, b"through the reflex");
 }
 
+/// A group this client creates itself streams its messages — no welcome
+/// ever arrives for it, so delivery proves the `LocalEvents::NewGroup`
+/// fan-in leased its topic.
+#[xmtp_common::test(unwrap_try = true)]
+async fn self_created_group_streams_its_messages() {
+    tester!(bo);
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = Client::stream_all_messages_with_callback_bidi(
+        Arc::new(bo.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = tx.send(message);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+
+    let group = bo.create_group(None, None)?;
+    group.send_msg(b"own group, own stream").await;
+
+    let delivered = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the local-group delivery")
+        .expect("callback channel closed")?;
+    assert_eq!(delivered.decrypted_message_bytes, b"own group, own stream");
+}
+
+/// A conversation this client creates itself surfaces on its own
+/// conversations stream (legacy multiplexes `LocalEvents::NewGroup`; the
+/// bidi stream must too — the creator never receives a welcome).
+#[xmtp_common::test(unwrap_try = true)]
+async fn self_created_conversation_surfaces_on_the_stream() {
+    tester!(bo);
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = Client::stream_conversations_with_callback_bidi(
+        Arc::new(bo.client.clone()),
+        None,
+        false,
+        move |conversation| {
+            let _ = tx.send(conversation);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+
+    let group = bo.create_group(None, None)?;
+
+    let conversation = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the local conversation")
+        .expect("callback channel closed")?;
+    assert_eq!(conversation.group_id, group.group_id);
+}
+
 /// A message sent after subscribing arrives decoded through the callback.
 #[xmtp_common::test(unwrap_try = true)]
 async fn callback_stream_delivers_live_messages() {

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
@@ -15,6 +15,40 @@ use crate::utils::MlsGroupExt;
 
 const WAIT: Duration = Duration::from_secs(20);
 
+/// The reflex headline: a conversation joined AFTER subscribing reaches the
+/// live stream without a re-subscribe — its welcome arrives over the leased
+/// welcome topic and the reflex leases the new group's topic on the same
+/// wire. The message is sent before the reflex could possibly have leased,
+/// so delivery also proves the cursored add replays it (catch-up ==
+/// subscribe).
+#[xmtp_common::test(unwrap_try = true)]
+async fn welcomed_group_joins_the_live_stream() {
+    tester!(alix);
+    tester!(bo);
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = Client::stream_all_messages_with_callback_bidi(
+        Arc::new(bo.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = tx.send(message);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+
+    let group = alix.create_group(None, None)?;
+    group.invite(&bo).await?;
+    group.send_msg(b"through the reflex").await;
+
+    let delivered = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the reflex-subscribed delivery")
+        .expect("callback channel closed")?;
+    assert_eq!(delivered.decrypted_message_bytes, b"through the reflex");
+}
+
 /// A message sent after subscribing arrives decoded through the callback.
 #[xmtp_common::test(unwrap_try = true)]
 async fn callback_stream_delivers_live_messages() {

--- a/crates/xmtp_mls/src/subscriptions/stream_router.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router.rs
@@ -63,11 +63,14 @@ use xmtp_db::refresh_state::EntityKind;
 use xmtp_proto::mls_v1;
 use xmtp_proto::types::{Cursor, GlobalCursor, GroupId, Topic};
 
+use xmtp_db::group::GroupQueryArgs;
+
 use super::process_message::{ProcessMessageFuture, process_one};
 use super::process_welcome::process_welcome_one;
-use super::{Result, SubscribeError};
+use super::{Result, SubscribeError, SyncWorkerEvent};
 use crate::context::XmtpSharedContext;
 use crate::groups::MlsGroup;
+use crate::groups::welcome_sync::WelcomeService;
 
 /// Default per-stream channel depth (chooseable per stream).
 pub const DEFAULT_STREAM_DEPTH: usize = 16;
@@ -129,6 +132,12 @@ enum Cmd<Context> {
         depth: usize,
         reply: oneshot::Sender<std::result::Result<RouterStream<StoredGroupMessage>, RouterError>>,
     },
+    AllMessages {
+        conversation_type: Option<ConversationType>,
+        consent_states: Option<Vec<ConsentState>>,
+        depth: usize,
+        reply: oneshot::Sender<std::result::Result<RouterStream<StoredGroupMessage>, RouterError>>,
+    },
     Conversations {
         conversation_type: Option<ConversationType>,
         include_duplicate_dms: bool,
@@ -169,6 +178,28 @@ where
         self.cmds
             .send(Cmd::Messages {
                 group_ids,
+                depth,
+                reply,
+            })
+            .map_err(|_| RouterError::Closed)?;
+        response.await.map_err(|_| RouterError::Closed)?
+    }
+
+    /// Stream every matching conversation's messages, growing with new
+    /// conversations: the subscribe-time set seeds the stream, and the
+    /// welcome auto-subscribe reflex leases each later-joined group's topic
+    /// as its welcome arrives — no re-subscribe needed.
+    pub async fn stream_all_messages(
+        &self,
+        conversation_type: Option<ConversationType>,
+        consent_states: Option<Vec<ConsentState>>,
+        depth: usize,
+    ) -> std::result::Result<RouterStream<StoredGroupMessage>, RouterError> {
+        let (reply, response) = oneshot::channel();
+        self.cmds
+            .send(Cmd::AllMessages {
+                conversation_type,
+                consent_states,
                 depth,
                 reply,
             })
@@ -325,6 +356,17 @@ where
             } => {
                 let _ = reply.send(self.subscribe_messages(group_ids, depth).await);
             }
+            Cmd::AllMessages {
+                conversation_type,
+                consent_states,
+                depth,
+                reply,
+            } => {
+                let _ = reply.send(
+                    self.subscribe_all_messages(conversation_type, consent_states, depth)
+                        .await,
+                );
+            }
             Cmd::Conversations {
                 conversation_type,
                 include_duplicate_dms,
@@ -393,6 +435,101 @@ where
             tx,
             dedup: StreamDedup::syncing(floors, seen),
             positions,
+            reflex: None,
+        };
+        let id = self.spawn(|kill| consumer.run(kill));
+        Ok(RouterStream {
+            id,
+            items,
+            ends: self.ends.clone(),
+        })
+    }
+
+    async fn subscribe_all_messages(
+        &mut self,
+        conversation_type: Option<ConversationType>,
+        consent_states: Option<Vec<ConsentState>>,
+        depth: usize,
+    ) -> std::result::Result<RouterStream<StoredGroupMessage>, RouterError> {
+        // Close the welcome gap first — same seeding as the legacy stream —
+        // so the subscribe-time set is current when the welcome lease takes
+        // over the live edge.
+        WelcomeService::new(&self.context)
+            .sync_welcomes()
+            .await
+            .map_err(SubscribeError::from)?;
+        let db = self.context.db();
+        let groups = db
+            .find_groups(GroupQueryArgs {
+                conversation_type,
+                consent_states: consent_states.clone(),
+                include_duplicate_dms: true,
+                // Sync groups are subscribed — their traffic nudges the
+                // device-sync worker — but intercepted at delivery, exactly
+                // like the legacy stream: internal payloads never surface.
+                include_sync_groups: conversation_type
+                    .map(|ct| matches!(ct, ConversationType::Sync))
+                    .unwrap_or(true),
+                ..Default::default()
+            })
+            .map_err(SubscribeError::from)?;
+        let sync_groups: HashSet<GroupId> = groups
+            .iter()
+            .filter(|g| matches!(g.conversation_type, ConversationType::Sync))
+            .map(|g| g.id)
+            .collect();
+        let group_ids: Vec<GroupId> = groups.into_iter().map(|g| g.id).collect();
+
+        // Message floors: exactly the static subscribe's seeding.
+        let seeds = db
+            .get_last_cursor_for_ids(
+                &group_ids,
+                &[EntityKind::ApplicationMessage, EntityKind::CommitMessage],
+            )
+            .map_err(SubscribeError::from)?;
+        let stored = db
+            .messages_newer_than(&seeds)
+            .map_err(SubscribeError::from)?;
+        let installation = self.context.installation_id();
+        let welcome_seed = db
+            .get_last_cursor_for_ids(&[installation], &[EntityKind::Welcome])
+            .map_err(SubscribeError::from)?
+            .get(installation.as_slice())
+            .cloned()
+            .unwrap_or_default()
+            .v3_welcome();
+        let known_welcomes: HashSet<Cursor> =
+            HashSet::from_iter(db.group_cursors().map_err(SubscribeError::from)?);
+
+        // One lease for the subscribe-time set. The welcome topic rides in
+        // it, so even an account with no conversations holds a live lease —
+        // the stream is simply one that has not grown yet.
+        let mut subs = vec![(Topic::new_welcome_message(installation), welcome_seed)];
+        let mut floors = HashMap::with_capacity(group_ids.len());
+        for group_id in &group_ids {
+            let position = seeds.get(group_id.as_slice()).cloned().unwrap_or_default();
+            let topic = Topic::new_group_message(*group_id);
+            subs.push((topic.clone(), position.max()));
+            floors.insert(topic, position);
+        }
+        let (positions, seen) = fold_stored(&floors, stored);
+
+        let lease = self.transport.lease(subs, DEFAULT_LEASE_DEPTH).await?;
+        let (tx, items) = mpsc::channel(depth.max(1));
+        let consumer = MessageConsumer {
+            factory: ProcessMessageFuture::new(self.context.clone()),
+            leases: LeaseSet::new(lease),
+            tx,
+            dedup: StreamDedup::syncing(floors, seen),
+            positions,
+            reflex: Some(Reflex {
+                context: self.context.clone(),
+                transport: self.transport.clone(),
+                known_welcomes,
+                conversation_type,
+                consent_states,
+                sync_groups,
+            }),
         };
         let id = self.spawn(|kill| consumer.run(kill));
         Ok(RouterStream {
@@ -571,6 +708,26 @@ impl LeaseSet {
     }
 }
 
+/// The growth machinery of an all-messages stream. The welcome topic rides
+/// in the lease set: every accepted welcome leases its group's topic on the
+/// same wire — the new lease IS the cursored-add wave, so catch-up and dedup
+/// fall out of the per-topic windows. The filters are the same ones the
+/// legacy conversations sub-stream applies (which is also why the reflex
+/// never adds a *new* sync group: the filter excludes them, exactly as
+/// legacy).
+struct Reflex<Context> {
+    context: Context,
+    transport: BidiTransport<V3Binding>,
+    /// Welcome dedup — consulted and updated sequentially in this task, the
+    /// serialization `process_welcome_one`'s contract asks for.
+    known_welcomes: HashSet<Cursor>,
+    conversation_type: Option<ConversationType>,
+    consent_states: Option<Vec<ConsentState>>,
+    /// Subscribe-time sync groups: their traffic nudges the device-sync
+    /// worker instead of surfacing (legacy `StreamAllMessages` parity).
+    sync_groups: HashSet<GroupId>,
+}
+
 /// One message stream: owns its leases, decodes sequentially, delivers on its
 /// bounded channel. A stall here (e.g. recovery sync) backs up only this
 /// stream's leases.
@@ -582,6 +739,8 @@ struct MessageConsumer<Context> {
     /// during the window so they hold the live edge when it closes.
     positions: HashMap<Topic, GlobalCursor>,
     dedup: StreamDedup,
+    /// `Some` for the all-messages stream: welcomes grow the topic set.
+    reflex: Option<Reflex<Context>>,
 }
 
 impl<Context> MessageConsumer<Context>
@@ -612,9 +771,141 @@ where
                 LeaseEvent::TopicsLive(topics) => {
                     tracing::debug!(?topics, "stream router: topics live");
                 }
-                LeaseEvent::WelcomeMessages(_) => {
-                    tracing::warn!("stream router: welcome delivery on a message lease");
+                LeaseEvent::WelcomeMessages(batch) => {
+                    if self.reflex.is_some() {
+                        if !self.absorb_welcomes(batch, &mut kill).await {
+                            return;
+                        }
+                    } else {
+                        tracing::warn!("stream router: welcome delivery on a message lease");
+                    }
                 }
+            }
+        }
+    }
+
+    /// The reflex: each welcome that passes the stream's filters leases its
+    /// group's topic — the stream grows without a re-subscribe. Returns
+    /// `false` when the stream must end.
+    async fn absorb_welcomes(
+        &mut self,
+        batch: Vec<mls_v1::WelcomeMessage>,
+        kill: &mut oneshot::Receiver<()>,
+    ) -> bool {
+        for proto in batch {
+            let typed = match xmtp_proto::types::WelcomeMessage::try_from(
+                V3ProtoWelcomeMessage::from(proto),
+            ) {
+                Ok(typed) => typed,
+                Err(e) => {
+                    tracing::warn!("stream router: skipping undecodable welcome: {e}");
+                    continue;
+                }
+            };
+            let Some(reflex) = self.reflex.as_ref() else {
+                return true;
+            };
+            if reflex.known_welcomes.contains(&typed.cursor) {
+                continue;
+            }
+            let context = reflex.context.clone();
+            let conversation_type = reflex.conversation_type;
+            let consent_states = reflex.consent_states.clone();
+            // Sequential against this stream's own set — the serialization
+            // `process_welcome_one`'s contract requires. Races the kill so
+            // dropping the stream releases the leases promptly.
+            let processed = tokio::select! {
+                processed = process_welcome_one(
+                    context,
+                    &reflex.known_welcomes,
+                    typed,
+                    conversation_type,
+                    true,
+                    consent_states,
+                ) => processed,
+                _ = &mut *kill => return false,
+            };
+            match processed {
+                Ok(outcome) => {
+                    if let Some(seen) = outcome.seen
+                        && let Some(reflex) = self.reflex.as_mut()
+                    {
+                        reflex.known_welcomes.insert(seen);
+                    }
+                    if let Some(group) = outcome.group
+                        && !self.add_group(group.group_id, kill).await
+                    {
+                        return false;
+                    }
+                }
+                // Welcome-processing errors surface as stream items — the
+                // legacy stream's conversations sub-stream does the same.
+                Err(e) => {
+                    if send_or_kill(&self.tx, kill, Err(e)).await.is_err() {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    /// Lease a newly-joined group's topic and open its catch-up window,
+    /// seeding exactly as the subscribe-time set was. Returns `false` when
+    /// the stream must end.
+    async fn add_group(&mut self, group_id: GroupId, kill: &mut oneshot::Receiver<()>) -> bool {
+        let topic = Topic::new_group_message(group_id);
+        if self.positions.contains_key(&topic) {
+            return true;
+        }
+        let Some(reflex) = self.reflex.as_ref() else {
+            return true;
+        };
+        let seeded = || -> Result<_> {
+            let db = reflex.context.db();
+            let seeds = db.get_last_cursor_for_ids(
+                &[group_id],
+                &[EntityKind::ApplicationMessage, EntityKind::CommitMessage],
+            )?;
+            let stored = db.messages_newer_than(&seeds)?;
+            let floor = seeds.get(group_id.as_slice()).cloned().unwrap_or_default();
+            // Window seed = the frozen durable floor; live position = the
+            // floor folded with stored identities — same split the
+            // subscribe-time seeding makes.
+            let floors = HashMap::from([(topic.clone(), floor)]);
+            let (positions, seen) = fold_stored(&floors, stored);
+            Ok((floors, positions, seen))
+        };
+        let (floors, positions, seen) = match seeded() {
+            Ok(seeded) => seeded,
+            Err(e) => {
+                // Seeding is local DB work; surface and skip this group (a
+                // re-subscribe recovers it from durable cursors).
+                return send_or_kill(&self.tx, kill, Err(e)).await.is_ok();
+            }
+        };
+        let subs = vec![(
+            topic.clone(),
+            floors.get(&topic).cloned().unwrap_or_default().max(),
+        )];
+        let lease = tokio::select! {
+            lease = reflex.transport.lease(subs, DEFAULT_LEASE_DEPTH) => lease,
+            _ = &mut *kill => return false,
+        };
+        match lease {
+            Ok(lease) => {
+                self.positions.extend(positions);
+                self.dedup.open_window(floors, seen);
+                self.leases.push(lease);
+                true
+            }
+            Err(e) => {
+                // A live stream's wire survives flaps (leases ride the resume
+                // wave), so a failed lease means the transport is going away:
+                // surface it and end; the consumer re-subscribes.
+                let error = SubscribeError::from(RouterError::from(e));
+                let _ = send_or_kill(&self.tx, kill, Err(error)).await;
+                false
             }
         }
     }
@@ -669,6 +960,18 @@ where
                                 message.sequence_id as u64,
                                 message.originator_id as u32,
                             ));
+                            if let Some(reflex) = &self.reflex
+                                && reflex.sync_groups.contains(&message.group_id)
+                            {
+                                // Sync-group traffic nudges the device-sync
+                                // worker; internal payloads never surface
+                                // (legacy `StreamAllMessages` parity).
+                                let _ = reflex
+                                    .context
+                                    .worker_events()
+                                    .send(SyncWorkerEvent::NewSyncGroupMsg);
+                                continue;
+                            }
                             send_or_kill(&self.tx, kill, Ok(message)).await
                         }
                         // Surfaced nothing (e.g. a commit) — position

--- a/crates/xmtp_mls/src/subscriptions/stream_router.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router.rs
@@ -3,7 +3,7 @@
 //! One [`StreamRouter`] per client. Each consumer stream leases its topics
 //! from the process-level [`BidiTransport`], decodes raw wire deliveries
 //! through the shared pipeline seams ([`process_one`] /
-//! [`process_welcome_one`]), and delivers decoded results on a bounded
+//! [`ProcessWelcomeFuture`]), and delivers decoded results on a bounded
 //! channel. Everything here speaks *stream* vocabulary — streams, messages,
 //! conversations, durable cursors — the transport's wire/topic/envelope world
 //! stays below the lease boundary.
@@ -16,6 +16,13 @@
 //! stream's own lease channel (where the transport's drop policy applies to
 //! it alone) and never delays a sibling. The router task itself only seeds,
 //! leases, and spawns; it holds no delivery path.
+//!
+//! Within a stream, message decode stays inline — but welcome processing
+//! does not: joining a group can run a full network sync, and a welcome
+//! inline on the lease-draining loop would wedge the whole stream behind it
+//! (past the lease's channel bound, the transport drops the lease and the
+//! stream ends). Welcomes and local-group events fan out to a capped set of
+//! spawned tasks instead (see [`WelcomeIntake`]).
 //!
 //! ## Cursors and dedup
 //!
@@ -34,10 +41,12 @@
 //! (drop everything at-or-below it — including a sibling's replay of older
 //! history) plus an exact-identity seen-set (see [`StreamDedup`]).
 //!
-//! Welcome dedup is a per-stream known-welcome set, consulted and updated
-//! sequentially inside that stream's task — exactly the serialization
-//! [`process_welcome_one`]'s contract asks for. Exact-identity sets are
-//! immune to the ordering caveat, so welcome streams need no window.
+//! Welcome dedup is a per-stream known-welcome set: consulted at intake on
+//! the stream's own task, snapshotted into each processing task, and
+//! recorded back at completion — the consumers' known/positions guards make
+//! completions idempotent, so concurrent same-cursor flights collapse to one
+//! delivery. Exact-identity sets are immune to the ordering caveat, so
+//! welcome streams need no window.
 //!
 //! ## Backpressure (same policy as every layer below)
 //!
@@ -47,7 +56,8 @@
 //! from durable state. A dead wire ends every affected stream the same way;
 //! transparent reconnect arrives with a later phase.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
 
 use tokio::sync::{broadcast, mpsc, oneshot};
 
@@ -55,25 +65,39 @@ use xmtp_api_d14n::v3::{V3ProtoGroupMessage, V3ProtoWelcomeMessage};
 use xmtp_api_d14n::{
     BidiTransport, DEFAULT_LEASE_DEPTH, LeaseEvent, TopicLease, TransportError, V3Binding,
 };
+use xmtp_common::task::JoinSet;
 use xmtp_db::consent_record::ConsentState;
 use xmtp_db::group::ConversationType;
 use xmtp_db::group_message::StoredGroupMessage;
 use xmtp_db::prelude::*;
 use xmtp_db::refresh_state::EntityKind;
 use xmtp_proto::mls_v1;
-use xmtp_proto::types::{Cursor, GlobalCursor, GroupId, Topic};
+use xmtp_proto::types::{Cursor, GlobalCursor, GroupId, InstallationId, SequenceId, Topic};
 
 use xmtp_db::group::GroupQueryArgs;
 
 use super::process_message::{ProcessMessageFuture, process_one};
-use super::process_welcome::{process_local_group_one, process_welcome_one};
-use super::{LocalEvents, Result, SubscribeError, SyncWorkerEvent};
+use super::process_welcome::{ProcessWelcomeFuture, WelcomeOutcome};
+use super::{LocalEvents, Result, SubscribeError, SyncWorkerEvent, WelcomeOrGroup};
 use crate::context::XmtpSharedContext;
 use crate::groups::MlsGroup;
 use crate::groups::welcome_sync::WelcomeService;
 
 /// Default per-stream channel depth (chooseable per stream).
 pub const DEFAULT_STREAM_DEPTH: usize = 16;
+
+/// Cap on in-flight welcome/local-group processing per stream. Enough to
+/// ride out a slow join (each task may run a network sync) without fanning a
+/// replay burst out into unbounded tasks; arrivals past the cap park in the
+/// intake's backlog.
+const MAX_WELCOME_TASKS: usize = 16;
+
+/// Cap on the intake backlog of arrivals parked past [`MAX_WELCOME_TASKS`].
+/// Welcome volume is join-rate-bounded, so this is generous for any
+/// realistic join burst. Overflow means the stream is unrecoverably behind —
+/// end it: the documented re-subscribe recovery replays welcomes from the
+/// durable cursor over the wire lease, so nothing is lost.
+const MAX_WELCOME_BACKLOG: usize = 512;
 
 #[derive(Debug, thiserror::Error)]
 pub enum RouterError {
@@ -92,12 +116,14 @@ pub enum RouterError {
 /// tasks: they survive the last handle dropping, and the router task lingers
 /// only to reap them before exiting.
 pub struct StreamRouter<Context> {
+    context: Context,
     cmds: mpsc::UnboundedSender<Cmd<Context>>,
 }
 
-impl<Context> Clone for StreamRouter<Context> {
+impl<Context: Clone> Clone for StreamRouter<Context> {
     fn clone(&self) -> Self {
         Self {
+            context: self.context.clone(),
             cmds: self.cmds.clone(),
         }
     }
@@ -157,14 +183,14 @@ where
         let (cmds, cmds_rx) = mpsc::unbounded_channel();
         let (ends_tx, ends_rx) = mpsc::unbounded_channel();
         let task = RouterTask {
-            context,
+            context: context.clone(),
             transport,
             consumers: HashMap::new(),
             next_id: 0,
             ends: ends_tx,
         };
         xmtp_common::spawn(None, task.run(cmds_rx, ends_rx));
-        Self { cmds }
+        Self { context, cmds }
     }
 
     /// Stream decoded messages for `group_ids`, resuming each group from its
@@ -195,6 +221,16 @@ where
         consent_states: Option<Vec<ConsentState>>,
         depth: usize,
     ) -> std::result::Result<RouterStream<StoredGroupMessage>, RouterError> {
+        // Close the welcome gap first — same seeding as the legacy stream —
+        // so the subscribe-time set is current when the welcome lease takes
+        // over the live edge. On the caller's task, not the router task: the
+        // router serializes subscribes, and one subscriber's network
+        // round-trip must not stall every sibling subscribe (and reap)
+        // behind it.
+        WelcomeService::new(&self.context)
+            .sync_welcomes()
+            .await
+            .map_err(SubscribeError::from)?;
         let (reply, response) = oneshot::channel();
         self.cmds
             .send(Cmd::AllMessages {
@@ -245,8 +281,9 @@ where
 /// the topics that lease added (a stream that grows mid-flight has one lease
 /// per addition, each with its own window), and the live positions — which
 /// kept advancing — take over per topic. The seen-set is shared across open
-/// windows (exact identity is safe across groups) and drops when the last
-/// window closes.
+/// windows (exact identity is safe across groups), records only for topics
+/// whose own window is open (a closed window's deliveries are already
+/// position-deduped), and drops when the last window closes.
 struct StreamDedup {
     /// Topics still inside their catch-up window → their frozen seed.
     syncing: HashMap<Topic, GlobalCursor>,
@@ -284,8 +321,12 @@ impl StreamDedup {
         }
     }
 
-    fn record(&mut self, cursor: Cursor) {
-        if !self.syncing.is_empty() {
+    /// Record a delivered identity — only while `topic`'s own window is
+    /// open. Once the window closes the position governs that topic, so
+    /// recording would only grow the seen-set for as long as any sibling
+    /// window stays open.
+    fn record(&mut self, topic: &Topic, cursor: Cursor) {
+        if self.syncing.contains_key(topic) {
             self.seen.insert(cursor);
         }
     }
@@ -392,49 +433,20 @@ where
         group_ids: Vec<GroupId>,
         depth: usize,
     ) -> std::result::Result<RouterStream<StoredGroupMessage>, RouterError> {
-        // Seed every group from its durable cursor; the cursored lease makes
-        // the server replay anything past it (catch-up == subscribe).
-        let seeds = self
-            .context
-            .db()
-            .get_last_cursor_for_ids(
-                &group_ids,
-                &[EntityKind::ApplicationMessage, EntityKind::CommitMessage],
-            )
-            .map_err(SubscribeError::from)?;
+        let db = self.context.db();
+        let seeds = seed_groups(&db, &group_ids)?;
 
-        // The streaming pipeline stores messages WITHOUT advancing the durable
-        // cursor (`allow_cursor_increment=false`), so the cursor alone is not a
-        // delivery floor: everything streamed since the last full sync is
-        // stored but still above it. Those exact identities seed the window's
-        // seen-set (so the server's replay of them is skipped) and fold into
-        // the live positions (so they stay skipped after the window). The wire
-        // cursor and the window floor stay at the durable cursor — a stored
-        // gap (6 and 8 stored, 7 missed) still gets 7 replayed and delivered.
-        let stored = self
-            .context
-            .db()
-            .messages_newer_than(&seeds)
-            .map_err(SubscribeError::from)?;
-
-        let mut subs = Vec::with_capacity(group_ids.len());
-        let mut floors = HashMap::with_capacity(group_ids.len());
-        for group_id in &group_ids {
-            let position = seeds.get(group_id.as_slice()).cloned().unwrap_or_default();
-            let topic = Topic::new_group_message(*group_id);
-            subs.push((topic.clone(), position.max()));
-            floors.insert(topic, position);
-        }
-        let (positions, seen) = fold_stored(&floors, stored);
-
-        let lease = self.transport.lease(subs, DEFAULT_LEASE_DEPTH).await?;
+        let lease = self
+            .transport
+            .lease(seeds.subs(), DEFAULT_LEASE_DEPTH)
+            .await?;
         let (tx, items) = mpsc::channel(depth.max(1));
         let consumer = MessageConsumer {
             factory: ProcessMessageFuture::new(self.context.clone()),
             leases: LeaseSet::new(lease),
             tx,
-            dedup: StreamDedup::syncing(floors, seen),
-            positions,
+            dedup: StreamDedup::syncing(seeds.floors, seeds.seen),
+            positions: seeds.positions,
             reflex: None,
         };
         let id = self.spawn(|kill| consumer.run(kill));
@@ -455,14 +467,15 @@ where
         // created in between is either in the query result or buffered on the
         // receiver — never dropped.
         let local_events = self.context.local_events().subscribe();
-        // Close the welcome gap first — same seeding as the legacy stream —
-        // so the subscribe-time set is current when the welcome lease takes
-        // over the live edge.
-        WelcomeService::new(&self.context)
-            .sync_welcomes()
-            .await
-            .map_err(SubscribeError::from)?;
         let db = self.context.db();
+        let installation = self.context.installation_id();
+        // Welcome floor and known set BEFORE the group query: a welcome
+        // processed in between then shows up in the query result AND above
+        // the floor — the positions guard absorbs that overlap. The reverse
+        // order would leave it in neither: not yet a group when queried,
+        // already below the floor when leased.
+        let welcome_floor = welcome_seed(&db, installation)?;
+        let known = known_welcomes_above(&db, welcome_floor)?;
         let groups = db
             .find_groups(GroupQueryArgs {
                 conversation_type,
@@ -483,40 +496,13 @@ where
             .map(|g| g.id)
             .collect();
         let group_ids: Vec<GroupId> = groups.into_iter().map(|g| g.id).collect();
-
-        // Message floors: exactly the static subscribe's seeding.
-        let seeds = db
-            .get_last_cursor_for_ids(
-                &group_ids,
-                &[EntityKind::ApplicationMessage, EntityKind::CommitMessage],
-            )
-            .map_err(SubscribeError::from)?;
-        let stored = db
-            .messages_newer_than(&seeds)
-            .map_err(SubscribeError::from)?;
-        let installation = self.context.installation_id();
-        let welcome_seed = db
-            .get_last_cursor_for_ids(&[installation], &[EntityKind::Welcome])
-            .map_err(SubscribeError::from)?
-            .get(installation.as_slice())
-            .cloned()
-            .unwrap_or_default()
-            .v3_welcome();
-        let known_welcomes: HashSet<Cursor> =
-            HashSet::from_iter(db.group_cursors().map_err(SubscribeError::from)?);
+        let seeds = seed_groups(&db, &group_ids)?;
 
         // One lease for the subscribe-time set. The welcome topic rides in
         // it, so even an account with no conversations holds a live lease —
         // the stream is simply one that has not grown yet.
-        let mut subs = vec![(Topic::new_welcome_message(installation), welcome_seed)];
-        let mut floors = HashMap::with_capacity(group_ids.len());
-        for group_id in &group_ids {
-            let position = seeds.get(group_id.as_slice()).cloned().unwrap_or_default();
-            let topic = Topic::new_group_message(*group_id);
-            subs.push((topic.clone(), position.max()));
-            floors.insert(topic, position);
-        }
-        let (positions, seen) = fold_stored(&floors, stored);
+        let mut subs = seeds.subs();
+        subs.push((Topic::new_welcome_message(installation), welcome_floor));
 
         let lease = self.transport.lease(subs, DEFAULT_LEASE_DEPTH).await?;
         let (tx, items) = mpsc::channel(depth.max(1));
@@ -524,16 +510,19 @@ where
             factory: ProcessMessageFuture::new(self.context.clone()),
             leases: LeaseSet::new(lease),
             tx,
-            dedup: StreamDedup::syncing(floors, seen),
-            positions,
+            dedup: StreamDedup::syncing(seeds.floors, seeds.seen),
+            positions: seeds.positions,
             reflex: Some(Reflex {
-                context: self.context.clone(),
                 transport: self.transport.clone(),
-                known_welcomes,
                 local_events,
-                conversation_type,
-                consent_states,
                 sync_groups,
+                intake: WelcomeIntake::new(
+                    self.context.clone(),
+                    known,
+                    conversation_type,
+                    true,
+                    consent_states,
+                ),
             }),
         };
         let id = self.spawn(|kill| consumer.run(kill));
@@ -559,19 +548,12 @@ where
         // Wire resume point: the durable welcome cursor — every welcome
         // *processed* (stored, ignored, or filtered) advances it, so nothing
         // already handled is replayed.
-        let seed = db
-            .get_last_cursor_for_ids(&[installation], &[EntityKind::Welcome])
-            .map_err(SubscribeError::from)?
-            .get(installation.as_slice())
-            .cloned()
-            .unwrap_or_default()
-            .v3_welcome();
+        let seed = welcome_seed(&db, installation)?;
         // Classification input for the pipeline: the welcome ids that became
         // groups. Per-stream — each stream's dedup is its own, so one
         // stream's delivery never suppresses another's (they may hold
         // different filters).
-        let known: HashSet<Cursor> =
-            HashSet::from_iter(db.group_cursors().map_err(SubscribeError::from)?);
+        let known = known_welcomes_above(&db, seed)?;
 
         let topic = Topic::new_welcome_message(installation);
         let lease = self
@@ -580,14 +562,16 @@ where
             .await?;
         let (tx, items) = mpsc::channel(depth.max(1));
         let consumer = WelcomeConsumer {
-            context: self.context.clone(),
             lease,
             tx,
-            known,
             local_events,
-            conversation_type,
-            include_duplicate_dms,
-            consent_states,
+            intake: WelcomeIntake::new(
+                self.context.clone(),
+                known,
+                conversation_type,
+                include_duplicate_dms,
+                consent_states,
+            ),
         };
         let id = self.spawn(|kill| consumer.run(kill));
         Ok(RouterStream {
@@ -618,6 +602,83 @@ where
         self.consumers.insert(id, ConsumerHandle { _kill: kill });
         id
     }
+}
+
+/// One seeding of a set of group topics from their durable cursors.
+///
+/// The streaming pipeline stores messages WITHOUT advancing the durable
+/// cursor (`allow_cursor_increment=false`), so the cursor alone is not a
+/// delivery floor: everything streamed since the last full sync is stored
+/// but still above it. Those exact identities seed the window's seen-set (so
+/// the server's replay of them is skipped) and fold into the live positions
+/// (so they stay skipped after the window). The wire cursor and the window
+/// floor stay at the durable cursor — a stored gap (6 and 8 stored, 7
+/// missed) still gets 7 replayed and delivered.
+struct GroupSeeds {
+    /// Frozen per-topic window floors: the durable resume points.
+    floors: HashMap<Topic, GlobalCursor>,
+    /// Live per-topic positions: the floors folded with stored identities.
+    positions: HashMap<Topic, GlobalCursor>,
+    /// The window's exact-identity seen-set: the stored identities.
+    seen: HashSet<Cursor>,
+}
+
+impl GroupSeeds {
+    /// The cursored adds for this seeding's lease wave: each topic from its
+    /// frozen floor — the cursored lease makes the server replay anything
+    /// past it (catch-up == subscribe).
+    fn subs(&self) -> Vec<(Topic, SequenceId)> {
+        self.floors
+            .iter()
+            .map(|(topic, floor)| (topic.clone(), floor.max()))
+            .collect()
+    }
+}
+
+/// Seed `group_ids` from their durable cursors (see [`GroupSeeds`]).
+fn seed_groups(
+    db: &(impl QueryRefreshState + QueryGroupMessage),
+    group_ids: &[GroupId],
+) -> Result<GroupSeeds> {
+    let seeds = db.get_last_cursor_for_ids(
+        group_ids,
+        &[EntityKind::ApplicationMessage, EntityKind::CommitMessage],
+    )?;
+    let stored = db.messages_newer_than(&seeds)?;
+    let mut floors = HashMap::with_capacity(group_ids.len());
+    for group_id in group_ids {
+        let floor = seeds.get(group_id.as_slice()).cloned().unwrap_or_default();
+        floors.insert(Topic::new_group_message(*group_id), floor);
+    }
+    let (positions, seen) = fold_stored(&floors, stored);
+    Ok(GroupSeeds {
+        floors,
+        positions,
+        seen,
+    })
+}
+
+/// The durable welcome cursor: this installation's wire resume point for its
+/// welcome topic.
+fn welcome_seed(db: &impl QueryRefreshState, installation: InstallationId) -> Result<SequenceId> {
+    Ok(db
+        .get_last_cursor_for_ids(&[installation], &[EntityKind::Welcome])?
+        .get(installation.as_slice())
+        .cloned()
+        .unwrap_or_default()
+        .v3_welcome())
+}
+
+/// The welcome cursors that already became groups, restricted to those the
+/// wire can still deliver: anything at-or-below the lease floor is filtered
+/// by the transport's delivery guarantee, so seeding it would only bloat the
+/// set every processing task snapshots.
+fn known_welcomes_above(db: &impl QueryGroup, floor: SequenceId) -> Result<HashSet<Cursor>> {
+    Ok(db
+        .group_cursors()?
+        .into_iter()
+        .filter(|cursor| cursor.sequence_id > floor)
+        .collect())
 }
 
 /// Fold locally-stored identities above the durable floors into the live
@@ -658,62 +719,228 @@ async fn send_or_kill<T>(
 /// A stream's leases, polled as one. A static stream holds exactly its
 /// subscribe-time lease; a growing stream pushes one lease per late
 /// addition — the transport multiplexes them onto the one wire, and a new
-/// lease IS the cursored-add wave for its topics, so each lease's
-/// `CatchUpComplete` closes exactly its own topics' dedup windows.
+/// lease IS the cursored-add wave for its topics. Every feed item carries
+/// its lease's topics, so each lease's `CatchUpComplete` closes exactly its
+/// own topics' dedup windows.
 struct LeaseSet {
     feeds: futures::stream::SelectAll<LeaseFeed>,
-    /// idx → the topics that lease holds (for window completion).
-    topics: HashMap<u64, Vec<Topic>>,
-    next_idx: u64,
 }
 
 type LeaseFeed = std::pin::Pin<
-    Box<dyn futures::Stream<Item = (u64, Option<LeaseEvent<V3Binding>>)> + Send + 'static>,
+    Box<dyn futures::Stream<Item = (Arc<[Topic]>, Option<LeaseEvent<V3Binding>>)> + Send + 'static>,
 >;
 
 impl LeaseSet {
     fn new(lease: TopicLease<V3Binding>) -> Self {
         let mut set = Self {
             feeds: futures::stream::SelectAll::new(),
-            topics: HashMap::new(),
-            next_idx: 0,
         };
         set.push(lease);
         set
     }
 
-    fn push(&mut self, lease: TopicLease<V3Binding>) -> u64 {
-        let idx = self.next_idx;
-        self.next_idx += 1;
-        self.topics.insert(idx, lease.topics().to_vec());
-        // The lease lives inside its feed; a `(idx, None)` marks its death.
+    fn push(&mut self, lease: TopicLease<V3Binding>) {
+        // Captured once at push: the topics this lease's `CatchUpComplete`
+        // closes. The lease lives inside its feed; a `None` event marks its
+        // death.
+        let topics: Arc<[Topic]> = lease.topics().into();
         self.feeds.push(Box::pin(futures::stream::unfold(
-            (idx, Some(lease)),
-            |(idx, lease)| async move {
-                let mut lease = lease?;
-                match lease.next().await {
-                    Some(event) => Some(((idx, Some(event)), (idx, Some(lease)))),
-                    None => Some(((idx, None), (idx, None))),
+            Some(lease),
+            move |lease| {
+                let topics = topics.clone();
+                async move {
+                    let mut lease = lease?;
+                    match lease.next().await {
+                        Some(event) => Some(((topics, Some(event)), Some(lease))),
+                        None => Some(((topics, None), None)),
+                    }
                 }
             },
         )));
-        idx
     }
 
-    fn topics_of(&self, idx: u64) -> &[Topic] {
-        self.topics.get(&idx).map(Vec::as_slice).unwrap_or(&[])
-    }
-
-    /// Next event across every lease. `None` means a lease closed — the wire
-    /// died or the transport dropped this consumer — and the stream ends
-    /// (recovery is a re-subscribe from durable cursors, same as before).
-    async fn next(&mut self) -> Option<(u64, LeaseEvent<V3Binding>)> {
+    /// Next event across every lease, tagged with its lease's topics. `None`
+    /// means a lease closed — the wire died or the transport dropped this
+    /// consumer — and the stream ends (recovery is a re-subscribe from
+    /// durable cursors, same as before).
+    async fn next(&mut self) -> Option<(Arc<[Topic]>, LeaseEvent<V3Binding>)> {
         use futures::StreamExt;
         match self.feeds.next().await? {
-            (idx, Some(event)) => Some((idx, event)),
+            (topics, Some(event)) => Some((topics, event)),
             (_, None) => None,
         }
     }
+}
+
+/// What the `LocalEvents` arm woke up for.
+enum LocalWake {
+    Event(LocalEvents),
+    /// The broadcast lapped this receiver: events were dropped unseen.
+    Lagged,
+}
+
+/// The next local event, parking forever on close (the lease side ends the
+/// stream). Lag is surfaced, not absorbed: a dropped `NewGroup` is a group
+/// nothing will re-announce — the message consumer reconciles, the
+/// conversation stream warns (legacy parity: recovery is a re-subscribe).
+async fn next_local_wake(events: &mut broadcast::Receiver<LocalEvents>) -> LocalWake {
+    match events.recv().await {
+        Ok(event) => LocalWake::Event(event),
+        Err(broadcast::error::RecvError::Lagged(n)) => {
+            tracing::warn!("stream router: missed {n} local events");
+            LocalWake::Lagged
+        }
+        Err(broadcast::error::RecvError::Closed) => std::future::pending().await,
+    }
+}
+
+/// Shared intake for the two growing consumers: welcomes off the wire and
+/// locally-created groups off the `LocalEvents` broadcast, run through the
+/// same pipeline ([`ProcessWelcomeFuture`]) and filters.
+///
+/// Processing is spawned, not inlined: a welcome can take seconds (joining
+/// runs a network sync), and the intake runs on the lease-draining task —
+/// inline processing would stop the drain and wedge the lease past its
+/// channel bound, ending the whole stream (the transport's backpressure
+/// drop). The legacy conversation stream spawns onto a `JoinSet` for the
+/// same reason; this one is capped, with arrivals past the cap parked in
+/// the backlog.
+///
+/// Each task snapshots the known set at spawn (the pipeline's contract), so
+/// concurrent same-cursor flights are possible; they resolve at completion,
+/// where the consumers' known/positions guards make them idempotent.
+struct WelcomeIntake<Context> {
+    context: Context,
+    /// Welcome dedup: every cursor this stream has resolved (or knew at
+    /// subscribe). Consulted at intake, snapshotted per task, recorded back
+    /// by the consumer at completion.
+    known: HashSet<Cursor>,
+    conversation_type: Option<ConversationType>,
+    include_duplicate_dms: bool,
+    consent_states: Option<Vec<ConsentState>>,
+    /// In-flight processing, capped at [`MAX_WELCOME_TASKS`]. Dropped with
+    /// the consumer, which aborts every in-flight task.
+    tasks: JoinSet<Result<WelcomeOutcome<Context>>>,
+    /// Arrivals past the cap, in arrival order; capped at
+    /// [`MAX_WELCOME_BACKLOG`].
+    backlog: VecDeque<WelcomeOrGroup>,
+}
+
+impl<Context> WelcomeIntake<Context>
+where
+    Context: XmtpSharedContext + 'static,
+{
+    fn new(
+        context: Context,
+        known: HashSet<Cursor>,
+        conversation_type: Option<ConversationType>,
+        include_duplicate_dms: bool,
+        consent_states: Option<Vec<ConsentState>>,
+    ) -> Self {
+        Self {
+            context,
+            known,
+            conversation_type,
+            include_duplicate_dms,
+            consent_states,
+            tasks: JoinSet::new(),
+            backlog: VecDeque::new(),
+        }
+    }
+
+    /// Wire welcomes: decode, drop the already-known, queue the rest.
+    /// Returns `false` when the backlog overflowed (the stream must end).
+    fn absorb_batch(&mut self, batch: Vec<mls_v1::WelcomeMessage>) -> bool {
+        for proto in batch {
+            let typed = match xmtp_proto::types::WelcomeMessage::try_from(
+                V3ProtoWelcomeMessage::from(proto),
+            ) {
+                Ok(typed) => typed,
+                Err(e) => {
+                    tracing::warn!("stream router: skipping undecodable welcome: {e}");
+                    continue;
+                }
+            };
+            if self.known.contains(&typed.cursor) {
+                // Already a group before subscribe, or already resolved by
+                // this stream. This must NOT fall through to the pipeline —
+                // its known-id path re-surfaces the group from store, which
+                // would re-emit the conversation every time a sibling's
+                // cursored re-add replays this welcome.
+                continue;
+            }
+            if !self.enqueue(WelcomeOrGroup::Welcome(typed)) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// A locally-created group: no welcome will arrive for it, so it takes
+    /// the same pipeline and filters a welcome does (no cursor — dedup is
+    /// the once-per-creation broadcast plus the completion guards).
+    /// Returns `false` when the backlog overflowed (the stream must end).
+    fn absorb_local(&mut self, group_id: GroupId) -> bool {
+        self.enqueue(WelcomeOrGroup::Group(group_id))
+    }
+
+    /// Queues an item, refilling the task set. Returns `false` — without
+    /// queueing — when the backlog is at [`MAX_WELCOME_BACKLOG`] (the stream
+    /// must end).
+    fn enqueue(&mut self, item: WelcomeOrGroup) -> bool {
+        if self.backlog.len() >= MAX_WELCOME_BACKLOG {
+            return false;
+        }
+        self.backlog.push_back(item);
+        self.pump();
+        true
+    }
+
+    /// Refill the task set from the backlog, up to the cap.
+    fn pump(&mut self) {
+        while self.tasks.len() < MAX_WELCOME_TASKS {
+            let Some(item) = self.backlog.pop_front() else {
+                return;
+            };
+            let task = ProcessWelcomeFuture::new(
+                self.known.clone(),
+                self.context.clone(),
+                item,
+                self.conversation_type,
+                self.include_duplicate_dms,
+                self.consent_states.clone(),
+            );
+            self.tasks
+                .spawn(async move { Ok(task?.process().await?.into_outcome()) });
+        }
+    }
+
+    /// The next finished task, parking forever while nothing is in flight
+    /// (the backlog is non-empty only at the cap, so idle means empty).
+    async fn next_outcome(&mut self) -> Result<WelcomeOutcome<Context>> {
+        loop {
+            match self.tasks.join_next().await {
+                Some(Ok(outcome)) => {
+                    self.pump();
+                    return outcome;
+                }
+                // A panicked task: skip it, like the legacy conversation
+                // stream's completion arm does.
+                Some(Err(e)) => {
+                    tracing::warn!("stream router: welcome processing task failed: {e}");
+                    self.pump();
+                }
+                None => return std::future::pending().await,
+            }
+        }
+    }
+}
+
+/// What the growth arms woke up for.
+enum ReflexWake<Context> {
+    Local(LocalWake),
+    /// A spawned welcome/local-group task finished.
+    Outcome(Result<WelcomeOutcome<Context>>),
 }
 
 /// The growth machinery of an all-messages stream. The welcome topic rides
@@ -721,45 +948,48 @@ impl LeaseSet {
 /// group off the `LocalEvents` broadcast, for which no welcome will ever
 /// arrive — leases its group's topic on the same wire; the new lease IS the
 /// cursored-add wave, so catch-up and dedup fall out of the per-topic
-/// windows. The filters are the same ones the legacy conversations
-/// sub-stream applies (which is also why the reflex never adds a *new* sync
-/// group: the filter excludes them, exactly as legacy).
+/// windows. Growth never adds a sync group: the welcome path filters virtual
+/// groups inside the pipeline, and the local-group path — whose pipeline
+/// filter deliberately admits stored virtual groups — is guarded at
+/// completion. Sync-group traffic belongs to the device-sync worker, and
+/// only the subscribe-time interception set carries it there.
 struct Reflex<Context> {
-    context: Context,
     transport: BidiTransport<V3Binding>,
-    /// Welcome dedup — consulted and updated sequentially in this task, the
-    /// serialization `process_welcome_one`'s contract asks for.
-    known_welcomes: HashSet<Cursor>,
     /// Locally-created groups — no welcome will ever arrive for these, so
     /// they grow the stream through the same add-path as welcomes.
     local_events: broadcast::Receiver<LocalEvents>,
-    conversation_type: Option<ConversationType>,
-    consent_states: Option<Vec<ConsentState>>,
     /// Subscribe-time sync groups: their traffic nudges the device-sync
     /// worker instead of surfacing (legacy `StreamAllMessages` parity).
     sync_groups: HashSet<GroupId>,
+    intake: WelcomeIntake<Context>,
 }
 
-impl<Context> Reflex<Context> {
-    /// The next local event, absorbing broadcast lag (missed events warn —
-    /// a lagged NewGroup is recovered by re-subscribe, same as legacy) and
-    /// parking forever on close (the lease side ends the stream).
-    async fn next_local_event(reflex: &mut Option<Self>) -> LocalEvents {
+impl<Context> Reflex<Context>
+where
+    Context: XmtpSharedContext + 'static,
+{
+    /// Both growth arms as one future; a static stream (`None`) parks
+    /// forever — the lease side ends the stream.
+    async fn wake(reflex: &mut Option<Self>) -> ReflexWake<Context> {
         let Some(reflex) = reflex.as_mut() else {
             return std::future::pending().await;
         };
-        loop {
-            match reflex.local_events.recv().await {
-                Ok(event) => return event,
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    tracing::warn!("bidi reflex missed {n} local events");
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    return std::future::pending().await;
-                }
-            }
+        tokio::select! {
+            local = next_local_wake(&mut reflex.local_events) => ReflexWake::Local(local),
+            outcome = reflex.intake.next_outcome() => ReflexWake::Outcome(outcome),
         }
     }
+}
+
+/// How [`MessageConsumer::add_group`] left the stream.
+enum AddGroup {
+    /// The group's topic is leased (now, or already was).
+    Tracked,
+    /// Seeding failed: the group is not leased, and its welcome must stay
+    /// unrecorded so a wire replay can retry it.
+    Skipped,
+    /// The stream must end.
+    End,
 }
 
 /// One message stream: owns its leases, decodes sequentially, delivers on its
@@ -783,208 +1013,192 @@ where
 {
     async fn run(mut self, mut kill: oneshot::Receiver<()>) {
         loop {
-            enum Wake {
-                Lease(u64, LeaseEvent<V3Binding>),
-                Local(LocalEvents),
-                Done,
+            enum Wake<Context> {
+                Lease(Arc<[Topic]>, LeaseEvent<V3Binding>),
+                Reflex(ReflexWake<Context>),
             }
             let wake = tokio::select! {
                 event = self.leases.next() => match event {
-                    Some((idx, event)) => Wake::Lease(idx, event),
+                    Some((topics, event)) => Wake::Lease(topics, event),
                     // Wire death or transport backpressure drop on any lease:
                     // the stream ends (tx drops); the consumer re-subscribes.
-                    None => Wake::Done,
+                    None => return,
                 },
-                local = Reflex::next_local_event(&mut self.reflex) => Wake::Local(local),
-                _ = &mut kill => Wake::Done,
+                wake = Reflex::wake(&mut self.reflex) => Wake::Reflex(wake),
+                _ = &mut kill => return,
             };
-            let (idx, event) = match wake {
-                Wake::Done => return,
-                Wake::Local(LocalEvents::NewGroup(group_id)) => {
-                    if !self.absorb_local_group(group_id, &mut kill).await {
+            match wake {
+                Wake::Reflex(ReflexWake::Local(LocalWake::Event(LocalEvents::NewGroup(id)))) => {
+                    if !self.absorb_local_group(id) {
                         return;
                     }
-                    continue;
                 }
-                Wake::Local(_) => continue,
-                Wake::Lease(idx, event) => (idx, event),
-            };
-            match event {
-                LeaseEvent::GroupMessages(batch) => {
+                Wake::Reflex(ReflexWake::Local(LocalWake::Event(_))) => {}
+                Wake::Reflex(ReflexWake::Local(LocalWake::Lagged)) => {
+                    if !self.reconcile(&mut kill).await {
+                        return;
+                    }
+                }
+                Wake::Reflex(ReflexWake::Outcome(outcome)) => {
+                    if !self.absorb_outcome(outcome, &mut kill).await {
+                        return;
+                    }
+                }
+                Wake::Lease(_, LeaseEvent::GroupMessages(batch)) => {
                     if !self.deliver_batch(batch, &mut kill).await {
                         return;
                     }
                 }
-                LeaseEvent::CatchUpComplete => {
+                Wake::Lease(topics, LeaseEvent::CatchUpComplete) => {
                     tracing::debug!("stream router: message stream caught up");
-                    self.dedup.complete(self.leases.topics_of(idx));
+                    self.dedup.complete(&topics);
                 }
-                LeaseEvent::TopicsLive(topics) => {
+                Wake::Lease(_, LeaseEvent::TopicsLive(topics)) => {
                     tracing::debug!(?topics, "stream router: topics live");
                 }
-                LeaseEvent::WelcomeMessages(batch) => {
-                    if self.reflex.is_some() {
-                        if !self.absorb_welcomes(batch, &mut kill).await {
+                Wake::Lease(_, LeaseEvent::WelcomeMessages(batch)) => match self.reflex.as_mut() {
+                    Some(reflex) => {
+                        if !reflex.intake.absorb_batch(batch) {
                             return;
                         }
-                    } else {
-                        tracing::warn!("stream router: welcome delivery on a message lease");
                     }
-                }
+                    None => tracing::warn!("stream router: welcome delivery on a message lease"),
+                },
             }
         }
     }
 
-    /// A locally-created group: no welcome will arrive, so the reflex runs
-    /// the id through the same pipeline and filters a welcome takes and
-    /// leases its topic. Returns `false` when the stream must end.
-    async fn absorb_local_group(
-        &mut self,
-        group_id: GroupId,
-        kill: &mut oneshot::Receiver<()>,
-    ) -> bool {
-        let Some(reflex) = self.reflex.as_ref() else {
-            return true;
-        };
+    /// A locally-created group grows the stream through the same processing
+    /// (and filters) a welcome takes — unless its topic is already leased
+    /// (the subscribe-time set, or an earlier growth, got it). Returns
+    /// `false` when the stream must end.
+    fn absorb_local_group(&mut self, group_id: GroupId) -> bool {
         if self
             .positions
             .contains_key(&Topic::new_group_message(group_id))
         {
             return true;
         }
-        let processed = tokio::select! {
-            processed = process_local_group_one(
-                reflex.context.clone(),
-                group_id,
-                reflex.conversation_type,
-                true,
-                reflex.consent_states.clone(),
-            ) => processed,
-            _ = &mut *kill => return false,
-        };
-        match processed {
-            Ok(outcome) => match outcome.group {
-                Some(group) => self.add_group(group.group_id, kill).await,
-                None => true,
-            },
-            Err(e) => send_or_kill(&self.tx, kill, Err(e)).await.is_ok(),
+        match self.reflex.as_mut() {
+            Some(reflex) => reflex.intake.absorb_local(group_id),
+            None => true,
         }
     }
 
-    /// The reflex: each welcome that passes the stream's filters leases its
-    /// group's topic — the stream grows without a re-subscribe. Returns
-    /// `false` when the stream must end.
-    async fn absorb_welcomes(
-        &mut self,
-        batch: Vec<mls_v1::WelcomeMessage>,
-        kill: &mut oneshot::Receiver<()>,
-    ) -> bool {
-        for proto in batch {
-            let typed = match xmtp_proto::types::WelcomeMessage::try_from(
-                V3ProtoWelcomeMessage::from(proto),
-            ) {
-                Ok(typed) => typed,
-                Err(e) => {
-                    tracing::warn!("stream router: skipping undecodable welcome: {e}");
-                    continue;
-                }
-            };
-            let Some(reflex) = self.reflex.as_ref() else {
-                return true;
-            };
-            if reflex.known_welcomes.contains(&typed.cursor) {
-                continue;
+    /// The `LocalEvents` broadcast lapped this stream: any number of
+    /// `NewGroup` announcements are gone for good, and nothing re-announces
+    /// a local group. Recover by re-running the subscribe-time group query
+    /// and adding whatever the stream does not already track — the positions
+    /// guard skips everything it does. Returns `false` when the stream must
+    /// end.
+    async fn reconcile(&mut self, kill: &mut oneshot::Receiver<()>) -> bool {
+        let groups = match self.reflex.as_ref() {
+            Some(reflex) => reflex.intake.context.db().find_groups(GroupQueryArgs {
+                conversation_type: reflex.intake.conversation_type,
+                consent_states: reflex.intake.consent_states.clone(),
+                include_duplicate_dms: true,
+                // Growth never adds sync groups; the subscribe-time
+                // interception set is untouched by a lag.
+                ..Default::default()
+            }),
+            None => return true,
+        };
+        let groups = match groups {
+            Ok(groups) => groups,
+            Err(e) => {
+                // The lapped announcements are unrecoverable in-stream; end
+                // after surfacing so a re-subscribe re-seeds from a fresh
+                // query instead of running with a silent hole.
+                let _ = send_or_kill(&self.tx, kill, Err(e.into())).await;
+                return false;
             }
-            let context = reflex.context.clone();
-            let conversation_type = reflex.conversation_type;
-            let consent_states = reflex.consent_states.clone();
-            // Sequential against this stream's own set — the serialization
-            // `process_welcome_one`'s contract requires. Races the kill so
-            // dropping the stream releases the leases promptly.
-            let processed = tokio::select! {
-                processed = process_welcome_one(
-                    context,
-                    &reflex.known_welcomes,
-                    typed,
-                    conversation_type,
-                    true,
-                    consent_states,
-                ) => processed,
-                _ = &mut *kill => return false,
-            };
-            match processed {
-                Ok(outcome) => {
-                    if let Some(seen) = outcome.seen
-                        && let Some(reflex) = self.reflex.as_mut()
-                    {
-                        reflex.known_welcomes.insert(seen);
-                    }
-                    if let Some(group) = outcome.group
-                        && !self.add_group(group.group_id, kill).await
-                    {
-                        return false;
-                    }
-                }
-                // Welcome-processing errors surface as stream items — the
-                // legacy stream's conversations sub-stream does the same.
-                Err(e) => {
-                    if send_or_kill(&self.tx, kill, Err(e)).await.is_err() {
-                        return false;
-                    }
-                }
+        };
+        for group in groups {
+            match self.add_group(group.id, kill).await {
+                AddGroup::Tracked => {}
+                // A group this pass cannot add has no other way back in —
+                // its announcement is already lost and a local group's
+                // welcome never replays — so end rather than run with a
+                // silent hole (`add_group` already surfaced the error).
+                AddGroup::Skipped | AddGroup::End => return false,
             }
         }
         true
     }
 
+    /// A finished welcome/local-group task: lease the accepted group's
+    /// topic, then record the welcome as known. The order matters twice
+    /// over: recording only after the group is tracked keeps a transiently
+    /// failed add recoverable (the unrecorded welcome replays on the wire),
+    /// and the positions guard inside [`Self::add_group`] collapses
+    /// concurrent same-cursor completions to one lease. Returns `false`
+    /// when the stream must end.
+    async fn absorb_outcome(
+        &mut self,
+        outcome: Result<WelcomeOutcome<Context>>,
+        kill: &mut oneshot::Receiver<()>,
+    ) -> bool {
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            // Welcome-processing errors surface as stream items — the
+            // legacy stream's conversations sub-stream does the same.
+            Err(e) => return send_or_kill(&self.tx, kill, Err(e)).await.is_ok(),
+        };
+        // Growth never adds a sync group (only the local-group path can
+        // carry one this far — see [`Reflex`]) — but its welcome still
+        // becomes known, like any other filtered welcome.
+        let group = outcome
+            .group
+            .filter(|group| !matches!(group.conversation_type, ConversationType::Sync));
+        let tracked = match group {
+            Some(group) => match self.add_group(group.group_id, kill).await {
+                AddGroup::Tracked => true,
+                AddGroup::Skipped => false,
+                AddGroup::End => return false,
+            },
+            None => true,
+        };
+        if tracked
+            && let Some(seen) = outcome.seen
+            && let Some(reflex) = self.reflex.as_mut()
+        {
+            reflex.intake.known.insert(seen);
+        }
+        true
+    }
+
     /// Lease a newly-joined group's topic and open its catch-up window,
-    /// seeding exactly as the subscribe-time set was. Returns `false` when
-    /// the stream must end.
-    async fn add_group(&mut self, group_id: GroupId, kill: &mut oneshot::Receiver<()>) -> bool {
+    /// seeding exactly as the subscribe-time set was.
+    async fn add_group(&mut self, group_id: GroupId, kill: &mut oneshot::Receiver<()>) -> AddGroup {
         let topic = Topic::new_group_message(group_id);
         if self.positions.contains_key(&topic) {
-            return true;
+            return AddGroup::Tracked;
         }
         let Some(reflex) = self.reflex.as_ref() else {
-            return true;
+            // Static streams never grow; nothing routes here without a reflex.
+            return AddGroup::Tracked;
         };
-        let seeded = || -> Result<_> {
-            let db = reflex.context.db();
-            let seeds = db.get_last_cursor_for_ids(
-                &[group_id],
-                &[EntityKind::ApplicationMessage, EntityKind::CommitMessage],
-            )?;
-            let stored = db.messages_newer_than(&seeds)?;
-            let floor = seeds.get(group_id.as_slice()).cloned().unwrap_or_default();
-            // Window seed = the frozen durable floor; live position = the
-            // floor folded with stored identities — same split the
-            // subscribe-time seeding makes.
-            let floors = HashMap::from([(topic.clone(), floor)]);
-            let (positions, seen) = fold_stored(&floors, stored);
-            Ok((floors, positions, seen))
-        };
-        let (floors, positions, seen) = match seeded() {
-            Ok(seeded) => seeded,
+        let seeds = match seed_groups(&reflex.intake.context.db(), &[group_id]) {
+            Ok(seeds) => seeds,
             Err(e) => {
-                // Seeding is local DB work; surface and skip this group (a
-                // re-subscribe recovers it from durable cursors).
-                return send_or_kill(&self.tx, kill, Err(e)).await.is_ok();
+                // Seeding is local DB work; surface and skip this group (its
+                // unrecorded welcome replay — or a re-subscribe — retries it).
+                return match send_or_kill(&self.tx, kill, Err(e)).await {
+                    Ok(()) => AddGroup::Skipped,
+                    Err(()) => AddGroup::End,
+                };
             }
         };
-        let subs = vec![(
-            topic.clone(),
-            floors.get(&topic).cloned().unwrap_or_default().max(),
-        )];
         let lease = tokio::select! {
-            lease = reflex.transport.lease(subs, DEFAULT_LEASE_DEPTH) => lease,
-            _ = &mut *kill => return false,
+            lease = reflex.transport.lease(seeds.subs(), DEFAULT_LEASE_DEPTH) => lease,
+            _ = &mut *kill => return AddGroup::End,
         };
         match lease {
             Ok(lease) => {
-                self.positions.extend(positions);
-                self.dedup.open_window(floors, seen);
+                self.positions.extend(seeds.positions);
+                self.dedup.open_window(seeds.floors, seeds.seen);
                 self.leases.push(lease);
-                true
+                AddGroup::Tracked
             }
             Err(e) => {
                 // A live stream's wire survives flaps (leases ride the resume
@@ -992,7 +1206,7 @@ where
                 // surface it and end; the consumer re-subscribes.
                 let error = SubscribeError::from(RouterError::from(e));
                 let _ = send_or_kill(&self.tx, kill, Err(error)).await;
-                false
+                AddGroup::End
             }
         }
     }
@@ -1036,17 +1250,20 @@ where
                     if let Some(position) = self.positions.get_mut(&topic) {
                         position.apply(&processed.next_cursor);
                     }
-                    self.dedup.record(cursor);
+                    self.dedup.record(&topic, cursor);
                     match processed.message {
                         Some(message) => {
                             // The pipeline may surface a different message
                             // than the envelope named (recovery sync stores
                             // ahead) — record the delivered identity too, or
                             // its own replay envelope would deliver it twice.
-                            self.dedup.record(Cursor::new(
-                                message.sequence_id as u64,
-                                message.originator_id as u32,
-                            ));
+                            self.dedup.record(
+                                &topic,
+                                Cursor::new(
+                                    message.sequence_id as u64,
+                                    message.originator_id as u32,
+                                ),
+                            );
                             if let Some(reflex) = &self.reflex
                                 && reflex.sync_groups.contains(&message.group_id)
                             {
@@ -1054,6 +1271,7 @@ where
                                 // worker; internal payloads never surface
                                 // (legacy `StreamAllMessages` parity).
                                 let _ = reflex
+                                    .intake
                                     .context
                                     .worker_events()
                                     .send(SyncWorkerEvent::NewSyncGroupMsg);
@@ -1085,17 +1303,15 @@ where
 ///
 /// Locally-created conversations merge in from the `LocalEvents` broadcast —
 /// no welcome ever arrives for a group this client created, and legacy
-/// multiplexes the same events. Dedup for those is the broadcast itself:
-/// one event per creation.
+/// multiplexes the same events. Dedup for those is the once-per-creation
+/// broadcast plus the known set: a group created off a welcome pointer
+/// records its welcome cursor, so the wire replay of that welcome does not
+/// surface the conversation a second time.
 struct WelcomeConsumer<Context> {
-    context: Context,
     lease: TopicLease<V3Binding>,
     tx: mpsc::Sender<Result<MlsGroup<Context>>>,
-    known: HashSet<Cursor>,
     local_events: broadcast::Receiver<LocalEvents>,
-    conversation_type: Option<ConversationType>,
-    include_duplicate_dms: bool,
-    consent_states: Option<Vec<ConsentState>>,
+    intake: WelcomeIntake<Context>,
 }
 
 impl<Context> WelcomeConsumer<Context>
@@ -1104,148 +1320,80 @@ where
 {
     async fn run(mut self, mut kill: oneshot::Receiver<()>) {
         loop {
-            enum Wake {
+            enum Wake<Context> {
                 Lease(LeaseEvent<V3Binding>),
-                Local(LocalEvents),
-                Done,
+                Local(LocalWake),
+                Outcome(Result<WelcomeOutcome<Context>>),
             }
             let wake = tokio::select! {
                 event = self.lease.next() => match event {
                     Some(event) => Wake::Lease(event),
-                    None => Wake::Done,
+                    None => return,
                 },
-                local = Self::next_local_event(&mut self.local_events) => Wake::Local(local),
-                _ = &mut kill => Wake::Done,
+                local = next_local_wake(&mut self.local_events) => Wake::Local(local),
+                outcome = self.intake.next_outcome() => Wake::Outcome(outcome),
+                _ = &mut kill => return,
             };
-            let event = match wake {
-                Wake::Done => return,
-                Wake::Local(LocalEvents::NewGroup(group_id)) => {
-                    if !self.surface_local_group(group_id, &mut kill).await {
-                        return;
-                    }
-                    continue;
-                }
-                Wake::Local(_) => continue,
-                Wake::Lease(event) => event,
-            };
-            match event {
-                LeaseEvent::WelcomeMessages(batch) => {
-                    if !self.deliver_batch(batch, &mut kill).await {
+            match wake {
+                Wake::Local(LocalWake::Event(LocalEvents::NewGroup(group_id))) => {
+                    if !self.intake.absorb_local(group_id) {
                         return;
                     }
                 }
-                LeaseEvent::CatchUpComplete => {
+                // A lagged broadcast (already warned) loses local groups
+                // only; recovery is a re-subscribe, exactly as legacy.
+                Wake::Local(_) => {}
+                Wake::Outcome(outcome) => {
+                    if !self.deliver_outcome(outcome, &mut kill).await {
+                        return;
+                    }
+                }
+                Wake::Lease(LeaseEvent::WelcomeMessages(batch)) => {
+                    if !self.intake.absorb_batch(batch) {
+                        return;
+                    }
+                }
+                Wake::Lease(LeaseEvent::CatchUpComplete) => {
                     // Exact-identity dedup needs no window; nothing to flip.
                     tracing::debug!("stream router: conversation stream caught up");
                 }
-                LeaseEvent::TopicsLive(_) => {}
-                LeaseEvent::GroupMessages(_) => {
+                Wake::Lease(LeaseEvent::TopicsLive(_)) => {}
+                Wake::Lease(LeaseEvent::GroupMessages(_)) => {
                     tracing::warn!("stream router: group delivery on a welcome lease");
                 }
             }
         }
     }
 
-    /// The next local event, absorbing broadcast lag and parking on close
-    /// (the lease side ends the stream).
-    async fn next_local_event(events: &mut broadcast::Receiver<LocalEvents>) -> LocalEvents {
-        loop {
-            match events.recv().await {
-                Ok(event) => return event,
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    tracing::warn!("conversation stream missed {n} local events");
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    return std::future::pending().await;
-                }
-            }
-        }
-    }
-
-    /// A group this client just created: run it through the same pipeline
-    /// and filters a welcome takes, and surface it. Returns `false` when the
-    /// stream must end.
-    async fn surface_local_group(
+    /// A finished welcome/local-group task: record it known, surface the
+    /// conversation. Recording first makes completions idempotent — a
+    /// concurrent same-cursor flight (both spawned before either resolved)
+    /// finds the cursor already known and surfaces nothing. Returns `false`
+    /// when the stream must end.
+    async fn deliver_outcome(
         &mut self,
-        group_id: GroupId,
+        outcome: Result<WelcomeOutcome<Context>>,
         kill: &mut oneshot::Receiver<()>,
     ) -> bool {
-        let processed = tokio::select! {
-            processed = process_local_group_one(
-                self.context.clone(),
-                group_id,
-                self.conversation_type,
-                self.include_duplicate_dms,
-                self.consent_states.clone(),
-            ) => processed,
-            _ = &mut *kill => return false,
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(e) => return send_or_kill(&self.tx, kill, Err(e)).await.is_ok(),
         };
-        let delivered = match processed {
-            Ok(outcome) => match outcome.group {
-                Some(group) => send_or_kill(&self.tx, kill, Ok(group)).await,
-                None => return true,
-            },
-            Err(e) => send_or_kill(&self.tx, kill, Err(e)).await,
-        };
-        delivered.is_ok()
-    }
-
-    async fn deliver_batch(
-        &mut self,
-        batch: Vec<mls_v1::WelcomeMessage>,
-        kill: &mut oneshot::Receiver<()>,
-    ) -> bool {
-        for proto in batch {
-            let typed = match xmtp_proto::types::WelcomeMessage::try_from(
-                V3ProtoWelcomeMessage::from(proto),
-            ) {
-                Ok(typed) => typed,
-                Err(e) => {
-                    tracing::warn!("stream router: skipping undecodable welcome: {e}");
-                    continue;
-                }
-            };
-            if self.known.contains(&typed.cursor) {
-                // Already a group before subscribe, or already delivered by
-                // this stream. This must NOT fall through to
-                // `process_welcome_one` — its known-id path re-surfaces the
-                // group from store, which would re-emit the conversation every
-                // time a sibling's cursored re-add replays this welcome.
-                continue;
-            }
-
-            // Sequential against this stream's own set — exactly the
-            // serialization `process_welcome_one`'s contract requires. Races
-            // the kill so dropping the stream releases the lease promptly
-            // even mid-processing.
-            let processed = tokio::select! {
-                processed = process_welcome_one(
-                    self.context.clone(),
-                    &self.known,
-                    typed,
-                    self.conversation_type,
-                    self.include_duplicate_dms,
-                    self.consent_states.clone(),
-                ) => processed,
-                _ = &mut *kill => return false,
-            };
-            let delivered = match processed {
-                Ok(outcome) => {
-                    if let Some(seen) = outcome.seen {
-                        self.known.insert(seen);
-                    }
-                    match outcome.group {
-                        Some(group) => send_or_kill(&self.tx, kill, Ok(group)).await,
-                        None => continue,
-                    }
-                }
-                Err(e) => send_or_kill(&self.tx, kill, Err(e)).await,
-            };
-            if delivered.is_err() {
-                return false;
-            }
+        if let Some(seen) = outcome.seen
+            && !self.intake.known.insert(seen)
+        {
+            return true;
         }
-        true
+        match outcome.group {
+            // A sync group never surfaces (only the local-group path can
+            // carry one this far — the welcome path filters virtual groups
+            // inside the pipeline): it is the device-sync worker's, not the
+            // subscriber's.
+            Some(group) if !matches!(group.conversation_type, ConversationType::Sync) => {
+                send_or_kill(&self.tx, kill, Ok(group)).await.is_ok()
+            }
+            _ => true,
+        }
     }
 }
 
@@ -1274,7 +1422,7 @@ mod tests {
         // A live message leapfrogs the replay its own wave requested.
         let live = Cursor::new(100, 0u32);
         assert!(!dedup.has_seen(&position, &topic, &live));
-        dedup.record(live);
+        dedup.record(&topic, live);
         position.apply(&live);
 
         // The replay behind it still delivers during the window...
@@ -1283,7 +1431,7 @@ mod tests {
             !dedup.has_seen(&position, &topic, &replayed),
             "the window must not swallow the replay behind an early live delivery"
         );
-        dedup.record(replayed);
+        dedup.record(&topic, replayed);
         // ...while exact duplicates are still skipped.
         assert!(dedup.has_seen(&position, &topic, &replayed));
 
@@ -1360,11 +1508,37 @@ mod tests {
         let position = GlobalCursor::default();
 
         // Envelope 10 errors; recovery surfaces stored message 11.
-        dedup.record(Cursor::new(10, 0u32)); // the envelope
-        dedup.record(Cursor::new(11, 0u32)); // the delivered message
+        dedup.record(&topic, Cursor::new(10, 0u32)); // the envelope
+        dedup.record(&topic, Cursor::new(11, 0u32)); // the delivered message
         assert!(
             dedup.has_seen(&position, &topic, &Cursor::new(11, 0u32)),
             "the replay envelope for the already-delivered message must be skipped"
         );
+    }
+
+    /// Recording is scoped to open windows: an identity delivered on a topic
+    /// whose window is not open (closed, or never had one) is position-deduped
+    /// and must not grow the seen-set kept for a sibling still syncing.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn record_only_tracks_topics_with_open_windows() {
+        let syncing = Topic::new_group_message([1u8; 16]);
+        let live = Topic::new_group_message([2u8; 16]);
+        let mut dedup = StreamDedup::syncing(
+            HashMap::from([(syncing.clone(), GlobalCursor::default())]),
+            HashSet::new(),
+        );
+        let position = GlobalCursor::default();
+
+        // A record for the window-less topic must not land in the shared
+        // seen-set (observable through the still-open sibling window).
+        dedup.record(&live, Cursor::new(10, 0u32));
+        assert!(
+            !dedup.has_seen(&position, &syncing, &Cursor::new(10, 0u32)),
+            "an identity from a window-less topic must not be recorded"
+        );
+
+        // The same identity recorded under the open window is tracked.
+        dedup.record(&syncing, Cursor::new(10, 0u32));
+        assert!(dedup.has_seen(&position, &syncing, &Cursor::new(10, 0u32)));
     }
 }

--- a/crates/xmtp_mls/src/subscriptions/stream_router.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router.rs
@@ -201,24 +201,26 @@ where
 
 /// Dedup for one message stream.
 ///
-/// Steady state (`Live`) is the per-topic position: wire order is
-/// cursor-monotonic, so a high-water mark suffices. During the catch-up
-/// window (`Syncing`) it is not — a live delivery already in flight for a
-/// shared topic can arrive *before* the replay this stream's cursored add
-/// requested (see the transport's delivery-order contract) — so the window
-/// checks the **frozen subscribe-time seed** (anything at-or-below the
-/// durable resume point is never for this stream, including a sibling
-/// lease's replay of older history) plus an exact-identity seen-set. The set
-/// is bounded by the window: it drops at `CatchUpComplete`, when the live
-/// positions (which kept advancing) take over.
-enum StreamDedup {
-    Syncing {
-        /// Per-topic durable positions frozen at subscribe.
-        seeds: HashMap<Topic, GlobalCursor>,
-        /// Exact identities delivered during the window.
-        seen: HashSet<Cursor>,
-    },
-    Live,
+/// Steady state is the per-topic position: wire order is cursor-monotonic,
+/// so a high-water mark suffices. During a topic's catch-up window it is
+/// not — a live delivery already in flight for a shared topic can arrive
+/// *before* the replay this stream's cursored add requested (see the
+/// transport's delivery-order contract) — so the window checks the **frozen
+/// subscribe-time seed** (anything at-or-below the durable resume point is
+/// never for this stream, including a sibling lease's replay of older
+/// history) plus an exact-identity seen-set.
+///
+/// Windows are **per topic**: each lease's `CatchUpComplete` closes exactly
+/// the topics that lease added (a stream that grows mid-flight has one lease
+/// per addition, each with its own window), and the live positions — which
+/// kept advancing — take over per topic. The seen-set is shared across open
+/// windows (exact identity is safe across groups) and drops when the last
+/// window closes.
+struct StreamDedup {
+    /// Topics still inside their catch-up window → their frozen seed.
+    syncing: HashMap<Topic, GlobalCursor>,
+    /// Exact identities delivered while any window is open.
+    seen: HashSet<Cursor>,
 }
 
 impl StreamDedup {
@@ -227,26 +229,44 @@ impl StreamDedup {
     /// delivery floor, because the streaming pipeline stores without
     /// advancing it.
     fn syncing(seeds: HashMap<Topic, GlobalCursor>, seen: HashSet<Cursor>) -> Self {
-        Self::Syncing { seeds, seen }
+        Self {
+            syncing: seeds,
+            seen,
+        }
+    }
+
+    /// Open windows for late-added topics (a growing stream's new lease),
+    /// folding their locally-stored identities into the shared seen-set.
+    fn open_window(
+        &mut self,
+        seeds: HashMap<Topic, GlobalCursor>,
+        seen: impl IntoIterator<Item = Cursor>,
+    ) {
+        self.syncing.extend(seeds);
+        self.seen.extend(seen);
     }
 
     fn has_seen(&self, position: &GlobalCursor, topic: &Topic, cursor: &Cursor) -> bool {
-        match self {
-            Self::Syncing { seeds, seen } => {
-                seeds.get(topic).is_some_and(|seed| seed.has_seen(cursor)) || seen.contains(cursor)
-            }
-            Self::Live => position.has_seen(cursor),
+        match self.syncing.get(topic) {
+            Some(seed) => seed.has_seen(cursor) || self.seen.contains(cursor),
+            None => position.has_seen(cursor),
         }
     }
 
     fn record(&mut self, cursor: Cursor) {
-        if let Self::Syncing { seen, .. } = self {
-            seen.insert(cursor);
+        if !self.syncing.is_empty() {
+            self.seen.insert(cursor);
         }
     }
 
-    fn complete(&mut self) {
-        *self = Self::Live;
+    /// Close the window for `topics` (their lease's `CatchUpComplete`).
+    fn complete(&mut self, topics: &[Topic]) {
+        for topic in topics {
+            self.syncing.remove(topic);
+        }
+        if self.syncing.is_empty() {
+            self.seen = HashSet::new();
+        }
     }
 }
 
@@ -369,7 +389,7 @@ where
         let (tx, items) = mpsc::channel(depth.max(1));
         let consumer = MessageConsumer {
             factory: ProcessMessageFuture::new(self.context.clone()),
-            lease,
+            leases: LeaseSet::new(lease),
             tx,
             dedup: StreamDedup::syncing(floors, seen),
             positions,
@@ -489,12 +509,74 @@ async fn send_or_kill<T>(
     }
 }
 
-/// One message stream: owns its lease, decodes sequentially, delivers on its
+/// A stream's leases, polled as one. A static stream holds exactly its
+/// subscribe-time lease; a growing stream pushes one lease per late
+/// addition — the transport multiplexes them onto the one wire, and a new
+/// lease IS the cursored-add wave for its topics, so each lease's
+/// `CatchUpComplete` closes exactly its own topics' dedup windows.
+struct LeaseSet {
+    feeds: futures::stream::SelectAll<LeaseFeed>,
+    /// idx → the topics that lease holds (for window completion).
+    topics: HashMap<u64, Vec<Topic>>,
+    next_idx: u64,
+}
+
+type LeaseFeed = std::pin::Pin<
+    Box<dyn futures::Stream<Item = (u64, Option<LeaseEvent<V3Binding>>)> + Send + 'static>,
+>;
+
+impl LeaseSet {
+    fn new(lease: TopicLease<V3Binding>) -> Self {
+        let mut set = Self {
+            feeds: futures::stream::SelectAll::new(),
+            topics: HashMap::new(),
+            next_idx: 0,
+        };
+        set.push(lease);
+        set
+    }
+
+    fn push(&mut self, lease: TopicLease<V3Binding>) -> u64 {
+        let idx = self.next_idx;
+        self.next_idx += 1;
+        self.topics.insert(idx, lease.topics().to_vec());
+        // The lease lives inside its feed; a `(idx, None)` marks its death.
+        self.feeds
+            .push(Box::pin(futures::stream::unfold(
+                (idx, Some(lease)),
+                |(idx, lease)| async move {
+                    let mut lease = lease?;
+                    match lease.next().await {
+                        Some(event) => Some(((idx, Some(event)), (idx, Some(lease)))),
+                        None => Some(((idx, None), (idx, None))),
+                    }
+                },
+            )));
+        idx
+    }
+
+    fn topics_of(&self, idx: u64) -> &[Topic] {
+        self.topics.get(&idx).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    /// Next event across every lease. `None` means a lease closed — the wire
+    /// died or the transport dropped this consumer — and the stream ends
+    /// (recovery is a re-subscribe from durable cursors, same as before).
+    async fn next(&mut self) -> Option<(u64, LeaseEvent<V3Binding>)> {
+        use futures::StreamExt;
+        match self.feeds.next().await? {
+            (idx, Some(event)) => Some((idx, event)),
+            (_, None) => None,
+        }
+    }
+}
+
+/// One message stream: owns its leases, decodes sequentially, delivers on its
 /// bounded channel. A stall here (e.g. recovery sync) backs up only this
-/// stream's lease.
+/// stream's leases.
 struct MessageConsumer<Context> {
     factory: ProcessMessageFuture<Context>,
-    lease: TopicLease<V3Binding>,
+    leases: LeaseSet,
     tx: mpsc::Sender<Result<StoredGroupMessage>>,
     /// Live per-topic positions — steady-state dedup; they keep advancing
     /// during the window so they hold the live edge when it closes.
@@ -508,11 +590,11 @@ where
 {
     async fn run(mut self, mut kill: oneshot::Receiver<()>) {
         loop {
-            let event = tokio::select! {
-                event = self.lease.next() => match event {
+            let (idx, event) = tokio::select! {
+                event = self.leases.next() => match event {
                     Some(event) => event,
-                    // Wire death or transport backpressure drop: the stream
-                    // ends (tx drops); the consumer re-subscribes.
+                    // Wire death or transport backpressure drop on any lease:
+                    // the stream ends (tx drops); the consumer re-subscribes.
                     None => return,
                 },
                 _ = &mut kill => return,
@@ -525,7 +607,7 @@ where
                 }
                 LeaseEvent::CatchUpComplete => {
                     tracing::debug!("stream router: message stream caught up");
-                    self.dedup.complete();
+                    self.dedup.complete(self.leases.topics_of(idx));
                 }
                 LeaseEvent::TopicsLive(topics) => {
                     tracing::debug!(?topics, "stream router: topics live");
@@ -754,9 +836,41 @@ mod tests {
         assert!(dedup.has_seen(&position, &topic, &replayed));
 
         // Window closes: the position (already at the live edge) takes over.
-        dedup.complete();
+        dedup.complete(std::slice::from_ref(&topic));
         assert!(dedup.has_seen(&position, &topic, &replayed));
         assert!(!dedup.has_seen(&position, &topic, &Cursor::new(101, 0u32)));
+    }
+
+    /// Windows are per topic: one lease's `CatchUpComplete` closes only its
+    /// own topics' windows — a still-syncing sibling keeps its seed and the
+    /// shared seen-set until the last window closes.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn windows_close_per_topic() {
+        let early = Topic::new_group_message([1u8; 16]);
+        let late = Topic::new_group_message([2u8; 16]);
+        let mut seed = GlobalCursor::default();
+        seed.apply(&Cursor::new(50, 0u32));
+        let mut dedup = StreamDedup::syncing(
+            HashMap::from([(early.clone(), GlobalCursor::default())]),
+            HashSet::new(),
+        );
+        dedup.open_window(
+            HashMap::from([(late.clone(), seed)]),
+            [Cursor::new(60, 0u32)],
+        );
+
+        // Closing the early topic flips it to position dedup...
+        dedup.complete(std::slice::from_ref(&early));
+        let position = GlobalCursor::default();
+        assert!(!dedup.has_seen(&position, &early, &Cursor::new(60, 0u32)));
+        // ...while the late topic still dedups by its frozen seed + seen-set.
+        assert!(dedup.has_seen(&position, &late, &Cursor::new(50, 0u32)));
+        assert!(dedup.has_seen(&position, &late, &Cursor::new(60, 0u32)));
+        assert!(!dedup.has_seen(&position, &late, &Cursor::new(61, 0u32)));
+
+        // The last window closing drops the seen-set.
+        dedup.complete(std::slice::from_ref(&late));
+        assert!(!dedup.has_seen(&position, &late, &Cursor::new(60, 0u32)));
     }
 
     /// Sequence ids are not scoped per group: a stored identity in one group

--- a/crates/xmtp_mls/src/subscriptions/stream_router.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router.rs
@@ -49,7 +49,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
 use xmtp_api_d14n::v3::{V3ProtoGroupMessage, V3ProtoWelcomeMessage};
 use xmtp_api_d14n::{
@@ -66,8 +66,8 @@ use xmtp_proto::types::{Cursor, GlobalCursor, GroupId, Topic};
 use xmtp_db::group::GroupQueryArgs;
 
 use super::process_message::{ProcessMessageFuture, process_one};
-use super::process_welcome::process_welcome_one;
-use super::{Result, SubscribeError, SyncWorkerEvent};
+use super::process_welcome::{process_local_group_one, process_welcome_one};
+use super::{LocalEvents, Result, SubscribeError, SyncWorkerEvent};
 use crate::context::XmtpSharedContext;
 use crate::groups::MlsGroup;
 use crate::groups::welcome_sync::WelcomeService;
@@ -451,6 +451,10 @@ where
         consent_states: Option<Vec<ConsentState>>,
         depth: usize,
     ) -> std::result::Result<RouterStream<StoredGroupMessage>, RouterError> {
+        // The local-events receiver subscribes BEFORE the seed query: a group
+        // created in between is either in the query result or buffered on the
+        // receiver — never dropped.
+        let local_events = self.context.local_events().subscribe();
         // Close the welcome gap first — same seeding as the legacy stream —
         // so the subscribe-time set is current when the welcome lease takes
         // over the live edge.
@@ -526,6 +530,7 @@ where
                 context: self.context.clone(),
                 transport: self.transport.clone(),
                 known_welcomes,
+                local_events,
                 conversation_type,
                 consent_states,
                 sync_groups,
@@ -546,6 +551,9 @@ where
         consent_states: Option<Vec<ConsentState>>,
         depth: usize,
     ) -> std::result::Result<RouterStream<MlsGroup<Context>>, RouterError> {
+        // Before the cursor seed, so a group created mid-subscribe is either
+        // past the seed (replayed) or buffered on the receiver.
+        let local_events = self.context.local_events().subscribe();
         let db = self.context.db();
         let installation = self.context.installation_id();
         // Wire resume point: the durable welcome cursor — every welcome
@@ -576,6 +584,7 @@ where
             lease,
             tx,
             known,
+            local_events,
             conversation_type,
             include_duplicate_dms,
             consent_states,
@@ -678,17 +687,16 @@ impl LeaseSet {
         self.next_idx += 1;
         self.topics.insert(idx, lease.topics().to_vec());
         // The lease lives inside its feed; a `(idx, None)` marks its death.
-        self.feeds
-            .push(Box::pin(futures::stream::unfold(
-                (idx, Some(lease)),
-                |(idx, lease)| async move {
-                    let mut lease = lease?;
-                    match lease.next().await {
-                        Some(event) => Some(((idx, Some(event)), (idx, Some(lease)))),
-                        None => Some(((idx, None), (idx, None))),
-                    }
-                },
-            )));
+        self.feeds.push(Box::pin(futures::stream::unfold(
+            (idx, Some(lease)),
+            |(idx, lease)| async move {
+                let mut lease = lease?;
+                match lease.next().await {
+                    Some(event) => Some(((idx, Some(event)), (idx, Some(lease)))),
+                    None => Some(((idx, None), (idx, None))),
+                }
+            },
+        )));
         idx
     }
 
@@ -709,23 +717,49 @@ impl LeaseSet {
 }
 
 /// The growth machinery of an all-messages stream. The welcome topic rides
-/// in the lease set: every accepted welcome leases its group's topic on the
-/// same wire — the new lease IS the cursored-add wave, so catch-up and dedup
-/// fall out of the per-topic windows. The filters are the same ones the
-/// legacy conversations sub-stream applies (which is also why the reflex
-/// never adds a *new* sync group: the filter excludes them, exactly as
-/// legacy).
+/// in the lease set: every accepted welcome — and every locally-created
+/// group off the `LocalEvents` broadcast, for which no welcome will ever
+/// arrive — leases its group's topic on the same wire; the new lease IS the
+/// cursored-add wave, so catch-up and dedup fall out of the per-topic
+/// windows. The filters are the same ones the legacy conversations
+/// sub-stream applies (which is also why the reflex never adds a *new* sync
+/// group: the filter excludes them, exactly as legacy).
 struct Reflex<Context> {
     context: Context,
     transport: BidiTransport<V3Binding>,
     /// Welcome dedup — consulted and updated sequentially in this task, the
     /// serialization `process_welcome_one`'s contract asks for.
     known_welcomes: HashSet<Cursor>,
+    /// Locally-created groups — no welcome will ever arrive for these, so
+    /// they grow the stream through the same add-path as welcomes.
+    local_events: broadcast::Receiver<LocalEvents>,
     conversation_type: Option<ConversationType>,
     consent_states: Option<Vec<ConsentState>>,
     /// Subscribe-time sync groups: their traffic nudges the device-sync
     /// worker instead of surfacing (legacy `StreamAllMessages` parity).
     sync_groups: HashSet<GroupId>,
+}
+
+impl<Context> Reflex<Context> {
+    /// The next local event, absorbing broadcast lag (missed events warn —
+    /// a lagged NewGroup is recovered by re-subscribe, same as legacy) and
+    /// parking forever on close (the lease side ends the stream).
+    async fn next_local_event(reflex: &mut Option<Self>) -> LocalEvents {
+        let Some(reflex) = reflex.as_mut() else {
+            return std::future::pending().await;
+        };
+        loop {
+            match reflex.local_events.recv().await {
+                Ok(event) => return event,
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!("bidi reflex missed {n} local events");
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    return std::future::pending().await;
+                }
+            }
+        }
+    }
 }
 
 /// One message stream: owns its leases, decodes sequentially, delivers on its
@@ -749,14 +783,31 @@ where
 {
     async fn run(mut self, mut kill: oneshot::Receiver<()>) {
         loop {
-            let (idx, event) = tokio::select! {
+            enum Wake {
+                Lease(u64, LeaseEvent<V3Binding>),
+                Local(LocalEvents),
+                Done,
+            }
+            let wake = tokio::select! {
                 event = self.leases.next() => match event {
-                    Some(event) => event,
+                    Some((idx, event)) => Wake::Lease(idx, event),
                     // Wire death or transport backpressure drop on any lease:
                     // the stream ends (tx drops); the consumer re-subscribes.
-                    None => return,
+                    None => Wake::Done,
                 },
-                _ = &mut kill => return,
+                local = Reflex::next_local_event(&mut self.reflex) => Wake::Local(local),
+                _ = &mut kill => Wake::Done,
+            };
+            let (idx, event) = match wake {
+                Wake::Done => return,
+                Wake::Local(LocalEvents::NewGroup(group_id)) => {
+                    if !self.absorb_local_group(group_id, &mut kill).await {
+                        return;
+                    }
+                    continue;
+                }
+                Wake::Local(_) => continue,
+                Wake::Lease(idx, event) => (idx, event),
             };
             match event {
                 LeaseEvent::GroupMessages(batch) => {
@@ -781,6 +832,42 @@ where
                     }
                 }
             }
+        }
+    }
+
+    /// A locally-created group: no welcome will arrive, so the reflex runs
+    /// the id through the same pipeline and filters a welcome takes and
+    /// leases its topic. Returns `false` when the stream must end.
+    async fn absorb_local_group(
+        &mut self,
+        group_id: GroupId,
+        kill: &mut oneshot::Receiver<()>,
+    ) -> bool {
+        let Some(reflex) = self.reflex.as_ref() else {
+            return true;
+        };
+        if self
+            .positions
+            .contains_key(&Topic::new_group_message(group_id))
+        {
+            return true;
+        }
+        let processed = tokio::select! {
+            processed = process_local_group_one(
+                reflex.context.clone(),
+                group_id,
+                reflex.conversation_type,
+                true,
+                reflex.consent_states.clone(),
+            ) => processed,
+            _ = &mut *kill => return false,
+        };
+        match processed {
+            Ok(outcome) => match outcome.group {
+                Some(group) => self.add_group(group.group_id, kill).await,
+                None => true,
+            },
+            Err(e) => send_or_kill(&self.tx, kill, Err(e)).await.is_ok(),
         }
     }
 
@@ -996,15 +1083,16 @@ where
 /// known-welcome set (per-stream, so streams with different filters never
 /// suppress each other's deliveries).
 ///
-/// Locally-created conversations are not merged in yet: this consumer only
-/// speaks the welcome topic, so a client does not see its own `create_group`
-/// on this stream. That parity arrives with the auto-subscribe reflex work,
-/// which fans local new-group events into both stream kinds.
+/// Locally-created conversations merge in from the `LocalEvents` broadcast —
+/// no welcome ever arrives for a group this client created, and legacy
+/// multiplexes the same events. Dedup for those is the broadcast itself:
+/// one event per creation.
 struct WelcomeConsumer<Context> {
     context: Context,
     lease: TopicLease<V3Binding>,
     tx: mpsc::Sender<Result<MlsGroup<Context>>>,
     known: HashSet<Cursor>,
+    local_events: broadcast::Receiver<LocalEvents>,
     conversation_type: Option<ConversationType>,
     include_duplicate_dms: bool,
     consent_states: Option<Vec<ConsentState>>,
@@ -1016,12 +1104,29 @@ where
 {
     async fn run(mut self, mut kill: oneshot::Receiver<()>) {
         loop {
-            let event = tokio::select! {
+            enum Wake {
+                Lease(LeaseEvent<V3Binding>),
+                Local(LocalEvents),
+                Done,
+            }
+            let wake = tokio::select! {
                 event = self.lease.next() => match event {
-                    Some(event) => event,
-                    None => return,
+                    Some(event) => Wake::Lease(event),
+                    None => Wake::Done,
                 },
-                _ = &mut kill => return,
+                local = Self::next_local_event(&mut self.local_events) => Wake::Local(local),
+                _ = &mut kill => Wake::Done,
+            };
+            let event = match wake {
+                Wake::Done => return,
+                Wake::Local(LocalEvents::NewGroup(group_id)) => {
+                    if !self.surface_local_group(group_id, &mut kill).await {
+                        return;
+                    }
+                    continue;
+                }
+                Wake::Local(_) => continue,
+                Wake::Lease(event) => event,
             };
             match event {
                 LeaseEvent::WelcomeMessages(batch) => {
@@ -1039,6 +1144,50 @@ where
                 }
             }
         }
+    }
+
+    /// The next local event, absorbing broadcast lag and parking on close
+    /// (the lease side ends the stream).
+    async fn next_local_event(events: &mut broadcast::Receiver<LocalEvents>) -> LocalEvents {
+        loop {
+            match events.recv().await {
+                Ok(event) => return event,
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!("conversation stream missed {n} local events");
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    return std::future::pending().await;
+                }
+            }
+        }
+    }
+
+    /// A group this client just created: run it through the same pipeline
+    /// and filters a welcome takes, and surface it. Returns `false` when the
+    /// stream must end.
+    async fn surface_local_group(
+        &mut self,
+        group_id: GroupId,
+        kill: &mut oneshot::Receiver<()>,
+    ) -> bool {
+        let processed = tokio::select! {
+            processed = process_local_group_one(
+                self.context.clone(),
+                group_id,
+                self.conversation_type,
+                self.include_duplicate_dms,
+                self.consent_states.clone(),
+            ) => processed,
+            _ = &mut *kill => return false,
+        };
+        let delivered = match processed {
+            Ok(outcome) => match outcome.group {
+                Some(group) => send_or_kill(&self.tx, kill, Ok(group)).await,
+                None => return true,
+            },
+            Err(e) => send_or_kill(&self.tx, kill, Err(e)).await,
+        };
+        delivered.is_ok()
     }
 
     async fn deliver_batch(

--- a/crates/xmtp_mls/src/subscriptions/stream_router_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router_tests.rs
@@ -22,7 +22,7 @@ where
         async move {
             BidiConnection::open(&api, initial)
                 .await
-                .map_err(|e| Box::new(e) as OpenError)
+                .map_err(OpenError::new)
         }
     })
 }


### PR DESCRIPTION
Follow-up to #3832: the bidi streams now GROW at runtime — full legacy parity for the callback surface.

## What
- **Multi-lease consumer**: a message stream rides many leases (`SelectAll` of lease feeds); a new lease *is* the cursored add. Dedup becomes per-topic catch-up windows, each closed by exactly its own lease's `CatchUpComplete`.
- **Welcome auto-subscribe reflex**: `stream_all_messages` leases the client's welcome topic; arriving welcomes run the legacy conversations-substream pipeline and lease each accepted group live. The empty-account park and callback-layer sync interception from #3832 dissolve (welcome topic ⇒ never an empty lease; interception moved consumer-side, legacy-exact).
- **Local new-group fan-in**: `LocalEvents::NewGroup` reaches both stream kinds via the legacy `WelcomeOrGroup::Group` pipeline; receivers subscribe before the seed query so mid-subscribe creations can't fall through.
- **Hardening from a 10-angle deep review** (line-scan/removed-behavior/cross-file/pitfalls/parity/reuse/simplify/efficiency/altitude/conventions + adversarial verification): welcome intake off the hot loop (capped task set — a slow join can't wedge the stream past the transport's drop bound); growth arms skip sync groups (device-sync payloads can't leak via the local-event arm) and record their seen-cursors (no double conversation delivery); welcome floor read before the group query (closes a subscribe-race that could permanently miss a group); seen recorded only after a group is tracked (transient seeding failure no longer eats the welcome); unretryable reconnects close the transport instead of redialing forever; `StreamClosed` telemetry rides a drop guard so binding-side aborts still pair; `OpenError` carries retryability across the type erasure; dedup recording scoped per open window; known-welcome seed bounded to the floor; seeding/intake/lifecycle logic consolidated.

## Tests
- 49/49 transport + router + callback tests (new: `unretryable_reconnect_closes_every_lease`, `record_only_tracks_topics_with_open_windows`, plus the growth headliners `welcomed_group_joins_the_live_stream`, `self_created_group_streams_its_messages`, `self_created_conversation_surfaces_on_the_stream`).
- **The entire mobile streaming suite passes with the gate ON**: `XMTP_BIDI_STREAMS_ENABLED=1` → 15/15 through the real FFI dispatch (on #3832 alone, 6 of those fail by documented interim scope — this PR closes them).

## Notes
- Suspend/resume remain crate-level; the FFI exposure owes a suspended latch, a resume drain-barrier and a deadline (doc'd inline + plan).
- Next: capability fallback latch so a non-v3 backend falls back to legacy streams instead of refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dynamic stream growth to MLS bidi streams via welcome reflex and local fan-in
> - `StreamRouter::stream_all_messages` is a new method that auto-grows the message stream as new conversations are joined (via welcome) or locally created, pre-syncing welcomes before subscribing.
> - A new `WelcomeIntake` component manages bounded concurrent welcome processing with a backlog cap; overflow terminates the stream.
> - `LeaseSet` multiplexes multiple `TopicLease` feeds so the all-messages consumer can add leases at runtime for new groups.
> - A new `Reflex` component drives stream growth by reacting to `LocalEvents` and welcome task completions in the message consumer loop.
> - `OpenError` is now a struct (not a type alias) that carries retryability; an unretryable reconnect failure now shuts down the transport and ends all active leases instead of retrying indefinitely.
> - Risk: streams now terminate on welcome backlog overflow or unretryable transport failures, which are new failure modes absent from the previous implementation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2b9360.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->