### PR TITLE
fix(xmtp_proto): sort proto inputs so codegen output is machine-independent

### DIFF
--- a/crates/xmtp_proto/build.rs
+++ b/crates/xmtp_proto/build.rs
@@ -107,7 +107,7 @@ fn main() -> Result<()> {
         &format!("{}/googleapis/", out_dir.display()),
     ];
 
-    let proto_files = WalkDir::new(out_dir.join("proto").join("proto"))
+    let mut proto_files = WalkDir::new(out_dir.join("proto").join("proto"))
         .min_depth(1)
         .into_iter()
         .filter_entry(|f| {
@@ -118,6 +118,10 @@ fn main() -> Result<()> {
             if p.is_dir() { None } else { Some(p) }
         })
         .collect::<Vec<_>>();
+    // prost emits each package file in input order, and WalkDir yields raw
+    // readdir order — filesystem- and machine-dependent. Sort, or every
+    // regen on a different machine rewrites unchanged generated files.
+    proto_files.sort();
 
     let files = &proto_files
         .iter()


### PR DESCRIPTION
## Summary

Every proto regen on a different machine rewrites thousands of lines of *unchanged* generated code (see the generated-file churn in #3845). Root cause: `crates/xmtp_proto/build.rs` feeds the `.proto` files to codegen in bare `WalkDir` order — raw `readdir` order, which is filesystem- and machine-dependent — and prost emits each package's file by concatenating messages in input order. Two machines, two orders, full-file rewrites.

One line fixes it: sort the collected proto paths before codegen. Output becomes machine-independent, so a regen only touches files whose `.proto` actually changed.

Verified by running the regen twice back-to-back on the follow-up branch: the second run produces zero changes.

Companion PR canonicalizes the checked-in files to the sorted order (one-time shuffle): the two are split so this fix is reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AVuJ7VAgen2fFhtJQ6zid


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort `.proto` file inputs in `build.rs` to ensure deterministic codegen output
> Filesystem iteration order is platform-dependent, causing non-deterministic protobuf codegen across machines. [build.rs](https://github.com/xmtp/libxmtp/pull/3848/files#diff-118dd1bc11c95808d34e710ca7ad2115b5a29ebe30bc22544fcef10cfd074d56) now sorts the collected `.proto` file list lexicographically before processing, making the output machine-independent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87b55b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->