### PR TITLE
feat(xmtp_mls): one-shot catch-up — history-only bidi run that half-closes at live

### DIFF
--- a/crates/xmtp_mls/src/subscriptions/catch_up.rs
+++ b/crates/xmtp_mls/src/subscriptions/catch_up.rs
@@ -1,0 +1,664 @@
+//! One-shot bounded catch-up over the XIP-83 bidi wire.
+//!
+//! [`Client::catch_up_to_live`] brings the local store current with the
+//! server — every pending welcome joined, every leased-topic message replayed
+//! and processed — and then stops, leaving nothing running. XIP-83 bounded
+//! sync: one `Subscribe` stream opened with a `history_only` Mutate for every
+//! topic this client owns (each from its durable cursor), a half-close once
+//! everything owed has arrived, and a server-side close in reply. The shape
+//! for "sync me, then let the process sleep" callers — an agent priming
+//! before it serves, a mobile background fetch — where a live stream would be
+//! wasted.
+//!
+//! ## Its own wire, not the shared transport
+//!
+//! The process-shared [`BidiTransport`](xmtp_api_d14n::BidiTransport) is a
+//! live-delivery machine: its ledger assumes every wave crosses to live
+//! delivery, keeps wire positions for reconnects, and holds the wire open for
+//! its leases. A `history_only` wave never registers for live delivery, so it
+//! has no place in that bookkeeping — and a bounded run has no reconnect
+//! state worth keeping. Each call opens its own [`BidiConnection`], which
+//! also means a concurrently-running live stream is untouched: both paths
+//! store through the same pipeline, whose DB fast-path makes double delivery
+//! a cheap lookup, and each keeps its own delivery dedup.
+//!
+//! ## The discovery loop
+//!
+//! Welcomes can join groups whose own history is then owed too. Processing a
+//! welcome that becomes a group issues a follow-up `history_only` Mutate for
+//! that group's topic on the same stream (joins run their own group sync, so
+//! the follow-up wave usually replays nothing — it exists to close the gap
+//! between the join's sync and this run's live edge). The half-close waits
+//! until no wave is outstanding and no welcome is still processing, so
+//! chained discoveries extend the run instead of escaping it.
+//!
+//! Two things deliberately do NOT extend the run: groups created locally
+//! mid-run (their creator already holds their state; nothing is owed from
+//! the server) and messages published after a topic's wave was frozen (the
+//! next call — or a live stream — picks them up; "live" here means the
+//! server's freeze point per wave).
+//!
+//! ## Durable cursors
+//!
+//! Group messages are processed exactly as the streaming pipeline does —
+//! stored without advancing the durable message cursor — so a failed message
+//! is never skipped past and a later query-path sync retries it. The cost is
+//! symmetric too: a repeat call re-requests the tail since the last durable
+//! advance and drops the already-stored copies at the seed's seen-set.
+//! Welcome cursors DO advance (the welcome pipeline advances them on every
+//! processed welcome, streamed or not).
+//!
+//! ## Fallback
+//!
+//! Dispatch mirrors the stream entry points: the bidi path when
+//! [`bidi_streams_active`], the legacy full sync otherwise. A backend that
+//! refuses the bidi surface latches the process onto legacy (same latch the
+//! streams use) and this call completes on the legacy path — the caller
+//! never sees the refusal.
+
+use std::collections::{HashSet, VecDeque};
+use std::time::Duration;
+
+use xmtp_api_d14n::v3::V3ProtoGroupMessage;
+use xmtp_api_d14n::{BidiConnection, BidiEvent, OpenError, TryMutateError};
+use xmtp_common::{ErrorCode, RetryableError, retryable};
+use xmtp_db::group::{ConversationType, GroupQueryArgs};
+use xmtp_db::prelude::*;
+use xmtp_db::refresh_state::EntityKind;
+use xmtp_proto::api_client::XmtpMlsBidiStreams;
+use xmtp_proto::mls_v1::subscribe_request::v1::{Mutate, mutate::Subscription};
+use xmtp_proto::types::{Cursor, GroupId, SequenceId, Topic};
+
+use super::process_message::{ProcessMessageFuture, process_one};
+use super::router_callbacks::{
+    bidi_streams_active, latch_bidi_unsupported, open_is_backend_refusal,
+};
+use super::stream_router::{WelcomeIntake, known_welcomes_above, seed_groups, welcome_seed};
+use super::{SubscribeError, SyncWorkerEvent};
+use crate::Client;
+use crate::context::XmtpSharedContext;
+use crate::groups::welcome_sync::WelcomeService;
+
+/// Wire deaths tolerated before giving up. Each retry reseeds from durable
+/// state, so progress made before a death is never repeated over the wire
+/// beyond the (deduped) tail since the last durable advance.
+const MAX_ATTEMPTS: u32 = 3;
+
+/// Base backoff between attempts (scaled by the attempt number).
+const RETRY_BACKOFF: Duration = Duration::from_millis(500);
+
+/// How long to wait for the server's close after the half-close. By this
+/// point every wave has completed — the drain is courtesy, not correctness —
+/// so a peer that never closes only costs this much patience.
+const POST_FINISH_DRAIN: Duration = Duration::from_secs(5);
+
+/// What one [`Client::catch_up_to_live`] call brought home — counts of what
+/// it PERSISTED, not what the wire replayed: retries reseed from durable
+/// state and replay, and already-stored history is deduped before counting,
+/// so these are "new since the last call". This is the mobile host's "did
+/// anything arrive" signal (notification content, background-refresh
+/// `newData`, up-to-date UI).
+///
+/// Device-sync (virtual) groups are excluded from both counts: their
+/// traffic is internal plumbing that never surfaces as a conversation or
+/// message.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CatchUpSummary {
+    /// Application messages newly persisted by this call.
+    pub messages: u64,
+    /// Conversations newly joined by this call.
+    pub conversations: u64,
+}
+
+#[derive(Debug, thiserror::Error, ErrorCode)]
+pub enum CatchUpError {
+    /// Seeding, processing, or the legacy fallback failed.
+    #[error(transparent)]
+    #[error_code(inherit)]
+    Subscribe(#[from] SubscribeError),
+    /// Bidi unsupported.
+    ///
+    /// The backend refuses the bidi surface — the latch-worthy verdict
+    /// ([`open_is_backend_refusal`]). The dispatch layer falls back to the
+    /// legacy sync; this never escapes [`Client::catch_up_to_live`]. Not
+    /// retryable.
+    #[error("the backend does not support bidi streams: {0}")]
+    Unsupported(OpenError),
+    /// Catch-up stream could not open.
+    ///
+    /// A wire open no redial can fix, without a capability verdict. The
+    /// dispatch layer serves the call on the legacy sync path. Not
+    /// retryable.
+    #[error("the catch-up stream could not open: {0}")]
+    DeadEnd(OpenError),
+    /// Catch-up did not complete.
+    ///
+    /// The wire kept dying before catch-up completed. Everything processed
+    /// before each death is kept; calling again resumes from durable state.
+    /// Retryable.
+    #[error("catch-up did not complete within {attempts} attempts")]
+    Exhausted { attempts: u32 },
+}
+
+impl RetryableError for CatchUpError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::Subscribe(e) => retryable!(e),
+            // The backend verdict is latched process-wide, and a dead-end
+            // open is unretryable by definition — redialing changes neither.
+            Self::Unsupported(_) | Self::DeadEnd(_) => false,
+            // Wire deaths are transient; a fresh call resumes from durable
+            // state.
+            Self::Exhausted { .. } => true,
+        }
+    }
+}
+
+/// How one bounded run over the wire ended.
+enum AttemptEnd {
+    /// Every wave completed and every welcome resolved — the store is
+    /// current to each topic's freeze point.
+    Complete,
+    /// The wire died (or the welcome backlog overflowed) mid-run; retry
+    /// from durable state.
+    WireDied,
+}
+
+/// The one `history_only` wave shape this module sends: cursored adds, no
+/// removes, bounded catch-up only (XIP-83 bounded sync).
+fn history_only_mutate(adds: Vec<(Topic, SequenceId)>, mutate_id: u64) -> Mutate {
+    Mutate {
+        adds: adds
+            .into_iter()
+            .map(|(topic, cursor)| Subscription {
+                topic: topic.to_bytes().into_vec(),
+                id_cursor: cursor,
+            })
+            .collect(),
+        removes: vec![],
+        history_only: true,
+        mutate_id,
+    }
+}
+
+impl<Context> Client<Context>
+where
+    Context: XmtpSharedContext + 'static,
+    Context::ApiClient: XmtpMlsBidiStreams + Clone + Send + Sync + 'static,
+    <Context::ApiClient as XmtpMlsBidiStreams>::SubscribeStream: 'static,
+{
+    /// Bring the local store current with the server, then stop: pending
+    /// welcomes joined, every conversation's messages replayed from its
+    /// durable cursor and processed, nothing left running afterwards. See
+    /// the module docs for the wire shape and its bounds.
+    ///
+    /// Individual message- and welcome-processing failures are logged, not
+    /// fatal — like a live stream, the durable cursors are not advanced
+    /// past them (a failed welcome stays unrecorded), so the next call, a
+    /// welcome stream, or a sync retries exactly the failed items. The
+    /// pipelines already retry transient errors internally; what fails here
+    /// is data-dependent, and failing the whole call over it would turn
+    /// "everything else synced, one item pending replay" into a hard error
+    /// on every wake. `Ok` therefore means "everything owed was received
+    /// and attempted", not "zero processing errors".
+    pub async fn catch_up_to_live(&self) -> Result<CatchUpSummary, CatchUpError> {
+        if bidi_streams_active() {
+            match self.catch_up_bidi().await {
+                Ok(summary) => return Ok(summary),
+                Err(CatchUpError::Unsupported(e)) => {
+                    tracing::error!(
+                        "bidi catch-up refused by the backend, \
+                         latching this process onto the legacy streams: {e}"
+                    );
+                    latch_bidi_unsupported();
+                }
+                Err(CatchUpError::DeadEnd(e)) => {
+                    tracing::warn!(
+                        "bidi catch-up open failed unretryably, \
+                         serving this call on the legacy path: {e}"
+                    );
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        self.catch_up_legacy().await
+    }
+
+    /// The bidi arm: bounded runs with a bounded retry on wire death. The
+    /// summary accumulates across retries — an attempt's stores survive its
+    /// wire death, and the next attempt reseeds from durable state, so its
+    /// replays of them are deduped and never recounted.
+    pub(crate) async fn catch_up_bidi(&self) -> Result<CatchUpSummary, CatchUpError> {
+        let mut summary = CatchUpSummary::default();
+        for attempt in 1..=MAX_ATTEMPTS {
+            match self.catch_up_attempt(&mut summary).await? {
+                AttemptEnd::Complete => return Ok(summary),
+                AttemptEnd::WireDied => {
+                    tracing::warn!(attempt, "catch-up wire died; retrying from durable state");
+                    tokio::time::sleep(RETRY_BACKOFF * attempt).await;
+                }
+            }
+        }
+        Err(CatchUpError::Exhausted {
+            attempts: MAX_ATTEMPTS,
+        })
+    }
+
+    /// The legacy arm: full welcome + group sync. The legacy sync reports
+    /// groups synced, not items persisted, so the summary is a before/after
+    /// diff of the store: identities above the PRE-call durable cursors,
+    /// minus those already stored when the call began. (The query path
+    /// advances cursors as it stores, so post-call cursors cannot serve as
+    /// the diff floor.)
+    async fn catch_up_legacy(&self) -> Result<CatchUpSummary, CatchUpError> {
+        let db = self.context.db();
+        let query = || GroupQueryArgs {
+            include_duplicate_dms: true,
+            include_sync_groups: true,
+            ..Default::default()
+        };
+        let pre_groups = db.find_groups(query()).map_err(SubscribeError::from)?;
+        let pre_ids: HashSet<GroupId> = pre_groups.iter().map(|g| g.id).collect();
+        let group_ids: Vec<GroupId> = pre_ids.iter().copied().collect();
+        let mut cursors = db
+            .get_last_cursor_for_ids(
+                &group_ids,
+                &[EntityKind::ApplicationMessage, EntityKind::CommitMessage],
+            )
+            .map_err(SubscribeError::from)?;
+        let pre_stored: HashSet<Cursor> = db
+            .messages_newer_than(&cursors)
+            .map_err(SubscribeError::from)?
+            .into_iter()
+            .map(|(_, cursor)| cursor)
+            .collect();
+
+        WelcomeService::new(&self.context)
+            .sync_all_welcomes_and_groups(None)
+            .await
+            .map_err(|e| CatchUpError::from(SubscribeError::from(Box::new(e))))?;
+
+        let post_groups = db.find_groups(query()).map_err(SubscribeError::from)?;
+        let mut summary = CatchUpSummary::default();
+        let mut sync_ids: HashSet<GroupId> = HashSet::new();
+        for group in &post_groups {
+            if matches!(group.conversation_type, ConversationType::Sync) {
+                sync_ids.insert(group.id);
+            }
+            if !pre_ids.contains(&group.id) {
+                // A group joined during the call: everything stored for it
+                // is new.
+                cursors.insert(group.id.as_slice().to_vec(), Default::default());
+                if !matches!(group.conversation_type, ConversationType::Sync) {
+                    summary.conversations += 1;
+                }
+            }
+        }
+        summary.messages = db
+            .messages_newer_than(&cursors)
+            .map_err(SubscribeError::from)?
+            .into_iter()
+            .filter(|(group_id, cursor)| {
+                !sync_ids.contains(group_id) && !pre_stored.contains(cursor)
+            })
+            .count() as u64;
+        Ok(summary)
+    }
+
+    /// One bounded run: subscribe everything `history_only`, process what
+    /// arrives (welcomes may add follow-up waves), half-close once nothing
+    /// is owed, and let the server close. Newly persisted items count into
+    /// `summary`; replays of already-stored history do not (the seeded
+    /// seen-set and the intake's known/floor guards drop them first).
+    async fn catch_up_attempt(
+        &self,
+        summary: &mut CatchUpSummary,
+    ) -> Result<AttemptEnd, CatchUpError> {
+        let db = self.context.db();
+        let installation = self.context.installation_id();
+        // Welcome floor and known set BEFORE the group query, exactly as the
+        // all-messages subscribe orders them: a welcome processed in between
+        // shows up in the query result AND above the floor, and the tracked
+        // set absorbs the overlap; the reverse order would leave it in
+        // neither.
+        let welcome_floor = welcome_seed(&db, installation)?;
+        let known = known_welcomes_above(&db, welcome_floor)?;
+        let groups = db
+            .find_groups(GroupQueryArgs {
+                include_duplicate_dms: true,
+                // Sync groups are caught up too — their replayed traffic
+                // nudges the device-sync worker, like the streams do.
+                include_sync_groups: true,
+                ..Default::default()
+            })
+            .map_err(SubscribeError::from)?;
+        let mut sync_groups: HashSet<GroupId> = groups
+            .iter()
+            .filter(|g| matches!(g.conversation_type, ConversationType::Sync))
+            .map(|g| g.id)
+            .collect();
+        let group_ids: Vec<GroupId> = groups.into_iter().map(|g| g.id).collect();
+        let seeds = seed_groups(&db, &group_ids)?;
+
+        let mut tracked: HashSet<Topic> = seeds.floors.keys().cloned().collect();
+        let mut subs = seeds.subs();
+        subs.push((Topic::new_welcome_message(installation), welcome_floor));
+        // Already-stored identities above the floors: replays of these are
+        // skipped without touching the pipeline (stored by an earlier stream
+        // or sync — the durable cursor alone is not a delivery floor).
+        let mut seen = seeds.seen;
+
+        let api = self.context.api().api_client.clone();
+        let mut conn = match BidiConnection::open(&api, history_only_mutate(subs, 1)).await {
+            Ok(conn) => conn,
+            Err(e) => {
+                let open = OpenError::new(e);
+                return if open_is_backend_refusal(&open) {
+                    Err(CatchUpError::Unsupported(open))
+                } else if open.is_retryable() {
+                    // A transient dial failure consumes an attempt.
+                    Ok(AttemptEnd::WireDied)
+                } else {
+                    Err(CatchUpError::DeadEnd(open))
+                };
+            }
+        };
+
+        let factory = ProcessMessageFuture::new(self.context.clone());
+        let mut intake =
+            WelcomeIntake::new(self.context.clone(), welcome_floor, known, None, true, None);
+        // Waves whose CatchUpComplete is still owed (including queued,
+        // not-yet-sent follow-ups) — `1` is the initial wave.
+        let mut outstanding: HashSet<u64> = HashSet::from([1]);
+        let mut next_mutate_id: u64 = 2;
+        // Follow-up waves awaiting a command slot. `try_mutate`, never
+        // `mutate`: this task is the sole event drainer, and parking on the
+        // command channel while events back up is the documented deadlock.
+        let mut queued: VecDeque<Mutate> = VecDeque::new();
+
+        loop {
+            while let Some(wave) = queued.pop_front() {
+                match conn.try_mutate(wave) {
+                    Ok(()) => {}
+                    Err(TryMutateError::Full(wave)) => {
+                        // Retried next turn; replay frames keep arriving (or
+                        // the watchdog ends the wire and the bounded attempt
+                        // retry takes over), so the loop keeps turning —
+                        // drainage is bounded by wire liveness, not by luck.
+                        tracing::debug!(
+                            queued_waves = queued.len() + 1,
+                            "catch-up follow-up wave deferred on a full command slot"
+                        );
+                        queued.push_front(wave);
+                        break;
+                    }
+                    Err(TryMutateError::Closed(_)) => return Ok(AttemptEnd::WireDied),
+                }
+            }
+            if outstanding.is_empty() && queued.is_empty() && intake.is_idle() {
+                break;
+            }
+            tokio::select! {
+                event = conn.next() => match event {
+                    None => return Ok(AttemptEnd::WireDied),
+                    Some(BidiEvent::GroupMessages { messages, .. }) => {
+                        self.process_group_batch(&factory, messages, &mut seen, &sync_groups, summary)
+                            .await;
+                    }
+                    Some(BidiEvent::WelcomeMessages { messages, .. }) => {
+                        if !intake.absorb_batch(messages) {
+                            tracing::warn!(
+                                outstanding_waves = outstanding.len(),
+                                queued_waves = queued.len(),
+                                "catch-up welcome backlog overflowed; \
+                                 ending the attempt to retry from durable state"
+                            );
+                            return Ok(AttemptEnd::WireDied);
+                        }
+                    }
+                    Some(BidiEvent::CatchUpComplete { mutate_id }) => {
+                        outstanding.remove(&mutate_id);
+                    }
+                    // No wave of ours registers for live delivery, so no
+                    // topic ever crosses; tolerate the marker anyway.
+                    Some(BidiEvent::Started { .. }) | Some(BidiEvent::TopicsLive { .. }) => {}
+                },
+                outcome = intake.next_outcome() => match outcome {
+                    Ok(outcome) => {
+                        if let Some(group) = outcome.group {
+                            if matches!(group.conversation_type, ConversationType::Sync) {
+                                sync_groups.insert(group.group_id);
+                            }
+                            let topic = Topic::new_group_message(group.group_id);
+                            if !tracked.contains(&topic) {
+                                if !matches!(group.conversation_type, ConversationType::Sync) {
+                                    summary.conversations += 1;
+                                }
+                                let gseeds = seed_groups(&db, &[group.group_id])?;
+                                let adds = gseeds.subs();
+                                seen.extend(gseeds.seen);
+                                tracked.insert(topic);
+                                let mutate_id = next_mutate_id;
+                                next_mutate_id += 1;
+                                outstanding.insert(mutate_id);
+                                queued.push_back(history_only_mutate(adds, mutate_id));
+                            }
+                        }
+                        if let Some(cursor) = outcome.seen {
+                            intake.known.insert(cursor);
+                        }
+                    }
+                    // The welcome stays unrecorded, so it replays on the
+                    // next call (or any welcome stream/sync) — same recovery
+                    // as a live stream surfacing the error.
+                    Err(e) => tracing::warn!("catch-up welcome processing failed: {e}"),
+                },
+            }
+        }
+
+        // Bounded-sync half-close (XIP-83): we are done sending; the server
+        // finishes and closes its side. Everything owed has already arrived
+        // and been attempted, so from here the run is complete no matter how
+        // gracefully the wire goes down.
+        if conn.finish().await.is_ok() {
+            let drain = async { while conn.next().await.is_some() {} };
+            if tokio::time::timeout(POST_FINISH_DRAIN, drain)
+                .await
+                .is_err()
+            {
+                tracing::debug!("catch-up peer did not close after the half-close; dropping");
+            }
+        }
+        Ok(AttemptEnd::Complete)
+    }
+
+    /// Decode and process one replay batch through the streaming pipeline.
+    /// Failures are logged and skipped — the durable cursor never advances
+    /// past them, so a later sync retries (module docs).
+    async fn process_group_batch(
+        &self,
+        factory: &ProcessMessageFuture<Context>,
+        batch: Vec<xmtp_proto::mls_v1::GroupMessage>,
+        seen: &mut HashSet<Cursor>,
+        sync_groups: &HashSet<GroupId>,
+        summary: &mut CatchUpSummary,
+    ) {
+        for proto in batch {
+            let typed =
+                match xmtp_proto::types::GroupMessage::try_from(V3ProtoGroupMessage::from(proto)) {
+                    Ok(typed) => typed,
+                    Err(e) => {
+                        tracing::warn!("catch-up skipping undecodable group message: {e}");
+                        continue;
+                    }
+                };
+            if !seen.insert(typed.cursor) {
+                continue;
+            }
+            let (topic, cursor) = (Topic::new_group_message(typed.group_id), typed.cursor);
+            match process_one(factory, typed).await {
+                Ok(processed) => {
+                    if let Some(message) = processed.message {
+                        // The pipeline may store ahead of the envelope it was
+                        // handed (recovery sync) — record the surfaced
+                        // identity too, so its own replay frame is skipped.
+                        seen.insert(Cursor::new(
+                            message.sequence_id as u64,
+                            message.originator_id as u32,
+                        ));
+                        if sync_groups.contains(&message.group_id) {
+                            let _ = self
+                                .context
+                                .worker_events()
+                                .send(SyncWorkerEvent::NewSyncGroupMsg);
+                        } else {
+                            // Surfacing past the seeded seen-set means this
+                            // identity was not stored when the call began —
+                            // a newly persisted message.
+                            summary.messages += 1;
+                        }
+                    }
+                }
+                // The identity is in the log so a message that fails every
+                // catch-up (a poison message pinning its durable cursor) is
+                // traceable across runs.
+                Err(e) => tracing::warn!(
+                    %topic,
+                    ?cursor,
+                    "catch-up message processing failed (durable cursor held; a later sync retries): {e}"
+                ),
+            }
+        }
+    }
+}
+
+/// Live integration tests over a real v3 backend (docker node), like
+/// `bidi_tests` — native-only, v3-only.
+#[cfg(all(test, not(feature = "d14n")))]
+mod tests {
+    use super::CatchUpSummary;
+    use crate::tester;
+    use crate::utils::MlsGroupExt;
+    use xmtp_db::group_message::MsgQueryArgs;
+
+    /// A client that has never streamed or synced catches up: the pending
+    /// welcome joins the group (discovery adds a follow-up wave on the same
+    /// stream) and the group's history lands in the store.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn catch_up_joins_pending_groups_and_stores_history() {
+        tester!(alix);
+        tester!(bo);
+
+        let group = bo.create_group(None, None)?;
+        group.invite(&alix).await?;
+        group.send_msg(b"while you were out").await;
+        group.send_msg(b"still out").await;
+
+        let summary = alix.catch_up_bidi().await?;
+
+        let alix_group = alix.group(&group.group_id)?;
+        let bodies: Vec<Vec<u8>> = alix_group
+            .find_messages(&MsgQueryArgs::default())?
+            .into_iter()
+            .map(|m| m.decrypted_message_bytes)
+            .collect();
+        assert!(bodies.contains(&b"while you were out".to_vec()));
+        assert!(bodies.contains(&b"still out".to_vec()));
+        assert_eq!(summary.conversations, 1, "the joined group must be counted");
+        assert!(
+            summary.messages >= 2,
+            "the stored history must be counted (got {})",
+            summary.messages
+        );
+    }
+
+    /// A member with a stale durable cursor gets the missed tail replayed
+    /// and stored — and a second run finds nothing new to do.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn catch_up_replays_the_missed_tail_idempotently() {
+        tester!(alix);
+        tester!(bo);
+
+        let group = alix.create_group(None, None)?;
+        group.invite(&bo).await?;
+        bo.sync_welcomes().await?;
+        let bo_group = bo.group(&group.group_id)?;
+        bo_group.sync().await?; // durable cursor at "now"
+
+        group.send_msg(b"missed one").await;
+        group.send_msg(b"missed two").await;
+
+        let first = bo.catch_up_bidi().await?;
+        let count_after_first = bo_group.find_messages(&MsgQueryArgs::default())?.len();
+        let bodies: Vec<Vec<u8>> = bo_group
+            .find_messages(&MsgQueryArgs::default())?
+            .into_iter()
+            .map(|m| m.decrypted_message_bytes)
+            .collect();
+        assert!(bodies.contains(&b"missed one".to_vec()));
+        assert!(bodies.contains(&b"missed two".to_vec()));
+        assert!(
+            first.messages >= 2,
+            "the replayed tail must be counted (got {})",
+            first.messages
+        );
+        assert_eq!(first.conversations, 0, "no new group was joined");
+
+        // The honesty proof for the counter: the replay of already-stored
+        // history persists nothing, so the summary must say so.
+        let second = bo.catch_up_bidi().await?;
+        let count_after_second = bo_group.find_messages(&MsgQueryArgs::default())?.len();
+        assert_eq!(count_after_first, count_after_second);
+        assert_eq!(
+            second,
+            CatchUpSummary::default(),
+            "a second run persists nothing and must report zero"
+        );
+    }
+
+    /// Nothing owed at all — a fresh client's run is just the welcome-topic
+    /// wave, the half-close, and the server's close.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn catch_up_with_nothing_owed_completes() {
+        tester!(alix);
+        let summary = alix.catch_up_bidi().await?;
+        assert_eq!(
+            summary,
+            CatchUpSummary::default(),
+            "nothing owed means nothing counted"
+        );
+    }
+
+    /// The legacy arm reports the same summary shape: a pending welcome and
+    /// its history count on the first call (diffed against the pre-call
+    /// store), and a repeat call — cursors now advanced by the query path —
+    /// reports zero.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn legacy_catch_up_counts_the_same_way() {
+        tester!(alix);
+        tester!(bo);
+
+        let group = alix.create_group(None, None)?;
+        group.invite(&bo).await?;
+        group.send_msg(b"legacy one").await;
+        group.send_msg(b"legacy two").await;
+
+        let first = bo.catch_up_legacy().await?;
+        assert_eq!(
+            first.conversations, 1,
+            "the welcome-joined group must be counted"
+        );
+        assert!(
+            first.messages >= 2,
+            "the synced history must be counted (got {})",
+            first.messages
+        );
+
+        let second = bo.catch_up_legacy().await?;
+        assert_eq!(
+            second,
+            CatchUpSummary::default(),
+            "a repeat legacy run persists nothing and must report zero"
+        );
+    }
+}

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -26,6 +26,10 @@ mod d14n_bidi_tests;
 // Randomized delivery fuzz over the live node (same gating as `bidi_tests`).
 #[cfg(all(test, not(target_arch = "wasm32"), not(feature = "d14n")))]
 mod bidi_fuzz_tests;
