### PR TITLE
fix(node): forward streamAllMessages errors to JavaScript callbacks

### DIFF
--- a/bindings/node/src/conversations/streams.rs
+++ b/bindings/node/src/conversations/streams.rs
@@ -99,49 +99,30 @@ impl Conversations {
         .collect()
     });
 
-    let on_message =
-      move |message: std::result::Result<_, xmtp_mls::subscriptions::SubscribeError>| {
-        tracing::trace!(
-            inbox_id,
-            conversation_type = ?conversation_type,
-            "[received] message result"
+    let on_message = move |message| {
+      tracing::trace!(
+          inbox_id,
+          conversation_type = ?conversation_type,
+          "[received] message result"
+      );
+
+      if let Err(error) = &message {
+        tracing::warn!(
+          inbox_id,
+          error = ?error,
+          "[received] forwarding message error to callback"
         );
+      }
 
-        // Skip any messages that are errors
-        if let Err(err) = &message {
-          tracing::warn!(
-            inbox_id,
-            error = ?err,
-            "[received] message error, swallowing to continue stream"
-          );
-          return; // Skip this message entirely
-        }
-
-        // For successful messages, try to transform and pass to JS
-        // otherwise log error and continue stream
-        match message
+      let status = callback.call(
+        message
           .map(Into::into)
           .map_err(ErrorWrapper::from)
-          .map_err(Error::from)
-        {
-          Ok(transformed_msg) => {
-            tracing::trace!(
-              inbox_id,
-              "[received] calling tsfn callback with successful message"
-            );
-            let status = callback.call(Ok(transformed_msg), ThreadsafeFunctionCallMode::Blocking);
-            tracing::info!("Stream status: {:?}", status);
-          }
-          Err(err) => {
-            // Just in case the transformation itself fails
-            tracing::error!(
-              inbox_id,
-              error = ?err,
-              "[received] error during message transformation, swallowing to continue stream"
-            );
-          }
-        }
-      };
+          .map_err(Error::from),
+        ThreadsafeFunctionCallMode::Blocking,
+      );
+      tracing::info!("Stream status: {:?}", status);
+    };
     let on_close = move || {
       on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
     };

--- a/sdks/js/node-sdk/test/streams.test.ts
+++ b/sdks/js/node-sdk/test/streams.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { StreamFailedError } from "@/utils/errors";
-import { createStream } from "@/utils/streams";
+import { createStream, type StreamCallback } from "@/utils/streams";
 
 describe("createStream", () => {
   it("should forward StreamFailedError to onError", async () => {
@@ -34,5 +34,41 @@ describe("createStream", () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     expect(onErrorSpy).toHaveBeenCalledWith(expect.any(StreamFailedError));
+  });
+
+  it("should report item errors without ending the stream", async () => {
+    const itemError = new Error("message processing failed");
+    const onErrorSpy = vi.fn();
+    const onFailSpy = vi.fn();
+    const onValueSpy = vi.fn();
+    let emit!: StreamCallback<number>;
+
+    const mockStreamFunction = vi.fn(
+      async (callback: StreamCallback<number>) => {
+        emit = callback;
+        return Promise.resolve({
+          end: vi.fn(),
+          endAndWait: vi.fn().mockResolvedValue(undefined),
+          isClosed: vi.fn().mockReturnValue(false),
+          waitForReady: vi.fn().mockResolvedValue(undefined),
+        });
+      },
+    );
+
+    const stream = await createStream<number>(mockStreamFunction, undefined, {
+      onError: onErrorSpy,
+      onFail: onFailSpy,
+      onValue: onValueSpy,
+    });
+
+    emit(itemError, undefined);
+    emit(null, 42);
+
+    expect(onErrorSpy).toHaveBeenCalledOnce();
+    expect(onErrorSpy).toHaveBeenCalledWith(itemError);
+    expect(onValueSpy).toHaveBeenCalledWith(42);
+    expect(onFailSpy).not.toHaveBeenCalled();
+
+    void stream.end();
   });
 });


### PR DESCRIPTION
## Summary

Forward per-item `SubscribeError` values emitted by
`Conversations::stream_all_messages` to the Node N-API callback instead of
logging and discarding them.

The stream continues consuming subsequent items after reporting the error.

## Context

#899 and #1182 introduced stream error propagation so external SDKs could
observe and handle failures.

#1938 later made `stream_all_messages` a special case: errors are logged and
discarded before crossing the N-API boundary. At that time the Node
`AsyncStream` ended when an error reached it. xmtp-js #1118 subsequently
changed that behavior: item errors are passed to `onError` and the stream
remains active.

As a result, the original reason for suppressing these errors no longer
applies. Keeping the suppression now makes the Node SDK's `onError` handler
unreachable for aggregate message-stream item errors, while conversation,
single-conversation message, consent, preference, Mobile, and WASM streams
still expose their errors.

This makes failures associated with reports such as #2351 and #3541 silent to
Node applications and prevents consumers from applying an explicit recovery
policy.

## Behavior

Before:

`Rust stream item Err -> warning log -> no JavaScript callback`

After:

`Rust stream item Err -> callback(error, undefined) -> stream continues`

There is no public API signature change.

## Scope

This PR restores observability at the Node binding boundary. It does not claim
to fix the underlying transport or MLS delivery omissions tracked by #2351 and
#3541, and it does not change cursor or retry behavior.

## Verification

- `cargo check --locked -p bindings_node --lib`
- `yarn workspace @xmtp/node-sdk test test/streams.test.ts`
- `eslint node-sdk/test/streams.test.ts`

Refs #899, #1182, #1938, #2351, #3541.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward `streamAllMessages` errors to JavaScript callbacks instead of silently skipping them
> - Previously, message-level errors in the `Conversations.stream` async method were logged and dropped; the JS callback never received them.
> - Now, both `Ok` and `Err` results are forwarded to the JS `ThreadsafeFunction` via `ErrorWrapper`, so callers can handle per-item failures without the stream terminating.
> - A new test in [streams.test.ts](https://github.com/xmtp/libxmtp/pull/3837/files#diff-64e7b5b5481133421730affb2a831c2c0155f7450b0c2c4e9210e3c95a640295) verifies that item errors are reported to `onError` while subsequent values are still delivered and `onFail` is not called.
> - Behavioral Change: callbacks that previously only received successful messages will now also receive error results for failed items.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34a1b14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->