### PR TITLE
feat(xmtp_mls,bindings): centralized stream dispatch with legacy fallback latch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10557,6 +10557,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tonic",
  "toxiproxy_rust",
  "tracing",
  "tracing-subscriber",

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -77,9 +77,7 @@ use xmtp_mls::mls_common::group::GroupMetadataOptions;
 use xmtp_mls::mls_common::group_metadata::GroupMetadata;
 use xmtp_mls::mls_common::group_mutable_metadata::MessageDisappearingSettings;
 use xmtp_mls::mls_common::group_mutable_metadata::MetadataField;
-use xmtp_mls::subscriptions::router_callbacks::{
-    bidi_streams_enabled, stream_conversation_messages_with_callback_bidi,
-};
+use xmtp_mls::subscriptions::router_callbacks::stream_conversation_messages_with_callback_dispatch;
 use xmtp_mls::{
     client::Client as MlsClient,
     groups::{
@@ -1619,39 +1617,25 @@ impl From<&FfiMetadataField> for MetadataField {
 }
 
 impl FfiConversations {
-    /// One seam for every conversation stream: route over the shared bidi
-    /// wire when `XMTP_BIDI_STREAMS_ENABLED` is set, legacy otherwise. Lives
-    /// outside the exported impl (uniffi must not see the rust-only types).
+    /// One seam for every conversation stream: xmtp_mls dispatches between
+    /// the shared bidi wire and the legacy subscriptions. Lives outside the
+    /// exported impl (uniffi must not see the rust-only types).
     fn stream_conversations_dispatch(
         &self,
         conversation_type: Option<ConversationType>,
         callback: Arc<dyn FfiConversationCallback>,
     ) -> FfiStreamCloser {
-        let client = self.inner_client.clone();
         let close_cb = callback.clone();
-        if bidi_streams_enabled() {
-            FfiStreamCloser::new(RustXmtpClient::stream_conversations_with_callback_bidi(
-                client,
-                conversation_type,
-                false,
-                move |convo| match convo {
-                    Ok(c) => callback.on_conversation(Arc::new(c.into())),
-                    Err(e) => callback.on_error(e.into()),
-                },
-                move || close_cb.on_close(),
-            ))
-        } else {
-            FfiStreamCloser::new(RustXmtpClient::stream_conversations_with_callback(
-                client,
-                conversation_type,
-                move |convo| match convo {
-                    Ok(c) => callback.on_conversation(Arc::new(c.into())),
-                    Err(e) => callback.on_error(e.into()),
-                },
-                move || close_cb.on_close(),
-                false,
-            ))
-        }
+        FfiStreamCloser::new(RustXmtpClient::stream_conversations_with_callback_dispatch(
+            self.inner_client.clone(),
+            conversation_type,
+            false,
+            move |convo| match convo {
+                Ok(c) => callback.on_conversation(Arc::new(c.into())),
+                Err(e) => callback.on_error(e.into()),
+            },
+            move || close_cb.on_close(),
+        ))
     }
 }
 
@@ -1945,29 +1929,16 @@ impl FfiConversations {
         let consents: Option<Vec<ConsentState>> =
             consent_states.map(|states| states.into_iter().map(|state| state.into()).collect());
         let close_cb = message_callback.clone();
-        if bidi_streams_enabled() {
-            FfiStreamCloser::new(RustXmtpClient::stream_all_messages_with_callback_bidi(
-                self.inner_client.clone(),
-                conversation_type.map(Into::into),
-                consents,
-                move |msg| match msg {
-                    Ok(m) => message_callback.on_message(m.into()),
-                    Err(e) => message_callback.on_error(e.into()),
-                },
-                move || close_cb.on_close(),
-            ))
-        } else {
-            FfiStreamCloser::new(RustXmtpClient::stream_all_messages_with_callback(
-                self.inner_client.context.clone(),
-                conversation_type.map(Into::into),
-                consents,
-                move |msg| match msg {
-                    Ok(m) => message_callback.on_message(m.into()),
-                    Err(e) => message_callback.on_error(e.into()),
-                },
-                move || close_cb.on_close(),
-            ))
-        }
+        FfiStreamCloser::new(RustXmtpClient::stream_all_messages_with_callback_dispatch(
+            self.inner_client.clone(),
+            conversation_type.map(Into::into),
+            consents,
+            move |msg| match msg {
+                Ok(m) => message_callback.on_message(m.into()),
+                Err(e) => message_callback.on_error(e.into()),
+            },
+            move || close_cb.on_close(),
+        ))
     }
 
     /// Get notified when there is a new consent update either locally or is synced from another device
@@ -3055,29 +3026,16 @@ impl FfiConversation {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream(&self, message_callback: Arc<dyn FfiMessageCallback>) -> FfiStreamCloser {
         let close_cb = message_callback.clone();
-        if bidi_streams_enabled() {
-            let handle = stream_conversation_messages_with_callback_bidi(
-                self.inner.context.clone(),
-                self.inner.group_id,
-                move |message| match message {
-                    Ok(m) => message_callback.on_message(m.into()),
-                    Err(e) => message_callback.on_error(e.into()),
-                },
-                move || close_cb.on_close(),
-            );
-            FfiStreamCloser::new(handle)
-        } else {
-            let handle = MlsGroup::stream_with_callback(
-                self.inner.context.clone(),
-                self.inner.group_id,
-                move |message| match message {
-                    Ok(m) => message_callback.on_message(m.into()),
-                    Err(e) => message_callback.on_error(e.into()),
-                },
-                move || close_cb.on_close(),
-            );
-            FfiStreamCloser::new(handle)
-        }
+        let handle = stream_conversation_messages_with_callback_dispatch(
+            self.inner.context.clone(),
+            self.inner.group_id,
+            move |message| match message {
+                Ok(m) => message_callback.on_message(m.into()),
+                Err(e) => message_callback.on_error(e.into()),
+            },
+            move || close_cb.on_close(),
+        );
+        FfiStreamCloser::new(handle)
     }
 
     pub fn created_at_ns(&self) -> i64 {

--- a/bindings/node/src/conversation/streams.rs
+++ b/bindings/node/src/conversation/streams.rs
@@ -4,10 +4,7 @@ use napi::{
   threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
 use napi_derive::napi;
-use xmtp_mls::groups::MlsGroup;
-use xmtp_mls::subscriptions::router_callbacks::{
-  bidi_streams_enabled, stream_conversation_messages_with_callback_bidi,
-};
+use xmtp_mls::subscriptions::router_callbacks::stream_conversation_messages_with_callback_dispatch;
 
 #[napi]
 impl Conversation {
@@ -34,18 +31,12 @@ impl Conversation {
       on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
     };
 
-    if bidi_streams_enabled() {
-      let handle = stream_conversation_messages_with_callback_bidi(
-        group.context.clone(),
-        group.group_id,
-        on_message,
-        on_close,
-      );
-      Ok(StreamCloser::new(handle))
-    } else {
-      let handle =
-        MlsGroup::stream_with_callback(group.context.clone(), group.group_id, on_message, on_close);
-      Ok(StreamCloser::new(handle))
-    }
+    let handle = stream_conversation_messages_with_callback_dispatch(
+      group.context.clone(),
+      group.group_id,
+      on_message,
+      on_close,
+    );
+    Ok(StreamCloser::new(handle))
   }
 }

--- a/bindings/node/src/conversations/streams.rs
+++ b/bindings/node/src/conversations/streams.rs
@@ -9,7 +9,6 @@ use napi::bindgen_prelude::{Error, Result, Uint8Array};
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 use xmtp_db::consent_record::ConsentState as XmtpConsentState;
-use xmtp_mls::subscriptions::router_callbacks::bidi_streams_enabled;
 use xmtp_mls::worker::device_sync::preference_sync::PreferenceUpdate as XmtpUserPreferenceUpdate;
 
 #[napi(discriminant = "type")]
@@ -54,25 +53,14 @@ impl Conversations {
       on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
     };
 
-    if bidi_streams_enabled() {
-      let handle = RustXmtpClient::stream_conversations_with_callback_bidi(
-        self.inner_client.clone(),
-        conversation_type.map(|ct| ct.into()),
-        false,
-        on_conversation,
-        on_close,
-      );
-      Ok(StreamCloser::new(handle))
-    } else {
-      let handle = RustXmtpClient::stream_conversations_with_callback(
-        self.inner_client.clone(),
-        conversation_type.map(|ct| ct.into()),
-        on_conversation,
-        on_close,
-        false,
-      );
-      Ok(StreamCloser::new(handle))
-    }
+    let handle = RustXmtpClient::stream_conversations_with_callback_dispatch(
+      self.inner_client.clone(),
+      conversation_type.map(|ct| ct.into()),
+      false,
+      on_conversation,
+      on_close,
+    );
+    Ok(StreamCloser::new(handle))
   }
 
   #[napi]
@@ -144,25 +132,14 @@ impl Conversations {
       on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
     };
 
-    if bidi_streams_enabled() {
-      let handle = RustXmtpClient::stream_all_messages_with_callback_bidi(
-        self.inner_client.clone(),
-        conversation_type.map(Into::into),
-        consents,
-        on_message,
-        on_close,
-      );
-      Ok(StreamCloser::new(handle))
-    } else {
-      let handle = RustXmtpClient::stream_all_messages_with_callback(
-        self.inner_client.context.clone(),
-        conversation_type.map(Into::into),
-        consents,
-        on_message,
-        on_close,
-      );
-      Ok(StreamCloser::new(handle))
-    }
+    let handle = RustXmtpClient::stream_all_messages_with_callback_dispatch(
+      self.inner_client.clone(),
+      conversation_type.map(Into::into),
+      consents,
+      on_message,
+      on_close,
+    );
+    Ok(StreamCloser::new(handle))
   }
 
   #[napi]

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -1278,8 +1278,9 @@ where
                 if !e.is_retryable() {
                     // The backend refuses the surface outright — no redial
                     // can succeed. Shutting the ledger down ends every lease,
-                    // so consumers see their streams end and the next
-                    // subscribe carries the refusal to the caller.
+                    // so consumers see their streams end and every later
+                    // `lease()` fails with `Closed` — the refusal's
+                    // tombstone.
                     tracing::error!("bidi transport: reconnect refused ({e}); closing");
                     return AfterReopen::Shutdown;
                 }

--- a/crates/xmtp_api_d14n/src/queries/combined/streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/streams.rs
@@ -56,9 +56,15 @@ xmtp_common::if_native! {
     // The v3-shaped XIP-83 bidi surface (`mls_v1` frames). This client cannot
     // serve it — the d14n wire speaks its own envelope binding — so it refuses
     // at runtime with an unretryable error. The dyn full API always *has*
-    // `subscribe_bidi`; support is a runtime property of the backend. There is
-    // no automatic fallback to the legacy streams yet (that latch is follow-on
-    // work), so the opt-in env gate must only be enabled against v3 backends.
+    // `subscribe_bidi`; support is a runtime property of the backend. The
+    // unretryable refusal is what trips xmtp_mls's process-wide fallback
+    // latch (its router callbacks): the stream that hit it is served on the
+    // legacy path in place and every later dispatch goes straight to legacy,
+    // so the opt-in env gate is safe to enable when this is the process's
+    // only backend. The latch is process-wide — in a mixed-backend process
+    // a bidi-capable donor wins the shared wire and clients of this backend
+    // are misrouted, not refused (the router-callbacks module docs call
+    // that hazard out).
     #[xmtp_common::async_trait]
     impl<V3, D14n, Store> xmtp_proto::api_client::XmtpMlsBidiStreams for MigrationClient<V3, D14n, Store>
     where

--- a/crates/xmtp_api_d14n/src/queries/d14n/streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/streams.rs
@@ -121,9 +121,15 @@ xmtp_common::if_native! {
     // The v3-shaped XIP-83 bidi surface (`mls_v1` frames). This client cannot
     // serve it — the d14n wire speaks its own envelope binding — so it refuses
     // at runtime with an unretryable error. The dyn full API always *has*
-    // `subscribe_bidi`; support is a runtime property of the backend. There is
-    // no automatic fallback to the legacy streams yet (that latch is follow-on
-    // work), so the opt-in env gate must only be enabled against v3 backends.
+    // `subscribe_bidi`; support is a runtime property of the backend. The
+    // unretryable refusal is what trips xmtp_mls's process-wide fallback
+    // latch (its router callbacks): the stream that hit it is served on the
+    // legacy path in place and every later dispatch goes straight to legacy,
+    // so the opt-in env gate is safe to enable when this is the process's
+    // only backend. The latch is process-wide — in a mixed-backend process
+    // a bidi-capable donor wins the shared wire and clients of this backend
+    // are misrouted, not refused (the router-callbacks module docs call
+    // that hazard out).
     #[xmtp_common::async_trait]
     impl<C, Store> xmtp_proto::api_client::XmtpMlsBidiStreams for D14nClient<C, Store>
     where

--- a/crates/xmtp_api_grpc/src/error.rs
+++ b/crates/xmtp_api_grpc/src/error.rs
@@ -106,6 +106,17 @@ impl From<ConversionError> for GrpcError {
     }
 }
 
+impl GrpcError {
+    /// Whether this is the server's `UNIMPLEMENTED` status — the backend's
+    /// own verdict that the RPC surface does not exist, as opposed to a
+    /// transient failure reaching it. Callers deciding between redialing and
+    /// falling back need that distinction, which `is_retryable` (a blanket
+    /// `true` here) erases.
+    pub fn is_unimplemented(&self) -> bool {
+        matches!(self, Self::Status(status) if status.code() == tonic::Code::Unimplemented)
+    }
+}
+
 impl xmtp_common::retry::RetryableError for GrpcError {
     fn is_retryable(&self) -> bool {
         true

--- a/crates/xmtp_mls/Cargo.toml
+++ b/crates/xmtp_mls/Cargo.toml
@@ -186,6 +186,8 @@ ctor.workspace = true
 mockito = "1.6.1"
 tempfile = "3.15.0"
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+# Building the real UNIMPLEMENTED status shape in the bidi latch tests.
+tonic.workspace = true
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -38,8 +38,9 @@ pub mod stream_router;
 #[cfg(all(test, not(target_arch = "wasm32"), not(feature = "d14n")))]
 mod stream_router_tests;
 // Callback adapters over the router: the process-shared transport, the
-// `XMTP_BIDI_STREAMS_ENABLED` gate, and the pull→push pumps the bindings
-// call (native-only, like the router).
+// `XMTP_BIDI_STREAMS_ENABLED` gate with its unsupported-backend latch, and
+// the dispatch entry points the bindings call (native-only, like the
+// router).
 #[cfg(not(target_arch = "wasm32"))]
 pub mod router_callbacks;
 #[cfg(all(test, not(target_arch = "wasm32"), not(feature = "d14n")))]
@@ -533,7 +534,7 @@ where
         &self,
         conversation_type: Option<ConversationType>,
         consent_state: Option<Vec<ConsentState>>,
-    ) -> Result<impl Stream<Item = Result<StoredGroupMessage>> + 'static> {
+    ) -> Result<impl Stream<Item = Result<StoredGroupMessage>> + 'static + use<Context>> {
         tracing::debug!(
             inbox_id = self.inbox_id(),
             installation_id = %self.context.installation_id(),

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -19,13 +19,31 @@
 //! its topics on the donor's wire, subscribe successfully, and receive
 //! nothing — hence the init log below.
 //!
-//! ## The gate
+//! ## The gate and the latch
 //!
 //! The bidi path is opt-in via [`BIDI_STREAMS_ENABLED_ENV`], read once at
 //! the first stream call: mobile apps set it at process init, agents in
 //! their deploy env. Unset (or anything but a truthy value) keeps the legacy
-//! streams. Dispatch on the gate lives with the bindings; the
-//! `*_with_callback_bidi` entry points here are the bidi arm.
+//! streams. The gate is only the opt-in — whether the backend can serve the
+//! surface is discovered at the first wire open. A backend that cannot
+//! refuses it — gRPC `UNIMPLEMENTED` from a v3 node without the surface, an
+//! in-process refusal from the d14n and migration api clients — and once the
+//! shared transport has tombstoned itself on such a refusal, every later
+//! stream sees it as `Closed` ([`is_bidi_unsupported`] classifies all
+//! three). Any of them trips a process-wide latch: the stream that hit it
+//! switches to the legacy path in place (the first caller loses nothing —
+//! nor does a startup burst, where every pre-latch stream hits its own
+//! refusal and falls back the same way), and every later dispatch goes
+//! straight to legacy ([`bidi_streams_active`]). The latch resets only with
+//! the process, so the env var is safe to enable against any *single*
+//! backend — the worst case is one refused open and a process on legacy
+//! streams. That safety leans on the one-backend-per-process assumption
+//! above: in a mixed process whose donor speaks bidi, other-backend clients
+//! are misrouted (receiving nothing), not refused, and no latch fires.
+//!
+//! Dispatch lives here, not with the bindings: each binding site makes one
+//! `*_with_callback_dispatch` call, and the `*_with_callback_bidi` entry
+//! points are the bidi arm.
 //!
 //! ## Pump semantics
 //!
@@ -33,7 +51,11 @@
 //! registered), then drain the router stream into the callback. A subscribe
 //! failure warns, fires `on_close()`, and carries the error out through the
 //! handle's result — legacy watchdog semantics; the warn is the reliable
-//! trace, since the bindings' closers rarely read the result. `on_close` fires once
+//! trace, since the bindings' closers rarely read the result. The exception
+//! is a latch-worthy refusal or dead-end open (above), which hands the
+//! stream's legacy fallback factory to the same watchdog runner the legacy
+//! entry points spawn — stale-trip re-subscribe and reconnect throttle
+//! included — instead of closing. `on_close` fires once
 //! at natural end — the wire-facing lease survives reconnects and suspends
 //! (transport docs), so a natural end means this consumer fell behind and
 //! was dropped, or the client shut down; re-subscribing recovers from
@@ -43,23 +65,29 @@
 //! never runs the task's tail but does drop it, so `StreamClosed` rides a
 //! drop guard.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, OnceLock};
 
+use futures::Stream;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
-use xmtp_api_d14n::{BidiConnection, BidiTransport, OpenError, V3Binding};
-use xmtp_common::{MaybeSend, StreamHandle};
+use xmtp_api_d14n::{BidiConnection, BidiTransport, OpenError, TransportError, V3Binding};
+use xmtp_api_grpc::error::GrpcError;
+use xmtp_common::{AbortHandle, MaybeSend, RetryableError, StreamHandle, StreamHandleError};
 use xmtp_db::consent_record::ConsentState;
 use xmtp_db::group::ConversationType;
 use xmtp_db::group_message::StoredGroupMessage;
-use xmtp_proto::api_client::XmtpMlsBidiStreams;
+use xmtp_proto::api::ApiClientError;
+use xmtp_proto::api_client::{XmtpMlsBidiStreams, XmtpMlsStreams};
 use xmtp_proto::types::{GroupId, InstallationId};
 
 use xmtp_common::Event;
 use xmtp_macro::log_event;
 
+use super::stream_messages::StreamGroupMessages;
 use super::stream_router::{DEFAULT_STREAM_DEPTH, RouterError, RouterStream, StreamRouter};
+use super::watchdog::run_watchdog_stream;
 use super::{Result, StreamKind, SubscribeError};
 use crate::Client;
 use crate::context::XmtpSharedContext;
@@ -75,7 +103,7 @@ pub const BIDI_STREAMS_ENABLED_ENV: &str = "XMTP_BIDI_STREAMS_ENABLED";
 /// the variable at init never races client construction, and never again,
 /// since an env lookup scans the whole environ under a lock. Toggling the
 /// variable mid-process has no effect.
-pub fn bidi_streams_enabled() -> bool {
+pub(crate) fn bidi_streams_enabled() -> bool {
     static ENABLED: LazyLock<bool> = LazyLock::new(|| {
         std::env::var(BIDI_STREAMS_ENABLED_ENV)
             .map(|v| {
@@ -87,6 +115,99 @@ pub fn bidi_streams_enabled() -> bool {
             .unwrap_or(false)
     });
     *ENABLED
+}
+
+/// Set once the backend refuses the bidi surface (see the module docs).
+/// Process-level like [`SHARED_TRANSPORT`], and for the same reason: one
+/// backend per process means one refusal verdict per process.
+static BIDI_UNSUPPORTED: AtomicBool = AtomicBool::new(false);
+
+/// Whether a new stream should take the bidi path: the gate is on and no
+/// earlier stream has latched the process onto legacy.
+pub fn bidi_streams_active() -> bool {
+    bidi_streams_enabled() && !BIDI_UNSUPPORTED.load(Ordering::Relaxed)
+}
+
+/// Latch the process onto the legacy streams. Called by the pump on a
+/// backend refusal; tests pre-set it to exercise the latched dispatch.
+pub(crate) fn latch_bidi_unsupported() {
+    BIDI_UNSUPPORTED.store(true, Ordering::Relaxed);
+}
+
+/// The latch's current state — test-only observability for the pump's
+/// fallback branch. Gated like `router_callbacks_tests`, its only consumer.
+#[cfg(all(test, not(feature = "d14n")))]
+pub(crate) fn bidi_unsupported_latched() -> bool {
+    BIDI_UNSUPPORTED.load(Ordering::Relaxed)
+}
+
+/// Whether a subscribe failure means the backend refuses the bidi surface —
+/// the latch-worthy condition. Two shapes qualify:
+///
+/// - A wire open whose error chain carries the backend's own verdict that
+///   the surface does not exist ([`open_is_backend_refusal`]) — that verdict
+///   is buried under wrappers whose retryability cannot be trusted, so the
+///   chain is walked instead of asking `is_retryable`.
+/// - [`TransportError::Closed`] from a later `lease()`. The process-shared
+///   transport is immortal — [`SHARED_TRANSPORT`] holds a handle for the
+///   life of the process — so its ledger only ever dies by tombstoning
+///   itself after an unretryable re-open: `Closed` is what the refusal looks
+///   like to every stream after the one that saw it directly. Latching is
+///   also the safe direction — the legacy path works everywhere.
+///
+/// A retryable open is a transient dial failure and a closed *router* is
+/// client teardown — neither says anything about backend capability, so
+/// neither latches.
+pub(crate) fn is_bidi_unsupported(e: &RouterError) -> bool {
+    match e {
+        RouterError::Transport(TransportError::Open(open)) => open_is_backend_refusal(open),
+        RouterError::Transport(TransportError::Closed) => true,
+        RouterError::Transport(TransportError::Empty)
+        | RouterError::Subscribe(_)
+        | RouterError::Closed => false,
+    }
+}
+
+/// Whether an open failure carries the backend refusing the bidi surface.
+/// The verdict is buried, not top-level: a real v3 node without the surface
+/// answers the dial with gRPC `UNIMPLEMENTED`, which arrives here as
+/// `ApiClientError::ClientWithEndpoint` → `NetworkError` →
+/// `GrpcError::Status` — and `GrpcError` reports itself blanket-retryable,
+/// so the refusal must be recognized by shape, not by `is_retryable`. The
+/// chain walk finds it wherever it sits.
+fn open_is_backend_refusal(open: &OpenError) -> bool {
+    let mut source = std::error::Error::source(open);
+    while let Some(e) = source {
+        if e.downcast_ref::<GrpcError>()
+            .is_some_and(GrpcError::is_unimplemented)
+        {
+            return true;
+        }
+        // The in-process d14n and migration api clients refuse
+        // `subscribe_bidi` outright with this variant, as does the transport
+        // trait's default `bidi_stream` (no full-duplex support) — every
+        // producer reachable from a bidi open is a capability verdict. The
+        // v3 dial goes straight to the grpc client, middleware-free; if a
+        // future d14n dial routes through middleware that maps local
+        // failures to `OtherUnretryable`, the refusal needs its own shape.
+        if matches!(
+            e.downcast_ref::<ApiClientError>(),
+            Some(ApiClientError::OtherUnretryable(_))
+        ) {
+            return true;
+        }
+        source = e.source();
+    }
+    false
+}
+
+/// Whether a subscribe failure is a dead end for THIS stream: a wire open no
+/// redial can fix. Not necessarily the backend refusing the surface (a
+/// garbled handshake response is unretryable too), so it must not latch the
+/// process — but retrying the bidi arm is pointless for the stream that hit
+/// it, which falls back to its legacy counterpart instead of error-closing.
+pub(crate) fn is_bidi_dead_end(e: &RouterError) -> bool {
+    matches!(e, RouterError::Transport(TransportError::Open(open)) if !open.is_retryable())
 }
 
 /// The process-wide transport (see the module docs). `OnceLock` rather than
@@ -179,40 +300,107 @@ async fn pump<T>(
 struct StreamClosedGuard {
     kind: StreamKind,
     installation: InstallationId,
+    armed: bool,
+}
+
+impl StreamClosedGuard {
+    /// Hand the pair-closing emit to someone else. The legacy fallback
+    /// stream emits its own `StreamClosed` on drop, so once it takes over
+    /// this guard must go quiet or the pair would close twice.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
 }
 
 impl Drop for StreamClosedGuard {
     fn drop(&mut self) {
-        log_event!(Event::StreamClosed, self.installation, kind = ?self.kind);
+        if self.armed {
+            log_event!(Event::StreamClosed, self.installation, kind = ?self.kind);
+        }
     }
 }
 
 /// One spawned bidi stream: emit `StreamOpened`, subscribe, signal ready,
 /// then pump into the callback until the stream ends or the client shuts
-/// down. Every entry point is this wrapper plus its subscribe future.
+/// down. Every entry point is this wrapper plus its subscribe future and a
+/// `fallback` factory that builds its legacy counterpart stream. When the
+/// subscribe fails with a backend refusal ([`is_bidi_unsupported`]) the task
+/// latches the process onto legacy; on a refusal or a dead-end open
+/// ([`is_bidi_dead_end`]) it keeps serving THIS stream by handing the
+/// factory to the legacy watchdog runner ([`run_watchdog_stream`]) — the
+/// same runner the legacy entry points spawn, stale-trip re-subscribe and
+/// reconnect throttle included — so the caller that discovered the incapable
+/// backend loses nothing. That also covers a startup burst: every stream
+/// created before the latch tripped hits its own refusal and rides its own
+/// fallback runner.
 ///
 /// `on_close` fires on the subscribe-failure and natural-end paths only (an
 /// aborted task must not invoke it — the caller asked for the end), exactly
 /// like the local-events streams; `StreamClosed` fires on every ending via
-/// the drop guard.
-fn pump_stream<T, S>(
+/// the drop guard (disarmed on the fallback path, where the legacy stream
+/// objects emit their own pair — and re-armed when the fallback fails at
+/// startup, having built no stream object to pair the open).
+pub(crate) fn pump_stream<T, S, FSub, FFut, FS>(
     kind: StreamKind,
     installation: InstallationId,
     cancel: CancellationToken,
     subscribe: S,
+    fallback: FSub,
     callback: impl FnMut(Result<T>) + MaybeSend + 'static,
     on_close: impl FnOnce() + MaybeSend + 'static,
 ) -> impl StreamHandle<StreamOutput = Result<()>>
 where
     T: MaybeSend + 'static,
     S: Future<Output = std::result::Result<RouterStream<T>, RouterError>> + MaybeSend + 'static,
+    FSub: FnMut() -> FFut + MaybeSend + 'static,
+    FFut: Future<Output = Result<FS>> + MaybeSend + 'static,
+    FS: Stream<Item = Result<T>> + MaybeSend + 'static,
 {
     let (tx, rx) = oneshot::channel();
     xmtp_common::spawn(Some(rx), async move {
         log_event!(Event::StreamOpened, installation, kind = ?kind);
-        let _closed = StreamClosedGuard { kind, installation };
+        let mut closed = StreamClosedGuard {
+            kind,
+            installation,
+            armed: true,
+        };
         let stream = match subscribe.await {
-            Ok(stream) => stream,
+            Err(e) if is_bidi_unsupported(&e) || is_bidi_dead_end(&e) => {
+                if is_bidi_unsupported(&e) {
+                    tracing::error!(
+                        "bidi {kind:?} stream refused by the backend, \
+                         latching this process onto the legacy streams: {e}"
+                    );
+                    latch_bidi_unsupported();
+                } else {
+                    // Not a capability verdict, but no redial of this open
+                    // can succeed either — serve this one stream on legacy
+                    // and leave the process-wide latch to a cleaner failure.
+                    tracing::warn!(
+                        "bidi {kind:?} stream open failed unretryably, \
+                         serving this stream on the legacy path: {e}"
+                    );
+                }
+                closed.disarm();
+                // The label the legacy entry point serving this shape logs
+                // under — the fallback IS that entry point's stream.
+                let label = match kind {
+                    StreamKind::All => "stream_all_messages",
+                    StreamKind::Conversations => "stream_conversations",
+                    StreamKind::Messages => "stream_messages",
+                };
+                let ready = move || {
+                    let _ = tx.send(());
+                };
+                let result =
+                    run_watchdog_stream(cancel, label, fallback, ready, callback, on_close).await;
+                if result.is_err() {
+                    // A startup failure built no legacy stream object, so
+                    // nothing else pairs the `StreamOpened` — re-arm.
+                    closed.armed = true;
+                }
+                return result;
+            }
             Err(e) => {
                 // The subscribe itself failed: warn (the handle's result
                 // carries the error but is rarely read), fire `on_close`
@@ -222,7 +410,11 @@ where
                 on_close();
                 return Err(e.into());
             }
+            Ok(stream) => stream,
         };
+        // The bidi path won: don't hold the fallback factory's captured
+        // clones for the (long) life of this stream.
+        drop(fallback);
         let _ = tx.send(());
         pump(stream, cancel, callback, on_close).await;
         tracing::debug!("bidi {kind:?} stream ended");
@@ -230,11 +422,66 @@ where
     })
 }
 
+/// The one `StreamHandle` shape a dispatcher can return: the two arms are
+/// distinct opaque handle types, and an `if` cannot unify them without a
+/// common carrier.
+enum DispatchHandle<B, L> {
+    Bidi(B),
+    Legacy(L),
+}
+
+#[xmtp_common::async_trait]
+impl<B, L, O> StreamHandle for DispatchHandle<B, L>
+where
+    B: StreamHandle<StreamOutput = O>,
+    L: StreamHandle<StreamOutput = O>,
+    O: MaybeSend,
+{
+    type StreamOutput = O;
+
+    async fn wait_for_ready(&mut self) {
+        match self {
+            Self::Bidi(h) => h.wait_for_ready().await,
+            Self::Legacy(h) => h.wait_for_ready().await,
+        }
+    }
+
+    fn end(&self) {
+        match self {
+            Self::Bidi(h) => h.end(),
+            Self::Legacy(h) => h.end(),
+        }
+    }
+
+    async fn join(self) -> std::result::Result<O, StreamHandleError> {
+        match self {
+            Self::Bidi(h) => h.join().await,
+            Self::Legacy(h) => h.join().await,
+        }
+    }
+
+    async fn end_and_wait(&mut self) -> std::result::Result<O, StreamHandleError> {
+        match self {
+            Self::Bidi(h) => h.end_and_wait().await,
+            Self::Legacy(h) => h.end_and_wait().await,
+        }
+    }
+
+    fn abort_handle(&self) -> Box<dyn AbortHandle> {
+        match self {
+            Self::Bidi(h) => h.abort_handle(),
+            Self::Legacy(h) => h.abort_handle(),
+        }
+    }
+}
+
 impl<Context> Client<Context>
 where
     Context: XmtpSharedContext + 'static,
-    Context::ApiClient: XmtpMlsBidiStreams + Clone + Send + Sync + 'static,
+    Context::ApiClient: XmtpMlsBidiStreams + XmtpMlsStreams + Clone + Send + Sync + 'static,
     <Context::ApiClient as XmtpMlsBidiStreams>::SubscribeStream: 'static,
+    Context::MlsStorage: 'static,
+    Context::Db: 'static,
 {
     /// This client's router over the process-shared bidi wire, created on
     /// first use.
@@ -247,12 +494,41 @@ where
             .await
     }
 
+    /// The one call the bindings make for an all-messages stream: the bidi
+    /// path when [`bidi_streams_active`], the legacy watchdog stream
+    /// otherwise.
+    pub fn stream_all_messages_with_callback_dispatch(
+        client: Arc<Client<Context>>,
+        conversation_type: Option<ConversationType>,
+        consent_states: Option<Vec<ConsentState>>,
+        callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
+        on_close: impl FnOnce() + MaybeSend + 'static,
+    ) -> impl StreamHandle<StreamOutput = Result<()>> {
+        if bidi_streams_active() {
+            DispatchHandle::Bidi(Self::stream_all_messages_with_callback_bidi(
+                client,
+                conversation_type,
+                consent_states,
+                callback,
+                on_close,
+            ))
+        } else {
+            DispatchHandle::Legacy(Self::stream_all_messages_with_callback(
+                client.context.clone(),
+                conversation_type,
+                consent_states,
+                callback,
+                on_close,
+            ))
+        }
+    }
+
     /// Bidi-path counterpart of `stream_all_messages_with_callback`: every
     /// matching conversation's messages, decoded, over the shared wire. The
     /// stream grows with new conversations — the router's welcome
     /// auto-subscribe reflex leases each later-joined group's topic as its
     /// welcome arrives, no re-subscribe needed.
-    pub fn stream_all_messages_with_callback_bidi(
+    pub(crate) fn stream_all_messages_with_callback_bidi(
         client: Arc<Client<Context>>,
         conversation_type: Option<ConversationType>,
         consent_states: Option<Vec<ConsentState>>,
@@ -261,6 +537,19 @@ where
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let installation = client.context.installation_id();
         let cancel = client.context.cancellation_token().clone();
+        let fallback = {
+            let client = client.clone();
+            let consent_states = consent_states.clone();
+            move || {
+                let client = client.clone();
+                let consent_states = consent_states.clone();
+                async move {
+                    client
+                        .stream_all_messages_owned(conversation_type, consent_states)
+                        .await
+                }
+            }
+        };
         let subscribe = async move {
             let router = client.stream_router().await;
             router
@@ -272,16 +561,46 @@ where
             installation,
             cancel,
             subscribe,
+            fallback,
             callback,
             on_close,
         )
+    }
+
+    /// The one call the bindings make for a conversations stream: the bidi
+    /// path when [`bidi_streams_active`], the legacy watchdog stream
+    /// otherwise.
+    pub fn stream_conversations_with_callback_dispatch(
+        client: Arc<Client<Context>>,
+        conversation_type: Option<ConversationType>,
+        include_duplicate_dms: bool,
+        callback: impl FnMut(Result<MlsGroup<Context>>) + MaybeSend + 'static,
+        on_close: impl FnOnce() + MaybeSend + 'static,
+    ) -> impl StreamHandle<StreamOutput = Result<()>> {
+        if bidi_streams_active() {
+            DispatchHandle::Bidi(Self::stream_conversations_with_callback_bidi(
+                client,
+                conversation_type,
+                include_duplicate_dms,
+                callback,
+                on_close,
+            ))
+        } else {
+            DispatchHandle::Legacy(Self::stream_conversations_with_callback(
+                client,
+                conversation_type,
+                callback,
+                on_close,
+                include_duplicate_dms,
+            ))
+        }
     }
 
     /// Bidi-path counterpart of `stream_conversations_with_callback`: new
     /// conversations — welcomes from the shared wire, plus this client's own
     /// locally-created groups via the `LocalEvents` broadcast (legacy
     /// parity).
-    pub fn stream_conversations_with_callback_bidi(
+    pub(crate) fn stream_conversations_with_callback_bidi(
         client: Arc<Client<Context>>,
         conversation_type: Option<ConversationType>,
         include_duplicate_dms: bool,
@@ -290,6 +609,17 @@ where
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let installation = client.context.installation_id();
         let cancel = client.context.cancellation_token().clone();
+        let fallback = {
+            let client = client.clone();
+            move || {
+                let client = client.clone();
+                async move {
+                    client
+                        .stream_conversations_owned(conversation_type, include_duplicate_dms)
+                        .await
+                }
+            }
+        };
         let subscribe = async move {
             let router = client.stream_router().await;
             router
@@ -306,9 +636,37 @@ where
             installation,
             cancel,
             subscribe,
+            fallback,
             callback,
             on_close,
         )
+    }
+}
+
+/// The one call the bindings make for a single conversation's message
+/// stream: the bidi path when [`bidi_streams_active`], the legacy watchdog
+/// stream otherwise. Context-based like the arms it dispatches between (a
+/// conversation object holds no client).
+pub fn stream_conversation_messages_with_callback_dispatch<Context>(
+    context: Context,
+    group_id: GroupId,
+    callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
+    on_close: impl FnOnce() + MaybeSend + 'static,
+) -> impl StreamHandle<StreamOutput = Result<()>>
+where
+    Context: XmtpSharedContext + 'static,
+    Context::ApiClient: XmtpMlsBidiStreams + XmtpMlsStreams + Clone + Send + Sync + 'static,
+    <Context::ApiClient as XmtpMlsBidiStreams>::SubscribeStream: 'static,
+    Context::Db: 'static,
+{
+    if bidi_streams_active() {
+        DispatchHandle::Bidi(stream_conversation_messages_with_callback_bidi(
+            context, group_id, callback, on_close,
+        ))
+    } else {
+        DispatchHandle::Legacy(MlsGroup::stream_with_callback(
+            context, group_id, callback, on_close,
+        ))
     }
 }
 
@@ -321,7 +679,7 @@ where
 /// exits with its last stream, dedup correctness lives in the transport's
 /// per-lease positions, and the wire is the process-shared transport either
 /// way.
-pub fn stream_conversation_messages_with_callback_bidi<Context>(
+pub(crate) fn stream_conversation_messages_with_callback_bidi<Context>(
     context: Context,
     group_id: GroupId,
     callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
@@ -329,11 +687,22 @@ pub fn stream_conversation_messages_with_callback_bidi<Context>(
 ) -> impl StreamHandle<StreamOutput = Result<()>>
 where
     Context: XmtpSharedContext + 'static,
-    Context::ApiClient: XmtpMlsBidiStreams + Clone + Send + Sync + 'static,
+    Context::ApiClient: XmtpMlsBidiStreams + XmtpMlsStreams + Clone + Send + Sync + 'static,
     <Context::ApiClient as XmtpMlsBidiStreams>::SubscribeStream: 'static,
+    Context::Db: 'static,
 {
     let installation = context.installation_id();
     let cancel = context.cancellation_token().clone();
+    // `StreamGroupMessages::new_owned` directly: the legacy entry point for
+    // this shape (`stream_messages_with_callback`) subscribes the same way —
+    // context-based, there is no group object to call `stream_owned` on.
+    let fallback = {
+        let context = context.clone();
+        move || {
+            let context = context.clone();
+            async move { StreamGroupMessages::new_owned(context, vec![group_id]).await }
+        }
+    };
     let subscribe = async move {
         let api = context.api().api_client.clone();
         let router = StreamRouter::new(context.clone(), shared_transport(api));
@@ -346,6 +715,7 @@ where
         installation,
         cancel,
         subscribe,
+        fallback,
         callback,
         on_close,
     )

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
@@ -8,7 +8,9 @@ use xmtp_common::StreamHandle;
 
 use crate::Client;
 use crate::subscriptions::router_callbacks::{
-    resume_bidi_streams, stream_conversation_messages_with_callback_bidi, suspend_bidi_streams,
+    bidi_streams_active, bidi_unsupported_latched, is_bidi_dead_end, is_bidi_unsupported,
+    latch_bidi_unsupported, pump_stream, resume_bidi_streams,
+    stream_conversation_messages_with_callback_bidi, suspend_bidi_streams,
 };
 use crate::tester;
 use crate::utils::MlsGroupExt;
@@ -380,6 +382,278 @@ async fn sync_group_messages_are_intercepted_not_delivered() {
     })
     .await;
     assert!(nudged.is_ok(), "the sync worker must be nudged");
+}
+
+/// A decode failure as the wire really produces one (0xff is an invalid
+/// wire type) — `prost::DecodeError` has no public constructor.
+fn garbled_frame() -> prost::DecodeError {
+    <xmtp_proto::mls_v1::GroupMessage as prost::Message>::decode(&[0xff][..])
+        .expect_err("an invalid wire type must not decode")
+}
+
+/// The latch classifier. Latch-worthy is the backend's own refusal of the
+/// surface, in each shape it really arrives in: a gRPC `UNIMPLEMENTED`
+/// buried under the v3 client's blanket-retryable wrapping, the in-process
+/// d14n/migration stub refusal (`OtherUnretryable`), and the tombstoned
+/// shared transport (`Closed`). Not latch-worthy: a transient dial failure,
+/// an unretryable-but-ambiguous open (still a dead end for the one stream
+/// that hit it), and a closed router.
+///
+/// The live end of this scenario — a shared-transport opener actually
+/// refusing and the pump latching mid-task — has no seam to inject through:
+/// `SHARED_TRANSPORT` is built from the first streamer's real api client by
+/// design, and a test-only override would weaken that invariant for one
+/// test's sake. This classification test plus the `pump_*` fallback tests
+/// below cover both halves instead, and the transport's own tests cover the
+/// opener refusing with `Open`.
+#[xmtp_common::test]
+fn only_a_backend_refusal_latches() {
+    use crate::subscriptions::stream_router::RouterError;
+    use xmtp_api_d14n::{OpenError, TransportError};
+    use xmtp_api_grpc::error::GrpcError;
+    use xmtp_common::RetryableError;
+    use xmtp_proto::api::ApiClientError;
+
+    // The real v3 layering of a node without the surface: tonic status →
+    // GrpcError (blanket-retryable) → NetworkError → ApiClientError — what
+    // `subscribe_bidi` hands the opener.
+    let unimplemented = OpenError::new(
+        ApiClientError::client(GrpcError::from(tonic::Status::unimplemented(
+            "unknown service xmtp.mls.api.v1.MlsApi",
+        )))
+        .endpoint("/xmtp.mls.api.v1.MlsApi/Subscribe"),
+    );
+    assert!(
+        unimplemented.is_retryable(),
+        "the grpc wrapping reports UNIMPLEMENTED as retryable — the trap \
+         the classifier must not fall into"
+    );
+    assert!(
+        is_bidi_unsupported(&RouterError::Transport(TransportError::Open(unimplemented))),
+        "UNIMPLEMENTED is the backend's own verdict and must latch, \
+         regardless of the wrapper's retryability"
+    );
+
+    // The in-process d14n/migration stub refusal.
+    let stub = RouterError::Transport(TransportError::Open(OpenError::new(
+        ApiClientError::OtherUnretryable(
+            "the v3 bidi subscription is not available on this client".into(),
+        ),
+    )));
+    assert!(is_bidi_unsupported(&stub), "the stub refusal must latch");
+    assert!(
+        is_bidi_dead_end(&stub),
+        "an unretryable open is also a dead end for the stream that hit it"
+    );
+
+    // A transient dial failure: worth redialing, neither latch nor fallback.
+    #[derive(Debug, thiserror::Error)]
+    #[error("dial failed")]
+    struct Transient;
+    impl RetryableError for Transient {
+        fn is_retryable(&self) -> bool {
+            true
+        }
+    }
+    let transient = RouterError::Transport(TransportError::Open(OpenError::new(Transient)));
+    assert!(
+        !is_bidi_unsupported(&transient),
+        "a retryable open failure is worth redialing, not latching"
+    );
+    assert!(!is_bidi_dead_end(&transient));
+
+    // Unretryable but not a capability verdict (a garbled handshake, say):
+    // the stream falls back, the process does not latch.
+    let garbled = RouterError::Transport(TransportError::Open(OpenError::new(
+        ApiClientError::DecodeError(garbled_frame()),
+    )));
+    assert!(
+        !is_bidi_unsupported(&garbled),
+        "an unretryable decode failure is not the backend refusing the surface"
+    );
+    assert!(
+        is_bidi_dead_end(&garbled),
+        "but it is a dead end, so the stream falls back"
+    );
+
+    // The tombstoned shared transport: the process-wide `OnceLock` handle is
+    // immortal, so its ledger only dies by shutting down after a refusal —
+    // `Closed` is the refusal as every later stream sees it.
+    assert!(
+        is_bidi_unsupported(&RouterError::Transport(TransportError::Closed)),
+        "a closed shared transport is the post-refusal tombstone and must latch"
+    );
+
+    // A closed router is client teardown, not backend capability.
+    assert!(
+        !is_bidi_unsupported(&RouterError::Closed),
+        "a closed router is client teardown"
+    );
+    assert!(!is_bidi_dead_end(&RouterError::Closed));
+}
+
+/// With the latch pre-set — the process already saw a refusal — a
+/// dispatcher-entered stream serves via the legacy path and delivery still
+/// works. No env mutation: with the latch set, the dispatcher's legacy arm
+/// is the same code path a gate-off process takes, so the default test
+/// environment exercises exactly the arm a latched gate-on process uses.
+#[xmtp_common::test(unwrap_try = true)]
+async fn latched_dispatch_delivers_via_legacy() {
+    // nextest runs one test per process, so setting this process's latch
+    // leaks nowhere.
+    latch_bidi_unsupported();
+    assert!(!bidi_streams_active(), "the latch must keep bidi inactive");
+
+    tester!(alix);
+    tester!(bo);
+
+    let group = alix.create_group(None, None)?;
+    group.invite(&bo).await?;
+    bo.sync_welcomes().await?;
+    bo.group(&group.group_id)?.sync().await?;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = Client::stream_all_messages_with_callback_dispatch(
+        Arc::new(bo.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = tx.send(message);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+
+    group.send_msg(b"latched onto legacy").await;
+    let delivered = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the legacy-path delivery")
+        .expect("callback channel closed")?;
+    assert_eq!(delivered.decrypted_message_bytes, b"latched onto legacy");
+}
+
+/// Drive [`pump_stream`] with a subscribe future failing as `error` and a
+/// small in-memory legacy fallback; returns the items the callback saw and
+/// how many times `on_close` fired. Ready must fire off the fallback —
+/// `wait_for_ready` would hang otherwise, so the timeout doubles as that
+/// assertion.
+async fn pump_through_fallback(
+    error: crate::subscriptions::stream_router::RouterError,
+) -> (Vec<u8>, usize) {
+    use crate::subscriptions::StreamKind;
+    use crate::subscriptions::stream_router::RouterStream;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio_util::sync::CancellationToken;
+    use xmtp_proto::types::InstallationId;
+
+    let subscribe = async move { Err::<RouterStream<u8>, _>(error) };
+    // A fresh two-item stream per subscribe call, like the real factories.
+    let fallback = || async { Ok(futures::stream::iter(vec![Ok(1u8), Ok(2u8)])) };
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let closes = Arc::new(AtomicUsize::new(0));
+    let on_close = {
+        let closes = closes.clone();
+        move || {
+            closes.fetch_add(1, Ordering::SeqCst);
+        }
+    };
+    let mut handle = pump_stream(
+        StreamKind::All,
+        InstallationId::from([0u8; 32]),
+        CancellationToken::new(),
+        subscribe,
+        fallback,
+        move |item| {
+            let _ = tx.send(item);
+        },
+        on_close,
+    );
+    tokio::time::timeout(WAIT, handle.wait_for_ready())
+        .await
+        .expect("ready must fire off the fallback");
+    let result = tokio::time::timeout(WAIT, handle.join())
+        .await
+        .expect("the fallback stream ends, so the pump task must too");
+    assert!(
+        matches!(result, Ok(Ok(()))),
+        "the fallback must end cleanly: {result:?}"
+    );
+
+    let mut items = Vec::new();
+    while let Ok(item) = rx.try_recv() {
+        items.push(item.expect("fallback items are Ok"));
+    }
+    (items, closes.load(Ordering::SeqCst))
+}
+
+/// The pump's fallback branch on the real remote refusal shape: the
+/// subscribe fails with a wrapped gRPC `UNIMPLEMENTED`, and the pump must
+/// latch the process, signal ready off the fallback, deliver the fallback's
+/// items through the watchdog runner, and fire `on_close` exactly once at
+/// its natural end.
+#[xmtp_common::test(unwrap_try = true)]
+async fn pump_latches_and_serves_the_fallback_on_a_grpc_refusal() {
+    use crate::subscriptions::stream_router::RouterError;
+    use xmtp_api_d14n::{OpenError, TransportError};
+    use xmtp_api_grpc::error::GrpcError;
+    use xmtp_proto::api::ApiClientError;
+
+    let refusal = OpenError::new(
+        ApiClientError::client(GrpcError::from(tonic::Status::unimplemented(
+            "unknown service xmtp.mls.api.v1.MlsApi",
+        )))
+        .endpoint("/xmtp.mls.api.v1.MlsApi/Subscribe"),
+    );
+    let (items, closes) =
+        pump_through_fallback(RouterError::Transport(TransportError::Open(refusal))).await;
+    assert!(
+        bidi_unsupported_latched(),
+        "the refusal must latch the process"
+    );
+    assert_eq!(items, vec![1, 2], "the fallback's items reach the callback");
+    assert_eq!(closes, 1, "on_close fires exactly once, at the natural end");
+}
+
+/// Same branch on the in-process d14n/migration stub refusal
+/// (`OtherUnretryable`).
+#[xmtp_common::test(unwrap_try = true)]
+async fn pump_latches_and_serves_the_fallback_on_the_stub_refusal() {
+    use crate::subscriptions::stream_router::RouterError;
+    use xmtp_api_d14n::{OpenError, TransportError};
+    use xmtp_proto::api::ApiClientError;
+
+    let refusal = OpenError::new(ApiClientError::OtherUnretryable(
+        "the v3 bidi subscription is not available on this client".into(),
+    ));
+    let (items, closes) =
+        pump_through_fallback(RouterError::Transport(TransportError::Open(refusal))).await;
+    assert!(
+        bidi_unsupported_latched(),
+        "the stub refusal must latch the process"
+    );
+    assert_eq!(items, vec![1, 2], "the fallback's items reach the callback");
+    assert_eq!(closes, 1, "on_close fires exactly once, at the natural end");
+}
+
+/// A dead-end open that is NOT a capability refusal serves this one stream
+/// on the fallback but leaves the process unlatched — later dispatches may
+/// still take the bidi path.
+#[xmtp_common::test(unwrap_try = true)]
+async fn pump_serves_the_fallback_without_latching_on_a_dead_end() {
+    use crate::subscriptions::stream_router::RouterError;
+    use xmtp_api_d14n::{OpenError, TransportError};
+    use xmtp_proto::api::ApiClientError;
+
+    let dead_end = OpenError::new(ApiClientError::DecodeError(garbled_frame()));
+    let (items, closes) =
+        pump_through_fallback(RouterError::Transport(TransportError::Open(dead_end))).await;
+    assert!(
+        !bidi_unsupported_latched(),
+        "a dead end is not a capability verdict and must not latch"
+    );
+    assert_eq!(items, vec![1, 2], "the fallback's items reach the callback");
+    assert_eq!(closes, 1, "on_close fires exactly once, at the natural end");
 }
 
 /// `stream_all_messages` on an account with no matching conversations stays

--- a/crates/xmtp_mls/src/subscriptions/watchdog.rs
+++ b/crates/xmtp_mls/src/subscriptions/watchdog.rs
@@ -352,30 +352,19 @@ where
     }
 }
 
-/// Spawn a self-healing subscription: wrap each underlying stream in a [`WatchdogStream`],
-/// forward every item to `callback`, and transparently re-subscribe when the watchdog trips
-/// on a silently-dead stream — resuming from the persisted cursor.
-///
-/// `subscribe` builds a fresh underlying stream on each call (it owns its inputs and clones
-/// per call, so the returned stream is `'static`). The first call establishes the stream
-/// before readiness is signaled: a failure there is a *startup* failure and is propagated to
-/// the caller. Once the stream has been live, a creation failure is a transient hiccup and is
-/// retried with the reconnect throttle instead of terminating the subscription.
-///
-/// On a stale trip the next subscription is established *before* the throttle wait and while
-/// the stale stream is still in scope — so the new stream (and, for the conversation stream,
-/// its `LocalEvents` broadcast receiver) is already buffering during the wait, and events
-/// arriving mid-reconnect are not dropped. `on_close` runs exactly once when the loop ends
-/// (clean end, cancellation, or startup error).
+/// Spawn a self-healing subscription: [`run_watchdog_stream`] as its own task, with
+/// readiness signaled once the first underlying stream is established.
 ///
 /// This is the single implementation behind `stream_messages_with_callback`,
 /// `stream_conversations_with_callback`, and `stream_all_messages_with_callback`; keeping it
-/// in one place is what stops those three from drifting apart.
+/// in one place is what stops those three from drifting apart. (The bidi pump's legacy
+/// fallback awaits [`run_watchdog_stream`] inside its own already-spawned task — same
+/// runner, same semantics, no second spawn.)
 pub(crate) fn spawn_watchdog_stream<T, S, Fut, Sub, Cb, Close>(
     cancel: CancellationToken,
     label: &'static str,
-    mut subscribe: Sub,
-    mut callback: Cb,
+    subscribe: Sub,
+    callback: Cb,
     on_close: Close,
 ) -> impl StreamHandle<StreamOutput = Result<(), SubscribeError>>
 where
@@ -387,80 +376,122 @@ where
     Close: FnOnce() + MaybeSend + 'static,
 {
     let (tx, rx) = oneshot::channel();
-    xmtp_common::spawn(Some(rx), async move {
-        tracing::debug!(stream = label, "starting watchdog stream");
+    xmtp_common::spawn(
+        Some(rx),
+        run_watchdog_stream(
+            cancel,
+            label,
+            subscribe,
+            move || {
+                let _ = tx.send(());
+            },
+            callback,
+            on_close,
+        ),
+    )
+}
 
-        // Initial subscription. A failure here is a startup failure: propagate it so the
-        // caller's stream setup errors out rather than closing as a silent `Ok`.
-        let mut attempt_started = Instant::now();
-        let mut current = match subscribe().await {
-            Ok(stream) => stream,
-            Err(e) => {
-                tracing::warn!(stream = label, "failed to create stream: {e}");
-                on_close();
-                return Err(e);
-            }
-        };
-        let _ = tx.send(());
+/// Drive a self-healing subscription to completion: wrap each underlying stream in a
+/// [`WatchdogStream`], forward every item to `callback`, and transparently re-subscribe when
+/// the watchdog trips on a silently-dead stream — resuming from the persisted cursor.
+///
+/// `subscribe` builds a fresh underlying stream on each call (it owns its inputs and clones
+/// per call, so the returned stream is `'static`). The first call establishes the stream
+/// before `ready` is invoked: a failure there is a *startup* failure and is propagated to
+/// the caller. Once the stream has been live, a creation failure is a transient hiccup and is
+/// retried with the reconnect throttle instead of terminating the subscription.
+///
+/// On a stale trip the next subscription is established *before* the throttle wait and while
+/// the stale stream is still in scope — so the new stream (and, for the conversation stream,
+/// its `LocalEvents` broadcast receiver) is already buffering during the wait, and events
+/// arriving mid-reconnect are not dropped. `on_close` runs exactly once when the loop ends
+/// (clean end, cancellation, or startup error).
+pub(crate) async fn run_watchdog_stream<T, S, Fut, Sub, Ready, Cb, Close>(
+    cancel: CancellationToken,
+    label: &'static str,
+    mut subscribe: Sub,
+    ready: Ready,
+    mut callback: Cb,
+    on_close: Close,
+) -> Result<(), SubscribeError>
+where
+    T: 'static,
+    S: Stream<Item = Result<T, SubscribeError>> + MaybeSend + 'static,
+    Fut: Future<Output = Result<S, SubscribeError>> + MaybeSend + 'static,
+    Sub: FnMut() -> Fut + MaybeSend + 'static,
+    Ready: FnOnce() + MaybeSend + 'static,
+    Cb: FnMut(Result<T, SubscribeError>) + MaybeSend + 'static,
+    Close: FnOnce() + MaybeSend + 'static,
+{
+    tracing::debug!(stream = label, "starting watchdog stream");
 
-        let result = 'reconnect: loop {
-            // Consume the current subscription under the watchdog until it goes stale
-            // (silent), ends cleanly, or we're cancelled.
-            let watched = WatchdogStream::new(current, WATCHDOG.idle_timeout());
-            futures::pin_mut!(watched);
-            let mut stale = false;
-            let cancelled = loop {
-                tokio::select! {
-                    _ = cancel.cancelled() => break true,
-                    next = watched.next() => match next {
-                        Some(item) => {
-                            if matches!(&item, Err(SubscribeError::StreamStale)) {
-                                stale = true;
-                                break false;
-                            }
-                            callback(item);
-                        }
-                        None => break false,
-                    }
-                }
-            };
-            // Reconnect only on a watchdog stale-trip; a clean end or cancellation ends it.
-            if cancelled || !stale {
-                break 'reconnect Ok(());
-            }
-            tracing::debug!(stream = label, "stream went stale; reconnecting");
+    // Initial subscription. A failure here is a startup failure: propagate it so the
+    // caller's stream setup errors out rather than closing as a silent `Ok`.
+    let mut attempt_started = Instant::now();
+    let mut current = match subscribe().await {
+        Ok(stream) => stream,
+        Err(e) => {
+            tracing::warn!(stream = label, "failed to create stream: {e}");
+            on_close();
+            return Err(e);
+        }
+    };
+    ready();
 
-            // Re-subscribe *before* the throttle, while the stale `watched` is still in
-            // scope, so the new subscription is already buffering during the wait. A
-            // transient creation failure is retried with the throttle, not fatal.
-            let next = loop {
-                match subscribe().await {
-                    Ok(stream) => break stream,
-                    Err(e) => {
-                        tracing::warn!(
-                            stream = label,
-                            "failed to recreate stream, will retry: {e}"
-                        );
-                        tokio::select! {
-                            _ = cancel.cancelled() => break 'reconnect Ok(()),
-                            _ = WATCHDOG.reconnect_delay_since(attempt_started) => {}
-                        }
-                    }
-                }
-            };
-            // Throttle: never resubscribe faster than the floor. A long-idle trip waits ~0;
-            // only a tight loop is paced. `next` buffers during the wait.
+    let result = 'reconnect: loop {
+        // Consume the current subscription under the watchdog until it goes stale
+        // (silent), ends cleanly, or we're cancelled.
+        let watched = WatchdogStream::new(current, WATCHDOG.idle_timeout());
+        futures::pin_mut!(watched);
+        let mut stale = false;
+        let cancelled = loop {
             tokio::select! {
-                _ = cancel.cancelled() => break 'reconnect Ok(()),
-                _ = WATCHDOG.reconnect_delay_since(attempt_started) => {}
+                _ = cancel.cancelled() => break true,
+                next = watched.next() => match next {
+                    Some(item) => {
+                        if matches!(&item, Err(SubscribeError::StreamStale)) {
+                            stale = true;
+                            break false;
+                        }
+                        callback(item);
+                    }
+                    None => break false,
+                }
             }
-            attempt_started = Instant::now();
-            current = next;
         };
-        tracing::debug!(stream = label, "watchdog stream ended, dropping stream");
-        on_close();
-        result
-    })
+        // Reconnect only on a watchdog stale-trip; a clean end or cancellation ends it.
+        if cancelled || !stale {
+            break 'reconnect Ok(());
+        }
+        tracing::debug!(stream = label, "stream went stale; reconnecting");
+
+        // Re-subscribe *before* the throttle, while the stale `watched` is still in
+        // scope, so the new subscription is already buffering during the wait. A
+        // transient creation failure is retried with the throttle, not fatal.
+        let next = loop {
+            match subscribe().await {
+                Ok(stream) => break stream,
+                Err(e) => {
+                    tracing::warn!(stream = label, "failed to recreate stream, will retry: {e}");
+                    tokio::select! {
+                        _ = cancel.cancelled() => break 'reconnect Ok(()),
+                        _ = WATCHDOG.reconnect_delay_since(attempt_started) => {}
+                    }
+                }
+            }
+        };
+        // Throttle: never resubscribe faster than the floor. A long-idle trip waits ~0;
+        // only a tight loop is paced. `next` buffers during the wait.
+        tokio::select! {
+            _ = cancel.cancelled() => break 'reconnect Ok(()),
+            _ = WATCHDOG.reconnect_delay_since(attempt_started) => {}
+        }
+        attempt_started = Instant::now();
+        current = next;
+    };
+    tracing::debug!(stream = label, "watchdog stream ended, dropping stream");
+    on_close();
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Stacked on #3835. Makes `XMTP_BIDI_STREAMS_ENABLED` safe to enable against any single backend: a process that discovers its backend cannot serve the bidi surface falls back to the legacy streams — automatically, once, for the life of the process.

## What
- **Centralized dispatch**: the six copy-pasted `if bidi_streams_enabled()` sites across mobile/node bindings collapse into three `*_with_callback_dispatch` entry points in `xmtp_mls`. Bindings now build one closure set and make one call; the `*_bidi` entry points and the raw gate went `pub(crate)` so dispatch is the single seam the compiler enforces.
- **The unsupported latch**: a process-level flag flipped when a bidi subscribe fails with a backend refusal. Classification walks the error source chain: gRPC `UNIMPLEMENTED` (which the v3 client wraps in an *always-retryable* `GrpcError` — the naive `is_retryable` heuristic can literally never latch against a real remote backend), the in-process d14n/migration stub refusals, and `TransportError::Closed` (on the process-shared, never-rebuilt transport, `Closed` is always the tombstone of an unretryable reconnect refusal — latching is the safe direction and un-wedges the mid-process capability-loss loop). Dead-end-but-not-refusal errors (e.g. an unretryable decode blip) fall back for that stream *without* latching, so the next stream retries bidi.
- **In-task fallback with full legacy parity**: the stream that discovers the refusal doesn't die — the same task logs, latches, and serves the legacy stream through a factored-out watchdog runner (`run_watchdog_stream`), so even the latching stream keeps stale-trip re-subscribe and reconnect throttling. `spawn_watchdog_stream` is now a thin wrapper over the same loop; ungated suite proves byte-for-byte parity.

## Tests
- 73/73 across the transport/router/callback/watchdog suites, including: the classification matrix (wrapped-UNIMPLEMENTED latches despite reporting retryable; stub refusal latches; `Closed` latches; transient and decode-shaped errors don't), and three pump-level fallback tests (refusal → latch → ready fires → legacy items delivered → one `on_close`).
- Gated mobile streaming suite (`XMTP_BIDI_STREAMS_ENABLED=1`): 15/15. Ungated: 15/15 (watchdog refactor parity).

## Notes
- "Safe against any backend" carries a one-backend-per-process qualifier (documented): in a mixed process the shared transport binds to the first streamer's backend; a differently-pointed sibling misroutes rather than refuses — pre-existing, documented behavior.
- The latch resets only with the process; re-enabling bidi after a backend upgrade needs a restart (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add centralized stream dispatch with automatic legacy fallback for bidi streams
> - Introduces `_dispatch` entry points (`stream_all_messages_with_callback_dispatch`, `stream_conversations_with_callback_dispatch`, `stream_conversation_messages_with_callback_dispatch`) in [router_callbacks.rs](https://github.com/xmtp/libxmtp/pull/3838/files#diff-0c27658258694997d993ae3e2e444204d0c98a70f368560fd306949e8849549d) that select bidi or legacy streaming based on runtime capability.
> - Adds a process-wide `AtomicBool` latch (`latch_bidi_unsupported`) that permanently switches the process to legacy streams when a backend returns an UNIMPLEMENTED gRPC status, avoiding repeated failed bidi attempts.
> - Extends `pump_stream` to accept a legacy fallback factory; on bidi subscribe failure, it transparently hands off to the legacy watchdog runner without dropping the stream or double-emitting `StreamClosed` telemetry.
> - Removes per-call `bidi_streams_enabled` branching from all mobile and Node.js bindings, replacing it with unconditional calls to the new `_dispatch` functions.
> - Risk: The latch is process-wide and permanent for the session — once a backend refuses bidi, all subsequent streams use legacy even if the backend later supports bidi.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 099f20a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->