### PR TITLE
feat(xmtp_proto,xmtp_api_grpc,xmtp_api_d14n,xmtp_mls): key the shared bidi transport by destination

### DIFF
--- a/crates/xmtp_api_d14n/src/middleware/auth.rs
+++ b/crates/xmtp_api_d14n/src/middleware/auth.rs
@@ -162,6 +162,10 @@ impl<C> AuthMiddleware<C> {
 
 #[xmtp_common::async_trait]
 impl<C: Client> Client for AuthMiddleware<C> {
+    fn host(&self) -> &str {
+        self.inner.host()
+    }
+
     async fn request(
         &self,
         request: http::request::Builder,
@@ -250,6 +254,10 @@ mod tests {
 
     #[xmtp_common::async_trait]
     impl Client for TestClient {
+        fn host(&self) -> &str {
+            "mock://auth"
+        }
+
         async fn request(
             &self,
             request: http::request::Builder,

--- a/crates/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
+++ b/crates/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
@@ -57,6 +57,14 @@ impl<T: Client> MultiNodeClient<T> {
 /// This allows the MultiNodeClient to be used as a Client for any endpoint.
 #[xmtp_common::async_trait]
 impl<T: Client> Client for MultiNodeClient<T> {
+    // The gateway, always: `host()` is a connection identity and must not
+    // change over the client's lifetime, while the resolved node is a
+    // transient the gateway can re-issue. The gateway URL is the stable
+    // name for "this multi-node backend".
+    fn host(&self) -> &str {
+        self.gateway_client.host()
+    }
+
     async fn request(
         &self,
         request: http::request::Builder,

--- a/crates/xmtp_api_d14n/src/middleware/read_write_client/client.rs
+++ b/crates/xmtp_api_d14n/src/middleware/read_write_client/client.rs
@@ -37,6 +37,12 @@ where
     Read: Client,
     Write: Client,
 {
+    // The read side: connection identity here keys receive-only shared
+    // state (the bidi wire), and reads are where this client receives.
+    fn host(&self) -> &str {
+        self.read.host()
+    }
+
     async fn request(
         &self,
         request: http::request::Builder,

--- a/crates/xmtp_api_d14n/src/middleware/readonly_client.rs
+++ b/crates/xmtp_api_d14n/src/middleware/readonly_client.rs
@@ -39,6 +39,10 @@ impl<C> Client for ReadonlyClient<C>
 where
     C: Client,
 {
+    fn host(&self) -> &str {
+        self.inner.host()
+    }
+
     async fn request(
         &self,
         request: http::request::Builder,

--- a/crates/xmtp_api_d14n/src/queries/api_stats.rs
+++ b/crates/xmtp_api_d14n/src/queries/api_stats.rs
@@ -227,6 +227,10 @@ xmtp_common::if_native! {
         type SubscribeStream = <C as XmtpMlsBidiStreams>::SubscribeStream;
         type Error = <C as XmtpMlsBidiStreams>::Error;
 
+        fn host(&self) -> &str {
+            self.inner.host()
+        }
+
         async fn subscribe_bidi(
             &self,
             requests: futures::stream::BoxStream<'static, xmtp_proto::mls_v1::SubscribeRequest>,

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -437,7 +437,13 @@ where
     /// stream opens with the topic set it will serve) and returns an open
     /// [`Connection`]. Where that connection goes is entirely the opener's
     /// business — see the module docs on endpoint keying.
-    pub fn new<O, Fut>(opener: O) -> Self
+    ///
+    /// `initially_suspended` births the actor already [`Self::suspend`]ed:
+    /// the first lease registers and parks instead of dialing, and nothing
+    /// touches the network until [`Self::resume`]. For callers honoring a
+    /// suspend intent recorded before the transport existed — an app
+    /// launched into the background that suspends before anything streams.
+    pub fn new<O, Fut>(opener: O, initially_suspended: bool) -> Self
     where
         O: Fn(B::Mutate) -> Fut + MaybeSend + MaybeSync + 'static,
         Fut: Future<Output = Result<Connection<B>, OpenError>> + MaybeSend + 'static,
@@ -452,7 +458,12 @@ where
         // which happens exactly when every handle and lease is dropped.
         xmtp_common::spawn(
             None,
-            run_ledger::<B>(opener, cmds_rx, cmds.clone().downgrade()),
+            run_ledger::<B>(
+                opener,
+                cmds_rx,
+                cmds.clone().downgrade(),
+                initially_suspended,
+            ),
         );
         Self { cmds }
     }
@@ -1770,6 +1781,7 @@ async fn run_ledger<B: TransportBinding>(
     // For minting lease handles. Weak, so the task's own copy never keeps the
     // command channel (and therefore itself) alive.
     lease_cmds: mpsc::WeakUnboundedSender<Cmd<B>>,
+    initially_suspended: bool,
 ) where
     B::GroupMessage: Clone,
     B::WelcomeMessage: Clone,
@@ -1782,7 +1794,7 @@ async fn run_ledger<B: TransportBinding>(
         conn: None,
         reconnect_delay: RECONNECT_INITIAL_DELAY,
         reconnect_at: tokio::time::Instant::now(),
-        suspended: false,
+        suspended: initially_suspended,
         wire_opens: 0,
         resume_notify: Vec::new(),
         outbox: Outbox::default(),
@@ -2649,17 +2661,25 @@ mod tests {
     /// A transport whose opener mints a fresh scripted session per open and
     /// parks the server end where the test can grab it.
     fn transport() -> (BidiTransport<V3Binding>, Servers) {
+        transport_born(false)
+    }
+
+    /// [`transport`], with the birth state explicit.
+    fn transport_born(suspended: bool) -> (BidiTransport<V3Binding>, Servers) {
         let servers: Servers = Arc::default();
         let sink = servers.clone();
-        let transport = BidiTransport::new(move |initial| {
-            let (api, server) = mock_pair();
-            sink.lock().unwrap().push(server);
-            async move {
-                BidiConnection::open(&api, initial)
-                    .await
-                    .map_err(OpenError::new)
-            }
-        });
+        let transport = BidiTransport::new(
+            move |initial| {
+                let (api, server) = mock_pair();
+                sink.lock().unwrap().push(server);
+                async move {
+                    BidiConnection::open(&api, initial)
+                        .await
+                        .map_err(OpenError::new)
+                }
+            },
+            suspended,
+        );
         (transport, servers)
     }
 
@@ -3540,6 +3560,50 @@ mod tests {
         tokio::time::timeout(WAIT, resumed).await?.unwrap()?;
     }
 
+    /// A transport born suspended — the suspend intent predates the
+    /// transport, an app launched into the background — parks its first
+    /// lease instead of dialing; `resume()` opens the wire, the parked
+    /// lease's wave rides the open to catch-up, and live delivery follows.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn a_born_suspended_transport_parks_the_first_lease() {
+        let (transport, servers) = transport_born(true);
+
+        // The first lease registers but must not dial.
+        let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        // Well past several reconnect backoffs: still nothing on the network.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert!(
+            servers.lock().unwrap().is_empty(),
+            "a born-suspended transport must keep its first lease parked"
+        );
+
+        let resumed = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+        let mut server = wait_for_server(&servers).await;
+        // Every leased topic is owned by the parked wave, so the open's
+        // first frame is that wave itself — no resume wave precedes it.
+        let wave = server.next_mutate().await;
+        assert_eq!(
+            wave.adds.iter().map(|add| &add.topic).collect::<Vec<_>>(),
+            vec![&group_topic(b"g1").cloned_vec()],
+            "the parked lease's adds open the wire"
+        );
+        server.send(catchup_complete(wave.mutate_id));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+        tokio::time::timeout(WAIT, resumed).await?.unwrap()?;
+
+        server.send(live(vec![group_msg(1, b"g1")], vec![]));
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::GroupMessages(_))
+        ));
+    }
+
     /// A `resume()` waiter whose last lease disappears mid-catch-up must
     /// resolve — with nothing leased there is nothing left to await.
     #[xmtp_common::test(unwrap_try = true)]
@@ -3581,21 +3645,24 @@ mod tests {
         let transport: BidiTransport<V3Binding> = {
             let sink = servers.clone();
             let dials = dials.clone();
-            BidiTransport::new(move |initial| {
-                let n = dials.fetch_add(1, Ordering::SeqCst);
-                let sink = sink.clone();
-                async move {
-                    if n == 0 {
-                        std::future::pending::<()>().await;
-                        unreachable!("the hung dial never resolves");
+            BidiTransport::new(
+                move |initial| {
+                    let n = dials.fetch_add(1, Ordering::SeqCst);
+                    let sink = sink.clone();
+                    async move {
+                        if n == 0 {
+                            std::future::pending::<()>().await;
+                            unreachable!("the hung dial never resolves");
+                        }
+                        let (api, server) = mock_pair();
+                        sink.lock().unwrap().push(server);
+                        BidiConnection::open(&api, initial)
+                            .await
+                            .map_err(OpenError::new)
                     }
-                    let (api, server) = mock_pair();
-                    sink.lock().unwrap().push(server);
-                    BidiConnection::open(&api, initial)
-                        .await
-                        .map_err(OpenError::new)
-                }
-            })
+                },
+                false,
+            )
         };
 
         // The cold open hangs; drive it from a task and wait for the dial
@@ -3639,21 +3706,24 @@ mod tests {
         let transport: BidiTransport<V3Binding> = {
             let sink = servers.clone();
             let dials = dials.clone();
-            BidiTransport::new(move |initial| {
-                let n = dials.fetch_add(1, Ordering::SeqCst);
-                let sink = sink.clone();
-                async move {
-                    if n == 0 {
-                        std::future::pending::<()>().await;
-                        unreachable!("the hung dial never resolves");
+            BidiTransport::new(
+                move |initial| {
+                    let n = dials.fetch_add(1, Ordering::SeqCst);
+                    let sink = sink.clone();
+                    async move {
+                        if n == 0 {
+                            std::future::pending::<()>().await;
+                            unreachable!("the hung dial never resolves");
+                        }
+                        let (api, server) = mock_pair();
+                        sink.lock().unwrap().push(server);
+                        BidiConnection::open(&api, initial)
+                            .await
+                            .map_err(OpenError::new)
                     }
-                    let (api, server) = mock_pair();
-                    sink.lock().unwrap().push(server);
-                    BidiConnection::open(&api, initial)
-                        .await
-                        .map_err(OpenError::new)
-                }
-            })
+                },
+                false,
+            )
         };
 
         let leased = tokio::spawn({
@@ -3716,29 +3786,32 @@ mod tests {
             let dials = dials.clone();
             let gate = gate.clone();
             let network_down = network_down.clone();
-            BidiTransport::new(move |initial| {
-                let n = dials.fetch_add(1, Ordering::SeqCst);
-                let sink = sink.clone();
-                let gate = gate.clone();
-                let network_down = network_down.clone();
-                async move {
-                    // Dial 1 holds until released, then fails — the window
-                    // for the rest of the burst to arrive mid-dial. Later
-                    // dials fail fast until the network comes back.
-                    if n == 1 {
-                        gate.notified().await;
-                        return Err(OpenError::retryable(std::io::Error::other("down")));
+            BidiTransport::new(
+                move |initial| {
+                    let n = dials.fetch_add(1, Ordering::SeqCst);
+                    let sink = sink.clone();
+                    let gate = gate.clone();
+                    let network_down = network_down.clone();
+                    async move {
+                        // Dial 1 holds until released, then fails — the window
+                        // for the rest of the burst to arrive mid-dial. Later
+                        // dials fail fast until the network comes back.
+                        if n == 1 {
+                            gate.notified().await;
+                            return Err(OpenError::retryable(std::io::Error::other("down")));
+                        }
+                        if n >= 2 && network_down.load(Ordering::SeqCst) {
+                            return Err(OpenError::retryable(std::io::Error::other("down")));
+                        }
+                        let (api, server) = mock_pair();
+                        sink.lock().unwrap().push(server);
+                        BidiConnection::open(&api, initial)
+                            .await
+                            .map_err(OpenError::new)
                     }
-                    if n >= 2 && network_down.load(Ordering::SeqCst) {
-                        return Err(OpenError::retryable(std::io::Error::other("down")));
-                    }
-                    let (api, server) = mock_pair();
-                    sink.lock().unwrap().push(server);
-                    BidiConnection::open(&api, initial)
-                        .await
-                        .map_err(OpenError::new)
-                }
-            })
+                },
+                false,
+            )
         };
 
         let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
@@ -4671,9 +4744,10 @@ mod tests {
     /// nothing — the transport stays usable for a later attempt.
     #[xmtp_common::test(unwrap_try = true)]
     async fn open_failure_surfaces_and_registers_nothing() {
-        let transport = BidiTransport::<V3Binding>::new(|_initial| async {
-            Err(OpenError::unretryable(Refused))
-        });
+        let transport = BidiTransport::<V3Binding>::new(
+            |_initial| async { Err(OpenError::unretryable(Refused)) },
+            false,
+        );
         let denied = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await;
         assert!(matches!(denied, Err(TransportError::Open(_))));
         // Still alive: the next attempt reaches the opener again (and fails the
@@ -4693,23 +4767,26 @@ mod tests {
         let transport: BidiTransport<V3Binding> = {
             let sink = servers.clone();
             let dials = dials.clone();
-            BidiTransport::new(move |initial| {
-                let n = dials.fetch_add(1, Ordering::SeqCst);
-                let sink = sink.clone();
-                async move {
-                    // The backend accepts the first dial, then refuses the
-                    // surface outright — a server dropping bidi support, not
-                    // a flap.
-                    if n > 0 {
-                        return Err(OpenError::new(Refused));
+            BidiTransport::new(
+                move |initial| {
+                    let n = dials.fetch_add(1, Ordering::SeqCst);
+                    let sink = sink.clone();
+                    async move {
+                        // The backend accepts the first dial, then refuses the
+                        // surface outright — a server dropping bidi support, not
+                        // a flap.
+                        if n > 0 {
+                            return Err(OpenError::new(Refused));
+                        }
+                        let (api, server) = mock_pair();
+                        sink.lock().unwrap().push(server);
+                        BidiConnection::open(&api, initial)
+                            .await
+                            .map_err(OpenError::new)
                     }
-                    let (api, server) = mock_pair();
-                    sink.lock().unwrap().push(server);
-                    BidiConnection::open(&api, initial)
-                        .await
-                        .map_err(OpenError::new)
-                }
-            })
+                },
+                false,
+            )
         };
 
         let mut alpha = transport.lease(vec![(group_topic(b"g1"), 0)], 8).await?;

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -2563,6 +2563,10 @@ mod tests {
         type SubscribeStream = BoxStream<'static, Result<SubscribeResponse, ApiClientError>>;
         type Error = ApiClientError;
 
+        fn host(&self) -> &str {
+            "mock://bidi"
+        }
+
         async fn subscribe_bidi(
             &self,
             requests: BoxStream<'static, SubscribeRequest>,

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport_props.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport_props.rs
@@ -131,30 +131,33 @@ type Servers = Arc<Mutex<Vec<MockServer>>>;
 fn model_transport() -> (BidiTransport<V3Binding>, Servers) {
     let servers: Servers = Arc::default();
     let sink = servers.clone();
-    let transport = BidiTransport::new(move |initial| {
-        let (to_client, inbound) = tokio::sync::mpsc::unbounded_channel();
-        let (captured, from_client) = tokio::sync::mpsc::unbounded_channel();
-        let api = MockApi {
-            inbound: Mutex::new(Some(inbound)),
-            captured,
-        };
-        let server = MockServer {
-            to_client,
-            from_client,
-        };
-        server.send(subscribe_response::v1::Response::Started(
-            subscribe_response::v1::Started {
-                keepalive_interval_ms: NO_KEEPALIVE,
-                capabilities: vec![],
-            },
-        ));
-        sink.lock().unwrap().push(server);
-        async move {
-            BidiConnection::open(&api, initial)
-                .await
-                .map_err(OpenError::new)
-        }
-    });
+    let transport = BidiTransport::new(
+        move |initial| {
+            let (to_client, inbound) = tokio::sync::mpsc::unbounded_channel();
+            let (captured, from_client) = tokio::sync::mpsc::unbounded_channel();
+            let api = MockApi {
+                inbound: Mutex::new(Some(inbound)),
+                captured,
+            };
+            let server = MockServer {
+                to_client,
+                from_client,
+            };
+            server.send(subscribe_response::v1::Response::Started(
+                subscribe_response::v1::Started {
+                    keepalive_interval_ms: NO_KEEPALIVE,
+                    capabilities: vec![],
+                },
+            ));
+            sink.lock().unwrap().push(server);
+            async move {
+                BidiConnection::open(&api, initial)
+                    .await
+                    .map_err(OpenError::new)
+            }
+        },
+        false,
+    );
     (transport, servers)
 }
 

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport_props.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport_props.rs
@@ -84,6 +84,10 @@ impl XmtpMlsBidiStreams for MockApi {
     type SubscribeStream = BoxStream<'static, Result<SubscribeResponse, ApiClientError>>;
     type Error = ApiClientError;
 
+    fn host(&self) -> &str {
+        "mock://bidi"
+    }
+
     async fn subscribe_bidi(
         &self,
         requests: BoxStream<'static, SubscribeRequest>,

--- a/crates/xmtp_api_d14n/src/queries/boxed_streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/boxed_streams.rs
@@ -155,6 +155,10 @@ xmtp_common::if_native! {
         type SubscribeStream = xmtp_proto::api_client::BoxedSubscribeS<Self::Error>;
         type Error = <C as xmtp_proto::api_client::XmtpMlsBidiStreams>::Error;
 
+        fn host(&self) -> &str {
+            self.inner.host()
+        }
+
         async fn subscribe_bidi(
             &self,
             requests: futures::stream::BoxStream<'static, xmtp_proto::mls_v1::SubscribeRequest>,

--- a/crates/xmtp_api_d14n/src/queries/combined/streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/streams.rs
@@ -57,14 +57,12 @@ xmtp_common::if_native! {
     // serve it — the d14n wire speaks its own envelope binding — so it refuses
     // at runtime with an unretryable error. The dyn full API always *has*
     // `subscribe_bidi`; support is a runtime property of the backend. The
-    // unretryable refusal is what trips xmtp_mls's process-wide fallback
+    // unretryable refusal is what trips xmtp_mls's per-destination fallback
     // latch (its router callbacks): the stream that hit it is served on the
-    // legacy path in place and every later dispatch goes straight to legacy,
-    // so the opt-in env gate is safe to enable when this is the process's
-    // only backend. The latch is process-wide — in a mixed-backend process
-    // a bidi-capable donor wins the shared wire and clients of this backend
-    // are misrouted, not refused (the router-callbacks module docs call
-    // that hazard out).
+    // legacy path in place and every later dispatch to this client's host
+    // goes straight to legacy, so the opt-in env gate is safe to enable with
+    // this client in the process — its streams ride legacy while a
+    // bidi-capable backend at another host keeps its own wire.
     #[xmtp_common::async_trait]
     impl<V3, D14n, Store> xmtp_proto::api_client::XmtpMlsBidiStreams for MigrationClient<V3, D14n, Store>
     where
@@ -74,6 +72,15 @@ xmtp_common::if_native! {
     {
         type SubscribeStream = xmtp_proto::api_client::BoxedSubscribeS<ApiClientError>;
         type Error = ApiClientError;
+
+        // A reserved key, not the v3 URL this client also dials: this
+        // surface never opens a wire, and keying by the real v3 backend
+        // would let its refusal latch a destination a bidi-capable pure-v3
+        // sibling could actually serve (order-dependent poisoning). The
+        // reserved scheme can never collide with a servable destination.
+        fn host(&self) -> &str {
+            "unsupported://migration"
+        }
 
         async fn subscribe_bidi(
             &self,

--- a/crates/xmtp_api_d14n/src/queries/combined/tests.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/tests.rs
@@ -29,6 +29,10 @@ impl TestNetworkClient {
 
 #[xmtp_common::async_trait]
 impl Client for TestNetworkClient {
+    fn host(&self) -> &str {
+        "mock://combined"
+    }
+
     async fn request(
         &self,
         request: http::request::Builder,

--- a/crates/xmtp_api_d14n/src/queries/d14n/streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/streams.rs
@@ -122,14 +122,12 @@ xmtp_common::if_native! {
     // serve it — the d14n wire speaks its own envelope binding — so it refuses
     // at runtime with an unretryable error. The dyn full API always *has*
     // `subscribe_bidi`; support is a runtime property of the backend. The
-    // unretryable refusal is what trips xmtp_mls's process-wide fallback
+    // unretryable refusal is what trips xmtp_mls's per-destination fallback
     // latch (its router callbacks): the stream that hit it is served on the
-    // legacy path in place and every later dispatch goes straight to legacy,
-    // so the opt-in env gate is safe to enable when this is the process's
-    // only backend. The latch is process-wide — in a mixed-backend process
-    // a bidi-capable donor wins the shared wire and clients of this backend
-    // are misrouted, not refused (the router-callbacks module docs call
-    // that hazard out).
+    // legacy path in place and every later dispatch to this client's host
+    // goes straight to legacy, so the opt-in env gate is safe to enable with
+    // this client in the process — its streams ride legacy while a
+    // bidi-capable backend at another host keeps its own wire.
     #[xmtp_common::async_trait]
     impl<C, Store> xmtp_proto::api_client::XmtpMlsBidiStreams for D14nClient<C, Store>
     where
@@ -138,6 +136,14 @@ xmtp_common::if_native! {
     {
         type SubscribeStream = xmtp_proto::api_client::BoxedSubscribeS<ApiClientError>;
         type Error = ApiClientError;
+
+        // A reserved key, not the dialed URL: this surface never opens a
+        // wire, and keying by a real backend URL would let its refusal latch
+        // a destination a bidi-capable sibling could actually serve. The
+        // reserved scheme can never collide with a servable destination.
+        fn host(&self) -> &str {
+            "unsupported://d14n"
+        }
 
         async fn subscribe_bidi(
             &self,

--- a/crates/xmtp_api_d14n/src/queries/v3/bidi.rs
+++ b/crates/xmtp_api_d14n/src/queries/v3/bidi.rs
@@ -22,6 +22,10 @@ where
 
     type Error = ApiClientError;
 
+    fn host(&self) -> &str {
+        self.client.host()
+    }
+
     // Spans the open handshake (not the stream's lifetime) as `rpc.subscribe_bidi`.
     // Bidi is consumed directly by `xmtp_mls` with no `xmtp_api` wrapper in front,
     // so this transport impl is the RPC boundary — the same layer the other

--- a/crates/xmtp_api_d14n/src/queries/v3/connection.rs
+++ b/crates/xmtp_api_d14n/src/queries/v3/connection.rs
@@ -205,6 +205,10 @@ mod tests {
         type SubscribeStream = BoxStream<'static, Result<SubscribeResponse, ApiClientError>>;
         type Error = ApiClientError;
 
+        fn host(&self) -> &str {
+            "mock://bidi"
+        }
+
         async fn subscribe_bidi(
             &self,
             requests: BoxStream<'static, SubscribeRequest>,
@@ -641,6 +645,10 @@ mod tests {
     impl XmtpMlsBidiStreams for WedgedWireApi {
         type SubscribeStream = BoxStream<'static, Result<SubscribeResponse, ApiClientError>>;
         type Error = ApiClientError;
+
+        fn host(&self) -> &str {
+            "mock://bidi"
+        }
 
         async fn subscribe_bidi(
             &self,

--- a/crates/xmtp_api_grpc/src/grpc_client/client.rs
+++ b/crates/xmtp_api_grpc/src/grpc_client/client.rs
@@ -13,6 +13,7 @@ use pin_project::pin_project;
 use prost::bytes::Bytes;
 use std::{
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll, ready},
 };
 use tonic::{
@@ -63,23 +64,14 @@ impl<T> ToHttp for tonic::Response<T> {
 #[derive(Clone, Debug)]
 pub struct GrpcClient {
     inner: tonic::client::Grpc<crate::GrpcService>,
+    /// The URL this client dials ([`Client::host`]), as `Url` serializes it —
+    /// one normalization for every spelling of the same destination.
+    host: Arc<str>,
     app_version: MetadataValue<metadata::Ascii>,
     libxmtp_version: MetadataValue<metadata::Ascii>,
 }
 
 impl GrpcClient {
-    pub fn new(
-        service: crate::GrpcService,
-        app_version: MetadataValue<metadata::Ascii>,
-        libxmtp_version: MetadataValue<metadata::Ascii>,
-    ) -> Self {
-        Self {
-            inner: tonic::client::Grpc::new(service),
-            app_version,
-            libxmtp_version,
-        }
-    }
-
     /// Builds a tonic request from a body and a generic HTTP Request.
     ///
     /// Generic over the body type `B` so the same path serves both the
@@ -146,6 +138,10 @@ impl Stream for GrpcStream {
 
 #[xmtp_common::async_trait]
 impl Client for GrpcClient {
+    fn host(&self) -> &str {
+        &self.host
+    }
+
     async fn request(
         &self,
         request: http::request::Builder,
@@ -292,11 +288,13 @@ impl ApiBuilder for ClientBuilder {
 
     fn build(self) -> Result<Self::Output, Self::Error> {
         let host = self.host.ok_or(GrpcBuilderError::MissingHostUrl)?;
+        let host_str: Arc<str> = host.as_str().into();
         let channel = crate::GrpcService::new(host, self.limit)?;
         Ok(GrpcClient {
             inner: tonic::client::Grpc::new(channel)
                 .max_decoding_message_size(GRPC_PAYLOAD_LIMIT)
                 .max_encoding_message_size(GRPC_PAYLOAD_LIMIT),
+            host: host_str,
             app_version: self
                 .app_version
                 .unwrap_or(MetadataValue::try_from("0.0.0")?),

--- a/crates/xmtp_mls/src/subscriptions/bidi_fuzz_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/bidi_fuzz_tests.rs
@@ -883,14 +883,17 @@ async fn fuzz_transport_delivery(seed: u64, rounds: usize) {
     let mut welcome_topics = Vec::new();
     for consumer in &consumers {
         let api = consumer.context.api().api_client.clone();
-        transports.push(BidiTransport::new(move |initial| {
-            let api = api.clone();
-            async move {
-                BidiConnection::open(&api, initial)
-                    .await
-                    .map_err(OpenError::new)
-            }
-        }));
+        transports.push(BidiTransport::new(
+            move |initial| {
+                let api = api.clone();
+                async move {
+                    BidiConnection::open(&api, initial)
+                        .await
+                        .map_err(OpenError::new)
+                }
+            },
+            false,
+        ));
         // Each consumer's welcome topic is fuzzed like any other: its
         // leases may include it, and a fuzz op mints real welcomes by
         // creating groups WITH random consumers. Its own id space, so its

--- a/crates/xmtp_mls/src/subscriptions/catch_up.rs
+++ b/crates/xmtp_mls/src/subscriptions/catch_up.rs
@@ -52,9 +52,9 @@
 //!
 //! Dispatch mirrors the stream entry points: the bidi path when
 //! [`bidi_streams_active`], the legacy full sync otherwise. A backend that
-//! refuses the bidi surface latches the process onto legacy (same latch the
-//! streams use) and this call completes on the legacy path — the caller
-//! never sees the refusal.
+//! refuses the bidi surface latches its destination onto legacy (same
+//! per-destination latch the streams use) and this call completes on the
+//! legacy path — the caller never sees the refusal.
 
 use std::collections::{HashSet, VecDeque};
 use std::time::Duration;
@@ -203,15 +203,16 @@ where
     /// on every wake. `Ok` therefore means "everything owed was received
     /// and attempted", not "zero processing errors".
     pub async fn catch_up_to_live(&self) -> Result<CatchUpSummary, CatchUpError> {
-        if bidi_streams_active() {
+        let host = self.context.api().api_client.host().to_owned();
+        if bidi_streams_active(&host) {
             match self.catch_up_bidi().await {
                 Ok(summary) => return Ok(summary),
                 Err(CatchUpError::Unsupported(e)) => {
                     tracing::error!(
                         "bidi catch-up refused by the backend, \
-                         latching this process onto the legacy streams: {e}"
+                         latching {host} onto the legacy streams: {e}"
                     );
-                    latch_bidi_unsupported();
+                    latch_bidi_unsupported(&host);
                 }
                 Err(CatchUpError::DeadEnd(e)) => {
                     tracing::warn!(

--- a/crates/xmtp_mls/src/subscriptions/catch_up.rs
+++ b/crates/xmtp_mls/src/subscriptions/catch_up.rs
@@ -20,7 +20,10 @@
 //! state worth keeping. Each call opens its own [`BidiConnection`], which
 //! also means a concurrently-running live stream is untouched: both paths
 //! store through the same pipeline, whose DB fast-path makes double delivery
-//! a cheap lookup, and each keeps its own delivery dedup.
+//! a cheap lookup, and each keeps its own delivery dedup. For the same
+//! reason this call deliberately ignores the stream-suspend intent (the
+//! app-lifecycle suspend/resume pair): a backgrounded app calling it IS the
+//! background fetch, and the bounded wire closes when the run does.
 //!
 //! ## The discovery loop
 //!

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -136,12 +136,25 @@ struct SharedWires {
     /// Destinations that refused the surface; their dispatches go straight
     /// to legacy.
     unsupported: HashSet<String>,
+    /// [`suspend_bidi_streams`] intent for transports that don't exist yet:
+    /// set while the app is backgrounded, cleared by [`resume_bidi_streams`],
+    /// read at transport creation so a STREAM wire born under it opens
+    /// parked (the one-shot catch-up dials its own bounded wire regardless —
+    /// a background fetch is a deliberate dial). One flag, not
+    /// per-destination — the suspend call is app-lifecycle-scoped (it has no
+    /// endpoint to name, and a destination that hasn't streamed yet can't be
+    /// keyed in advance), while every EXISTING transport keeps its own
+    /// suspended state in its actor. Guarded by the registry's own mutex, so
+    /// flag flips and transport creation serialize: whichever order a
+    /// suspend and a first lease land in, the wire ends up parked.
+    suspend_requested: bool,
 }
 
 static SHARED_WIRES: LazyLock<Mutex<SharedWires>> = LazyLock::new(|| {
     Mutex::new(SharedWires {
         transports: HashMap::new(),
         unsupported: HashSet::new(),
+        suspend_requested: false,
     })
 });
 
@@ -254,34 +267,59 @@ where
     C::SubscribeStream: 'static,
 {
     let host = api.host().to_owned();
-    SHARED_WIRES
-        .lock()
+    let mut wires = SHARED_WIRES.lock();
+    // A transport created while the app is backgrounded is born suspended —
+    // its first lease parks instead of dialing (see [`SharedWires`]).
+    let born_suspended = wires.suspend_requested;
+    wires
         .transports
         .entry(host)
         .or_insert_with_key(|host| {
             // Whoever streams to this destination first donates their api
             // client for the life of the process.
-            tracing::info!(%host, "bidi: initializing the shared transport for a destination");
-            BidiTransport::new(move |initial| {
-                let api = api.clone();
-                async move {
-                    BidiConnection::open(&api, initial)
-                        .await
-                        .map_err(OpenError::new)
-                }
-            })
+            tracing::info!(
+                %host,
+                suspended = born_suspended,
+                "bidi: initializing the shared transport for a destination"
+            );
+            BidiTransport::new(
+                move |initial| {
+                    let api = api.clone();
+                    async move {
+                        BidiConnection::open(&api, initial)
+                            .await
+                            .map_err(OpenError::new)
+                    }
+                },
+                born_suspended,
+            )
         })
         .clone()
 }
 
 /// Take the shared bidi wires — every destination's — off the network (the
 /// `didEnterBackground` half of the app-lifecycle pair). Leases and wire
-/// positions are kept; nothing reconnects until [`resume_bidi_streams`]. A
-/// no-op when no transport was ever opened (gate off, or nothing ever
-/// streamed).
+/// positions are kept; nothing reconnects until [`resume_bidi_streams`].
+/// The intent also outlives the transports it applies to: a destination
+/// whose transport doesn't exist yet gets one born suspended at its first
+/// stream, so an app launched into the background that suspends before
+/// anything streams never opens a STREAM wire live (see [`SharedWires`];
+/// [`Client::catch_up_to_live`](crate::Client::catch_up_to_live) is exempt
+/// by design — a background fetch is a deliberate dial). A wire born
+/// suspended defers its backend's capability discovery to the resume
+/// re-open; see [`settle_lifecycle`] for how a refusal there still latches.
 pub async fn suspend_bidi_streams() -> Result<()> {
-    let transports: Vec<_> = SHARED_WIRES.lock().transports.values().cloned().collect();
-    settle_lifecycle(futures::future::join_all(transports.iter().map(|t| t.suspend())).await)
+    let wires: Vec<_> = {
+        let mut shared = SHARED_WIRES.lock();
+        shared.suspend_requested = true;
+        shared
+            .transports
+            .iter()
+            .map(|(host, t)| (host.clone(), t.clone()))
+            .collect()
+    };
+    let results = futures::future::join_all(wires.iter().map(|(_, t)| t.suspend())).await;
+    settle_lifecycle(&wires, results)
 }
 
 /// Bring the shared bidi wires back (`willEnterForeground`), resolving once
@@ -291,30 +329,57 @@ pub async fn suspend_bidi_streams() -> Result<()> {
 /// is down, and a concurrent fresh subscribe on a shared transport extends
 /// it — the FFI exposure (follow-on) owes callers a processing-drain barrier
 /// and a deadline before this can honestly serve as the background-fetch
-/// primitive. A no-op when no transport was ever opened.
+/// primitive. Also clears the recorded suspend intent
+/// ([`suspend_bidi_streams`]), so transports created from here on are born
+/// live again. A no-op when no transport was ever opened.
 pub async fn resume_bidi_streams() -> Result<()> {
-    let transports: Vec<_> = SHARED_WIRES.lock().transports.values().cloned().collect();
-    settle_lifecycle(futures::future::join_all(transports.iter().map(|t| t.resume())).await)
+    let wires: Vec<_> = {
+        let mut shared = SHARED_WIRES.lock();
+        shared.suspend_requested = false;
+        shared
+            .transports
+            .iter()
+            .map(|(host, t)| (host.clone(), t.clone()))
+            .collect()
+    };
+    let results = futures::future::join_all(wires.iter().map(|(_, t)| t.resume())).await;
+    settle_lifecycle(&wires, results)
 }
 
 /// Fold a lifecycle fan-out's results, driving EVERY destination before
 /// reporting: `join_all` (never `try_join_all`) upstream, so one dead wire
-/// cannot abandon the others mid-suspend/resume. A `Closed` transport is a
-/// tombstoned destination (backend refused the surface) — permanently off
-/// the network with its streams on legacy, so the lifecycle intent holds
-/// for it vacuously; any other error is reported after the fan-out settles.
-fn settle_lifecycle(results: Vec<std::result::Result<(), TransportError>>) -> Result<()> {
-    for result in results {
+/// cannot abandon the others mid-suspend/resume.
+///
+/// A `Closed` transport is a tombstoned destination — its ledger only ever
+/// dies by shutting down after an unretryable re-open, so `Closed` here is
+/// the same verdict a stream's `lease()` would see, and it latches the same
+/// way ([`is_bidi_unsupported`]). That latch matters most for a
+/// born-suspended wire: its capability discovery is deferred to the resume
+/// re-open, so a refusal there is seen by NO stream — the parked leases
+/// just end (their `on_close` fires; re-subscribing recovers, and lands on
+/// legacy because of this latch). The lifecycle intent holds for a
+/// tombstoned destination vacuously — permanently off the network, streams
+/// on legacy — so `Closed` is not an error here. No other error shape is
+/// reachable today (`suspend()`/`resume()` only produce `Closed`); anything
+/// else is surfaced defensively after the fan-out settles.
+fn settle_lifecycle(
+    wires: &[(String, BidiTransport<V3Binding>)],
+    results: Vec<std::result::Result<(), TransportError>>,
+) -> Result<()> {
+    let mut first_error = None;
+    for ((host, _), result) in wires.iter().zip(results) {
         match result {
-            Ok(()) | Err(TransportError::Closed) => {}
-            Err(e) => {
-                return Err(SubscribeError::from(
-                    super::stream_router::RouterError::Transport(e),
-                ));
-            }
+            Ok(()) => {}
+            Err(TransportError::Closed) => latch_bidi_unsupported(host),
+            Err(e) => first_error = first_error.or(Some(e)),
         }
     }
-    Ok(())
+    match first_error {
+        None => Ok(()),
+        Some(e) => Err(SubscribeError::from(
+            super::stream_router::RouterError::Transport(e),
+        )),
+    }
 }
 
 /// Drain a router stream into a callback until it ends or the client shuts

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -2,44 +2,47 @@
 //! the bindings call, plus the pieces that decide *whether* and *where* the
 //! bidi path runs.
 //!
-//! ## One wire per process
+//! ## One wire per destination
 //!
-//! Every client in the process shares ONE [`BidiTransport`]: topics from all
-//! of them multiplex onto a single bidi stream, and the transport's leases
-//! keep them apart (welcome topics are per-installation; a group topic two
-//! clients share is subscribed once and fanned out). One client per process —
-//! mobile — makes this invisible; a process running many clients (agents)
-//! gets O(1) wires instead of O(clients). The first client to stream donates
-//! its api client to the opener, which assumes one backend per process: true
-//! for mobile, agents, and `nextest`'s process-per-test runs. Auth is not at
-//! stake — the shared wire is receive-only (publishes keep each client's own
-//! api client and whatever authorization it carries), and on v3 the donated
-//! client attaches only version-attribution headers. The hazard of mixing
-//! backends is misrouting: a sibling client pointed elsewhere would lease
-//! its topics on the donor's wire, subscribe successfully, and receive
-//! nothing — hence the init log below.
+//! Clients dialing the same backend URL share ONE [`BidiTransport`]: topics
+//! from all of them multiplex onto a single bidi stream, and the transport's
+//! leases keep them apart (welcome topics are per-installation; a group
+//! topic two clients share is subscribed once and fanned out). One client
+//! per process — mobile — makes this invisible; a process running many
+//! clients (agents) gets one wire per backend instead of one per client.
+//! Wires are keyed by the URL the client's api client dials
+//! ([`XmtpMlsBidiStreams::host`]) — connection identity, not network
+//! identity: two clients behind the same proxy share that proxy's wire,
+//! while a proxied and a direct client to the same backend keep separate
+//! wires and separate failure domains (a severed proxy reconnects alone —
+//! the toxiproxy test clients depend on exactly this). The first client to
+//! stream to a destination donates its api client to that destination's
+//! opener. Auth is not at stake — a shared wire is receive-only (publishes
+//! keep each client's own api client and whatever authorization it carries),
+//! and on v3 the donated client attaches only version-attribution headers.
 //!
 //! ## The gate and the latch
 //!
 //! The bidi path is opt-in via [`BIDI_STREAMS_ENABLED_ENV`], read once at
 //! the first stream call: mobile apps set it at process init, agents in
 //! their deploy env. Unset (or anything but a truthy value) keeps the legacy
-//! streams. The gate is only the opt-in — whether the backend can serve the
-//! surface is discovered at the first wire open. A backend that cannot
+//! streams. The gate is only the opt-in — whether a backend can serve the
+//! surface is discovered at its first wire open. A backend that cannot
 //! refuses it — gRPC `UNIMPLEMENTED` from a v3 node without the surface, an
-//! in-process refusal from the d14n and migration api clients — and once the
-//! shared transport has tombstoned itself on such a refusal, every later
-//! stream sees it as `Closed` ([`is_bidi_unsupported`] classifies all
-//! three). Any of them trips a process-wide latch: the stream that hit it
-//! switches to the legacy path in place (the first caller loses nothing —
-//! nor does a startup burst, where every pre-latch stream hits its own
-//! refusal and falls back the same way), and every later dispatch goes
-//! straight to legacy ([`bidi_streams_active`]). The latch resets only with
-//! the process, so the env var is safe to enable against any *single*
-//! backend — the worst case is one refused open and a process on legacy
-//! streams. That safety leans on the one-backend-per-process assumption
-//! above: in a mixed process whose donor speaks bidi, other-backend clients
-//! are misrouted (receiving nothing), not refused, and no latch fires.
+//! in-process refusal from the d14n and migration api clients — and once a
+//! destination's transport has tombstoned itself on such a refusal, every
+//! later stream to it sees `Closed` ([`is_bidi_unsupported`] classifies all
+//! three). Any of them latches that destination onto the legacy streams:
+//! the stream that hit it switches to the legacy path in place (the first
+//! caller loses nothing — nor does a startup burst, where every pre-latch
+//! stream hits its own refusal and falls back the same way), and every
+//! later dispatch to that destination goes straight to legacy
+//! ([`bidi_streams_active`]). Destinations latch independently — a process
+//! mixing a bidi-capable v3 backend with, say, a d14n client keeps bidi on
+//! the v3 wire while the d14n client's streams ride legacy. Latches reset
+//! only with the process, so the env var is safe to enable against any
+//! backend mix — the worst case per destination is one refused open and its
+//! streams on legacy.
 //!
 //! Dispatch lives here, not with the bindings: each binding site makes one
 //! `*_with_callback_dispatch` call, and the `*_with_callback_bidi` entry
@@ -65,8 +68,10 @@
 //! never runs the task's tail but does drop it, so `StreamClosed` rides a
 //! drop guard.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, LazyLock, OnceLock};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, LazyLock};
+
+use parking_lot::Mutex;
 
 use futures::Stream;
 use tokio::sync::oneshot;
@@ -117,28 +122,53 @@ pub(crate) fn bidi_streams_enabled() -> bool {
     *ENABLED
 }
 
-/// Set once the backend refuses the bidi surface (see the module docs).
-/// Process-level like [`SHARED_TRANSPORT`], and for the same reason: one
-/// backend per process means one refusal verdict per process.
-static BIDI_UNSUPPORTED: AtomicBool = AtomicBool::new(false);
-
-/// Whether a new stream should take the bidi path: the gate is on and no
-/// earlier stream has latched the process onto legacy.
-pub fn bidi_streams_active() -> bool {
-    bidi_streams_enabled() && !BIDI_UNSUPPORTED.load(Ordering::Relaxed)
+/// Process-shared per-destination wire state (see the module docs): the
+/// transports, one per dialed URL, and the destinations whose backend
+/// refused the bidi surface. Process-level because both facts outlive any
+/// one client — clients dialing the same place share a wire, and a
+/// backend's capability verdict holds for everyone dialing it.
+struct SharedWires {
+    /// One transport per destination, created at that destination's first
+    /// stream. Entries are immortal (each holds the transport for the life
+    /// of the process — see [`shared_transport`]); real processes dial one
+    /// to three backends, so the map never meaningfully grows.
+    transports: HashMap<String, BidiTransport<V3Binding>>,
+    /// Destinations that refused the surface; their dispatches go straight
+    /// to legacy.
+    unsupported: HashSet<String>,
 }
 
-/// Latch the process onto the legacy streams. Called by the pump on a
+static SHARED_WIRES: LazyLock<Mutex<SharedWires>> = LazyLock::new(|| {
+    Mutex::new(SharedWires {
+        transports: HashMap::new(),
+        unsupported: HashSet::new(),
+    })
+});
+
+/// Whether a new stream to `host` should take the bidi path: the gate is on
+/// and no earlier stream has latched that destination onto legacy.
+pub fn bidi_streams_active(host: &str) -> bool {
+    bidi_streams_enabled() && !SHARED_WIRES.lock().unsupported.contains(host)
+}
+
+/// Latch a destination onto the legacy streams. Called by the pump on a
 /// backend refusal; tests pre-set it to exercise the latched dispatch.
-pub(crate) fn latch_bidi_unsupported() {
-    BIDI_UNSUPPORTED.store(true, Ordering::Relaxed);
+pub(crate) fn latch_bidi_unsupported(host: &str) {
+    SHARED_WIRES.lock().unsupported.insert(host.to_owned());
 }
 
-/// The latch's current state — test-only observability for the pump's
+/// A latch's current state — test-only observability for the pump's
 /// fallback branch. Gated like `router_callbacks_tests`, its only consumer.
 #[cfg(all(test, not(feature = "d14n")))]
-pub(crate) fn bidi_unsupported_latched() -> bool {
-    BIDI_UNSUPPORTED.load(Ordering::Relaxed)
+pub(crate) fn bidi_unsupported_latched(host: &str) -> bool {
+    SHARED_WIRES.lock().unsupported.contains(host)
+}
+
+/// The transport count — test-only observability for the per-destination
+/// keying.
+#[cfg(all(test, not(feature = "d14n")))]
+pub(crate) fn shared_transport_count() -> usize {
+    SHARED_WIRES.lock().transports.len()
 }
 
 /// Whether a subscribe failure means the backend refuses the bidi surface —
@@ -148,9 +178,9 @@ pub(crate) fn bidi_unsupported_latched() -> bool {
 ///   the surface does not exist ([`open_is_backend_refusal`]) — that verdict
 ///   is buried under wrappers whose retryability cannot be trusted, so the
 ///   chain is walked instead of asking `is_retryable`.
-/// - [`TransportError::Closed`] from a later `lease()`. The process-shared
-///   transport is immortal — [`SHARED_TRANSPORT`] holds a handle for the
-///   life of the process — so its ledger only ever dies by tombstoning
+/// - [`TransportError::Closed`] from a later `lease()`. A destination's
+///   shared transport is immortal — [`SHARED_WIRES`] holds its handle for
+///   the life of the process — so its ledger only ever dies by tombstoning
 ///   itself after an unretryable re-open: `Closed` is what the refusal looks
 ///   like to every stream after the one that saw it directly. Latching is
 ///   also the safe direction — the legacy path works everywhere.
@@ -210,26 +240,28 @@ pub(crate) fn is_bidi_dead_end(e: &RouterError) -> bool {
     matches!(e, RouterError::Transport(TransportError::Open(open)) if !open.is_retryable())
 }
 
-/// The process-wide transport (see the module docs). `OnceLock` rather than
-/// per-client state: the whole point is that clients share the wire.
+/// The shared transport for the destination `api` dials, created at that
+/// destination's first stream (see the module docs and [`SHARED_WIRES`]).
 ///
-/// Its ledger task is bound to the async runtime alive at first use — the
-/// one-runtime-per-process reality of mobile, node, and agents. A process
-/// that tears its runtime down and starts another (some non-`nextest` test
-/// harnesses) would find the cached transport dead; `nextest`'s
-/// process-per-test model keeps tests clear of that.
-static SHARED_TRANSPORT: OnceLock<BidiTransport<V3Binding>> = OnceLock::new();
-
-fn shared_transport<C>(api: C) -> BidiTransport<V3Binding>
+/// A transport's ledger task is bound to the async runtime alive at its
+/// first use — the one-runtime-per-process reality of mobile, node, and
+/// agents. A process that tears its runtime down and starts another (some
+/// non-`nextest` test harnesses) would find the cached transport dead;
+/// `nextest`'s process-per-test model keeps tests clear of that.
+pub(crate) fn shared_transport<C>(api: C) -> BidiTransport<V3Binding>
 where
     C: XmtpMlsBidiStreams + Clone + Send + Sync + 'static,
     C::SubscribeStream: 'static,
 {
-    SHARED_TRANSPORT
-        .get_or_init(move || {
-            // Whoever streams first donates their api client for the life of
-            // the process — log it, so a mixed-backend accident is findable.
-            tracing::info!("bidi: initializing the process-shared transport");
+    let host = api.host().to_owned();
+    SHARED_WIRES
+        .lock()
+        .transports
+        .entry(host)
+        .or_insert_with_key(|host| {
+            // Whoever streams to this destination first donates their api
+            // client for the life of the process.
+            tracing::info!(%host, "bidi: initializing the shared transport for a destination");
             BidiTransport::new(move |initial| {
                 let api = api.clone();
                 async move {
@@ -242,36 +274,47 @@ where
         .clone()
 }
 
-/// Take the shared bidi wire off the network (the `didEnterBackground` half
-/// of the app-lifecycle pair). Leases and wire positions are kept; nothing
-/// reconnects until [`resume_bidi_streams`]. A no-op when the transport was
-/// never opened (gate off, or nothing ever streamed).
+/// Take the shared bidi wires — every destination's — off the network (the
+/// `didEnterBackground` half of the app-lifecycle pair). Leases and wire
+/// positions are kept; nothing reconnects until [`resume_bidi_streams`]. A
+/// no-op when no transport was ever opened (gate off, or nothing ever
+/// streamed).
 pub async fn suspend_bidi_streams() -> Result<()> {
-    let Some(transport) = SHARED_TRANSPORT.get() else {
-        return Ok(());
-    };
-    transport
-        .suspend()
-        .await
-        .map_err(|e| super::stream_router::RouterError::Transport(e).into())
+    let transports: Vec<_> = SHARED_WIRES.lock().transports.values().cloned().collect();
+    settle_lifecycle(futures::future::join_all(transports.iter().map(|t| t.suspend())).await)
 }
 
-/// Bring the shared bidi wire back (`willEnterForeground`), resolving once
-/// a live wire has no catch-up wave left in flight. That is a wire-level
-/// mark: replayed messages may still be decoding and storing in the stream
-/// pipeline behind it; the wait is unbounded while the network is down, and
-/// a concurrent fresh subscribe on the shared transport extends it — the
-/// FFI exposure (follow-on) owes callers a processing-drain barrier and a
-/// deadline before this can honestly serve as the background-fetch
-/// primitive. A no-op when the transport was never opened.
+/// Bring the shared bidi wires back (`willEnterForeground`), resolving once
+/// every destination's live wire has no catch-up wave left in flight. That
+/// is a wire-level mark: replayed messages may still be decoding and storing
+/// in the stream pipeline behind it; the wait is unbounded while the network
+/// is down, and a concurrent fresh subscribe on a shared transport extends
+/// it — the FFI exposure (follow-on) owes callers a processing-drain barrier
+/// and a deadline before this can honestly serve as the background-fetch
+/// primitive. A no-op when no transport was ever opened.
 pub async fn resume_bidi_streams() -> Result<()> {
-    let Some(transport) = SHARED_TRANSPORT.get() else {
-        return Ok(());
-    };
-    transport
-        .resume()
-        .await
-        .map_err(|e| super::stream_router::RouterError::Transport(e).into())
+    let transports: Vec<_> = SHARED_WIRES.lock().transports.values().cloned().collect();
+    settle_lifecycle(futures::future::join_all(transports.iter().map(|t| t.resume())).await)
+}
+
+/// Fold a lifecycle fan-out's results, driving EVERY destination before
+/// reporting: `join_all` (never `try_join_all`) upstream, so one dead wire
+/// cannot abandon the others mid-suspend/resume. A `Closed` transport is a
+/// tombstoned destination (backend refused the surface) — permanently off
+/// the network with its streams on legacy, so the lifecycle intent holds
+/// for it vacuously; any other error is reported after the fan-out settles.
+fn settle_lifecycle(results: Vec<std::result::Result<(), TransportError>>) -> Result<()> {
+    for result in results {
+        match result {
+            Ok(()) | Err(TransportError::Closed) => {}
+            Err(e) => {
+                return Err(SubscribeError::from(
+                    super::stream_router::RouterError::Transport(e),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Drain a router stream into a callback until it ends or the client shuts
@@ -321,12 +364,40 @@ impl Drop for StreamClosedGuard {
     }
 }
 
+/// Where a stream comes from: the per-stream identity [`pump_stream`]
+/// needs, derived from ONE context so the latch destination can never
+/// disagree with the client that built the subscribe and fallback futures.
+pub(crate) struct StreamOrigin {
+    pub(crate) kind: StreamKind,
+    pub(crate) installation: InstallationId,
+    /// The destination key ([`XmtpMlsBidiStreams::host`]) the stream
+    /// latches on a backend refusal.
+    pub(crate) host: String,
+    pub(crate) cancel: CancellationToken,
+}
+
+impl StreamOrigin {
+    fn new<Context>(kind: StreamKind, context: &Context) -> Self
+    where
+        Context: XmtpSharedContext,
+        Context::ApiClient: XmtpMlsBidiStreams,
+    {
+        Self {
+            kind,
+            installation: context.installation_id(),
+            host: context.api().api_client.host().to_owned(),
+            cancel: context.cancellation_token().clone(),
+        }
+    }
+}
+
 /// One spawned bidi stream: emit `StreamOpened`, subscribe, signal ready,
 /// then pump into the callback until the stream ends or the client shuts
 /// down. Every entry point is this wrapper plus its subscribe future and a
 /// `fallback` factory that builds its legacy counterpart stream. When the
 /// subscribe fails with a backend refusal ([`is_bidi_unsupported`]) the task
-/// latches the process onto legacy; on a refusal or a dead-end open
+/// latches the stream's destination ([`StreamOrigin::host`]) onto legacy;
+/// on a refusal or a dead-end open
 /// ([`is_bidi_dead_end`]) it keeps serving THIS stream by handing the
 /// factory to the legacy watchdog runner ([`run_watchdog_stream`]) — the
 /// same runner the legacy entry points spawn, stale-trip re-subscribe and
@@ -342,9 +413,7 @@ impl Drop for StreamClosedGuard {
 /// objects emit their own pair — and re-armed when the fallback fails at
 /// startup, having built no stream object to pair the open).
 pub(crate) fn pump_stream<T, S, FSub, FFut, FS>(
-    kind: StreamKind,
-    installation: InstallationId,
-    cancel: CancellationToken,
+    origin: StreamOrigin,
     subscribe: S,
     fallback: FSub,
     callback: impl FnMut(Result<T>) + MaybeSend + 'static,
@@ -359,6 +428,12 @@ where
 {
     let (tx, rx) = oneshot::channel();
     xmtp_common::spawn(Some(rx), async move {
+        let StreamOrigin {
+            kind,
+            installation,
+            host,
+            cancel,
+        } = origin;
         log_event!(Event::StreamOpened, installation, kind = ?kind);
         let mut closed = StreamClosedGuard {
             kind,
@@ -370,13 +445,13 @@ where
                 if is_bidi_unsupported(&e) {
                     tracing::error!(
                         "bidi {kind:?} stream refused by the backend, \
-                         latching this process onto the legacy streams: {e}"
+                         latching {host} onto the legacy streams: {e}"
                     );
-                    latch_bidi_unsupported();
+                    latch_bidi_unsupported(&host);
                 } else {
                     // Not a capability verdict, but no redial of this open
                     // can succeed either — serve this one stream on legacy
-                    // and leave the process-wide latch to a cleaner failure.
+                    // and leave this destination's latch to a cleaner failure.
                     tracing::warn!(
                         "bidi {kind:?} stream open failed unretryably, \
                          serving this stream on the legacy path: {e}"
@@ -414,8 +489,9 @@ where
             Ok(stream) => stream,
         };
         // The bidi path won: don't hold the fallback factory's captured
-        // clones for the (long) life of this stream.
-        drop(fallback);
+        // clones — or the latch host, needed only on the losing arms — for
+        // the (long) life of this stream.
+        drop((fallback, host));
         let _ = tx.send(());
         pump(stream, cancel, callback, on_close).await;
         tracing::debug!("bidi {kind:?} stream ended");
@@ -505,7 +581,7 @@ where
         callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
         on_close: impl FnOnce() + MaybeSend + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
-        if bidi_streams_active() {
+        if bidi_streams_active(client.context.api().api_client.host()) {
             DispatchHandle::Bidi(Self::stream_all_messages_with_callback_bidi(
                 client,
                 conversation_type,
@@ -536,8 +612,7 @@ where
         callback: impl FnMut(Result<StoredGroupMessage>) + MaybeSend + 'static,
         on_close: impl FnOnce() + MaybeSend + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
-        let installation = client.context.installation_id();
-        let cancel = client.context.cancellation_token().clone();
+        let origin = StreamOrigin::new(StreamKind::All, &client.context);
         let fallback = {
             let client = client.clone();
             let consent_states = consent_states.clone();
@@ -557,15 +632,7 @@ where
                 .stream_all_messages(conversation_type, consent_states, DEFAULT_STREAM_DEPTH)
                 .await
         };
-        pump_stream(
-            StreamKind::All,
-            installation,
-            cancel,
-            subscribe,
-            fallback,
-            callback,
-            on_close,
-        )
+        pump_stream(origin, subscribe, fallback, callback, on_close)
     }
 
     /// The one call the bindings make for a conversations stream: the bidi
@@ -578,7 +645,7 @@ where
         callback: impl FnMut(Result<MlsGroup<Context>>) + MaybeSend + 'static,
         on_close: impl FnOnce() + MaybeSend + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
-        if bidi_streams_active() {
+        if bidi_streams_active(client.context.api().api_client.host()) {
             DispatchHandle::Bidi(Self::stream_conversations_with_callback_bidi(
                 client,
                 conversation_type,
@@ -608,8 +675,7 @@ where
         callback: impl FnMut(Result<MlsGroup<Context>>) + MaybeSend + 'static,
         on_close: impl FnOnce() + MaybeSend + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
-        let installation = client.context.installation_id();
-        let cancel = client.context.cancellation_token().clone();
+        let origin = StreamOrigin::new(StreamKind::Conversations, &client.context);
         let fallback = {
             let client = client.clone();
             move || {
@@ -632,15 +698,7 @@ where
                 )
                 .await
         };
-        pump_stream(
-            StreamKind::Conversations,
-            installation,
-            cancel,
-            subscribe,
-            fallback,
-            callback,
-            on_close,
-        )
+        pump_stream(origin, subscribe, fallback, callback, on_close)
     }
 }
 
@@ -660,7 +718,7 @@ where
     <Context::ApiClient as XmtpMlsBidiStreams>::SubscribeStream: 'static,
     Context::Db: 'static,
 {
-    if bidi_streams_active() {
+    if bidi_streams_active(context.api().api_client.host()) {
         DispatchHandle::Bidi(stream_conversation_messages_with_callback_bidi(
             context, group_id, callback, on_close,
         ))
@@ -692,8 +750,7 @@ where
     <Context::ApiClient as XmtpMlsBidiStreams>::SubscribeStream: 'static,
     Context::Db: 'static,
 {
-    let installation = context.installation_id();
-    let cancel = context.cancellation_token().clone();
+    let origin = StreamOrigin::new(StreamKind::Messages, &context);
     // `StreamGroupMessages::new_owned` directly: the legacy entry point for
     // this shape (`stream_messages_with_callback`) subscribes the same way —
     // context-based, there is no group object to call `stream_owned` on.
@@ -711,13 +768,5 @@ where
             .stream_messages(vec![group_id], DEFAULT_STREAM_DEPTH)
             .await
     };
-    pump_stream(
-        StreamKind::Messages,
-        installation,
-        cancel,
-        subscribe,
-        fallback,
-        callback,
-        on_close,
-    )
+    pump_stream(origin, subscribe, fallback, callback, on_close)
 }

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
@@ -8,9 +8,10 @@ use xmtp_common::StreamHandle;
 
 use crate::Client;
 use crate::subscriptions::router_callbacks::{
-    bidi_streams_active, bidi_unsupported_latched, is_bidi_dead_end, is_bidi_unsupported,
-    latch_bidi_unsupported, pump_stream, resume_bidi_streams,
-    stream_conversation_messages_with_callback_bidi, suspend_bidi_streams,
+    StreamOrigin, bidi_streams_active, bidi_unsupported_latched, is_bidi_dead_end,
+    is_bidi_unsupported, latch_bidi_unsupported, pump_stream, resume_bidi_streams,
+    shared_transport, shared_transport_count, stream_conversation_messages_with_callback_bidi,
+    suspend_bidi_streams,
 };
 use crate::tester;
 use crate::utils::MlsGroupExt;
@@ -401,11 +402,11 @@ fn garbled_frame() -> prost::DecodeError {
 ///
 /// The live end of this scenario — a shared-transport opener actually
 /// refusing and the pump latching mid-task — has no seam to inject through:
-/// `SHARED_TRANSPORT` is built from the first streamer's real api client by
-/// design, and a test-only override would weaken that invariant for one
-/// test's sake. This classification test plus the `pump_*` fallback tests
-/// below cover both halves instead, and the transport's own tests cover the
-/// opener refusing with `Open`.
+/// a destination's shared transport is built from the first streamer's real
+/// api client by design, and a test-only override would weaken that
+/// invariant for one test's sake. This classification test plus the `pump_*`
+/// fallback tests below cover both halves instead, and the transport's own
+/// tests cover the opener refusing with `Open`.
 #[xmtp_common::test]
 fn only_a_backend_refusal_latches() {
     use crate::subscriptions::stream_router::RouterError;
@@ -476,9 +477,9 @@ fn only_a_backend_refusal_latches() {
         "but it is a dead end, so the stream falls back"
     );
 
-    // The tombstoned shared transport: the process-wide `OnceLock` handle is
-    // immortal, so its ledger only dies by shutting down after a refusal —
-    // `Closed` is the refusal as every later stream sees it.
+    // The tombstoned shared transport: a destination's handle is immortal,
+    // so its ledger only dies by shutting down after a refusal — `Closed` is
+    // the refusal as every later stream to that destination sees it.
     assert!(
         is_bidi_unsupported(&RouterError::Transport(TransportError::Closed)),
         "a closed shared transport is the post-refusal tombstone and must latch"
@@ -492,20 +493,29 @@ fn only_a_backend_refusal_latches() {
     assert!(!is_bidi_dead_end(&RouterError::Closed));
 }
 
-/// With the latch pre-set — the process already saw a refusal — a
-/// dispatcher-entered stream serves via the legacy path and delivery still
-/// works. No env mutation: with the latch set, the dispatcher's legacy arm
-/// is the same code path a gate-off process takes, so the default test
-/// environment exercises exactly the arm a latched gate-on process uses.
+/// With the latch pre-set — the process already saw this destination
+/// refuse — a dispatcher-entered stream serves via the legacy path and
+/// delivery still works. No env mutation: with the latch set, the
+/// dispatcher's legacy arm is the same code path a gate-off process takes,
+/// so the default test environment exercises exactly the arm a latched
+/// gate-on process uses.
 #[xmtp_common::test(unwrap_try = true)]
 async fn latched_dispatch_delivers_via_legacy() {
-    // nextest runs one test per process, so setting this process's latch
-    // leaks nowhere.
-    latch_bidi_unsupported();
-    assert!(!bidi_streams_active(), "the latch must keep bidi inactive");
+    use crate::context::XmtpSharedContext;
+    use xmtp_proto::api_client::XmtpMlsBidiStreams;
 
     tester!(alix);
     tester!(bo);
+
+    // The destination the dispatcher will look up is the tester's real
+    // backend; nextest runs one test per process, so latching it leaks
+    // nowhere.
+    let host = bo.client.context.api().api_client.host().to_owned();
+    latch_bidi_unsupported(&host);
+    assert!(
+        !bidi_streams_active(&host),
+        "the latch must keep bidi inactive for this destination"
+    );
 
     let group = alix.create_group(None, None)?;
     group.invite(&bo).await?;
@@ -538,6 +548,7 @@ async fn latched_dispatch_delivers_via_legacy() {
 /// `wait_for_ready` would hang otherwise, so the timeout doubles as that
 /// assertion.
 async fn pump_through_fallback(
+    host: &str,
     error: crate::subscriptions::stream_router::RouterError,
 ) -> (Vec<u8>, usize) {
     use crate::subscriptions::StreamKind;
@@ -558,10 +569,14 @@ async fn pump_through_fallback(
             closes.fetch_add(1, Ordering::SeqCst);
         }
     };
+    let origin = StreamOrigin {
+        kind: StreamKind::All,
+        installation: InstallationId::from([0u8; 32]),
+        host: host.to_owned(),
+        cancel: CancellationToken::new(),
+    };
     let mut handle = pump_stream(
-        StreamKind::All,
-        InstallationId::from([0u8; 32]),
-        CancellationToken::new(),
+        origin,
         subscribe,
         fallback,
         move |item| {
@@ -605,11 +620,14 @@ async fn pump_latches_and_serves_the_fallback_on_a_grpc_refusal() {
         )))
         .endpoint("/xmtp.mls.api.v1.MlsApi/Subscribe"),
     );
-    let (items, closes) =
-        pump_through_fallback(RouterError::Transport(TransportError::Open(refusal))).await;
+    let (items, closes) = pump_through_fallback(
+        "test://grpc-refusal",
+        RouterError::Transport(TransportError::Open(refusal)),
+    )
+    .await;
     assert!(
-        bidi_unsupported_latched(),
-        "the refusal must latch the process"
+        bidi_unsupported_latched("test://grpc-refusal"),
+        "the refusal must latch its destination"
     );
     assert_eq!(items, vec![1, 2], "the fallback's items reach the callback");
     assert_eq!(closes, 1, "on_close fires exactly once, at the natural end");
@@ -626,11 +644,14 @@ async fn pump_latches_and_serves_the_fallback_on_the_stub_refusal() {
     let refusal = OpenError::new(ApiClientError::OtherUnretryable(
         "the v3 bidi subscription is not available on this client".into(),
     ));
-    let (items, closes) =
-        pump_through_fallback(RouterError::Transport(TransportError::Open(refusal))).await;
+    let (items, closes) = pump_through_fallback(
+        "test://stub-refusal",
+        RouterError::Transport(TransportError::Open(refusal)),
+    )
+    .await;
     assert!(
-        bidi_unsupported_latched(),
-        "the stub refusal must latch the process"
+        bidi_unsupported_latched("test://stub-refusal"),
+        "the stub refusal must latch its destination"
     );
     assert_eq!(items, vec![1, 2], "the fallback's items reach the callback");
     assert_eq!(closes, 1, "on_close fires exactly once, at the natural end");
@@ -646,10 +667,13 @@ async fn pump_serves_the_fallback_without_latching_on_a_dead_end() {
     use xmtp_proto::api::ApiClientError;
 
     let dead_end = OpenError::new(ApiClientError::DecodeError(garbled_frame()));
-    let (items, closes) =
-        pump_through_fallback(RouterError::Transport(TransportError::Open(dead_end))).await;
+    let (items, closes) = pump_through_fallback(
+        "test://dead-end",
+        RouterError::Transport(TransportError::Open(dead_end)),
+    )
+    .await;
     assert!(
-        !bidi_unsupported_latched(),
+        !bidi_unsupported_latched("test://dead-end"),
         "a dead end is not a capability verdict and must not latch"
     );
     assert_eq!(items, vec![1, 2], "the fallback's items reach the callback");
@@ -687,4 +711,63 @@ async fn stream_all_with_no_conversations_stays_open() {
         "an empty subscription must stay open, not error-close"
     );
     assert!(rx.try_recv().is_err(), "nothing should have been delivered");
+}
+
+/// A bidi api that never opens — just enough identity to key a transport.
+#[derive(Clone)]
+struct FixedHostApi(&'static str);
+
+#[xmtp_common::async_trait]
+impl xmtp_proto::api_client::XmtpMlsBidiStreams for FixedHostApi {
+    type SubscribeStream = futures::stream::BoxStream<
+        'static,
+        std::result::Result<xmtp_proto::mls_v1::SubscribeResponse, xmtp_proto::api::ApiClientError>,
+    >;
+    type Error = xmtp_proto::api::ApiClientError;
+
+    fn host(&self) -> &str {
+        self.0
+    }
+
+    async fn subscribe_bidi(
+        &self,
+        _requests: futures::stream::BoxStream<'static, xmtp_proto::mls_v1::SubscribeRequest>,
+    ) -> std::result::Result<Self::SubscribeStream, Self::Error> {
+        Err(xmtp_proto::api::ApiClientError::OtherUnretryable(
+            "this test api never opens".into(),
+        ))
+    }
+}
+
+/// Transports key by dialed URL: a second client to the same host shares
+/// the wire, a different host — the same backend behind a proxy, say — gets
+/// its own. (nextest's process-per-test model keeps the count clean.)
+#[xmtp_common::test]
+async fn transports_key_by_destination() {
+    let before = shared_transport_count();
+    let _a = shared_transport(FixedHostApi("test://backend-a"));
+    let _a_again = shared_transport(FixedHostApi("test://backend-a"));
+    assert_eq!(
+        shared_transport_count(),
+        before + 1,
+        "the same host shares one transport"
+    );
+    let _b = shared_transport(FixedHostApi("test://backend-b"));
+    assert_eq!(
+        shared_transport_count(),
+        before + 2,
+        "a different host gets its own"
+    );
+}
+
+/// Latches are per destination: one backend refusing the surface leaves
+/// every other destination's dispatch untouched.
+#[xmtp_common::test]
+fn destinations_latch_independently() {
+    latch_bidi_unsupported("test://refusing-backend");
+    assert!(bidi_unsupported_latched("test://refusing-backend"));
+    assert!(
+        !bidi_unsupported_latched("test://healthy-backend"),
+        "a sibling destination must not inherit the latch"
+    );
 }

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks_tests.rs
@@ -313,6 +313,52 @@ async fn suspend_resume_replays_what_was_missed() {
     assert_eq!(delivered.decrypted_message_bytes, b"backgrounded again");
 }
 
+/// The launched-into-background case: `suspend_bidi_streams()` lands before
+/// any stream exists — no transport yet, only the intent is recorded — so
+/// the first stream's wire opens parked instead of live. A message sent
+/// while parked arrives only after `resume_bidi_streams()`. (Process-per-
+/// test keeps the recorded intent from leaking anywhere.)
+#[xmtp_common::test(unwrap_try = true)]
+async fn suspend_before_the_first_stream_parks_the_wire() {
+    suspend_bidi_streams().await?;
+
+    tester!(alix);
+    tester!(bo);
+    let group = alix.create_group(None, None)?;
+    group.invite(&bo).await?;
+    bo.sync_welcomes().await?;
+    bo.group(&group.group_id)?.sync().await?;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut handle = Client::stream_all_messages_with_callback_bidi(
+        Arc::new(bo.client.clone()),
+        None,
+        None,
+        move |message| {
+            let _ = tx.send(message);
+        },
+        || {},
+    );
+    handle.wait_for_ready().await;
+
+    // The wire is parked: nothing may deliver, no matter how long we wait.
+    group.send_msg(b"sent before resume").await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(
+        rx.try_recv().is_err(),
+        "a wire born suspended must not deliver before resume"
+    );
+
+    // Resume opens the wire; the parked lease catches up from its cursors
+    // and the missed message arrives.
+    resume_bidi_streams().await?;
+    let delivered = tokio::time::timeout(WAIT, rx.recv())
+        .await
+        .expect("timed out waiting for the post-resume delivery")
+        .expect("callback channel closed")?;
+    assert_eq!(delivered.decrypted_message_bytes, b"sent before resume");
+}
+
 /// The lifecycle helpers are safe to call before anything ever streamed:
 /// with no transport in the process they resolve as no-ops. (Real on
 /// mobile — backgrounding can beat the first subscription.)
@@ -323,6 +369,10 @@ async fn lifecycle_helpers_are_noops_without_a_transport() {
     suspend_bidi_streams().await?;
     resume_bidi_streams().await?;
     suspend_bidi_streams().await?;
+    // End resumed: a trailing suspend would leave the recorded intent set,
+    // making any later first wire in this process park (harmless under
+    // process-per-test, a trap under any single-process runner).
+    resume_bidi_streams().await?;
 }
 
 /// Sync-group traffic is intercepted, exactly like the legacy stream: it
@@ -769,5 +819,32 @@ fn destinations_latch_independently() {
     assert!(
         !bidi_unsupported_latched("test://healthy-backend"),
         "a sibling destination must not inherit the latch"
+    );
+}
+
+/// A born-suspended wire defers its backend's capability discovery to the
+/// resume re-open — past the point where any stream could see the refusal
+/// and latch. The lifecycle fold must latch it instead: suspend intent, a
+/// first lease that parks, then a resume whose open refuses tombstones the
+/// transport, and the destination ends up latched so re-subscribes ride
+/// legacy.
+#[xmtp_common::test(unwrap_try = true)]
+async fn a_resume_time_refusal_latches_its_destination() {
+    use xmtp_proto::types::Topic;
+
+    suspend_bidi_streams().await?;
+    let transport = shared_transport(FixedHostApi("test://born-refused"));
+    // Registers and parks — born suspended, the refusing opener never runs.
+    let _lease = transport
+        .lease(vec![(Topic::new_group_message(b"g"), 0)], 8)
+        .await?;
+
+    // The re-open runs the opener, the refusal tombstones the transport,
+    // and the fold latches the destination — while the call itself settles
+    // Ok (a tombstoned destination is vacuously resumed).
+    resume_bidi_streams().await?;
+    assert!(
+        bidi_unsupported_latched("test://born-refused"),
+        "a refusal first seen at resume must latch its destination"
     );
 }

--- a/crates/xmtp_mls/src/subscriptions/stream_router_tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router_tests.rs
@@ -17,14 +17,17 @@ where
     C: xmtp_proto::api_client::XmtpMlsBidiStreams + Clone + Send + Sync + 'static,
     C::SubscribeStream: 'static,
 {
-    BidiTransport::new(move |initial| {
-        let api = api.clone();
-        async move {
-            BidiConnection::open(&api, initial)
-                .await
-                .map_err(OpenError::new)
-        }
-    })
+    BidiTransport::new(
+        move |initial| {
+            let api = api.clone();
+            async move {
+                BidiConnection::open(&api, initial)
+                    .await
+                    .map_err(OpenError::new)
+            }
+        },
+        false,
+    )
 }
 
 /// Live delivery: a message sent after subscribing arrives decoded on the

--- a/crates/xmtp_proto/src/api_client.rs
+++ b/crates/xmtp_proto/src/api_client.rs
@@ -182,6 +182,13 @@ xmtp_common::if_native! {
 
         type Error: RetryableError + 'static;
 
+        /// The URL this client's bidi surface dials
+        /// ([`Client::host`](crate::traits::Client::host)) — the wire-sharing
+        /// key: clients whose surfaces dial the same URL multiplex onto one
+        /// process-shared wire, and each URL carries its own unsupported
+        /// latch (see xmtp_mls's router callbacks).
+        fn host(&self) -> &str;
+
         /// Open the bidirectional stream. `requests` is the outbound
         /// client→server frame stream (typically fed by a channel; the first
         /// frame is usually a `Mutate` naming the initial topic set); the

--- a/crates/xmtp_proto/src/api_client/impls.rs
+++ b/crates/xmtp_proto/src/api_client/impls.rs
@@ -417,6 +417,10 @@ xmtp_common::if_native! {
         type Error = <T as XmtpMlsBidiStreams>::Error;
         type SubscribeStream = <T as XmtpMlsBidiStreams>::SubscribeStream;
 
+        fn host(&self) -> &str {
+            (**self).host()
+        }
+
         async fn subscribe_bidi(
             &self,
             requests: futures::stream::BoxStream<'static, crate::mls_v1::SubscribeRequest>,
@@ -432,6 +436,10 @@ xmtp_common::if_native! {
     {
         type Error = <T as XmtpMlsBidiStreams>::Error;
         type SubscribeStream = <T as XmtpMlsBidiStreams>::SubscribeStream;
+
+        fn host(&self) -> &str {
+            (**self).host()
+        }
 
         async fn subscribe_bidi(
             &self,

--- a/crates/xmtp_proto/src/traits.rs
+++ b/crates/xmtp_proto/src/traits.rs
@@ -129,6 +129,13 @@ impl Stream for BytesStream {
 /// an http response is easily derived from a grpc, jsonrpc or rest api.
 #[xmtp_common::async_trait]
 pub trait Client: MaybeSend + MaybeSync {
+    /// The URL this transport dials — its connection identity. Two clients
+    /// share process-level connection state (the XIP-83 shared bidi wire)
+    /// exactly when their hosts match, so this must name where the bytes
+    /// actually go: a client behind a proxy reports the proxy's URL, keeping
+    /// it a separate failure domain from a direct client to the same backend.
+    fn host(&self) -> &str;
+
     async fn request(
         &self,
         request: request::Builder,
@@ -178,6 +185,10 @@ impl<T: MaybeSend + MaybeSync + ?Sized> Client for &T
 where
     T: Client,
 {
+    fn host(&self) -> &str {
+        (**self).host()
+    }
+
     async fn request(
         &self,
         request: request::Builder,
@@ -211,6 +222,10 @@ impl<T: MaybeSend + MaybeSync + ?Sized> Client for Box<T>
 where
     T: Client,
 {
+    fn host(&self) -> &str {
+        (**self).host()
+    }
+
     async fn request(
         &self,
         request: request::Builder,
@@ -244,6 +259,10 @@ impl<T: MaybeSend + MaybeSync + ?Sized> Client for Arc<T>
 where
     T: Client,
 {
+    fn host(&self) -> &str {
+        (**self).host()
+    }
+
     async fn request(
         &self,
         request: request::Builder,

--- a/crates/xmtp_proto/src/traits/boxed_client.rs
+++ b/crates/xmtp_proto/src/traits/boxed_client.rs
@@ -31,6 +31,10 @@ impl<C> Client for BoxedClient<C>
 where
     C: Client,
 {
+    fn host(&self) -> &str {
+        self.inner.host()
+    }
+
     async fn request(
         &self,
         request: request::Builder,

--- a/crates/xmtp_proto/src/traits/mock.rs
+++ b/crates/xmtp_proto/src/traits/mock.rs
@@ -69,6 +69,8 @@ mockall::mock! {
 
     #[xmtp_common::async_trait]
     impl Client for NetworkClient {
+        fn host(&self) -> &str;
+
         async fn request(
             &self,
             request: http::request::Builder,


### PR DESCRIPTION
Two stacked commits that remove the one-backend-per-process assumption from the XIP-83 shared bidi transport, then use the resulting registry to fix suspend-before-first-stream.

## Commit 1 — key the shared bidi transport by destination

The process-shared `BidiTransport` becomes **one transport per dialed backend URL**. The single `SHARED_TRANSPORT: OnceLock` + global `BIDI_UNSUPPORTED: AtomicBool` are replaced by a mutex-guarded registry keying both the transports and the unsupported latch by destination.

- `xmtp_proto::traits::Client` and `XmtpMlsBidiStreams` gain `fn host(&self) -> &str` — the URL the transport dials, i.e. its **connection identity**. No default impl, so the compiler enforces every client/wrapper states its identity (~15 impls).
- `GrpcClient` retains the dialed URL from its builder (as `Url` serializes it, so every spelling of the same URL normalizes to one key). The caller-less `GrpcClient::new` is deleted — it was a host/service divergence hazard.
- Sharing is connection identity, **not** network identity: clients behind the same proxy share that proxy's wire; a proxied and a direct client to the same backend keep separate failure domains (the toxiproxy tests depend on exactly this).
- Wrapper semantics: `MultiNodeClient` reports the stable gateway URL (the resolved node is transient); surfaces that never open a bidi wire (`D14nClient`, `MigrationClient`) key reserved `unsupported://` schemes so their refusal can never latch a destination a bidi-capable sibling could serve.
- The legacy-fallback latch is per-destination: one backend refusing bidi no longer condemns every other backend in the process to legacy streams.
- Suspend/resume fan out across every destination's wire (`join_all`, not fail-fast — one tombstoned wire must not abandon its healthy siblings mid-suspend).

## Commit 2 — honor suspend intent before a destination's transport exists

`suspend_bidi_streams()` was a no-op for a destination whose shared transport did not exist yet: an app launched into the background that suspended before opening any stream lost the intent, and the first stream then opened its wire live while backgrounded.

- The registry now records `suspend_requested` (set by suspend, cleared by resume, even when no transport exists yet). It lives under the same registry mutex as transport creation, so flag flips and first-lease creation serialize — either race order ends with the wire parked.
- `BidiTransport::new` gains `initially_suspended`, threaded into the ledger actor: a transport created under suspend intent is **born suspended**, and its first lease parks instead of dialing.
- Interaction bug found in review and fixed here: a born-suspended wire defers its backend's capability discovery to the resume-time re-open — past the point where any stream could observe the refusal and fall back. The lifecycle fold now latches a destination whose suspend/resume settles `Closed` (the same tombstone verdict a lease would see): parked streams end through their normal `on_close`, and re-subscribes ride legacy.
- `catch_up_to_live` deliberately ignores the intent — a backgrounded app calling it *is* the background fetch — and both sides document that.

One deliberate scope choice: `suspend_requested` is a single registry-level flag, not per-endpoint. The suspend API is app-lifecycle-scoped and names no endpoint, destinations that don't exist yet can't be pre-keyed, and already-created transports carry their own per-actor suspended state.

## Testing

- `just lint-rust` green at **both** commits (each stands alone).
- New unit/registry tests: `transports_key_by_destination`, `destinations_latch_independently`, `a_born_suspended_transport_parks_the_first_lease` (transport-level), `a_resume_time_refusal_latches_its_destination`.
- New live test against the docker node: `suspend_before_the_first_stream_parks_the_wire` — suspend with no transport → first stream opens parked (message sent, 500 ms silence) → resume → message delivered.
- Full v3 suite: 2416/2416 (only failure across runs was the pre-existing `should_reconnect` toxiproxy flake, which flakes identically on unmodified main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AVuJ7VAgen2fFhtJQ6zid


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key shared bidi transport and legacy fallback latch by destination host
> - Adds a `host() -> &str` method to the `Client` and `XmtpMlsBidiStreams` traits so each transport can identify the backend it dials; all middleware wrappers, boxed clients, and gRPC client delegate accordingly.
> - Replaces the single process-wide shared bidi transport and latch with a per-destination registry (`SharedWires`) keyed by `host()`, so different backends operate independently.
> - `BidiTransport::new` gains an `initially_suspended: bool` parameter; transports created while the app is backgrounded start suspended and defer connection until `resume_bidi_streams()` is called.
> - `suspend_bidi_streams` and `resume_bidi_streams` now fan out to all known destination transports and record intent so future transports are born in the correct state.
> - Risk: the per-destination registry and born-suspended flag change connection timing behavior; clients connecting to multiple backends now have independent latch and suspend state rather than a shared global.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 963f01b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->