### PR TITLE
feat(android): auto-manage stream lifecycle across app backgrounding

### DIFF
--- a/sdks/android/library/build.gradle
+++ b/sdks/android/library/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.62.2'
     implementation 'io.grpc:grpc-protobuf-lite:1.62.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0'
+    implementation 'androidx.lifecycle:lifecycle-process:2.7.0'
     implementation 'org.web3j:crypto:4.9.4'
     implementation "net.java.dev.jna:jna:5.17.0@aar"
     api 'com.google.protobuf:protobuf-kotlin-lite:3.22.3'

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/StreamLifecycleTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/StreamLifecycleTest.kt
@@ -1,0 +1,61 @@
+package org.xmtp.android.library
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StreamLifecycleTest {
+    /**
+     * One-shot catch-up joins a pending group and replays its history from
+     * durable cursors, then stops — and a second call finds nothing owed.
+     */
+    @Test
+    fun testCatchUpToLiveColdCatchesPendingGroupAndIsIdempotent() {
+        val fixtures = fixtures()
+        runBlocking {
+            // bo creates a group with alix and sends. alix has never synced, so
+            // both the welcome and the message are owed.
+            val boGroup =
+                fixtures.boClient.conversations.newGroup(listOf(fixtures.alixClient.inboxId))
+            boGroup.send("missed while away")
+
+            assertEquals(
+                0,
+                fixtures.alixClient.conversations
+                    .listGroups()
+                    .size,
+            )
+
+            val summary = fixtures.alixClient.catchUpToLive()
+            assertTrue(summary.completed)
+            assertEquals(1L, summary.conversations)
+            assertTrue(summary.messages >= 1)
+
+            val groups = fixtures.alixClient.conversations.listGroups()
+            assertEquals(1, groups.size)
+
+            // Catch-up delivered the real payload to the local store, not just a
+            // counter: the missed text is readable with no further sync.
+            val texts = groups.first().messages().map { it.body }
+            assertTrue(
+                "the missed message must be stored and readable after catch-up",
+                texts.contains("missed while away"),
+            )
+
+            // Nothing owed now: a second run persists nothing new on either axis.
+            val again = fixtures.alixClient.catchUpToLive()
+            assertEquals(0L, again.messages)
+            assertEquals(0L, again.conversations)
+        }
+    }
+
+    /** Backgrounding auto-management is a process-global toggle, on by default. */
+    @Test
+    fun testManageStreamLifecycleDefaultsOn() {
+        assertTrue(Client.manageStreamLifecycle)
+    }
+}

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -152,6 +152,19 @@ class Client(
         private const val TAG = "Client"
 
         /**
+         * Process-wide control for automatic stream-lifecycle management. When
+         * true (the default), the first [Client] created registers a
+         * [androidx.lifecycle.ProcessLifecycleOwner] observer that parks the
+         * shared streaming wire while the app is backgrounded and revives it on
+         * foreground. The streaming wire is shared across every client in the
+         * process, so this is a **process-global** setting, not per-client: set
+         * it to false **before creating your first client** to opt out (e.g. to
+         * manage the lifecycle yourself).
+         */
+        @JvmStatic
+        var manageStreamLifecycle: Boolean = true
+
+        /**
          * Sentinel value assigned to [Client.dbPath] when the client was created
          * via [createInMemory]. No file exists at this path.
          */
@@ -461,14 +474,24 @@ class Client(
                     )
                 }
 
-                Client(
-                    ffiClient,
-                    dbPath,
-                    ffiClient.installationId().toHex(),
-                    ffiClient.inboxId(),
-                    clientOptions.api.env,
-                    publicIdentity,
-                )
+                val client =
+                    Client(
+                        ffiClient,
+                        dbPath,
+                        ffiClient.installationId().toHex(),
+                        ffiClient.inboxId(),
+                        clientOptions.api.env,
+                        publicIdentity,
+                    )
+
+                // Keep the shared streaming wire in step with app
+                // foreground/background. Process-global and idempotent — the
+                // first managed client registers it for every client.
+                if (manageStreamLifecycle) {
+                    StreamLifecycleManager.enableIfNeeded()
+                }
+
+                client
             }
 
         // Function to create a client with a signing key
@@ -661,14 +684,19 @@ class Client(
                         clientOptions,
                         clientOptions.appContext,
                     )
-                Client(
-                    ffiClient,
-                    dbPath,
-                    ffiClient.installationId().toHex(),
-                    ffiClient.inboxId(),
-                    clientOptions.api.env,
-                    publicIdentity,
-                )
+                val client =
+                    Client(
+                        ffiClient,
+                        dbPath,
+                        ffiClient.installationId().toHex(),
+                        ffiClient.inboxId(),
+                        clientOptions.api.env,
+                        publicIdentity,
+                    )
+                if (manageStreamLifecycle) {
+                    StreamLifecycleManager.enableIfNeeded()
+                }
+                client
             }
     }
 
