### PR TITLE
feat(ios): auto-manage stream lifecycle across app backgrounding

### DIFF
--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -199,6 +199,16 @@ public final class Client {
 	/// ``createInMemory(account:options:)``. No file exists at this path.
 	public static let inMemoryDbPath = ":memory:"
 
+	/// Process-wide control for automatic stream-lifecycle management. When
+	/// `true` (the default), the first ``Client`` created registers app-lifecycle
+	/// observers that park the shared streaming wire while the app is
+	/// backgrounded and revive it on foreground. The streaming wire is shared
+	/// across every client in the process, so this is a **process-global**
+	/// setting, not per-client: set it to `false` **before creating your first
+	/// client** to opt out (e.g. in an app extension, or to manage the lifecycle
+	/// yourself). Has no effect on platforms without UIKit.
+	public static var manageStreamLifecycle = true
+
 	public let inboxID: InboxId
 	public let libXMTPVersion: String = getVersionInfo()
 	public let dbPath: String
@@ -304,6 +314,13 @@ public final class Client {
 			register(codec: codec)
 		}
 
+		// Keep the shared streaming wire in step with app foreground/background.
+		// Process-global and idempotent — the first managed client registers it
+		// for every client in the process.
+		if Client.manageStreamLifecycle {
+			StreamLifecycleManager.shared.enableIfNeeded()
+		}
+
 		return client
 	}
 
@@ -404,7 +421,7 @@ public final class Client {
 			inboxId: recoveredInboxId
 		)
 
