### PR TITLE
test(bindings): strengthen node catch-up test assertions

### DIFF
--- a/bindings/node/test/CatchUp.test.ts
+++ b/bindings/node/test/CatchUp.test.ts
@@ -19,15 +19,30 @@ describe('catchUpToLive', () => {
     ])
     await group.sendText('missed while away')
 
+    // Nothing has reached client2 yet — no welcome, no message.
     expect(client2.conversations().list().length).toBe(0)
 
     const summary = await client2.catchUpToLive()
     expect(Number(summary.conversations)).toBeGreaterThanOrEqual(1)
     expect(Number(summary.messages)).toBeGreaterThanOrEqual(1)
-    expect(client2.conversations().list().length).toBe(1)
 
-    // Nothing owed now: a second run persists nothing new.
+    // The group is now present locally...
+    const groups = client2.conversations().list()
+    expect(groups.length).toBe(1)
+    const group2 = groups[0].conversation
+    expect(group2.id()).toBe(group.id())
+
+    // ...and catch-up actually delivered the payload, not just a counter:
+    // the missed text is readable with no further sync() call.
+    const messages = await group2.listEnrichedMessages()
+    const texts = messages.map((m) => m.content.text)
+    expect(texts).toContain('missed while away')
+
+    // Nothing owed now: a second run persists nothing new — neither the
+    // already-delivered message nor the already-known conversation.
     const again = await client2.catchUpToLive()
     expect(Number(again.messages)).toBe(0)
+    expect(Number(again.conversations)).toBe(0)
+    expect(client2.conversations().list().length).toBe(1)
   })
 })


### PR DESCRIPTION
Follow-up to #3858. That PR added `catchUpToLive` to the node bindings with a happy-path test that asserted only the summary **counts**. This strengthens the same test so it proves the behavior that actually matters, without changing any production code.

### What's asserted now
- **Real payload delivery, not just a counter** — after catch-up, the joined group's `listEnrichedMessages()` is read (with no further `sync()`) and the missed text `"missed while away"` must be present. A counter bump alone no longer passes.
- **Group identity** — the conversation catch-up joined is the one client1 created (`group2.id() === group.id()`).
- **Idempotency on both axes** — the second `catchUpToLive()` must report `messages === 0` **and** `conversations === 0`, and the store still holds exactly the one group.

### Verification
Built with `--features test-utils` and ran `vitest run CatchUp` against a local backend — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strengthen `catchUpToLive` test assertions in node bindings
> Expands the `catchUpToLive` test in [CatchUp.test.ts](https://github.com/xmtp/libxmtp/pull/3862/files#diff-87b728ea9949cdfa8ae68c798970fe55bb7adaa69b5d40c6807827314dbdeec9) to more thoroughly validate behavior after catch-up.
>
> - Adds a precondition assertion that `client2` has no conversations before calling `catchUpToLive`
> - Asserts that the group appears in `client2`'s local conversation list with the correct id after catch-up
> - Verifies missed message content is readable via `listEnrichedMessages` without an extra sync call
> - Asserts that a second call to `catchUpToLive` returns zero new messages and zero new conversations, and that the local conversation count remains one
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e2b1dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->