@@ -774,6 +802,26 @@ class Client(
         withContext(Dispatchers.IO) {
             if (isInMemory) return@withContext
             ffiClient.dbReconnect()
+        }
+
+    /**
+     * Bring the local store current with the network, then stop — for background
+     * fetch and cold start, where holding a live stream is wasted because the
+     * wire is about to go away.
+     *
+     * Pass [timeoutMs] to bound the run against a background budget (a
+     * WorkManager job, an FCM handler); null runs to the live edge. A negative
+     * value is treated as 0 (return immediately). Cutting it short is safe:
+     * everything processed is persisted and a later call resumes from durable
+     * state.
+     *
+     * Check [CatchUpSummary.completed] before reading the counts: on the
+     * deadline path it is false and messages/conversations are reported as 0
+     * even though whatever was processed first is already persisted.
+     */
+    suspend fun catchUpToLive(timeoutMs: Long? = null): CatchUpSummary =
+        withContext(Dispatchers.IO) {
+            CatchUpSummary(ffiClient.catchUpToLive(timeoutMs?.coerceAtLeast(0)?.toULong()))
         }
 
     suspend fun inboxStatesForInboxIds(

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/StreamLifecycle.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/StreamLifecycle.kt
@@ -1,0 +1,154 @@
+package org.xmtp.android.library
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import uniffi.xmtpv3.FfiCatchUpSummary
+import uniffi.xmtpv3.resumeStreams
+import uniffi.xmtpv3.suspendStreams
+
+/**
+ * Counts of what a [Client.catchUpToLive] run brought into the local store, plus
+ * whether it reached the live edge.
+ */
+data class CatchUpSummary(
+    val messages: Long,
+    val conversations: Long,
+    val completed: Boolean,
+) {
+    internal constructor(ffi: FfiCatchUpSummary) : this(
+        messages = ffi.messages.toLong(),
+        conversations = ffi.conversations.toLong(),
+        completed = ffi.completed,
+    )
+}
+
+/**
+ * Keeps the process-shared streaming wire in step with app foreground/background.
+ *
+ * The streaming transport is shared across every [Client] in the process, so
+ * suspend/resume are process-global, not per-client. This is registered once per
+ * process via [ProcessLifecycleOwner] and never torn down — it lives for the
+ * process and holds no client state, which is why there's no deregistration hook
+ * to get wrong.
+ *
+ * Two design points, because both are easy to get wrong:
+ *
+ * - **Activities are already aggregated.** [ProcessLifecycleOwner] emits `ON_START`
+ *   when the *first* activity starts and `ON_STOP` when the *last* one stops, so
+ *   there is no per-activity counting to do here — androidx has done it.
+ *
+ * - **Transitions are reconciled, not fired.** Each callback only records the
+ *   desired state; a single serial loop drives the wire toward it one op at a
+ *   time, re-checking after each. `resumeStreams()` is unbounded while offline,
+ *   so a naive launch-per-callback could complete out of order and strand the
+ *   wire live-while-backgrounded; the loop instead converges to the last intent.
+ *
+ * **Known limitation — background launch.** Registration seeds the desired state
+ * from [ProcessLifecycleOwner]'s current state, so a process created in the
+ * background starts suspended. But a stream opened *after* that while still
+ * backgrounded opens a fresh live wire the model can't see (no lifecycle
+ * transition fires), so it can sit live-while-backgrounded until the next
+ * foreground/background cycle. Backgrounds that only catch up — the normal
+ * pattern — are unaffected, since [Client.catchUpToLive] uses its own
+ * connection, not this wire. The complete fix is for the shared transport to
+ * honor a suspend requested before it is first opened (a libxmtp follow-on).
+ */
+internal object StreamLifecycleManager {
+    private val lock = Any()
+    private var registered = false
+
+    // What app lifecycle wants the wire to be. Starts foreground.
+    private var desiredLive = true
+
+    // What we last drove the wire to. Streams open live at client creation.
+    private var appliedLive = true
+
+    // Whether a reconciler coroutine is currently draining toward desiredLive.
+    private var reconciling = false
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun enableIfNeeded() {
+        synchronized(lock) {
+            if (registered) return
+            registered = true
+        }
+        // ProcessLifecycleOwner.addObserver must be called on the main thread;
+        // client creation runs on Dispatchers.IO, so hop.
+        Handler(Looper.getMainLooper()).post {
+            val lifecycle = ProcessLifecycleOwner.get().lifecycle
+            lifecycle.addObserver(
+                object : DefaultLifecycleObserver {
+                    override fun onStart(owner: LifecycleOwner) = setDesired(true)
+
+                    override fun onStop(owner: LifecycleOwner) = setDesired(false)
+                },
+            )
+            // A process launched straight into the background (a service or
+            // receiver start, a WorkManager job) sits at CREATED and gets no
+            // onStop, so seed the backgrounded case explicitly — foreground is
+            // already the default. (Streams opened *after* this while still
+            // backgrounded aren't covered; see the class doc.)
+            if (!lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                setDesired(false)
+            }
+        }
+    }
+
+    private fun setDesired(live: Boolean) {
+        val shouldStart: Boolean
+        synchronized(lock) {
+            desiredLive = live
+            shouldStart = !reconciling && appliedLive != desiredLive
+            if (shouldStart) reconciling = true
+        }
+        if (shouldStart) scope.launch { reconcile() }
+    }
+
+    /**
+     * Drives the wire toward [desiredLive], one op at a time, until they agree.
+     * The lock is only held for the synchronous state reads/writes, never across
+     * the suspending op.
+     *
+     * A failed op does *not* advance [appliedLive]: recording a transition that
+     * never happened would leave the wire stuck in the wrong state with no retry.
+     * Instead the reconciler stops and leaves [appliedLive] misaligned, so the
+     * next foreground/background transition re-runs the op it was owed.
+     */
+    private suspend fun reconcile() {
+        while (true) {
+            val target =
+                synchronized(lock) {
+                    if (desiredLive == appliedLive) {
+                        reconciling = false
+                        return
+                    }
+                    desiredLive
+                }
+            val result =
+                runCatching {
+                    if (target) resumeStreams() else suspendStreams()
+                }
+            if (result.isFailure) {
+                Log.w(
+                    "XMTP",
+                    "Stream ${if (target) "resume" else "suspend"} failed; " +
+                        "retrying on the next lifecycle transition",
+                    result.exceptionOrNull(),
+                )
+                synchronized(lock) { reconciling = false }
+                return
+            }
+            synchronized(lock) { appliedLive = target }
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked on #3857** (mobile FFI). Review/merge that first; base is `tyler/ffi-stream-lifecycle`.

## What

Adds app-backgrounding stream lifecycle to the Android SDK:

- **`Client.catchUpToLive(timeoutMs)`** → `CatchUpSummary` passthrough. Branch on `completed` before reading counts. A negative `timeoutMs` is clamped to 0 (return now), not treated as unbounded.
- **Auto-registered lifecycle management** — the first `Client` registers a `ProcessLifecycleOwner` observer that parks the shared wire on `ON_STOP` and revives it on `ON_START`. Apps get correct backgrounding for free.
- **`Client.manageStreamLifecycle`** — a **process-global** toggle (default on; set `false` before creating your first client to opt out). Process-global, not per-client, because the streaming wire is shared.
- New dep: `androidx.lifecycle:lifecycle-process`. The Kotlin binding is generated into `.build/` by `./dev/bindings` (gitignored), so this PR carries no binding artifact.

## Design notes

- **Reconciled, not fired.** Each callback records desired state; a single serial loop drives the wire one op at a time, converging to the last intent (a naive launch-per-callback could reorder and strand the wire live-while-backgrounded; uniffi doesn't propagate cancellation).
- **Activities are already aggregated** by `ProcessLifecycleOwner` (first activity in / last out), so no per-activity counting.
- Registration seeds desired-state from `ProcessLifecycleOwner.currentState`, so a process created in the background starts suspended.

## Known limitation (documented; transport follow-on)

A stream opened *after* registration while still backgrounded opens a fresh live wire the SDK model can't see (no lifecycle transition fires). The complete fix is a small transport change (honor a suspend requested before the transport is first opened). Backgrounds that only catch up are unaffected, since `catchUpToLive` uses its own connection.

## Tests

`catchUpToLive` cold round-trip + `manageStreamLifecycle` default (instrumented; compiled here, run on an emulator in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-manage stream lifecycle across Android app backgrounding
> - Adds `StreamLifecycleManager` in [StreamLifecycle.kt](https://github.com/xmtp/libxmtp/pull/3860/files#diff-b14f0378e1c0236f155e8114343ccfaa7769afab6fff4ec17149fbab5be98bff) that registers a `ProcessLifecycleOwner` observer to automatically suspend streams when the app backgrounds and resume them on foreground.
> - Introduces `Client.manageStreamLifecycle` (defaults to `true`) that triggers `StreamLifecycleManager.enableIfNeeded()` on client creation, making lifecycle management opt-out.
> - Adds `Client.catchUpToLive(timeoutMs)` on Android and `FfiXmtpClient.catch_up_to_live()` in the FFI layer to replay missed messages and welcomes after resuming, returning a `CatchUpSummary` with message/conversation counts and a completion flag.
> - Exposes `suspend_streams` and `resume_streams` as top-level FFI functions backed by `router_callbacks` in the Rust layer.
> - Behavioral Change: all new `Client` instances automatically register process-wide lifecycle callbacks by default; set `Client.manageStreamLifecycle = false` before creation to opt out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d548ad3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->