### PR TITLE
feat(bindings): expose stream suspend/resume + catch_up_to_live to mobile FFI

### DIFF
--- a/bindings/mobile/src/lib.rs
+++ b/bindings/mobile/src/lib.rs
@@ -98,6 +98,9 @@ pub enum GenericError {
     Subscription(#[from] xmtp_mls::subscriptions::SubscribeError),
     #[error(transparent)]
     #[error_code(inherit)]
+    CatchUp(#[from] xmtp_mls::subscriptions::catch_up::CatchUpError),
+    #[error(transparent)]
+    #[error_code(inherit)]
     ApiClientBuild(#[from] xmtp_api_grpc::error::GrpcBuilderError),
     #[error(transparent)]
     #[error_code(inherit)]

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -192,6 +192,34 @@ pub async fn is_connected(api: Arc<XmtpApiClient>) -> bool {
     api.wrapper.api_client.is_connected().await
 }
 
+/// Take the streaming wire off the network — the "app entered background" half
+/// of the lifecycle pair. Kept subscriptions and their wire positions survive;
+/// nothing reconnects until [`resume_streams`]. A no-op when nothing is
+/// streaming (the bidi path is off, or no stream was ever opened), so it is
+/// always safe to call.
+///
+/// Process-scoped: one streaming wire is shared across every client in the
+/// process, so this is a free function, not a client method.
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn suspend_streams() -> Result<(), FfiError> {
+    xmtp_mls::subscriptions::router_callbacks::suspend_bidi_streams().await?;
+    Ok(())
+}
+
+/// Bring the streaming wire back after [`suspend_streams`] — the "app entered
+/// foreground" half. Fire-and-forget: do **not** await this to drive UI. It
+/// resolves at a wire-level mark (the reconnect's catch-up wave completing),
+/// which is unbounded while the network is down and can still have replayed
+/// messages decoding behind it; awaiting it for a "synced" spinner would stall.
+/// Let the message callbacks update the UI as messages arrive, and use
+/// [`FfiXmtpClient::catch_up_to_live`] when you need a bounded, awaitable
+/// "I am current now". A no-op when nothing is streaming.
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn resume_streams() -> Result<(), FfiError> {
+    xmtp_mls::subscriptions::router_callbacks::resume_bidi_streams().await?;
+    Ok(())
+}
+
 /**
  * Static Get the inbox state for each `inbox_id`.
  */
@@ -740,6 +768,36 @@ impl FfiXmtpClient {
         Ok(self.inner_client.close().await?)
     }
 
+    /// Bring the local store current with the server, then stop — for background
+    /// fetch and cold start, where a live stream would be wasted because the
+    /// process is about to be suspended. Pending welcomes are joined and every
+    /// conversation's missed messages are replayed from durable cursors and
+    /// persisted, then the wire closes.
+    ///
+    /// `timeout_ms` bounds the whole call (`None` = unbounded). On the deadline
+    /// the returned summary has `completed = false`; whatever was processed
+    /// first is already persisted and a later call resumes from durable state,
+    /// so cutting it short is always safe.
+    #[tracing::instrument(skip_all)]
+    pub async fn catch_up_to_live(
+        &self,
+        timeout_ms: Option<u64>,
+    ) -> Result<FfiCatchUpSummary, FfiError> {
+        let fut = self.inner_client.catch_up_to_live();
+        match timeout_ms {
+            None => Ok(fut.await?.into()),
+            Some(ms) => match tokio::time::timeout(std::time::Duration::from_millis(ms), fut).await
+            {
+                Ok(res) => Ok(res?.into()),
+                Err(_elapsed) => Ok(FfiCatchUpSummary {
+                    messages: 0,
+                    conversations: 0,
+                    completed: false,
+                }),
+            },
+        }
+    }
+
     #[tracing::instrument(skip_all)]
     pub async fn find_inbox_id(
         &self,
@@ -1150,6 +1208,31 @@ impl From<xmtp_mls::groups::welcome_sync::GroupSyncSummary> for FfiGroupSyncSumm
         Self {
             num_eligible: summary.num_eligible as u64,
             num_synced: summary.num_synced as u64,
+        }
+    }
+}
+
+/// Outcome of [`FfiXmtpClient::catch_up_to_live`].
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct FfiCatchUpSummary {
+    /// Application messages newly persisted by this call. Meaningful only when
+    /// `completed` is true; `0` on a deadline (the in-flight tally is dropped
+    /// with the cancelled future — the messages themselves are still stored).
+    pub messages: u64,
+    /// Conversations newly joined by this call. Same caveat as `messages`.
+    pub conversations: u64,
+    /// Whether catch-up finished before the deadline. `false` means `timeout_ms`
+    /// elapsed first; messages processed before then are persisted, and a later
+    /// call resumes from durable state.
+    pub completed: bool,
+}
+
+impl From<xmtp_mls::subscriptions::catch_up::CatchUpSummary> for FfiCatchUpSummary {
+    fn from(summary: xmtp_mls::subscriptions::catch_up::CatchUpSummary) -> Self {
+        Self {
+            messages: summary.messages,
+            conversations: summary.conversations,
+            completed: true,
         }
     }
 }

--- a/bindings/mobile/src/mls/tests/lifecycle.rs
+++ b/bindings/mobile/src/mls/tests/lifecycle.rs
@@ -1,0 +1,289 @@
+//! Tests for the app-backgrounding lifecycle surface: `suspend_streams` /
+//! `resume_streams` (the foreground/background pair) and
+//! `FfiXmtpClient::catch_up_to_live` (the bounded one-shot catch-up).
+//!
+//! The bidi path is gated on `XMTP_BIDI_STREAMS_ENABLED`, read once per process
+//! via a `LazyLock`. These tests set it at the top, before the first stream —
+//! which is why they must run under `nextest` (process-per-test), as
+//! `just test` does. The gate-off test deliberately leaves it unset.
+
+use super::*;
+use crate::mls::{resume_streams, suspend_streams};
+
+/// The Application-kind message payloads in a conversation's durable store, in
+/// order. Lets a test assert what catch-up/replay actually wrote to disk — the
+/// real bytes — rather than trusting a summary counter.
+async fn stored_app_payloads(convo: &FfiConversation) -> Vec<Vec<u8>> {
+    convo
+        .find_messages(FfiListMessagesOptions::default())
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|m| m.kind == FfiConversationMessageKind::Application)
+        .map(|m| m.content)
+        .collect()
+}
+
+/// Backgrounding round-trip: a kept lease survives `suspend_streams`, withholds
+/// everything published while the wire is off the network, and on
+/// `resume_streams` replays exactly that from its durable cursor.
+///
+/// v3-only. This exercises the *live* bidi wire — a `BidiTransport` over the v3
+/// `SubscribeEnvelopes` bidi RPC. The d14n gateway client does not expose that
+/// RPC, so under `--features d14n` the cold open is refused and the process
+/// latches onto the legacy streams (see the fallback latch in `router_callbacks`).
+/// `suspend`/`resume` only touch the bidi transport, so over legacy streams they
+/// are no-ops and cannot withhold — the withhold assertion below would rightly
+/// fail. The one-shot `catch_up_to_live` tests need no live wire, so they run on
+/// both backends.
+#[cfg_attr(
+    feature = "d14n",
+    ignore = "requires the v3 bidi wire, which the d14n backend does not expose (falls back to legacy streams, where suspend/resume are no-ops)"
+)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+async fn bidi_suspend_and_resume_redelivers() {
+    unsafe { std::env::set_var("XMTP_BIDI_STREAMS_ENABLED", "1") };
+
+    let alix = new_test_client().await;
+    let bo = new_test_client().await;
+
+    // bo owns the group handle; alix joins via its welcome and streams.
+    let bo_group = bo
+        .conversations()
+        .create_group_by_identity(
+            vec![alix.account_identifier.clone()],
+            FfiCreateGroupOptions::default(),
+        )
+        .await
+        .unwrap();
+    alix.inner_client.sync_welcomes().await.unwrap();
+
+    let cb = Arc::new(RustStreamCallback::default());
+    let stream = alix
+        .conversations()
+        .stream_all_messages(cb.clone(), None)
+        .await;
+    stream.wait_for_ready().await;
+
+    // Baseline: a live message is delivered over the bidi wire.
+    bo_group
+        .send(b"before".to_vec(), FfiSendMessageOpts::default())
+        .await
+        .unwrap();
+    cb.wait_for_delivery(Some(15)).await.unwrap();
+    assert_eq!(
+        cb.message_contents(),
+        vec![b"before".to_vec()],
+        "the live message is delivered before suspending"
+    );
+
+    // Background: take the shared wire off the network.
+    suspend_streams().await.unwrap();
+
+    // Published while suspended — must not reach the stream until resume.
+    bo_group
+        .send(b"during".to_vec(), FfiSendMessageOpts::default())
+        .await
+        .unwrap();
+
+    // Prove suspend actually withholds. Give the (now offline) wire a generous
+    // window to misbehave: were suspend a no-op, the live wire would deliver
+    // "during" here and this wait would return `Ok`, failing the test. A timeout
+    // (`Err`) is the pass — nothing arrived.
+    assert!(
+        cb.wait_for_delivery(Some(5)).await.is_err(),
+        "suspend must withhold delivery: nothing may arrive until resume"
+    );
+    assert_eq!(
+        cb.message_contents(),
+        vec![b"before".to_vec()],
+        "the message published while suspended must not have been delivered"
+    );
+
+    // Foreground: the kept lease reconnects and replays from its durable cursor.
+    resume_streams().await.unwrap();
+    cb.wait_for_delivery(Some(15)).await.unwrap();
+    assert_eq!(
+        cb.message_contents(),
+        vec![b"before".to_vec(), b"during".to_vec()],
+        "resume must redeliver exactly the withheld message, and only it, in order"
+    );
+
+    stream.end();
+}
+
+/// One-shot catch-up joins a pending group and replays its history from durable
+/// cursors, then stops — and a second call finds nothing owed (idempotent).
+#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+async fn bidi_catch_up_to_live_replays_and_is_idempotent() {
+    unsafe { std::env::set_var("XMTP_BIDI_STREAMS_ENABLED", "1") };
+
+    let alix = new_test_client().await;
+    let bo = new_test_client().await;
+
+    // bo creates a group with alix and sends. alix has never synced or streamed,
+    // so both the welcome and the message are owed.
+    let bo_group = bo
+        .conversations()
+        .create_group_by_identity(
+            vec![alix.account_identifier.clone()],
+            FfiCreateGroupOptions::default(),
+        )
+        .await
+        .unwrap();
+    bo_group
+        .send(b"missed while away".to_vec(), FfiSendMessageOpts::default())
+        .await
+        .unwrap();
+
+    let summary = alix.catch_up_to_live(None).await.unwrap();
+    assert!(summary.completed);
+    assert_eq!(
+        summary.conversations, 1,
+        "catch-up must join the one pending group"
+    );
+    assert!(
+        summary.messages >= 1,
+        "catch-up must replay the missed message"
+    );
+
+    let convos = alix
+        .conversations()
+        .list(FfiListConversationsOptions::default())
+        .unwrap();
+    assert_eq!(convos.len(), 1, "the group is now in alix's store");
+
+    // Catch-up wrote the real payload to disk, not just a counter: the missed
+    // text is readable with no further sync.
+    let payloads = stored_app_payloads(convos[0].conversation().as_ref()).await;
+    assert_eq!(
+        payloads,
+        vec![b"missed while away".to_vec()],
+        "the missed message is stored and readable after catch-up"
+    );
+
+    // Nothing owed now: idempotent — zero new on both axes.
+    let again = alix.catch_up_to_live(None).await.unwrap();
+    assert!(again.completed);
+    assert_eq!(
+        again.messages, 0,
+        "a second catch-up must not replay already-stored messages"
+    );
+    assert_eq!(
+        again.conversations, 0,
+        "a second catch-up must not rejoin the already-known group"
+    );
+}
+
+/// Cancellation safety: a deadline so short the run can be cut off mid-flight
+/// must leave no partial state. `tokio::time::timeout` DROPS the future on
+/// expiry, unwinding whatever `process_one`/welcome-join was in flight; a full
+/// run afterward must still converge the store from durable cursors, and a
+/// later call must find nothing owed. Convergence-after-cut is the assertion,
+/// so it holds whether or not the 1ms deadline actually fired.
+#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+async fn bidi_catch_up_to_live_bounded_run_is_cancel_safe() {
+    unsafe { std::env::set_var("XMTP_BIDI_STREAMS_ENABLED", "1") };
+
+    let alix = new_test_client().await;
+    let bo = new_test_client().await;
+
+    let bo_group = bo
+        .conversations()
+        .create_group_by_identity(
+            vec![alix.account_identifier.clone()],
+            FfiCreateGroupOptions::default(),
+        )
+        .await
+        .unwrap();
+    // Several messages so a 1ms deadline is likely to land mid-processing.
+    for i in 0..5 {
+        bo_group
+            .send(
+                format!("owed {i}").into_bytes(),
+                FfiSendMessageOpts::default(),
+            )
+            .await
+            .unwrap();
+    }
+
+    // May finish or be cut short — both are contractually valid. On the deadline
+    // the counts are zeroed (the in-flight tally is dropped with the future).
+    let bounded = alix.catch_up_to_live(Some(1)).await.unwrap();
+    if !bounded.completed {
+        assert_eq!(bounded.messages, 0);
+        assert_eq!(bounded.conversations, 0);
+    }
+
+    // Whether or not the bounded run was cut off, a full run converges the store
+    // from durable cursors — proving the cut left no partial/corrupt state.
+    let full = alix.catch_up_to_live(None).await.unwrap();
+    assert!(full.completed);
+    let convos = alix
+        .conversations()
+        .list(FfiListConversationsOptions::default())
+        .unwrap();
+    assert_eq!(convos.len(), 1, "the group converges regardless of the cut");
+
+    // Convergence means the whole history landed intact — all five owed messages,
+    // in order, with nothing dropped or duplicated by the cut-off run.
+    let payloads = stored_app_payloads(convos[0].conversation().as_ref()).await;
+    let expected: Vec<Vec<u8>> = (0..5).map(|i| format!("owed {i}").into_bytes()).collect();
+    assert_eq!(
+        payloads, expected,
+        "all five owed messages converge to the store, in order"
+    );
+
+    // And catch-up is now drained: nothing owed on either axis.
+    let again = alix.catch_up_to_live(None).await.unwrap();
+    assert!(again.completed);
+    assert_eq!(again.messages, 0);
+    assert_eq!(again.conversations, 0);
+}
+
+/// With the gate off, `suspend`/`resume` are safe no-ops and `catch_up_to_live`
+/// runs the legacy sync — still joining the pending group and reporting counts.
+/// (Its own process under nextest, so the gate is genuinely unset.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+async fn catch_up_to_live_falls_back_when_bidi_disabled() {
+    let alix = new_test_client().await;
+    let bo = new_test_client().await;
+
+    let bo_group = bo
+        .conversations()
+        .create_group_by_identity(
+            vec![alix.account_identifier.clone()],
+            FfiCreateGroupOptions::default(),
+        )
+        .await
+        .unwrap();
+    bo_group
+        .send(b"legacy path".to_vec(), FfiSendMessageOpts::default())
+        .await
+        .unwrap();
+
+    // Nothing is streaming, so these are no-ops regardless of the gate.
+    suspend_streams().await.unwrap();
+    resume_streams().await.unwrap();
+
+    let summary = alix.catch_up_to_live(None).await.unwrap();
+    assert!(summary.completed);
+    assert_eq!(
+        summary.conversations, 1,
+        "legacy catch-up must still join the one pending group"
+    );
+
+    let convos = alix
+        .conversations()
+        .list(FfiListConversationsOptions::default())
+        .unwrap();
+    assert_eq!(convos.len(), 1);
+
+    // The legacy sync path delivers the real payload too.
+    let payloads = stored_app_payloads(convos[0].conversation().as_ref()).await;
+    assert_eq!(
+        payloads,
+        vec![b"legacy path".to_vec()],
+        "legacy catch-up must store the missed message"
+    );
+}