+// One-shot bounded catch-up over the bidi wire (native-only, like the
+// connection it rides).
+#[cfg(not(target_arch = "wasm32"))]
+pub mod catch_up;
 pub(crate) mod d14n_compat;
 pub mod process_message;
 pub mod process_welcome;

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -175,7 +175,7 @@ pub(crate) fn is_bidi_unsupported(e: &RouterError) -> bool {
 /// `GrpcError::Status` — and `GrpcError` reports itself blanket-retryable,
 /// so the refusal must be recognized by shape, not by `is_retryable`. The
 /// chain walk finds it wherever it sits.
-fn open_is_backend_refusal(open: &OpenError) -> bool {
+pub(crate) fn open_is_backend_refusal(open: &OpenError) -> bool {
     let mut source = std::error::Error::source(open);
     while let Some(e) = source {
         if e.downcast_ref::<GrpcError>()

--- a/crates/xmtp_mls/src/subscriptions/stream_router.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router.rs
@@ -616,20 +616,20 @@ where
 /// (so they stay skipped after the window). The wire cursor and the window
 /// floor stay at the durable cursor — a stored gap (6 and 8 stored, 7
 /// missed) still gets 7 replayed and delivered.
-struct GroupSeeds {
+pub(crate) struct GroupSeeds {
     /// Frozen per-topic window floors: the durable resume points.
-    floors: HashMap<Topic, GlobalCursor>,
+    pub(crate) floors: HashMap<Topic, GlobalCursor>,
     /// Live per-topic positions: the floors folded with stored identities.
     positions: HashMap<Topic, GlobalCursor>,
     /// The window's exact-identity seen-set: the stored identities.
-    seen: HashSet<Cursor>,
+    pub(crate) seen: HashSet<Cursor>,
 }
 
 impl GroupSeeds {
     /// The cursored adds for this seeding's lease wave: each topic from its
     /// frozen floor — the cursored lease makes the server replay anything
     /// past it (catch-up == subscribe).
-    fn subs(&self) -> Vec<(Topic, SequenceId)> {
+    pub(crate) fn subs(&self) -> Vec<(Topic, SequenceId)> {
         self.floors
             .iter()
             .map(|(topic, floor)| (topic.clone(), floor.max()))
@@ -638,7 +638,7 @@ impl GroupSeeds {
 }
 
 /// Seed `group_ids` from their durable cursors (see [`GroupSeeds`]).
-fn seed_groups(
+pub(crate) fn seed_groups(
     db: &(impl QueryRefreshState + QueryGroupMessage),
     group_ids: &[GroupId],
 ) -> Result<GroupSeeds> {
@@ -662,7 +662,10 @@ fn seed_groups(
 
 /// The durable welcome cursor: this installation's wire resume point for its
 /// welcome topic.
-fn welcome_seed(db: &impl QueryRefreshState, installation: InstallationId) -> Result<SequenceId> {
+pub(crate) fn welcome_seed(
+    db: &impl QueryRefreshState,
+    installation: InstallationId,
+) -> Result<SequenceId> {
     Ok(db
         .get_last_cursor_for_ids(&[installation], &[EntityKind::Welcome])?
         .get(installation.as_slice())
@@ -676,7 +679,10 @@ fn welcome_seed(db: &impl QueryRefreshState, installation: InstallationId) -> Re
 /// at-or-below the durable cursor means already processed, group or not —
 /// so the known set only needs the above-floor overlap (welcomes processed
 /// since the last cursor advance).
-fn known_welcomes_above(db: &impl QueryGroup, floor: SequenceId) -> Result<HashSet<Cursor>> {
+pub(crate) fn known_welcomes_above(
+    db: &impl QueryGroup,
+    floor: SequenceId,
+) -> Result<HashSet<Cursor>> {
     Ok(db
         .group_cursors()?
         .into_iter()
@@ -812,7 +818,10 @@ async fn next_local_wake(events: &mut broadcast::Receiver<LocalEvents>) -> Local
 /// Each task snapshots the known set at spawn (the pipeline's contract), so
 /// concurrent same-cursor flights are possible; they resolve at completion,
 /// where the consumers' known/positions guards make them idempotent.
-struct WelcomeIntake<Context> {
+///
+/// Shared with the bounded catch-up (`catch_up`), whose welcome handling is
+/// this same intake over its own one-shot wire.
+pub(crate) struct WelcomeIntake<Context> {
     context: Context,
     /// The stream's durable welcome cursor at subscribe. Every welcome
     /// at-or-below it was already processed — stored, ignored, filtered, or
@@ -825,7 +834,7 @@ struct WelcomeIntake<Context> {
     /// Welcome dedup above the floor: every cursor this stream has resolved
     /// (or knew at subscribe). Consulted at intake, snapshotted per task,
     /// recorded back by the consumer at completion.
-    known: HashSet<Cursor>,
+    pub(crate) known: HashSet<Cursor>,
     conversation_type: Option<ConversationType>,
     include_duplicate_dms: bool,
     consent_states: Option<Vec<ConsentState>>,
@@ -841,7 +850,7 @@ impl<Context> WelcomeIntake<Context>
 where
     Context: XmtpSharedContext + 'static,
 {
-    fn new(
+    pub(crate) fn new(
         context: Context,
         floor: SequenceId,
         known: HashSet<Cursor>,
@@ -863,7 +872,7 @@ where
 
     /// Wire welcomes: decode, drop the already-processed, queue the rest.
     /// Returns `false` when the backlog overflowed (the stream must end).
-    fn absorb_batch(&mut self, batch: Vec<mls_v1::WelcomeMessage>) -> bool {
+    pub(crate) fn absorb_batch(&mut self, batch: Vec<mls_v1::WelcomeMessage>) -> bool {
         for proto in batch {
             let typed = match xmtp_proto::types::WelcomeMessage::try_from(
                 V3ProtoWelcomeMessage::from(proto),
@@ -940,24 +949,57 @@ where
         }
     }
 
+    /// Nothing queued and nothing in flight — every absorbed arrival has
+    /// resolved through [`Self::next_outcome`].
+    pub(crate) fn is_idle(&self) -> bool {
+        self.tasks.is_empty() && self.backlog.is_empty()
+    }
+
     /// The next finished task, parking forever while nothing is in flight
     /// (the backlog is non-empty only at the cap, so idle means empty).
-    async fn next_outcome(&mut self) -> Result<WelcomeOutcome<Context>> {
-        loop {
-            match self.tasks.join_next().await {
-                Some(Ok(outcome)) => {
-                    self.pump();
-                    return outcome;
-                }
-                // A panicked task: skip it, like the legacy conversation
-                // stream's completion arm does.
-                Some(Err(e)) => {
-                    tracing::warn!("stream router: welcome processing task failed: {e}");
-                    self.pump();
-                }
-                None => return std::future::pending().await,
+    ///
+    /// A task that dies instead of resolving (a panic) surfaces as an
+    /// error rather than being skipped: swallowing the last join would
+    /// leave the set empty and park the next poll on `pending()`, so a
+    /// caller whose other wake sources have gone quiet — the bounded
+    /// catch-up once its waves complete — would never re-check its
+    /// termination state. One error per dead task wakes the caller exactly
+    /// once; the welcome stays unrecorded, so the wire replays it later.
+    pub(crate) async fn next_outcome(&mut self) -> Result<WelcomeOutcome<Context>> {
+        match self.tasks.join_next().await {
+            Some(Ok(outcome)) => {
+                self.pump();
+                outcome
             }
+            Some(Err(e)) => {
+                self.pump();
+                Err(SubscribeError::BoxError(Box::new(WelcomeTaskDied(e))))
+            }
+            None => std::future::pending().await,
         }
+    }
+
+    /// Test-only seam: park a task that dies by panic, for the
+    /// panic-surfacing regression on [`Self::next_outcome`]. Gated like its
+    /// only caller (`stream_router_tests`): under `d14n` those tests are
+    /// compiled out and this would be dead code.
+    #[cfg(all(test, not(feature = "d14n")))]
+    pub(crate) fn spawn_panicking_task(&mut self) {
+        self.tasks.spawn(async { panic!("boom") });
+    }
+}
+
+/// A spawned welcome/local-group task died (panicked) instead of
+/// resolving. Not retryable in place: the welcome it carried stays
+/// unrecorded, so the wire replays it to the next stream or catch-up —
+/// that replay is the retry.
+#[derive(Debug, thiserror::Error)]
+#[error("welcome processing task died: {0}")]
+struct WelcomeTaskDied(xmtp_common::task::JoinError);
+
+impl xmtp_common::RetryableError for WelcomeTaskDied {
+    fn is_retryable(&self) -> bool {
+        false
     }
 }
 

--- a/crates/xmtp_mls/src/subscriptions/stream_router_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router_tests.rs
@@ -170,3 +170,28 @@ async fn sibling_conversation_streams_both_receive_a_welcome() {
         );
     }
 }
+
+/// A panicked welcome task must surface an error from `next_outcome`, not
+/// vanish: swallowed, the empty task set parks the next poll on `pending()`
+/// and a caller with no other wake source left (the bounded catch-up after
+/// its waves complete) never re-checks its `is_idle` termination — a hang.
+#[xmtp_common::test(unwrap_try = true)]
+async fn a_panicked_welcome_task_surfaces_instead_of_parking() {
+    use crate::subscriptions::stream_router::WelcomeIntake;
+    use std::collections::HashSet;
+
+    tester!(alix);
+    let mut intake = WelcomeIntake::new(alix.context.clone(), 0, HashSet::new(), None, true, None);
+    intake.spawn_panicking_task();
+
+    let outcome = tokio::time::timeout(WAIT, intake.next_outcome()).await;
+    match outcome {
+        Ok(Err(_)) => {} // the dead task surfaced; the caller wakes and re-checks
+        Ok(Ok(_)) => panic!("a dead task cannot produce an outcome"),
+        Err(_) => panic!("next_outcome parked forever on a dead task"),
+    }
+    assert!(
+        intake.is_idle(),
+        "nothing is left in flight once the dead task surfaced"
+    );
+}


### PR DESCRIPTION
Adds `Client::catch_up_to_live()`: a bounded, one-shot sync over the XIP-83 bidi wire that replays everything a client missed while offline, then ends — no live tail, no long-lived stream.

Returns a `CatchUpSummary { messages, conversations }` — counts of what the call **persisted** (not what the wire replayed: retries reseed and replay, already-stored history is deduped before counting), so mobile hosts get their "did anything new arrive" signal (NSE content, `BGAppRefreshTask` newData, up-to-date UI). Both dispatch arms report it: the bidi arm counts exactly via its seeded seen-set, the legacy arm via a before/after store diff against pre-call durable cursors. Device-sync groups are excluded from both counts.

## Design

- **Private wire, not the shared transport.** The transport's ledger is a live-delivery machine — `history_only` waves never cross to live and have no place in its wire-position bookkeeping. A private `BidiConnection` also leaves a concurrently-running live stream completely undisturbed.
- **Half-close deferred through a discovery loop.** The initial `history_only` Mutate covers every group topic plus the welcome topic at durable floors; each welcome that joins a group issues a follow-up `history_only` wave for that group on the same stream (`try_mutate` with a retry queue — parking on `mutate()` while being the sole event drainer is the documented deadlock). Only when no wave is outstanding and welcome intake is idle does it `finish()`; the server then closes, per the XIP-83 bounded-sync contract.
- **Processing is byte-identical to the streaming pipeline** — it reuses `WelcomeIntake` and `process_one`, so durable message cursors are *not* advanced: a poison message is never skipped past, and repeat calls replay the deduped tail. Advancing cursors at wave-complete is a clean follow-on if the replay tail ever matters.
- **Dispatch mirrors the stream entry points**: gate on → bidi with 3-attempt retry on wire death (backend refusal trips the same process-wide latch and the call completes on legacy `sync_all_welcomes_and_groups`); gate off → straight to legacy.

## Tests

Three live tests against the containerized node: a never-synced client joins a pending group purely through the catch-up's welcome wave and receives its history; a stale member gets the missed tail replayed idempotently (a second run adds nothing); a fresh client with nothing owed completes cleanly. Full `xmtp_mls` suite 692/692 (known `should_reconnect` flake passed on retry), lint green, d14n feature build clean.

Binding exposure (node + FFI) is a deliberate follow-up so this stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AVuJ7VAgen2fFhtJQ6zid

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add one-shot `catch_up_to_live` bidi catch-up with legacy fallback to `Client`
> - Adds [`catch_up.rs`](https://github.com/xmtp/libxmtp/pull/3854/files#diff-0f712bac68b7d394bd934c86f442148b513550fc9fd3df1d726880379c954003) implementing `Client::catch_up_to_live`, which performs a bounded one-shot catch-up over the XIP-83 bidi stream, half-closing once the server signals completion.
> - Falls back to a legacy sync path (`catch_up_legacy`) when bidi is unsupported or produces an unretryable open failure; the legacy path diffs store state before/after `sync_all_welcomes_and_groups` to produce counts.
> - Both paths return a `CatchUpSummary` with counts of newly persisted messages and joined conversations, excluding device-sync groups.
> - The bidi path retries up to 3 times with 500ms base backoff on wire death, drains up to 5s after half-close, and handles follow-up waves for newly discovered groups.
> - Fixes `WelcomeIntake::next_outcome()` to surface a `WelcomeTaskDied` error instead of silently skipping panicked tasks, preventing callers from parking indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aef34f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
