### PR TITLE
fix: install rustls crypto provider explicitly so device sync doesn't panic on Apple

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -149,6 +149,11 @@ pub async fn connect_to_backend(
     auth_handle: Option<Arc<gateway_auth::FfiAuthHandle>>,
 ) -> Result<Arc<XmtpApiClient>, FfiError> {
     init_logger();
+    // Install the rustls crypto provider explicitly. On Apple platforms the `#[ctor::ctor]`
+    // in `xmtp_cryptography` never fires (the constructor link section is unsupported), so
+    // relying on it would leave reqwest without a provider and panic on the history-sync HTTP
+    // path. Idempotent, so it is safe to call on every entry point. See issue #3846.
+    xmtp_cryptography::install_crypto_provider();
 
     let client_mode = client_mode.unwrap_or_default();
 
@@ -374,6 +379,9 @@ pub async fn create_client(
 ) -> Result<Arc<FfiXmtpClient>, FfiError> {
     let ident = account_identifier.clone();
     init_logger();
+    // See `connect_to_backend` — ensure the rustls provider is installed before the
+    // device-sync worker builds its history-server HTTP client. Idempotent. See issue #3846.
+    xmtp_cryptography::install_crypto_provider();
 
     let DbOptions {
         db,

--- a/bindings/node/src/client/backend.rs
+++ b/bindings/node/src/client/backend.rs
@@ -44,6 +44,10 @@ impl BackendBuilder {
   #[napi]
   #[xmtp_common::err_span]
   pub async fn build(&self) -> Result<Backend> {
+    // Ensure the rustls crypto provider is installed before any TLS/HTTP client is built,
+    // independent of whether the `#[ctor::ctor]` in `xmtp_cryptography` fired. Idempotent.
+    // See issue #3846.
+    xmtp_cryptography::install_crypto_provider();
     {
       let mut consumed = self
         .consumed

--- a/bindings/node/src/client/create_client.rs
+++ b/bindings/node/src/client/create_client.rs
@@ -226,6 +226,12 @@ async fn create_client_inner(
   app_version: Option<String>,
   nonce: u64,
 ) -> Result<Client> {
+  // Install the rustls crypto provider explicitly rather than relying solely on the
+  // `#[ctor::ctor]` in `xmtp_cryptography`, whose constructor link section does not run on
+  // some platforms (notably Apple). Without it, the device-sync worker's history-server HTTP
+  // client panics with "No provider set". Idempotent. See issue #3846.
+  xmtp_cryptography::install_crypto_provider();
+
   let root_identifier = account_identifier.clone();
   let internal_account_identifier = account_identifier.try_into()?;
   let identity_strategy = IdentityStrategy::new(inbox_id, internal_account_identifier, nonce, None);

--- a/crates/xmtp_cryptography/src/lib.rs
+++ b/crates/xmtp_cryptography/src/lib.rs
@@ -14,8 +14,28 @@ pub type Secret = tls_codec::SecretVLBytes; // Byte array with ZeroizeOnDrop
 // When upgrading to reqwest 0.13 and disabling the default aws-lc-rs crypto provider
 // some tests fail without initializing the ring crypto provider. Doing this here because
 // it is crypto related and all crates depend on this crate.
+//
+// Installs the process-default rustls crypto provider. Idempotent: subsequent calls are
+// cheap no-ops via `Once`, and `install_default` returning `Err` (provider already set) is
+// ignored, so it is safe to call even when a host process pre-installs its own provider.
+//
+// This is exposed publicly and must be called explicitly from binding entry points because
+// the `#[ctor::ctor]` below does not run on Apple platforms: `ctor` relies on the
+// `__DATA,__mod_init_func` Mach-O link section, which Apple no longer supports. When
+// `libxmtpv3.a` is statically linked into a Swift binary the constructor record is orphaned
+// and never fires, leaving the provider uninstalled and causing `reqwest` (rustls-no-provider)
+// to `panic!("No provider set")` on the first HTTP client build. See issue #3846.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn install_crypto_provider() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[ctor::ctor]
 fn install_rustls_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    install_crypto_provider();
 }


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3846

## Problem

`xmtp_cryptography` installs the process-default rustls crypto provider **only** through a constructor:

```rust
#[cfg(not(target_arch = "wasm32"))]
#[ctor::ctor]
fn install_rustls_crypto_provider() {
    let _ = rustls::crypto::ring::default_provider().install_default();
}
```

`ctor` 0.12 relies on a Mach-O initializer registered via the `__DATA,__mod_init_func` link section, which **Apple no longer supports**. When `libxmtpv3.a` is statically linked into a Swift binary the constructor record is orphaned and never fires, so the provider is never installed. The first time the device-sync worker builds an HTTP client for a history-archive upload/download, `reqwest` 0.13 (built with `rustls-no-provider`) hits `panic!("No provider set")`. Because the xcframework is built with `panic = 'abort'`, the responding app aborts and then crash-loops (~30s after each relaunch) until the pending sync request is purged.

Only the history-server **HTTP** path is affected; gRPC node traffic and consent/preference sync are unaffected.

## Fix

- `xmtp_cryptography` now exposes a public, idempotent `install_crypto_provider()` guarded by `std::sync::Once`.
- The existing `#[ctor::ctor]` delegates to it (unchanged behavior on non-Apple native platforms).
- The mobile bindings call `xmtp_cryptography::install_crypto_provider()` explicitly at the earliest entry points that build network/HTTP clients — `connect_to_backend` and `create_client` — so the provider is installed regardless of whether the constructor fires.

The explicit call is idempotent and cheap, so it is a no-op on platforms where the constructor already ran.

## Validation

- `cargo check -p xmtp_cryptography -p xmtpv3` — passes.
- `cargo clippy -p xmtp_cryptography -p xmtpv3 --no-deps -- -Dwarnings` — passes (no new warnings from the changed crates).
- `cargo fmt --check` — clean.

Behavior on non-Apple native and WASM targets is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix rustls crypto provider panic in device sync on Apple by installing it explicitly
> - Adds a public `install_crypto_provider()` function in [`xmtp_cryptography`](https://github.com/xmtp/libxmtp/pull/3847/files#diff-a075887b8d87bf780924d062938b4ae965cef3f87b354fd35e3179f5f59b60b5) that idempotently installs the rustls `ring` default provider using `Once`, so repeated calls are safe.
> - Calls `install_crypto_provider()` at the entry point of `create_client` and `connect_to_backend` in both the [mobile](https://github.com/xmtp/libxmtp/pull/3847/files#diff-ce381c5891b3b5967aca582076bc5241ba04fc310d39949fed1859da13d876ec) and [Node](https://github.com/xmtp/libxmtp/pull/3847/files#diff-86fd7673bc2918a6066d44922085f9ea6fd5930c8fa9cc643363d2807fedc30e) bindings to ensure the provider is registered before any TLS/HTTP usage by device-sync workers.
> - The existing `install_rustls_crypto_provider` constructor is updated to delegate to the new helper rather than calling `install_default()` directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 683d66d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->