### PR TITLE
ci: pin npm to major 11 in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -107,8 +107,10 @@ jobs:
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
 
-      - name: Update npm to latest
-        run: npm install -g npm@latest
+      # OIDC trusted publishing needs npm >= 11.5.1. Pinned to major 11 because
+      # npm 12 requires node >= 24.15, newer than the .node-version pin.
+      - name: Update npm
+        run: npm install -g npm@11
 
       - name: Publish to NPM
         if: ${{ inputs.dry-run != true }}


### PR DESCRIPTION
## Summary

Node and browser SDK releases are failing ([run](https://github.com/xmtp/libxmtp/actions/runs/29075647353/job/86309141108)):

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"11.6.1","node":"v24.11.0"}
```

The `Update npm to latest` step in the reusable `npm-publish.yml` workflow runs `npm install -g npm@latest`, which now resolves to npm 12.0.0. npm 12 requires node >= 24.15.0, but `.node-version` pins 24.11.0.

## Fix

Pin to `npm@11` instead of `npm@latest`:
- npm 11 satisfies OIDC trusted publishing (needs >= 11.5.1) used by `npm publish --provenance`
- npm 11 supports our pinned node (requires >= 22.9.0)
- Pinning the major prevents this class of breakage recurring on the next npm major release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin npm to major version 11 in npm-publish workflow
> Updates the `npm-publish` CI workflow to install `npm@11` instead of `npm@latest`, pinning the major version to avoid unexpected breakage from future npm releases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f3928b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->