### PR TITLE
feat(bindings): expose catch_up_to_live to node bindings

### DIFF
--- a/bindings/node/src/client/catch_up.rs
+++ b/bindings/node/src/client/catch_up.rs
@@ -1,0 +1,48 @@
+use crate::{ErrorWrapper, client::Client};
+use napi::bindgen_prelude::{BigInt, Result};
+use napi_derive::napi;
+
+/// Counts of what a single `catchUpToLive` run brought into the local store.
+#[napi(object)]
+pub struct CatchUpSummary {
+  /// Messages newly persisted during this run.
+  pub messages: BigInt,
+  /// Conversations newly joined during this run.
+  pub conversations: BigInt,
+}
+
+impl From<xmtp_mls::subscriptions::catch_up::CatchUpSummary> for CatchUpSummary {
+  fn from(summary: xmtp_mls::subscriptions::catch_up::CatchUpSummary) -> Self {
+    Self {
+      messages: BigInt::from(summary.messages),
+      conversations: BigInt::from(summary.conversations),
+    }
+  }
+}
+
+#[napi]
+impl Client {
+  /// Bring the local store current with the network, then stop — a bounded,
+  /// one-shot sync for agents that poll for new state rather than hold a live
+  /// stream.
+  ///
+  /// Idempotent: everything processed is persisted and catch-up does not
+  /// advance durable message cursors, so a later call resumes from durable
+  /// state and one with nothing owed reports zero.
+  ///
+  /// There is no caller deadline (unlike the mobile FFI, which faces OS
+  /// background budgets). The run is still internally bounded — capped retry
+  /// attempts with backoff, a short post-finish drain, and the wire watchdog —
+  /// so it cannot hang indefinitely on a healthy process. An agent that needs a
+  /// hard wall-clock bound can race this against its own timer.
+  #[napi]
+  #[xmtp_common::err_span]
+  pub async fn catch_up_to_live(&self) -> Result<CatchUpSummary> {
+    let summary = self
+      .inner_client
+      .catch_up_to_live()
+      .await
+      .map_err(ErrorWrapper::from)?;
+    Ok(summary.into())
+  }
+}

--- a/bindings/node/src/client/mod.rs
+++ b/bindings/node/src/client/mod.rs
@@ -10,6 +10,7 @@ use xmtp_mls::Client as MlsClient;
 use xmtp_mls::groups::MlsGroup;
 
 pub mod backend;
+mod catch_up;
 mod consent_state;
 pub mod create_client;
 pub(crate) mod gateway_auth;

--- a/bindings/node/test/CatchUp.test.ts
+++ b/bindings/node/test/CatchUp.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { createRegisteredClient, createUser } from '@test/helpers'
+import { IdentifierKind } from '../dist'
+
+describe('catchUpToLive', () => {
+  it('cold-catches a pending group and its history, then is idempotent', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    const client2 = await createRegisteredClient(user2)
+
+    // client1 creates a group with client2 and sends. client2 has never
+    // synced or streamed, so both the welcome and the message are owed.
+    const group = await client1.conversations().createGroupByIdentity([
+      {
+        identifier: user2.account.address,
+        identifierKind: IdentifierKind.Ethereum,
+      },
+    ])
+    await group.sendText('missed while away')
+
+    expect(client2.conversations().list().length).toBe(0)
+
+    const summary = await client2.catchUpToLive()
+    expect(Number(summary.conversations)).toBeGreaterThanOrEqual(1)
+    expect(Number(summary.messages)).toBeGreaterThanOrEqual(1)
+    expect(client2.conversations().list().length).toBe(1)
+
+    // Nothing owed now: a second run persists nothing new.
+    const again = await client2.catchUpToLive()
+    expect(Number(again.messages)).toBe(0)
+  })
+})


### PR DESCRIPTION
## What

Exposes **`Client.catchUpToLive()`** → `CatchUpSummary { messages, conversations }` to the node bindings, for agents that poll for new state rather than hold a live stream.

- No `timeoutMs` (unlike the mobile FFI — a node runtime isn't OS-budget-constrained). The run is still internally bounded (capped retries + backoff + post-finish drain + wire watchdog), so it can't hang indefinitely; an agent that needs a hard bound can race it against its own timer.
- suspend/resume are intentionally omitted — a node process isn't OS-backgrounded, so its wire has no reason to be parked. (Trivially addable later if an agent wants to pause its wire.)

## Test

`test/CatchUp.test.ts` — a cold catch-up joins a pending group + its history, then is idempotent. (Runs under `just node test` with a local node.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `catchUpToLive` method to Node.js bindings
> - Adds a new [catch_up.rs](https://github.com/xmtp/libxmtp/pull/3858/files#diff-198925006bbd750e405749e7d8a412c833be86bd77cbf8669b335593cd443473) module with an async `catchUpToLive()` N-API method on `Client` that calls the underlying `inner_client.catch_up_to_live()` and returns a `CatchUpSummary { messages: BigInt, conversations: BigInt }`.
> - Adds a [CatchUp.test.ts](https://github.com/xmtp/libxmtp/pull/3858/files#diff-87b728ea9949cdfa8ae68c798970fe55bb7adaa69b5d40c6807827314dbdeec9) vitest suite verifying that `catchUpToLive` returns non-zero counts on first run and zero on subsequent runs, confirming idempotency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 108cf40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->