-		return try Client(
+		let client = try Client(
 			ffiClient: ffiClient,
 			dbPath: dbPath,
 			installationID: ffiClient.installationId().toHex,
@@ -412,6 +429,10 @@ public final class Client {
 			environment: clientOptions.api.env,
 			publicIdentity: identity
 		)
+		if Client.manageStreamLifecycle {
+			StreamLifecycleManager.shared.enableIfNeeded()
+		}
+		return client
 	}
 
 	private static func initFFiClient(
@@ -928,6 +949,24 @@ public final class Client {
 	public func reconnectLocalDatabase() async throws {
 		guard !isInMemory else { return }
 		try await ffiClient.dbReconnect()
+	}
+
+	/// Bring the local store current with the network, then stop — for
+	/// background fetch and cold start, where holding a live stream is wasted
+	/// because the wire is about to go away.
+	///
+	/// Pass `timeoutMs` to bound the run against an OS background budget (a
+	/// `BGAppRefreshTask` window, an NSE budget); `nil` runs to the live edge.
+	/// Cutting it short is safe: everything processed is persisted and a later
+	/// call resumes from durable state.
+	///
+	/// Check ``CatchUpSummary/completed`` before reading the counts: on the
+	/// deadline path it is `false` and `messages`/`conversations` are reported
+	/// as `0` even though whatever was processed first is already persisted.
+	public func catchUpToLive(timeoutMs: UInt64? = nil) async throws
+		-> CatchUpSummary
+	{
+		try await CatchUpSummary(ffiClient.catchUpToLive(timeoutMs: timeoutMs))
 	}
 
 	public func inboxIdFromIdentity(identity: PublicIdentity) async throws

--- a/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -5229,6 +5229,20 @@ public protocol FfiXmtpClientProtocol: AnyObject, Sendable {
     func canMessage(accountIdentifiers: [FfiIdentifier]) async throws  -> [FfiIdentifier: Bool]
     
     /**
+     * Bring the local store current with the server, then stop — for background
+     * fetch and cold start, where a live stream would be wasted because the
+     * process is about to be suspended. Pending welcomes are joined and every
+     * conversation's missed messages are replayed from durable cursors and
+     * persisted, then the wire closes.
+     *
+     * `timeout_ms` bounds the whole call (`None` = unbounded). On the deadline
+     * the returned summary has `completed = false`; whatever was processed
+     * first is already persisted and a later call resumes from durable state,
+     * so cutting it short is always safe.
+     */
+    func catchUpToLive(timeoutMs: UInt64?) async throws  -> FfiCatchUpSummary
+    
+    /**
      * * Change the recovery identifier for your inboxId
      */
     func changeRecoveryIdentifier(newRecoveryIdentifier: FfiIdentifier) async throws  -> FfiSignatureRequest
@@ -5535,6 +5549,35 @@ open func canMessage(accountIdentifiers: [FfiIdentifier])async throws  -> [FfiId
             completeFunc: ffi_xmtpv3_rust_future_complete_rust_buffer,
             freeFunc: ffi_xmtpv3_rust_future_free_rust_buffer,
             liftFunc: FfiConverterDictionaryTypeFfiIdentifierBool.lift,
+            errorHandler: FfiConverterTypeFfiError_lift
+        )
+}
+    
+    /**
+     * Bring the local store current with the server, then stop — for background
+     * fetch and cold start, where a live stream would be wasted because the
+     * process is about to be suspended. Pending welcomes are joined and every
+     * conversation's missed messages are replayed from durable cursors and
+     * persisted, then the wire closes.
+     *
+     * `timeout_ms` bounds the whole call (`None` = unbounded). On the deadline
+     * the returned summary has `completed = false`; whatever was processed
+     * first is already persisted and a later call resumes from durable state,
+     * so cutting it short is always safe.
+     */
+open func catchUpToLive(timeoutMs: UInt64?)async throws  -> FfiCatchUpSummary  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_method_ffixmtpclient_catch_up_to_live(
+                    self.uniffiCloneHandle(),
+                    FfiConverterOptionUInt64.lower(timeoutMs)
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_rust_buffer,
+            completeFunc: ffi_xmtpv3_rust_future_complete_rust_buffer,
+            freeFunc: ffi_xmtpv3_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeFfiCatchUpSummary_lift,
             errorHandler: FfiConverterTypeFfiError_lift
         )
 }
@@ -6836,6 +6879,93 @@ public func FfiConverterTypeFfiBackupMetadata_lift(_ buf: RustBuffer) throws -> 
 #endif
 public func FfiConverterTypeFfiBackupMetadata_lower(_ value: FfiBackupMetadata) -> RustBuffer {
     return FfiConverterTypeFfiBackupMetadata.lower(value)
+}
+
+
+/**
+ * Outcome of [`FfiXmtpClient::catch_up_to_live`].
+ */
+public struct FfiCatchUpSummary: Equatable, Hashable {
+    /**
+     * Application messages newly persisted by this call. Meaningful only when
+     * `completed` is true; `0` on a deadline (the in-flight tally is dropped
+     * with the cancelled future — the messages themselves are still stored).
+     */
+    public var messages: UInt64
+    /**
+     * Conversations newly joined by this call. Same caveat as `messages`.
+     */
+    public var conversations: UInt64
+    /**
+     * Whether catch-up finished before the deadline. `false` means `timeout_ms`
+     * elapsed first; messages processed before then are persisted, and a later
+     * call resumes from durable state.
+     */
+    public var completed: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Application messages newly persisted by this call. Meaningful only when
+         * `completed` is true; `0` on a deadline (the in-flight tally is dropped
+         * with the cancelled future — the messages themselves are still stored).
+         */messages: UInt64, 
+        /**
+         * Conversations newly joined by this call. Same caveat as `messages`.
+         */conversations: UInt64, 
+        /**
+         * Whether catch-up finished before the deadline. `false` means `timeout_ms`
+         * elapsed first; messages processed before then are persisted, and a later
+         * call resumes from durable state.
+         */completed: Bool) {
+        self.messages = messages
+        self.conversations = conversations
+        self.completed = completed
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension FfiCatchUpSummary: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiCatchUpSummary: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiCatchUpSummary {
+        return
+            try FfiCatchUpSummary(
+                messages: FfiConverterUInt64.read(from: &buf), 
+                conversations: FfiConverterUInt64.read(from: &buf), 
+                completed: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiCatchUpSummary, into buf: inout [UInt8]) {
+        FfiConverterUInt64.write(value.messages, into: &buf)
+        FfiConverterUInt64.write(value.conversations, into: &buf)
+        FfiConverterBool.write(value.completed, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiCatchUpSummary_lift(_ buf: RustBuffer) throws -> FfiCatchUpSummary {
+    return try FfiConverterTypeFfiCatchUpSummary.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiCatchUpSummary_lower(_ value: FfiCatchUpSummary) -> RustBuffer {
+    return FfiConverterTypeFfiCatchUpSummary.lower(value)
 }
 
 
@@ -16398,6 +16528,30 @@ public func isConnected(api: XmtpApiClient)async  -> Bool  {
         )
 }
 /**
+ * Bring the streaming wire back after [`suspend_streams`] — the "app entered
+ * foreground" half. Fire-and-forget: do **not** await this to drive UI. It
+ * resolves at a wire-level mark (the reconnect's catch-up wave completing),
+ * which is unbounded while the network is down and can still have replayed
+ * messages decoding behind it; awaiting it for a "synced" spinner would stall.
+ * Let the message callbacks update the UI as messages arrive, and use
+ * [`FfiXmtpClient::catch_up_to_live`] when you need a bounded, awaitable
+ * "I am current now". A no-op when nothing is streaming.
+ */
+public func resumeStreams()async throws   {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_func_resume_streams(
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_void,
+            completeFunc: ffi_xmtpv3_rust_future_complete_void,
+            freeFunc: ffi_xmtpv3_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeFfiError_lift
+        )
+}
+/**
  * * Static revoke a list of installations
  */
 public func revokeInstallations(api: XmtpApiClient, recoveryIdentifier: FfiIdentifier, inboxId: String, installationIds: [Data])throws  -> FfiSignatureRequest  {
@@ -16409,6 +16563,30 @@ public func revokeInstallations(api: XmtpApiClient, recoveryIdentifier: FfiIdent
         FfiConverterSequenceData.lower(installationIds),$0
     )
 })
+}
+/**
+ * Take the streaming wire off the network — the "app entered background" half
+ * of the lifecycle pair. Kept subscriptions and their wire positions survive;
+ * nothing reconnects until [`resume_streams`]. A no-op when nothing is
+ * streaming (the bidi path is off, or no stream was ever opened), so it is
+ * always safe to call.
+ *
+ * Process-scoped: one streaming wire is shared across every client in the
+ * process, so this is a free function, not a client method.
+ */
+public func suspendStreams()async throws   {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_func_suspend_streams(
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_void,
+            completeFunc: ffi_xmtpv3_rust_future_complete_void,
+            freeFunc: ffi_xmtpv3_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeFfiError_lift
+        )
 }
 
 private enum InitializationResult {
@@ -16564,7 +16742,13 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_func_is_connected() != 54619) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_xmtpv3_checksum_func_resume_streams() != 3712) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xmtpv3_checksum_func_revoke_installations() != 46055) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_func_suspend_streams() != 58173) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffiinboxowner_get_identifier() != 59650) {
@@ -16973,6 +17157,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_can_message() != 35116) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_method_ffixmtpclient_catch_up_to_live() != 12917) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_change_recovery_identifier() != 49256) {

--- a/sdks/ios/Sources/XMTPiOS/StreamLifecycle.swift
+++ b/sdks/ios/Sources/XMTPiOS/StreamLifecycle.swift
@@ -1,0 +1,170 @@
+import Foundation
+import os
+
+#if canImport(UIKit)
+	import UIKit
+#endif
+
+/// Counts of what a ``Client/catchUpToLive(timeoutMs:)`` run brought into the
+/// local store, plus whether it reached the live edge.
+public struct CatchUpSummary: Sendable {
+	/// Messages newly persisted during this run.
+	public let messages: UInt64
+	/// Conversations newly joined during this run.
+	public let conversations: UInt64
+	/// `true` if catch-up reached the live edge; `false` if a `timeoutMs`
+	/// deadline cut it short. Partial progress is persisted either way.
+	public let completed: Bool
+
+	init(_ ffi: FfiCatchUpSummary) {
+		messages = ffi.messages
+		conversations = ffi.conversations
+		completed = ffi.completed
+	}
+}
+
+/// Keeps the process-shared streaming wire in step with app foreground /
+/// background.
+///
+/// The streaming transport is shared across every ``Client`` in the process, so
+/// suspend/resume are process-global, not per-client. This is registered **once
+/// per process** and never torn down — it lives for the process and captures no
+/// client state, which is why there's no matching deregistration hook to get
+/// wrong.
+///
+/// Two design points worth stating, because both are easy to get wrong:
+///
+/// - **Scenes are already aggregated.** We observe the `UIApplication`-level
+///   notifications, which UIKit posts only at the app boundary:
+///   `didEnterBackground` fires when the *last* scene backgrounds, and
+///   `willEnterForeground` when the *first* scene foregrounds. So there is no
+///   per-scene counting to do here — UIKit has done it. (Per-scene control
+///   would mean observing `UIScene.*` and counting; we deliberately don't.)
+///
+/// - **Transitions are reconciled, not fired.** Each notification only records
+///   the desired state; a single serial reconciler drives the wire toward it,
+///   one operation at a time. `resumeStreams()` is unbounded while offline and
+///   uniffi does not propagate task cancellation, so a naive
+///   `Task { await resume }` / `Task { await suspend }` per notification could
+///   complete out of order and strand the wire live-while-backgrounded. The
+///   reconciler instead re-checks the desired state after every applied op and
+///   issues a correcting op if it changed, converging to the last intent.
+///
+/// **Known limitation — background launch.** State is seeded to foreground and
+/// only reacts to *transitions*; a process launched straight into the
+/// background (silent push / `BGTask`) fires no `didEnterBackground`, so if it
+/// opens live streams and never foregrounds, the wire can stay live in the
+/// background. We can't seed from `UIApplication.shared.applicationState`
+/// without breaking app-extension builds (`.shared` is extension-unavailable).
+/// Backgrounds that only catch up — the normal pattern — are unaffected, since
+/// ``Client/catchUpToLive(timeoutMs:)`` uses its own connection, not this wire.
+/// The complete fix is for the shared transport to honor a suspend requested
+/// before it is first opened (a libxmtp follow-on).
+final class StreamLifecycleManager: @unchecked Sendable {
+	static let shared = StreamLifecycleManager()
+
+	private let lock = NSLock()
+	private var isRegistered = false
+	/// What app lifecycle wants the wire to be. Starts foreground.
+	private var desiredLive = true
+	/// What we last drove the wire to. Streams open live at client creation.
+	private var appliedLive = true
+	/// Whether a reconciler task is currently draining toward `desiredLive`.
+	private var isReconciling = false
+
+	private init() {}
+
+	func enableIfNeeded() {
+		#if canImport(UIKit)
+			lock.lock()
+			defer { lock.unlock() }
+			guard !isRegistered else { return }
+			isRegistered = true
+
+			let center = NotificationCenter.default
+			// Tokens intentionally discarded: these observers live for the
+			// process and capture only this singleton.
+			_ = center.addObserver(
+				forName: UIApplication.didEnterBackgroundNotification,
+				object: nil, queue: .main
+			) { [weak self] _ in
+				self?.setDesired(live: false)
+			}
+			_ = center.addObserver(
+				forName: UIApplication.willEnterForegroundNotification,
+				object: nil, queue: .main
+			) { [weak self] _ in
+				self?.setDesired(live: true)
+			}
+		#endif
+	}
+
+	private func setDesired(live: Bool) {
+		lock.lock()
+		desiredLive = live
+		let shouldStart = !isReconciling && appliedLive != desiredLive
+		if shouldStart { isReconciling = true }
+		lock.unlock()
+
+		if shouldStart {
+			Task { await reconcile() }
+		}
+	}
+
+	/// Drives the wire toward `desiredLive`, one op at a time, until they agree.
+	/// Applying an op is async and may be slow (`resumeStreams` blocks while
+	/// offline); the loop re-reads `desiredLive` afterward so a flip mid-op is
+	/// corrected rather than lost. The lock is only touched by the synchronous
+	/// helpers — never held across an `await`.
+	///
+	/// A failed op does *not* advance `appliedLive`: recording a transition that
+	/// never happened would leave the wire stuck in the wrong state with no retry.
+	/// Instead the reconciler stops and leaves `appliedLive` misaligned, so the
+	/// next foreground/background transition re-runs the op it was owed.
+	private func reconcile() async {
+		while let target = nextTarget() {
+			do {
+				if target {
+					try await resumeStreams()
+				} else {
+					try await suspendStreams()
+				}
+			} catch {
+				os_log(
+					"Stream %{public}@ failed; retrying on the next lifecycle transition: %{public}@",
+					log: OSLog.default, type: .error,
+					target ? "resume" : "suspend", error.localizedDescription
+				)
+				stopReconciling()
+				return
+			}
+			markApplied(target)
+		}
+	}
+
+	/// The next state to apply, or `nil` when the wire already matches intent
+	/// (clearing the reconciling flag so the next transition restarts the loop).
+	private func nextTarget() -> Bool? {
+		lock.lock()
+		defer { lock.unlock() }
+		guard desiredLive != appliedLive else {
+			isReconciling = false
+			return nil
+		}
+		return desiredLive
+	}
+
+	private func markApplied(_ live: Bool) {
+		lock.lock()
+		defer { lock.unlock() }
+		appliedLive = live
+	}
+
+	/// Clears the reconciling flag without advancing `appliedLive`, so a later
+	/// transition restarts the loop and retries the op that failed.
+	private func stopReconciling() {
+		lock.lock()
+		defer { lock.unlock() }
+		isReconciling = false
+	}
+}

--- a/sdks/ios/Tests/XMTPTests/StreamLifecycleTests.swift
+++ b/sdks/ios/Tests/XMTPTests/StreamLifecycleTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import XMTPiOS
+import XMTPTestHelpers
+
+@available(iOS 16, *)
+class StreamLifecycleTests: XCTestCase {
+	override func setUp() {
+		super.setUp()
+		setupLocalEnv()
+	}
+
+	/// One-shot catch-up joins a pending group and replays its history from
+	/// durable cursors, then stops — and a second call finds nothing owed.
+	func testCatchUpToLiveColdCatchesPendingGroupAndIsIdempotent() async throws {
+		let fixtures = try await fixtures()
+
+		// bo creates a group with alix and sends. alix has never synced, so both
+		// the welcome and the message are owed.
+		let boGroup = try await fixtures.boClient.conversations.newGroup(
+			with: [fixtures.alixClient.inboxID]
+		)
+		_ = try await boGroup.send(content: "missed while away")
+
+		let before = try await fixtures.alixClient.conversations.listGroups()
+		XCTAssertEqual(before.count, 0)
+
+		let summary = try await fixtures.alixClient.catchUpToLive()
+		XCTAssertTrue(summary.completed)
+		XCTAssertEqual(summary.conversations, 1)
+		XCTAssertGreaterThanOrEqual(summary.messages, 1)
+
+		let groups = try await fixtures.alixClient.conversations.listGroups()
+		XCTAssertEqual(groups.count, 1)
+
+		// Catch-up delivered the real payload to the local store, not just a
+		// counter: the missed text is readable with no further sync.
+		let texts: [String] = try await groups[0].messages().compactMap {
+			try? $0.content()
+		}
+		XCTAssertTrue(
+			texts.contains("missed while away"),
+			"the missed message must be stored and readable after catch-up"
+		)
+
+		// Nothing owed now: a second run persists nothing new on either axis.
+		let again = try await fixtures.alixClient.catchUpToLive()
+		XCTAssertEqual(again.messages, 0)
+		XCTAssertEqual(again.conversations, 0)
+
+		try fixtures.cleanUpDatabases()
+	}
+
+	/// Backgrounding auto-management is a process-global toggle, on by default.
+	func testManageStreamLifecycleDefaultsOn() {
+		XCTAssertTrue(Client.manageStreamLifecycle)
+	}
+}


### PR DESCRIPTION
> **Stacked on #3857** (mobile FFI). Review/merge that first; base is `tyler/ffi-stream-lifecycle`.

## What

Adds app-backgrounding stream lifecycle to the iOS SDK:

- **`Client.catchUpToLive(timeoutMs:)`** → `CatchUpSummary` passthrough. Branch on `completed` before reading counts (0 on the deadline path).
- **Auto-registered lifecycle management** — the first `Client` registers `NotificationCenter` observers that park the shared wire on `didEnterBackground` and revive it on `willEnterForeground`. Apps get correct backgrounding for free.
- **`Client.manageStreamLifecycle`** — a **process-global** toggle (default on; set `false` before creating your first client to opt out). Process-global, not per-client, because the streaming wire is shared across every client in the process.
- Regenerated `xmtpv3.swift`.

## Design notes

- **Reconciled, not fired.** Each notification only records desired state; a single serial reconciler drives the wire one op at a time, converging to the last intent. A naive `Task { await suspend/resume }` per notification could complete out of order and strand the wire live-while-backgrounded (uniffi doesn't propagate task cancellation).
- **Scenes are already aggregated** — we observe app-level `UIApplication` notifications (UIKit posts them only at the app boundary: last scene out / first scene in), so there's no per-scene counting.
- **Extension-safe** — only notification-name statics, never `UIApplication.shared`.

## Known limitation (documented; transport follow-on)

A process launched straight into the background that opens *live* streams before any foreground can sit live-while-backgrounded — iOS can't detect background-launch without the extension-unavailable `UIApplication.shared`. The complete fix is a small transport change (honor a suspend requested before the transport is first opened). Backgrounds that only catch up (the normal pattern) are unaffected, since `catchUpToLive` uses its own connection.

## Tests (local node)

`catchUpToLive` cold round-trip + `manageStreamLifecycle` default. `swift build` and tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-manage stream lifecycle across app backgrounding in the iOS SDK
> - Adds [`StreamLifecycleManager`](https://github.com/xmtp/libxmtp/pull/3859/files#diff-5c9b42f47cc560e374ebdd786bb372e6fb42374c87a7f32c034d34002027172b), a process-scoped singleton that observes UIKit foreground/background notifications and calls `suspendStreams()`/`resumeStreams()` on the shared FFI streaming wire.
> - Registers the manager automatically on first `Client` creation when the new `Client.manageStreamLifecycle` flag is `true` (default).
> - Adds `Client.catchUpToLive(timeoutMs:)` to sync the local store with the network after a gap, returning a `CatchUpSummary` with message and conversation counts.
> - Adds `suspendStreams()` and `resumeStreams()` free functions and `FfiCatchUpSummary` to the generated FFI bindings in [`xmtpv3.swift`](https://github.com/xmtp/libxmtp/pull/3859/files#diff-a700aa043faadbfda772fbdb5bb89d90475d4da4e02fe6a77691d111cd6d85bb).
> - Behavioral Change: existing apps using the iOS SDK will now have stream suspension on backgrounding enabled by default; set `Client.manageStreamLifecycle = false` to opt out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 527b9bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->