--- a/bindings/mobile/src/mls/tests/mod.rs
+++ b/bindings/mobile/src/mls/tests/mod.rs
@@ -90,6 +90,7 @@ mod content_types;
 mod dms;
 mod group_management;
 mod identity;
+mod lifecycle;
 mod networking;
 mod static_methods;
 mod streaming;
@@ -125,6 +126,16 @@ impl Default for RustStreamCallback {
 impl RustStreamCallback {
     pub fn message_count(&self) -> u32 {
         self.num_messages.load(Ordering::SeqCst)
+    }
+
+    /// Raw payloads of the messages delivered to this callback, in arrival order.
+    /// Lets a test assert *what* the stream delivered, not just how many.
+    pub fn message_contents(&self) -> Vec<Vec<u8>> {
+        self.messages
+            .lock()
+            .iter()
+            .map(|m| m.content.clone())
+            .collect()
     }
 
     pub fn consent_updates_count(&self) -> usize {


### PR DESCRIPTION
## What

Exposes the app-backgrounding stream lifecycle + one-shot catch-up to the mobile FFI:

- **`suspendStreams()` / `resumeStreams()`** — process-global free functions that park/revive the shared streaming wire (the `didEnterBackground`/`willEnterForeground` pair). No-ops when nothing is streaming, so always safe to call.
- **`FfiXmtpClient.catchUpToLive(timeoutMs)`** → `FfiCatchUpSummary { messages, conversations, completed }` — a bounded one-shot catch-up for background fetch / cold start (opens its own connection, replays from durable cursors, then stops). `timeoutMs` bounds the whole run; on the deadline `completed = false` and the counts are zeroed (whatever was processed first is still persisted).
- **`GenericError::CatchUp`** for the new error path.

## Design notes

- suspend/resume are **free functions, not client methods** — one wire is shared across every client in the process, so hanging a process-global op off a per-client object would be a lie in a multi-client process.
- `resume` resolves at a wire-level mark and is unbounded offline — documented as fire-and-forget; `catchUpToLive` is the awaitable "I'm current now".

## Tests (against the local node)

- `bidi_suspend_and_resume_redelivers` — a kept lease survives `suspend`, replays the missed message on `resume`.
- `bidi_catch_up_to_live_replays_and_is_idempotent` — cold catch-up joins a pending group + replays history; a second run is a no-op.
- `bidi_catch_up_to_live_bounded_run_is_cancel_safe` — a 1ms bounded run followed by a full run converges the store, proving that dropping the future mid-flight leaves no partial state.
- `catch_up_to_live_falls_back_when_bidi_disabled` — gate off → legacy sync path.

The iOS and Android SDK PRs stack on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose stream suspend/resume and `catch_up_to_live` to mobile FFI
> - Adds `suspend_streams` and `resume_streams` free functions to the mobile FFI that pause and resume bidi streaming process-wide without losing subscription state.
> - Adds `catch_up_to_live` method on `FfiXmtpClient` that runs a catch-up sync, returning an `FfiCatchUpSummary` with message/conversation counts and a `completed` flag; accepts an optional timeout and returns `completed: false` with zeroed counts on expiry.
> - Adds `CatchUp` error variant to `GenericError` with automatic conversion from `xmtp_mls::subscriptions::catch_up::CatchUpError`.
> - Adds lifecycle integration tests covering suspend/resume redelivery, catch-up idempotency, bounded timeout semantics, and fallback behavior when bidi streaming is disabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e5fca1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->