### PR TITLE
feat(xmtp_api_d14n,xmtp_mls): bidi observability — wire, wave, and stream lifecycle in trace logs

### DIFF
--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -617,6 +617,9 @@ where
     B::WelcomeMessage: Clone,
 {
     owner: WaveOwner,
+    /// When the wave was issued — observability only: its `CatchUpComplete`
+    /// logs the mutate→completion latency.
+    issued_at: std::time::Instant,
     /// The wave's adds as sent: which topics it asked to replay, from where.
     /// A lower re-add claims a topic out of a sibling's wave server-side
     /// (XIP-83), so claims are what decide whether a resolving lease's
@@ -638,6 +641,7 @@ where
     fn new(owner: WaveOwner, claims: HashMap<Topic, B::Cursor>) -> Self {
         Self {
             owner,
+            issued_at: std::time::Instant::now(),
             claims,
             holds: Vec::new(),
             progress_group: None,
@@ -1293,7 +1297,13 @@ where
                 );
                 false
             }
-            Err(mpsc::error::TrySendError::Closed(_)) => false,
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::debug!(
+                    lease = id.0,
+                    "bidi transport: lease receiver dropped; releasing it"
+                );
+                false
+            }
         }
     }
 
@@ -1316,6 +1326,14 @@ where
             }
             Event::CatchUpComplete { mutate_id } => {
                 if let Some(wave) = self.pending_waves.remove(&WaveId(mutate_id)) {
+                    tracing::debug!(
+                        wave = mutate_id,
+                        elapsed_ms = wave.issued_at.elapsed().as_millis() as u64,
+                        topics = wave.claims.len(),
+                        deferred_completions = wave.holds.len(),
+                        waves_left = self.pending_waves.len(),
+                        "bidi transport: catch-up wave resolved"
+                    );
                     if let WaveOwner::Lease(lease) = wave.owner {
                         self.complete(lease, &mut dropped);
                     }
@@ -1765,6 +1783,7 @@ async fn run_ledger<B: TransportBinding>(
         reconnect_delay: RECONNECT_INITIAL_DELAY,
         reconnect_at: tokio::time::Instant::now(),
         suspended: false,
+        wire_opens: 0,
         resume_notify: Vec::new(),
         outbox: Outbox::default(),
         deferred: std::collections::VecDeque::new(),
@@ -1804,6 +1823,9 @@ where
     /// `suspend()`ed: the wire stays down on purpose — no lazy open for new
     /// leases, no reconnect backoff — until `resume()` clears it.
     suspended: bool,
+    /// Wires opened over this transport's lifetime (cold opens + reopens) —
+    /// observability only: `wire_opens - 1` is the reconnect count.
+    wire_opens: u64,
     /// `resume()` callers awaiting a resume wave that hasn't been sent yet
     /// (the open failed, or hasn't happened). [`Self::reopen`] moves them
     /// onto the resume wave it sends; until then they park here across
@@ -1915,6 +1937,11 @@ where
                 OpenOutcome::Opened(wire) => {
                     self.conn = Some(wire);
                     self.reconnect_delay = RECONNECT_INITIAL_DELAY;
+                    self.wire_opens += 1;
+                    tracing::info!(
+                        topics = topics.len(),
+                        "bidi transport: wire opened (cold open)"
+                    );
                 }
                 OpenOutcome::Failed(e) => {
                     // The failure also travels to the caller, but join
@@ -1949,6 +1976,12 @@ where
         // arrives via the sibling-gap rule; module docs).
         let (tx, events) = mpsc::channel(depth.max(1));
         let id = self.ledger.register(topics.clone(), floors.clone(), tx);
+        tracing::debug!(
+            lease = id.0,
+            wave = wave.0,
+            topics = topics.len(),
+            "bidi transport: lease registered"
+        );
         self.ledger
             .pending_waves
             .insert(wave, PendingWave::new(WaveOwner::Lease(id), floors));
@@ -2084,7 +2117,12 @@ where
         drop(self.conn.take());
         self.reconnect_at = tokio::time::Instant::now() + self.reconnect_delay;
         if !self.ledger.leases.is_empty() {
-            tracing::warn!("bidi transport: wire died; reconnecting from last-seen positions");
+            tracing::warn!(
+                leases = self.ledger.leases.len(),
+                interrupted_waves = self.ledger.pending_waves.len(),
+                retry_in_ms = self.reconnect_delay.as_millis() as u64,
+                "bidi transport: wire died; reconnecting from last-seen positions"
+            );
         }
         self.settle_idle_waiters();
         Flow::Continue
@@ -2138,6 +2176,7 @@ where
         // When every leased topic is owned by an interrupted wave there is no
         // resume wave (an adds-nothing wave is refused by the wire contract)
         // and the first re-issue seeds the open instead.
+        let resumed_topics = resume_adds.len();
         let resume_wave = (!resume_adds.is_empty()).then(|| self.ledger.next_wave_id());
         let mut outbound = std::collections::VecDeque::with_capacity(reissues.len() + 1);
         let resume_pending = resume_wave.map(|wave| {
@@ -2170,6 +2209,13 @@ where
             OpenOutcome::Opened(wire) => {
                 self.conn = Some(wire);
                 self.reconnect_delay = RECONNECT_INITIAL_DELAY;
+                self.wire_opens += 1;
+                tracing::info!(
+                    reconnects = self.wire_opens.saturating_sub(1),
+                    resumed_topics,
+                    reissued_waves = reissue_waves.len(),
+                    "bidi transport: wire reopened"
+                );
                 // Waves from the dead wire can never resolve on this one —
                 // drop them; the re-issues re-home the interrupted leases'
                 // obligations (progress carried forward). Completions that

--- a/crates/xmtp_mls/src/subscriptions/catch_up.rs
+++ b/crates/xmtp_mls/src/subscriptions/catch_up.rs
@@ -59,6 +59,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::time::Duration;
 
+use tracing::Instrument;
 use xmtp_api_d14n::v3::V3ProtoGroupMessage;
 use xmtp_api_d14n::{BidiConnection, BidiEvent, OpenError, TryMutateError};
 use xmtp_common::{ErrorCode, RetryableError, retryable};
@@ -483,6 +484,8 @@ where
         sync_groups: &HashSet<GroupId>,
         summary: &mut CatchUpSummary,
     ) {
+        let batch_started = std::time::Instant::now();
+        let batch_size = batch.len();
         for proto in batch {
             let typed =
                 match xmtp_proto::types::GroupMessage::try_from(V3ProtoGroupMessage::from(proto)) {
@@ -496,7 +499,17 @@ where
                 continue;
             }
             let (topic, cursor) = (Topic::new_group_message(typed.group_id), typed.cursor);
-            match process_one(factory, typed).await {
+            let started = std::time::Instant::now();
+            let result = process_one(factory, typed)
+                .instrument(tracing::debug_span!("process_envelope", %topic, ?cursor))
+                .await;
+            tracing::trace!(
+                %topic,
+                ?cursor,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "catch-up: envelope processed"
+            );
+            match result {
                 Ok(processed) => {
                     if let Some(message) = processed.message {
                         // The pipeline may store ahead of the envelope it was
@@ -529,6 +542,11 @@ where
                 ),
             }
         }
+        tracing::debug!(
+            batch = batch_size,
+            elapsed_ms = batch_started.elapsed().as_millis() as u64,
+            "catch-up: message batch processed"
+        );
     }
 }
 

--- a/crates/xmtp_mls/src/subscriptions/stream_router.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router.rs
@@ -64,6 +64,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use tokio::sync::{broadcast, mpsc, oneshot};
+use tracing::Instrument;
 
 use xmtp_api_d14n::v3::{V3ProtoGroupMessage, V3ProtoWelcomeMessage};
 use xmtp_api_d14n::{
@@ -475,8 +476,15 @@ where
             tx,
             dedup: StreamDedup::syncing(tracked.clone(), seeds.seen),
             tracked,
+            delivered: 0,
+            deduped: 0,
             reflex: None,
         };
+        tracing::debug!(
+            groups = group_ids.len(),
+            depth,
+            "stream router: message stream subscribed"
+        );
         let id = self.spawn(|kill| consumer.run(kill));
         Ok(RouterStream {
             id,
@@ -541,6 +549,8 @@ where
             tx,
             dedup: StreamDedup::syncing(tracked.clone(), seeds.seen),
             tracked,
+            delivered: 0,
+            deduped: 0,
             reflex: Some(Reflex {
                 transport: self.transport.clone(),
                 local_events,
@@ -555,6 +565,11 @@ where
                 ),
             }),
         };
+        tracing::debug!(
+            groups = group_ids.len(),
+            depth,
+            "stream router: all-messages stream subscribed"
+        );
         let id = self.spawn(|kill| consumer.run(kill));
         Ok(RouterStream {
             id,
@@ -603,7 +618,9 @@ where
                 include_duplicate_dms,
                 consent_states,
             ),
+            delivered: 0,
         };
+        tracing::debug!(depth, "stream router: conversation stream subscribed");
         let id = self.spawn(|kill| consumer.run(kill));
         Ok(RouterStream {
             id,
@@ -928,6 +945,12 @@ where
     /// must end).
     fn enqueue(&mut self, item: WelcomeOrGroup) -> bool {
         if self.backlog.len() >= MAX_WELCOME_BACKLOG {
+            tracing::warn!(
+                backlog = MAX_WELCOME_BACKLOG,
+                in_flight = self.tasks.len(),
+                "stream router: welcome backlog overflowed; ending the stream \
+                 (the consumer re-subscribes from durable state)"
+            );
             return false;
         }
         self.backlog.push_back(item);
@@ -941,6 +964,10 @@ where
             let Some(item) = self.backlog.pop_front() else {
                 return;
             };
+            let kind = match &item {
+                WelcomeOrGroup::Welcome(_) => "welcome",
+                WelcomeOrGroup::Group(_) => "group",
+            };
             let task = ProcessWelcomeFuture::new(
                 self.known.clone(),
                 self.context.clone(),
@@ -949,8 +976,18 @@ where
                 self.include_duplicate_dms,
                 self.consent_states.clone(),
             );
-            self.tasks
-                .spawn(async move { Ok(task?.process().await?.into_outcome()) });
+            self.tasks.spawn(
+                async move {
+                    let started = std::time::Instant::now();
+                    let outcome = task?.process().await?.into_outcome();
+                    tracing::trace!(
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "stream router: welcome processed"
+                    );
+                    Ok(outcome)
+                }
+                .instrument(tracing::debug_span!("process_welcome", kind)),
+            );
         }
     }
 
@@ -1076,6 +1113,11 @@ struct MessageConsumer<Context> {
     /// nothing) and the unleased-delivery filter.
     tracked: HashSet<Topic>,
     dedup: StreamDedup,
+    /// Messages surfaced to the consumer — observability only, logged in
+    /// the stream's end-of-life summary.
+    delivered: u64,
+    /// Deliveries the window's seen-set skipped — observability only.
+    deduped: u64,
     /// `Some` for the all-messages stream: welcomes grow the topic set.
     reflex: Option<Reflex<Context>>,
 }
@@ -1085,6 +1127,19 @@ where
     Context: XmtpSharedContext + 'static,
 {
     async fn run(mut self, mut kill: oneshot::Receiver<()>) {
+        let reason = self.drive(&mut kill).await;
+        tracing::info!(
+            delivered = self.delivered,
+            deduped = self.deduped,
+            topics = self.tracked.len(),
+            reason,
+            "stream router: message stream ended"
+        );
+    }
+
+    /// The stream's event loop; returns why it ended, for the end-of-life
+    /// summary.
+    async fn drive(&mut self, kill: &mut oneshot::Receiver<()>) -> &'static str {
         loop {
             enum Wake<Context> {
                 Lease(Arc<[Topic]>, LeaseEvent<V3Binding>),
@@ -1095,36 +1150,40 @@ where
                     Some((topics, event)) => Wake::Lease(topics, event),
                     // Wire death or transport backpressure drop on any lease:
                     // the stream ends (tx drops); the consumer re-subscribes.
-                    None => return,
+                    None => return "lease ended (transport shutdown or backpressure drop)",
                 },
                 wake = Reflex::wake(&mut self.reflex) => Wake::Reflex(wake),
-                _ = &mut kill => return,
+                _ = &mut *kill => return "stream handle dropped",
             };
             match wake {
                 Wake::Reflex(ReflexWake::Local(LocalWake::Event(LocalEvents::NewGroup(id)))) => {
                     if !self.absorb_local_group(id) {
-                        return;
+                        return "welcome intake ended";
                     }
                 }
                 Wake::Reflex(ReflexWake::Local(LocalWake::Event(_))) => {}
                 Wake::Reflex(ReflexWake::Local(LocalWake::Lagged)) => {
-                    if !self.reconcile(&mut kill).await {
-                        return;
+                    if !self.reconcile(kill).await {
+                        return "local-event lag unrecoverable";
                     }
                 }
                 Wake::Reflex(ReflexWake::Outcome(outcome)) => {
-                    if !self.absorb_outcome(outcome, &mut kill).await {
-                        return;
+                    if !self.absorb_outcome(outcome, kill).await {
+                        return "consumer gone";
                     }
                 }
                 Wake::Lease(_, LeaseEvent::GroupMessages(batch)) => {
-                    if !self.deliver_batch(batch, &mut kill).await {
-                        return;
+                    if !self.deliver_batch(batch, kill).await {
+                        return "consumer gone";
                     }
                 }
                 Wake::Lease(topics, LeaseEvent::CatchUpComplete) => {
-                    tracing::debug!("stream router: message stream caught up");
                     self.dedup.complete(&topics);
+                    tracing::debug!(
+                        topics = topics.len(),
+                        windows_open = self.dedup.syncing.len(),
+                        "stream router: message stream caught up"
+                    );
                 }
                 Wake::Lease(_, LeaseEvent::TopicsLive(topics)) => {
                     tracing::debug!(?topics, "stream router: topics live");
@@ -1132,7 +1191,7 @@ where
                 Wake::Lease(_, LeaseEvent::WelcomeMessages(batch)) => match self.reflex.as_mut() {
                     Some(reflex) => {
                         if !reflex.intake.absorb_batch(batch) {
-                            return;
+                            return "welcome intake ended";
                         }
                     }
                     None => tracing::warn!("stream router: welcome delivery on a message lease"),
@@ -1287,6 +1346,8 @@ where
         batch: Vec<mls_v1::GroupMessage>,
         kill: &mut oneshot::Receiver<()>,
     ) -> bool {
+        let batch_started = std::time::Instant::now();
+        let batch_size = batch.len();
         for proto in batch {
             let typed =
                 match xmtp_proto::types::GroupMessage::try_from(V3ProtoGroupMessage::from(proto)) {
@@ -1303,6 +1364,12 @@ where
                 continue;
             }
             if self.dedup.suppress(&topic, &cursor) {
+                self.deduped += 1;
+                tracing::trace!(
+                    %topic,
+                    ?cursor,
+                    "stream router: skipping an already-delivered identity"
+                );
                 continue;
             }
 
@@ -1311,10 +1378,18 @@ where
             // recovery sync), so it races the kill: dropping the stream must
             // release the lease promptly, and cancelling here is the same
             // mid-processing drop a pull-based stream takes at an await point.
+            let started = std::time::Instant::now();
             let processed = tokio::select! {
-                processed = process_one(&self.factory, typed) => processed,
+                processed = process_one(&self.factory, typed)
+                    .instrument(tracing::debug_span!("process_envelope", %topic, ?cursor)) => processed,
                 _ = &mut *kill => return false,
             };
+            tracing::trace!(
+                %topic,
+                ?cursor,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "stream router: envelope processed"
+            );
             let delivered = match processed {
                 Ok(processed) => {
                     match processed.message {
@@ -1347,7 +1422,11 @@ where
                                     .send(SyncWorkerEvent::NewSyncGroupMsg);
                                 continue;
                             }
-                            send_or_kill(&self.tx, kill, Ok(message)).await
+                            let sent = send_or_kill(&self.tx, kill, Ok(message)).await;
+                            if sent.is_ok() {
+                                self.delivered += 1;
+                            }
+                            sent
                         }
                         // Surfaced nothing (e.g. a commit) — nothing to
                         // deliver.
@@ -1363,6 +1442,11 @@ where
                 return false;
             }
         }
+        tracing::debug!(
+            batch = batch_size,
+            elapsed_ms = batch_started.elapsed().as_millis() as u64,
+            "stream router: message batch processed"
+        );
         true
     }
 }
@@ -1382,6 +1466,9 @@ struct WelcomeConsumer<Context> {
     tx: mpsc::Sender<Result<MlsGroup<Context>>>,
     local_events: broadcast::Receiver<LocalEvents>,
     intake: WelcomeIntake<Context>,
+    /// Conversations surfaced to the consumer — observability only, logged
+    /// in the stream's end-of-life summary.
+    delivered: u64,
 }
 
 impl<Context> WelcomeConsumer<Context>
@@ -1389,6 +1476,17 @@ where
     Context: XmtpSharedContext + 'static,
 {
     async fn run(mut self, mut kill: oneshot::Receiver<()>) {
+        let reason = self.drive(&mut kill).await;
+        tracing::info!(
+            delivered = self.delivered,
+            reason,
+            "stream router: conversation stream ended"
+        );
+    }
+
+    /// The stream's event loop; returns why it ended, for the end-of-life
+    /// summary.
+    async fn drive(&mut self, kill: &mut oneshot::Receiver<()>) -> &'static str {
         loop {
             enum Wake<Context> {
                 Lease(LeaseEvent<V3Binding>),
@@ -1398,29 +1496,29 @@ where
             let wake = tokio::select! {
                 event = self.lease.next() => match event {
                     Some(event) => Wake::Lease(event),
-                    None => return,
+                    None => return "lease ended (transport shutdown or backpressure drop)",
                 },
                 local = next_local_wake(&mut self.local_events) => Wake::Local(local),
                 outcome = self.intake.next_outcome() => Wake::Outcome(outcome),
-                _ = &mut kill => return,
+                _ = &mut *kill => return "stream handle dropped",
             };
             match wake {
                 Wake::Local(LocalWake::Event(LocalEvents::NewGroup(group_id))) => {
                     if !self.intake.absorb_local(group_id) {
-                        return;
+                        return "welcome intake ended";
                     }
                 }
                 // A lagged broadcast (already warned) loses local groups
                 // only; recovery is a re-subscribe, exactly as legacy.
                 Wake::Local(_) => {}
                 Wake::Outcome(outcome) => {
-                    if !self.deliver_outcome(outcome, &mut kill).await {
-                        return;
+                    if !self.deliver_outcome(outcome, kill).await {
+                        return "consumer gone";
                     }
                 }
                 Wake::Lease(LeaseEvent::WelcomeMessages(batch)) => {
                     if !self.intake.absorb_batch(batch) {
-                        return;
+                        return "welcome intake ended";
                     }
                 }
                 Wake::Lease(LeaseEvent::CatchUpComplete) => {
@@ -1460,7 +1558,11 @@ where
             // inside the pipeline): it is the device-sync worker's, not the
             // subscriber's.
             Some(group) if !matches!(group.conversation_type, ConversationType::Sync) => {
-                send_or_kill(&self.tx, kill, Ok(group)).await.is_ok()
+                let sent = send_or_kill(&self.tx, kill, Ok(group)).await;
+                if sent.is_ok() {
+                    self.delivered += 1;
+                }
+                sent.is_ok()
             }
             _ => true,
         }


### PR DESCRIPTION
Phase G of the bidi integration plan, sized for trace-log consumption (per Andrew's ask): the wire, wave, and stream lifecycles now narrate themselves with structured fields. Stacked on #3855 (instruments the slimmed dedup); retarget to main after it lands.

## Transport (`bidi_transport.rs`)

- **Wire up/down**: `info!` on cold open and reopen (`reconnects`, `resumed_topics`, `reissued_waves`); the wire-died `warn!` now carries `leases`, `interrupted_waves`, and `retry_in_ms`.
- **Mutate latency**: every `PendingWave` is stamped at issue; its `CatchUpComplete` logs `elapsed_ms`, `topics`, `deferred_completions`, and `waves_left` at `debug!`.
- **Lease lifecycle**: `debug!` at registration (lease, wave, topics) and on receiver-dropped release; the wedged-drop `warn!` already existed.

## Router (`stream_router.rs`)

- **Stream end-of-life summary**: every message/conversation stream logs one `info!` at exit — `delivered`, `deduped`, `topics`, and a human `reason` ("lease ended (transport shutdown or backpressure drop)", "stream handle dropped", "consumer gone", …) — the dropped-streams signal.
- **Dedup hits**: counted per stream and visible per-frame at `trace!` (topic + cursor).
- **Subscribes and catch-ups**: `debug!` on stream creation (groups, depth) and on each lease's catch-up completion (topics, windows still open).

## Processing spans (`stream_router.rs`, `catch_up.rs`)

Per Andrew: how long does processing an envelope — or a batch — take.

- **`process_envelope` span** (`debug`, fields `topic` + `cursor`) wraps every `process_one` call on both the live router path and the catch-up replay path; the pipeline's existing `process_message` span nests inside it on the slow (decrypt/recovery-sync) path, so fast-path and recovery time are separable. Each envelope also emits an explicit `elapsed_ms` `trace!` at completion, so durations land in plain trace logs even where the subscriber doesn't emit span-close timings.
- **`process_welcome` span** (`debug`, field `kind` = welcome|group) wraps each spawned welcome/local-group task — the multi-second join-sync path — with the same `elapsed_ms` `trace!` at completion. Catch-up shares the router's `WelcomeIntake`, so this covers both.
- **Batch timing**: one `debug!` per delivered batch (`batch` size + `elapsed_ms`) on the router and catch-up paths.

Deliberately out of scope: a `subscribe_bidi` counter in `ApiStats` — its fields mirror into all three bindings' stat structs, and the wire-open `info!` gives the same signal in trace logs without that churn. Can follow up if the counter is wanted in `apiStatistics()`.

No behavior changes — counters, `Instant` stamps, spans, and log lines. Transport suite 48/48, `xmtp_mls` full suite green live, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AVuJ7VAgen2fFhtJQ6zid


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add trace-level observability for wire, wave, and stream lifecycle in `xmtp_api_d14n` and `xmtp_mls`
> - Adds `issued_at` to `PendingWave` in [bidi_transport.rs](https://github.com/xmtp/libxmtp/pull/3856/files#diff-d4217bbd27403da346b2451dab35cab51079f0ccb533baa2a2248a7fa3dbe458) to measure wave resolution latency; logs timing and topic/wave counts on `CatchUpComplete`.
> - Adds `wire_opens` counter to `LedgerTask`; emits structured info/warn logs on cold open, reconnect, and wire death with topic counts and reconnect stats.
> - Adds `delivered` and `deduped` counters to `MessageConsumer` and `delivered` to `WelcomeConsumer` in [stream_router.rs](https://github.com/xmtp/libxmtp/pull/3856/files#diff-f9a7fe85e5e034811e7a4454198333ec3adcdabd79c68f1c3a952279950de15c); logs end-of-life summaries with counts and termination reason.
> - Refactors `MessageConsumer.run` and `WelcomeConsumer.run` into `drive` methods that return structured termination reason strings for logging.
> - Instruments per-envelope and per-batch processing in [catch_up.rs](https://github.com/xmtp/libxmtp/pull/3856/files#diff-0f712bac68b7d394bd934c86f442148b513550fc9fd3df1d726880379c954003) and stream_router with `tracing` spans and elapsed_ms trace logs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd79ef1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->