### PR TITLE
fix(xmtp_mls_common,xmtp_mls): per-entry validation on steady-state registry writes + tolerant registry loads

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -175,6 +175,15 @@ impl From<ComponentTypedError> for ComponentSourceError {
                 component_id: id,
                 reason: "registered ComponentType is Unspecified".to_string(),
             },
+            // A COMPONENT_REGISTRY delta that violates the registry's
+            // write invariants (reserved/hardcoded/out-of-space id,
+            // immutable overwrite, undecodable metadata). Structurally
+            // a malformed value for the registry component; the reason
+            // string carries the specific violation.
+            ComponentTypedError::RegistryMutation(e) => Self::MalformedComponentValue {
+                component_id: ComponentId::COMPONENT_REGISTRY,
+                reason: e.to_string(),
+            },
         }
     }
 }
@@ -1127,6 +1136,7 @@ fn encode_inbox_id_set_delta(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use prost::Message;
     use tls_codec::VLBytes;
     use xmtp_mls_common::{
         app_data::{
@@ -1607,12 +1617,24 @@ mod tests {
     fn test_apply_component_registry_delta_against_empty() {
         // Bootstrap shape: a `TlsMapDelta<ComponentId, VLBytes>` of
         // all-`Insert` mutations applied against an empty map produces
-        // a materialized snapshot containing those entries.
+        // a materialized snapshot containing those entries. Values must
+        // be structurally valid `ComponentMetadata` — registry deltas
+        // are entry-validated at apply.
         let id_a = ComponentId::GROUP_NAME;
         let id_b = ComponentId::GROUP_DESCRIPTION;
+        let meta_a = registry_with(id_a, ComponentType::String)
+            .get(&id_a)
+            .unwrap()
+            .unwrap()
+            .encode_to_vec();
+        let meta_b = registry_with(id_b, ComponentType::Bytes)
+            .get(&id_b)
+            .unwrap()
+            .unwrap()
+            .encode_to_vec();
         let delta = TlsMapDelta::<ComponentId, VLBytes>::new()
-            .insert(id_a, VLBytes::new(vec![0x11; 4]))
-            .insert(id_b, VLBytes::new(vec![0x22; 4]));
+            .insert(id_a, VLBytes::new(meta_a.clone()))
+            .insert(id_b, VLBytes::new(meta_b.clone()));
         let payload = delta.tls_serialize_detached().unwrap();
 
         let new_bytes = apply_app_data_update_payload(
@@ -1626,11 +1648,11 @@ mod tests {
         assert_eq!(map.len(), 2);
         assert_eq!(
             map.get(&id_a).map(|v| v.as_slice()),
-            Some([0x11; 4].as_slice())
+            Some(meta_a.as_slice())
         );
         assert_eq!(
             map.get(&id_b).map(|v| v.as_slice()),
-            Some([0x22; 4].as_slice())
+            Some(meta_b.as_slice())
         );
     }
 

--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -152,6 +152,15 @@ where
                 in_batch.insert(openmls_id, Some(new_value));
             }
             AppDataUpdateOperation::Remove => {
+                // Maps straight to `updater.remove(&id)` below — the
+                // component impl's `apply_update_payload` is never
+                // consulted for `Remove`, so component-level Remove
+                // rejections (e.g. the whole-registry Remove ban in
+                // `ComponentRegistryComponent::expand_to_changes`) are
+                // enforced during commit validation
+                // (`ValidatedCommit::from_staged_commit`), not
+                // re-checked here. That's sound because both current
+                // commit-processing paths validate before applying.
                 in_batch.insert(openmls_id, None);
             }
         }
@@ -513,12 +522,12 @@ pub(crate) fn is_migrated_extensions(
 /// Empty registry is the **strictest** validator state, not the most
 /// permissive. Two layers make this safe:
 ///
-/// 1. **Sender gate** (`mls_sync.rs`): the `AppDataUpdate` sender path
-///    is guarded by `proposals_enabled(group) && !registry.is_empty()`.
-///    In production the second clause is false on unmigrated groups,
-///    so the legacy GCE path runs and no `AppDataUpdate` proposals get
+/// 1. **Sender gate** (`mls_sync.rs`): the `AppDataUpdate` sender
+///    paths are guarded by [`is_migrated_group`] (`COMPONENT_REGISTRY`
+///    present in the dict). That's false on unmigrated groups, so the
+///    legacy GCE path runs and no `AppDataUpdate` proposals get
 ///    emitted.
-///    (`test_update_group_name_uses_legacy_path_when_registry_is_empty`
+///    (`test_update_group_name_uses_legacy_path_when_proposals_disabled`
 ///    pins this.)
 /// 2. **Receiver deny-by-default**
 ///    (`xmtp_mls_common::app_data::validation::validate_component_write`):
@@ -558,12 +567,27 @@ pub(crate) fn load_component_registry_from_extensions(
             .dictionary()
             .get(&ComponentId::COMPONENT_REGISTRY.as_u16())
     {
-        return ComponentRegistry::from_bytes(bytes).map_err(|e| {
-            ComponentSourceError::MalformedComponentValue {
+        return ComponentRegistry::from_bytes(bytes)
+            .map_err(|e| ComponentSourceError::MalformedComponentValue {
                 component_id: ComponentId::COMPONENT_REGISTRY,
                 reason: format!("registry decode: {e}"),
-            }
-        });
+            })
+            .inspect(|reg| {
+                // Tolerated (preserved-but-invisible) entries mean the
+                // dict was written by a newer protocol version or
+                // carries a historical invalid entry. Writes to those
+                // components fall to deny-by-default; everything else
+                // validates normally. Loud so poisoned-registry
+                // incidents are diagnosable from logs.
+                let unrecognized: Vec<_> = reg.unrecognized_ids().collect();
+                if !unrecognized.is_empty() {
+                    tracing::warn!(
+                        ?unrecognized,
+                        "component registry contains unrecognized entries; \
+                         treating them as unregistered (deny-by-default)"
+                    );
+                }
+            });
     }
 
     // Pre-migration or test override.

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2955,29 +2955,26 @@ where
             IntentKind::MetadataUpdate => {
                 let metadata_intent = UpdateMetadataIntentData::try_from(intent.data.clone())?;
 
-                // Gate the AppDataUpdate path on the capability flag
-                // AND a non-empty component registry. The registry
-                // check keeps unmigrated groups on the legacy path so
-                // a sender doesn't publish commits the receiver would
-                // deny against an empty registry. `load_component_registry`
-                // also consults `TEST_REGISTRY_OVERRIDE`, so tests that
-                // install a fake registry exercise this branch even
-                // before a real bootstrap commit lands.
-                let proposals_on = self.proposals_enabled(openmls_group);
-                let registry_populated =
-                    !super::app_data::load_component_registry(openmls_group)?.is_empty();
+                // Route through AppDataUpdate only on migrated groups,
+                // via the same `is_migrated_group` predicate the
+                // UpdateAdminList / UpdatePermission gates use.
+                // `is_migrated_group` (not `registry.is_empty()`) is the
+                // correct migration signal: `ComponentRegistry::is_empty()`
+                // ignores preserved-but-unrecognized entries, so a migrated
+                // group whose entries were all tolerated as unrecognized
+                // would misreport as empty and mis-route to legacy.
+                let is_migrated = super::app_data::is_migrated_group(openmls_group);
                 tracing::debug!(
                     group_id = %self.group_id,
-                    proposals_enabled = proposals_on,
-                    registry_populated,
-                    path = if proposals_on && registry_populated {
+                    is_migrated,
+                    path = if is_migrated {
                         "app_data_update"
                     } else {
                         "legacy_gce"
                     },
                     "MetadataUpdate intent routing"
                 );
-                if proposals_on && registry_populated {
+                if is_migrated {
                     // Publish a STANDALONE AppDataUpdate proposal followed
                     // by a commit that references it (XIP §1.5.2 / §3.4).
                     // Both wire messages go in one publish batch — the

--- a/crates/xmtp_mls_common/src/app_data/component_registry.rs
+++ b/crates/xmtp_mls_common/src/app_data/component_registry.rs
@@ -82,15 +82,35 @@ pub enum ComponentRegistryError {
 /// through this map (their permissions are enforced in code).
 ///
 /// Stored at well-known component ID `0x8000` (`ComponentId::COMPONENT_REGISTRY`).
+///
+/// ## Unrecognized entries
+///
+/// [`from_bytes`](Self::from_bytes) tolerates entries that fail
+/// [`validate_entry`](Self::validate_entry) instead of rejecting the
+/// whole snapshot: they are kept out of `inner` (invisible to `get` /
+/// `iter` / `contains`, so writes against them fall to the
+/// deny-by-default `NoRegistryEntry` policy verdict) but preserved
+/// byte-for-byte in `unrecognized` so
+/// [`to_bytes`](Self::to_bytes) round-trips honestly. The registry is
+/// load-bearing for all app-data validation — every policy lookup
+/// decodes it — so a single entry written by a newer protocol version
+/// (or already present in a poisoned group) must degrade to "that one
+/// component is unwritable here," never to "no commit on this group
+/// can validate ever again."
 #[derive(Debug, Clone, PartialEq)]
 pub struct ComponentRegistry {
     inner: TlsMap<ComponentId, VLBytes>,
+    /// Entries that failed [`Self::validate_entry`] at decode time,
+    /// preserved raw. Never consulted for policy; only merged back in
+    /// [`Self::to_bytes`].
+    unrecognized: TlsMap<ComponentId, VLBytes>,
 }
 
 impl ComponentRegistry {
     pub fn new() -> Self {
         Self {
             inner: TlsMap::new(),
+            unrecognized: TlsMap::new(),
         }
     }
 
@@ -137,6 +157,11 @@ impl ComponentRegistry {
         self.validate_modifiable(&id)?;
         Self::validate_metadata(&id, &meta)?;
         let bytes = VLBytes::new(meta.encode_to_vec());
+        // A valid write repairs any unrecognized entry under the same
+        // id (e.g. a structurally broken entry a super admin is
+        // replacing) — the two maps must stay disjoint so `to_bytes`
+        // can't resurrect the stale bytes.
+        let _ = self.unrecognized.remove(&id);
         self.inner.set(id, bytes);
         Ok(())
     }
@@ -148,7 +173,12 @@ impl ComponentRegistry {
     /// in the registry to begin with, so this is just defense in depth.
     pub fn remove(&mut self, id: &ComponentId) -> Result<(), ComponentRegistryError> {
         self.validate_modifiable(id)?;
-        self.inner
+        if self.inner.remove(id).is_ok() {
+            return Ok(());
+        }
+        // Allow deleting an unrecognized entry with a modifiable id
+        // (repair-by-delete of a structurally broken entry).
+        self.unrecognized
             .remove(id)
             .map_err(|_| ComponentRegistryError::NotFound(*id))?;
         Ok(())
@@ -172,8 +202,11 @@ impl ComponentRegistry {
     /// Iterate over component IDs and their decoded metadata.
     ///
     /// Each item is a `Result` so that callers can decide how to handle a
-    /// corrupt entry. We never silently drop entries — a permission map is
-    /// security-critical and a missing entry would be a security bug.
+    /// corrupt entry. Yields only recognized (validated) entries;
+    /// unrecognized entries preserved by [`from_bytes`](Self::from_bytes)
+    /// are deliberately invisible here — writes against them fall to
+    /// deny-by-default — and are surfaced via
+    /// [`unrecognized_ids`](Self::unrecognized_ids) instead.
     pub fn iter(
         &self,
     ) -> impl Iterator<Item = Result<(ComponentId, ComponentMetadata), ComponentRegistryError>> + '_
@@ -192,6 +225,10 @@ impl ComponentRegistry {
     /// Serialize the registry as the **dict-storage format**: the
     /// raw `TlsMap<ComponentId, VLBytes>` snapshot.
     ///
+    /// Unrecognized entries preserved by [`from_bytes`](Self::from_bytes)
+    /// are merged back in, so a load → store round-trip never drops
+    /// data another (possibly newer) client wrote.
+    ///
     /// The dict always holds the registry's natively-encoded state.
     /// Wire-format encoding (a `TlsMapDelta` describing changes) is
     /// done piecemeal at the call site — there is no whole-registry
@@ -200,29 +237,67 @@ impl ComponentRegistry {
     /// `TlsMapDelta`-from-empty inline at the synthesis site (see
     /// `xmtp_mls::groups::app_data::migration::synthesize_initial_component_values`).
     pub fn to_bytes(&self) -> Result<Vec<u8>, ComponentRegistryError> {
-        Ok(self.inner.tls_serialize_detached()?)
+        if self.unrecognized.is_empty() {
+            return Ok(self.inner.tls_serialize_detached()?);
+        }
+        // The maps are disjoint by construction (`from_bytes` partitions;
+        // `set` purges), so this union has no collisions. Insert
+        // unrecognized first so that if the invariant is ever broken, a
+        // validated entry wins over stale preserved bytes.
+        let mut merged = self.unrecognized.clone();
+        for (id, raw) in self.inner.iter() {
+            merged.set(*id, raw.clone());
+        }
+        Ok(merged.tls_serialize_detached()?)
     }
 
     /// Deserialize a component registry from its **dict-storage
     /// format**: a raw `TlsMap<ComponentId, VLBytes>` snapshot.
     ///
-    /// Validates that every key is in the component ID space, not
-    /// reserved, and not hardcoded, and that every value decodes as a
-    /// valid [`ComponentMetadata`]. The same validation is appropriate
-    /// at the wire boundary (validator path) and at the dict boundary
-    /// (load path) — peers cannot smuggle structurally invalid entries
-    /// in either direction.
+    /// Fails only when the outer `TlsMap` doesn't decode (truncated /
+    /// non-canonical bytes). Individual entries that fail
+    /// [`validate_entry`](Self::validate_entry) — unknown-range ids,
+    /// reserved ids, hardcoded ids, undecodable or structurally
+    /// incomplete [`ComponentMetadata`] — are tolerated: kept invisible
+    /// to reads (writes against them fall to deny-by-default) but
+    /// preserved for [`to_bytes`](Self::to_bytes). Rejecting the whole
+    /// snapshot would let one entry from a newer protocol version make
+    /// every future commit on the group unvalidatable for every member
+    /// running this version. Callers that care can inspect
+    /// [`unrecognized_ids`](Self::unrecognized_ids) and log.
+    ///
+    /// New entries cannot *enter* a group's registry unvalidated: the
+    /// steady-state wire path validates per-mutation
+    /// (`ComponentRegistryComponent::apply_update_payload` /
+    /// `expand_to_changes`) and the bootstrap validator validates each
+    /// entry of the initial delta. Tolerance here is the read-side
+    /// backstop, not the enforcement point.
     ///
     /// Immutability is intentionally not enforced here because it's a
     /// write-time concern, not a wire-format invariant.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ComponentRegistryError> {
         let snapshot = TlsMap::<ComponentId, VLBytes>::tls_deserialize_exact(bytes)?;
         let mut inner: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        let mut unrecognized: TlsMap<ComponentId, VLBytes> = TlsMap::new();
         for (id, raw) in snapshot.into_iter() {
-            Self::validate_entry(id, raw.as_slice())?;
-            inner.set(id, raw);
+            match Self::validate_entry(id, raw.as_slice()) {
+                Ok(()) => inner.set(id, raw),
+                Err(_) => unrecognized.set(id, raw),
+            }
         }
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            unrecognized,
+        })
+    }
+
+    /// Component ids of entries [`from_bytes`](Self::from_bytes)
+    /// preserved but could not validate. Empty in the overwhelmingly
+    /// common case; non-empty means the dict was written by a newer
+    /// protocol version (or carries a historical invalid entry) and is
+    /// worth a log line at the load site.
+    pub fn unrecognized_ids(&self) -> impl Iterator<Item = ComponentId> + '_ {
+        self.unrecognized.iter().map(|(id, _)| *id)
     }
 
     /// Validate one `(ComponentId, raw bytes)` entry against the
@@ -352,7 +427,10 @@ impl ComponentRegistry {
     /// that handle corrupt in-memory state — paths that the public API can
     /// never reach because both `set` and `from_bytes` validate eagerly.
     fn from_inner_for_test(inner: TlsMap<ComponentId, VLBytes>) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            unrecognized: TlsMap::new(),
+        }
     }
 }
 
@@ -771,26 +849,38 @@ mod tests {
         assert!(restored.is_empty());
     }
 
-    #[xmtp_common::test]
-    fn test_from_bytes_rejects_out_of_space_id() {
-        // Build a TlsMapDelta directly with an out-of-space key (0x0001)
-        // and serialize it, then try to load it as a ComponentRegistry.
-        let bytes = raw_bytes_with_entry(ComponentId::new(0x0001), sample_meta().encode_to_vec());
-        let result = ComponentRegistry::from_bytes(&bytes);
-        assert!(matches!(
-            result,
-            Err(ComponentRegistryError::InvalidComponentId(_))
-        ));
+    /// Assert the tolerance contract for one invalid entry: the load
+    /// succeeds, the entry is invisible to every read, it is reported
+    /// via `unrecognized_ids`, and `to_bytes` preserves it verbatim.
+    fn assert_tolerated(bytes: &[u8], id: ComponentId) {
+        let reg = ComponentRegistry::from_bytes(bytes).unwrap();
+        assert!(reg.get(&id).unwrap().is_none());
+        assert!(!reg.contains(&id));
+        assert_eq!(reg.len(), 0);
+        assert!(reg.iter().next().is_none());
+        assert_eq!(reg.unrecognized_ids().collect::<Vec<_>>(), vec![id]);
+        // Round-trip preserves the raw entry byte-for-byte.
+        assert_eq!(reg.to_bytes().unwrap(), bytes);
     }
 
     #[xmtp_common::test]
-    fn test_from_bytes_rejects_reserved_id() {
-        let bytes = raw_bytes_with_entry(ComponentId::new(0xFF50), sample_meta().encode_to_vec());
-        let result = ComponentRegistry::from_bytes(&bytes);
-        assert!(matches!(
-            result,
-            Err(ComponentRegistryError::ReservedRange(_))
-        ));
+    fn test_from_bytes_tolerates_out_of_space_id() {
+        // An out-of-space key (0x0001) is preserved-but-invisible: it
+        // must not poison the load, because the registry is what makes
+        // every other commit on the group validatable.
+        let id = ComponentId::new(0x0001);
+        let bytes = raw_bytes_with_entry(id, sample_meta().encode_to_vec());
+        assert_tolerated(&bytes, id);
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_tolerates_reserved_id() {
+        // Reserved-range ids are future protocol slots — a newer
+        // version allocating one must degrade to "unknown entry" on
+        // this version, not "registry unloadable".
+        let id = ComponentId::new(0xFF50);
+        let bytes = raw_bytes_with_entry(id, sample_meta().encode_to_vec());
+        assert_tolerated(&bytes, id);
     }
 
     /// Build a TLS-encoded `TlsMap<ComponentId, VLBytes>` snapshot
@@ -804,44 +894,38 @@ mod tests {
     }
 
     #[xmtp_common::test]
-    fn test_from_bytes_rejects_hardcoded_id() {
-        // Peers must not be able to smuggle hardcoded entries past the wire
-        // boundary, since their permissions are enforced in code.
+    fn test_from_bytes_tolerates_hardcoded_id() {
+        // A smuggled shadow entry for a hardcoded component stays
+        // invisible — its permissions are enforced in code, so hiding
+        // the entry preserves exactly the enforcement that matters.
         let bytes = raw_bytes_with_entry(
             ComponentId::COMPONENT_REGISTRY,
             sample_meta().encode_to_vec(),
         );
-        assert!(matches!(
-            ComponentRegistry::from_bytes(&bytes),
-            Err(ComponentRegistryError::HardcodedComponent(_))
-        ));
+        assert_tolerated(&bytes, ComponentId::COMPONENT_REGISTRY);
 
         let bytes =
             raw_bytes_with_entry(ComponentId::SUPER_ADMIN_LIST, sample_meta().encode_to_vec());
-        assert!(matches!(
-            ComponentRegistry::from_bytes(&bytes),
-            Err(ComponentRegistryError::HardcodedComponent(_))
-        ));
+        assert_tolerated(&bytes, ComponentId::SUPER_ADMIN_LIST);
     }
 
     #[xmtp_common::test]
-    fn test_from_bytes_rejects_missing_permissions() {
-        // A peer ships a metadata entry whose permissions field is None.
-        // The set() path catches this; from_bytes() must catch it too.
+    fn test_from_bytes_tolerates_missing_permissions() {
+        // A metadata entry whose permissions field is None is invisible
+        // rather than fatal: writes to that component then fail the
+        // deny-by-default `NoRegistryEntry` policy check, which is the
+        // safe direction.
         let meta = ComponentMetadata {
             permissions: None,
             external_committer_permissions: None,
             component_type: ComponentType::Bytes as i32,
         };
         let bytes = raw_bytes_with_entry(ComponentId::GROUP_NAME, meta.encode_to_vec());
-        assert!(matches!(
-            ComponentRegistry::from_bytes(&bytes),
-            Err(ComponentRegistryError::MissingPermissions(_))
-        ));
+        assert_tolerated(&bytes, ComponentId::GROUP_NAME);
     }
 
     #[xmtp_common::test]
-    fn test_from_bytes_rejects_missing_policy_field() {
+    fn test_from_bytes_tolerates_missing_policy_field() {
         // Permissions present, but one of the three policy fields is missing.
         let meta = new_component_metadata(
             ComponentPermissions {
@@ -852,19 +936,15 @@ mod tests {
             ComponentType::Bytes,
         );
         let bytes = raw_bytes_with_entry(ComponentId::GROUP_NAME, meta.encode_to_vec());
-        assert!(matches!(
-            ComponentRegistry::from_bytes(&bytes),
-            Err(ComponentRegistryError::MissingPolicyField(
-                _,
-                ComponentOp::Update
-            ))
-        ));
+        assert_tolerated(&bytes, ComponentId::GROUP_NAME);
     }
 
     #[xmtp_common::test]
-    fn test_from_bytes_rejects_constrained_violation() {
-        // A peer ships an ADMIN_LIST entry with an Allow policy, which
-        // violates the constrained-component invariant.
+    fn test_from_bytes_tolerates_constrained_violation() {
+        // An ADMIN_LIST entry with an Allow policy violates the
+        // constrained-component invariant; hiding it means admin-list
+        // writes deny until a super admin repairs the entry — instead
+        // of every commit on the group failing to validate.
         let meta = new_component_metadata(
             component_permissions()
                 .insert(allow())
@@ -874,10 +954,7 @@ mod tests {
             ComponentType::Bytes,
         );
         let bytes = raw_bytes_with_entry(ComponentId::ADMIN_LIST, meta.encode_to_vec());
-        assert!(matches!(
-            ComponentRegistry::from_bytes(&bytes),
-            Err(ComponentRegistryError::ConstrainedPolicyViolation(_))
-        ));
+        assert_tolerated(&bytes, ComponentId::ADMIN_LIST);
     }
 
     #[xmtp_common::test]
@@ -932,15 +1009,169 @@ mod tests {
     }
 
     #[xmtp_common::test]
-    fn test_from_bytes_rejects_malformed_protobuf() {
+    fn test_from_bytes_tolerates_malformed_protobuf_value() {
         // The key is valid but the value bytes are not a parseable
-        // ComponentMetadata. This is the wire-boundary path for a peer
-        // shipping garbage values.
+        // ComponentMetadata (e.g. a future breaking re-encoding).
+        // Preserved-but-invisible, like every other invalid entry.
         let bytes = raw_bytes_with_entry(ComponentId::GROUP_NAME, vec![0xFF, 0xFF, 0xFF, 0xFF]);
+        assert_tolerated(&bytes, ComponentId::GROUP_NAME);
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_rejects_undecodable_outer_map() {
+        // Entry-level tolerance never extends to the outer container:
+        // truncated or non-canonical snapshot bytes are a hard error.
+        let mut bytes =
+            raw_bytes_with_entry(ComponentId::GROUP_NAME, sample_meta().encode_to_vec());
+        bytes.truncate(bytes.len() - 1);
         assert!(matches!(
             ComponentRegistry::from_bytes(&bytes),
-            Err(ComponentRegistryError::DecodeError { .. })
+            Err(ComponentRegistryError::TlsCodecError(_))
         ));
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_mixed_valid_and_invalid_entries() {
+        // One valid entry, one reserved-range entry: the valid one is
+        // fully readable, the invalid one is preserved-but-invisible,
+        // and the round-trip loses neither.
+        let reserved = ComponentId::new(0xFF00);
+        let mut map: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        map.insert(
+            ComponentId::GROUP_NAME,
+            VLBytes::new(sample_meta().encode_to_vec()),
+        )
+        .unwrap();
+        map.insert(reserved, VLBytes::new(b"future-slot".to_vec()))
+            .unwrap();
+        let bytes = map.tls_serialize_detached().unwrap();
+
+        let reg = ComponentRegistry::from_bytes(&bytes).unwrap();
+        assert_eq!(reg.len(), 1);
+        assert_eq!(
+            reg.get(&ComponentId::GROUP_NAME).unwrap(),
+            Some(sample_meta())
+        );
+        assert!(!reg.contains(&reserved));
+        assert_eq!(reg.unrecognized_ids().collect::<Vec<_>>(), vec![reserved]);
+        assert_eq!(reg.to_bytes().unwrap(), bytes);
+    }
+
+    /// The headline tolerance property end-to-end at the unit level: a
+    /// blob carrying one valid entry and one poisoned entry must load,
+    /// keep the healthy component fully usable — including the
+    /// per-element policy gate commit validation runs
+    /// ([`validate_component_write`]) — deny writes against the
+    /// poisoned component, and round-trip byte-identically so the
+    /// poison is never dropped.
+    ///
+    /// The load/lookup/round-trip half deliberately overlaps
+    /// `test_from_bytes_mixed_valid_and_invalid_entries`; this test
+    /// adds the validation-gate half.
+    // TODO: the fuller end-to-end version — a poisoned
+    // COMPONENT_REGISTRY dict entry on a real group still validating
+    // unrelated commits through `ValidatedCommit::from_staged_commit`
+    // — belongs in xmtp_mls's group tests, where the commit pipeline
+    // exists.
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_poisoned_registry_still_validates_unrelated_writes() {
+        use crate::app_data::validation::{
+            ActorAuthority, ComponentChange, ComponentPermissionError, validate_component_write,
+        };
+
+        // One valid GROUP_NAME entry plus one reserved-range entry
+        // whose bytes aren't even valid ComponentMetadata — the shape
+        // a newer protocol version (or a historical bad write) would
+        // leave behind.
+        let poisoned = ComponentId::new(0xFF20);
+        let mut map: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        map.insert(
+            ComponentId::GROUP_NAME,
+            VLBytes::new(sample_meta().encode_to_vec()),
+        )?;
+        map.insert(poisoned, VLBytes::new(vec![0xDE, 0xAD, 0xBE, 0xEF]))?;
+        let bytes = map.tls_serialize_detached()?;
+
+        // The load tolerates the poison...
+        let reg = ComponentRegistry::from_bytes(&bytes)?;
+        assert_eq!(reg.unrecognized_ids().collect::<Vec<_>>(), vec![poisoned]);
+
+        // ...and the healthy entry stays fully usable: readable, and
+        // its raw bytes still pass entry validation.
+        assert_eq!(reg.get(&ComponentId::GROUP_NAME)?, Some(sample_meta()));
+        ComponentRegistry::validate_entry(ComponentId::GROUP_NAME, &sample_meta().encode_to_vec())?;
+
+        // The policy gate still allows a write to the healthy
+        // component against the poisoned registry...
+        let member = ActorAuthority {
+            is_admin: false,
+            is_super_admin: false,
+        };
+        let healthy_write = ComponentChange::builder()
+            .component_id(ComponentId::GROUP_NAME)
+            .op(ComponentOp::Insert)
+            .actor(member)
+            .build();
+        validate_component_write(&healthy_write, &reg)?;
+
+        // ...while a write against the poisoned component falls to
+        // deny-by-default (the entry is preserved but invisible).
+        let poisoned_write = ComponentChange::builder()
+            .component_id(poisoned)
+            .op(ComponentOp::Insert)
+            .actor(member)
+            .build();
+        assert!(matches!(
+            validate_component_write(&poisoned_write, &reg),
+            Err(ComponentPermissionError::NoRegistryEntry(id)) if id == poisoned
+        ));
+
+        // And serialization round-trips byte-identically — the poison
+        // is preserved, never dropped.
+        assert_eq!(reg.to_bytes()?, bytes);
+    }
+
+    #[xmtp_common::test]
+    fn test_set_repairs_unrecognized_entry() {
+        // A valid write to an id that currently holds an unrecognized
+        // entry replaces it — `to_bytes` must serialize the repaired
+        // value, not resurrect the broken bytes.
+        let broken = ComponentMetadata {
+            permissions: None,
+            external_committer_permissions: None,
+            component_type: ComponentType::Bytes as i32,
+        };
+        let bytes = raw_bytes_with_entry(ComponentId::GROUP_NAME, broken.encode_to_vec());
+        let mut reg = ComponentRegistry::from_bytes(&bytes).unwrap();
+        assert_eq!(reg.unrecognized_ids().count(), 1);
+
+        reg.set(ComponentId::GROUP_NAME, sample_meta()).unwrap();
+        assert_eq!(reg.unrecognized_ids().count(), 0);
+        assert_eq!(
+            reg.get(&ComponentId::GROUP_NAME).unwrap(),
+            Some(sample_meta())
+        );
+
+        let round_tripped = ComponentRegistry::from_bytes(&reg.to_bytes().unwrap()).unwrap();
+        assert_eq!(round_tripped.unrecognized_ids().count(), 0);
+        assert_eq!(
+            round_tripped.get(&ComponentId::GROUP_NAME).unwrap(),
+            Some(sample_meta())
+        );
+    }
+
+    #[xmtp_common::test]
+    fn test_remove_deletes_unrecognized_entry() {
+        // Repair-by-delete: removing a modifiable id that only exists
+        // as an unrecognized entry drops the preserved bytes.
+        let bytes = raw_bytes_with_entry(ComponentId::GROUP_NAME, vec![0xFF, 0xFF]);
+        let mut reg = ComponentRegistry::from_bytes(&bytes).unwrap();
+        assert_eq!(reg.unrecognized_ids().count(), 1);
+
+        reg.remove(&ComponentId::GROUP_NAME).unwrap();
+        assert_eq!(reg.unrecognized_ids().count(), 0);
+        let empty = ComponentRegistry::new();
+        assert_eq!(reg.to_bytes().unwrap(), empty.to_bytes().unwrap());
     }
 
     #[xmtp_common::test]

--- a/crates/xmtp_mls_common/src/app_data/components/tls_map_components.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/tls_map_components.rs
@@ -26,7 +26,7 @@ use xmtp_proto::xmtp::mls::message_contents::ComponentType;
 use crate::{
     app_data::{
         component_id::ComponentId,
-        component_registry::ComponentOp,
+        component_registry::{ComponentOp, ComponentRegistry, ComponentRegistryError},
         typed::{Component, ComponentTypedError, ExpandedComponentChange},
     },
     inbox_id::InboxId,
@@ -110,29 +110,42 @@ where
         }]),
         AppDataUpdateOperation::Update(payload) => {
             let delta = TlsMapDelta::<K, VLBytes>::tls_deserialize_exact(payload.as_slice())?;
-            let mut out = Vec::with_capacity(delta.mutations.len());
-            for mutation in delta.mutations {
-                match mutation {
-                    TlsMapMutation::Insert { value, .. } => out.push(ExpandedComponentChange {
-                        op: ComponentOp::Insert,
-                        value: Some(value.as_slice().to_vec()),
-                    }),
-                    TlsMapMutation::Update { value, .. } => out.push(ExpandedComponentChange {
-                        op: ComponentOp::Update,
-                        value: Some(value.as_slice().to_vec()),
-                    }),
-                    TlsMapMutation::Delete { key } => {
-                        let key_bytes = key.tls_serialize_detached()?;
-                        out.push(ExpandedComponentChange {
-                            op: ComponentOp::Delete,
-                            value: Some(key_bytes),
-                        });
-                    }
-                }
-            }
-            Ok(out)
+            expand_decoded_tls_map_delta(delta)
         }
     }
+}
+
+/// Expansion body shared by [`expand_tls_map_changes`] and the
+/// registry-specific [`ComponentRegistryComponent::expand_to_changes`]
+/// override (which validates the decoded delta first and must not
+/// decode the payload twice).
+fn expand_decoded_tls_map_delta<K>(
+    delta: TlsMapDelta<K, VLBytes>,
+) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError>
+where
+    K: tls_codec::Serialize + tls_codec::Size,
+{
+    let mut out = Vec::with_capacity(delta.mutations.len());
+    for mutation in delta.mutations {
+        match mutation {
+            TlsMapMutation::Insert { value, .. } => out.push(ExpandedComponentChange {
+                op: ComponentOp::Insert,
+                value: Some(value.as_slice().to_vec()),
+            }),
+            TlsMapMutation::Update { value, .. } => out.push(ExpandedComponentChange {
+                op: ComponentOp::Update,
+                value: Some(value.as_slice().to_vec()),
+            }),
+            TlsMapMutation::Delete { key } => {
+                let key_bytes = key.tls_serialize_detached()?;
+                out.push(ExpandedComponentChange {
+                    op: ComponentOp::Delete,
+                    value: Some(key_bytes),
+                });
+            }
+        }
+    }
+    Ok(out)
 }
 
 // ============================================================================
@@ -195,7 +208,84 @@ impl Component for GroupMembershipComponent {
 /// value is the prost-encoded
 /// [`ComponentMetadata`](xmtp_proto::xmtp::mls::message_contents::ComponentMetadata)
 /// describing one registered component.
+///
+/// Unlike the other map component, this impl validates every mutation
+/// in an incoming delta against the registry's write invariants (see
+/// [`validate_registry_delta`]) before applying or expanding it. The
+/// registry is load-bearing for *all* app-data validation — every
+/// policy lookup and every type-aware dispatch decodes it — so a
+/// single invalid entry accepted here would poison every subsequent
+/// [`ComponentRegistry::from_bytes`] load for every member of the
+/// group.
 pub struct ComponentRegistryComponent;
+
+/// Validate every mutation in a `COMPONENT_REGISTRY` delta against the
+/// registry's write invariants, mirroring what
+/// [`ComponentRegistry::set`] / [`ComponentRegistry::remove`] enforce
+/// for local writes:
+///
+/// - Insert/Update: the entry must pass
+///   [`ComponentRegistry::validate_entry`] (id in the component space,
+///   not reserved, not hardcoded, metadata decodable and structurally
+///   complete), and Updates must not target an immutable-range id
+///   (write-once).
+/// - Delete: the id must be modifiable at all — deletes of
+///   out-of-space / reserved / hardcoded / immutable ids are rejected.
+///   The tolerant [`ComponentRegistry::from_bytes`] means a poisoned
+///   dict CAN carry entries under such ids (preserved-but-invisible),
+///   so this arm is a deliberate policy choice, not dead code:
+///   non-modifiable poisoned entries are intentionally NOT
+///   wire-repairable via Delete. Deny-by-default already keeps them
+///   harmless, and keeping the non-modifiable ranges closed to every
+///   wire write beats opening a repair path nobody should need.
+///   (Poisoned entries under modifiable ids remain repairable — their
+///   Delete passes this check and removes the raw entry at apply.)
+///
+/// Shared by [`ComponentRegistryComponent::apply_update_payload`] and
+/// [`ComponentRegistryComponent::expand_to_changes`], so both call
+/// sites judge a delta's mutations identically. Scope caveat: this
+/// helper only sees `Update` payloads (the `TlsMapDelta`). The
+/// whole-registry `AppDataUpdateOperation::Remove` rejection in
+/// `expand_to_changes` is enforced only during commit validation
+/// (`ValidatedCommit::from_staged_commit` in `xmtp_mls`) — the apply
+/// pipeline (`accumulate_app_data_updates` in
+/// `xmtp_mls::groups::app_data`) maps `Remove` straight to a dict
+/// removal without consulting this component impl, and does not
+/// re-check because both current commit-processing paths validate
+/// before applying. The Remove ban is a validator-side guarantee, not
+/// an apply-time one.
+fn validate_registry_delta(
+    delta: &TlsMapDelta<ComponentId, VLBytes>,
+) -> Result<(), ComponentTypedError> {
+    for mutation in &delta.mutations {
+        match mutation {
+            TlsMapMutation::Insert { key, value } => {
+                ComponentRegistry::validate_entry(*key, value.as_slice())?;
+            }
+            TlsMapMutation::Update { key, value } => {
+                ComponentRegistry::validate_entry(*key, value.as_slice())?;
+                if key.is_immutable() {
+                    return Err(ComponentRegistryError::ImmutableComponent(*key).into());
+                }
+            }
+            TlsMapMutation::Delete { key } => {
+                if !key.is_in_component_space() {
+                    return Err(ComponentRegistryError::InvalidComponentId(*key).into());
+                }
+                if key.is_reserved() {
+                    return Err(ComponentRegistryError::ReservedRange(*key).into());
+                }
+                if key.is_hardcoded() {
+                    return Err(ComponentRegistryError::HardcodedComponent(*key).into());
+                }
+                if key.is_immutable() {
+                    return Err(ComponentRegistryError::ImmutableComponent(*key).into());
+                }
+            }
+        }
+    }
+    Ok(())
+}
 
 impl Component for ComponentRegistryComponent {
     const ID: ComponentId = ComponentId::COMPONENT_REGISTRY;
@@ -222,25 +312,75 @@ impl Component for ComponentRegistryComponent {
         payload: &[u8],
         prior: Option<&[u8]>,
     ) -> Result<Vec<u8>, ComponentTypedError> {
-        apply_tls_map_delta::<ComponentId>(payload, prior)
+        let delta = TlsMapDelta::<ComponentId, VLBytes>::tls_deserialize_exact(payload)?;
+        validate_registry_delta(&delta)?;
+        let mut map = match prior {
+            Some(bytes) => TlsMap::<ComponentId, VLBytes>::tls_deserialize_exact(bytes)?,
+            None => TlsMap::new(),
+        };
+        map.apply_delta(delta)?;
+        Ok(map.tls_serialize_detached()?)
     }
 
     fn expand_to_changes(
         op: &AppDataUpdateOperation,
-        prior: Option<&[u8]>,
+        _prior: Option<&[u8]>,
     ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
-        expand_tls_map_changes::<ComponentId>(op, prior)
+        match op {
+            // Removing the entire registry component is never legal —
+            // the registry is what makes every other app-data write
+            // validatable (deny-by-default keys off its entries), and
+            // its absence is also the "unmigrated group" marker. A
+            // commit deleting it would strand the group in a
+            // validated-but-unreadable state. `HardcodedComponent`
+            // is the same verdict `ComponentRegistry::remove` gives
+            // for this id.
+            AppDataUpdateOperation::Remove => Err(ComponentRegistryError::HardcodedComponent(
+                ComponentId::COMPONENT_REGISTRY,
+            )
+            .into()),
+            AppDataUpdateOperation::Update(payload) => {
+                let delta =
+                    TlsMapDelta::<ComponentId, VLBytes>::tls_deserialize_exact(payload.as_slice())?;
+                validate_registry_delta(&delta)?;
+                expand_decoded_tls_map_delta(delta)
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app_data::component_permissions::component_permissions;
+    use prost::Message;
+    use xmtp_proto::xmtp::mls::message_contents::{
+        MetadataPolicy as MetadataPolicyProto,
+        metadata_policy::{Kind as MetadataPolicyKind, MetadataBasePolicy},
+    };
 
     fn fixture_inbox_id(seed: u8) -> InboxId {
         let mut bytes = [0u8; 32];
         bytes[0] = seed;
         InboxId::from_bytes(bytes)
+    }
+
+    /// Encoded, structurally valid `ComponentMetadata` bytes — registry
+    /// deltas are entry-validated on apply/expand, so tests must carry
+    /// real metadata, not placeholder strings.
+    fn valid_meta_bytes() -> Vec<u8> {
+        let allow = MetadataPolicyProto {
+            kind: Some(MetadataPolicyKind::Base(MetadataBasePolicy::Allow as i32)),
+        };
+        crate::app_data::component_registry::new_component_metadata(
+            component_permissions()
+                .insert(allow.clone())
+                .update(allow.clone())
+                .delete(allow)
+                .call(),
+            ComponentType::Bytes,
+        )
+        .encode_to_vec()
     }
 
     #[xmtp_common::test(unwrap_try = true)]
@@ -373,26 +513,34 @@ mod tests {
 
     #[xmtp_common::test(unwrap_try = true)]
     fn component_registry_apply_update_replaces_metadata() {
+        let old_meta = valid_meta_bytes();
+        let mut new_meta = valid_meta_bytes();
+        // Same structural validity, different type tag so the
+        // replacement is observable.
+        new_meta = {
+            let mut decoded = xmtp_proto::xmtp::mls::message_contents::ComponentMetadata::decode(
+                new_meta.as_slice(),
+            )
+            .unwrap();
+            decoded.component_type = ComponentType::String as i32;
+            decoded.encode_to_vec()
+        };
+
         let mut prior_map: TlsMap<ComponentId, VLBytes> = TlsMap::new();
         prior_map
-            .insert(
-                ComponentId::GROUP_NAME,
-                VLBytes::new(b"old-policy".to_vec()),
-            )
+            .insert(ComponentId::GROUP_NAME, VLBytes::new(old_meta))
             .unwrap();
         let prior_bytes = ComponentRegistryComponent::encode_value(&prior_map).unwrap();
 
-        let delta = TlsMapDelta::<ComponentId, VLBytes>::new().update(
-            ComponentId::GROUP_NAME,
-            VLBytes::new(b"new-policy".to_vec()),
-        );
+        let delta = TlsMapDelta::<ComponentId, VLBytes>::new()
+            .update(ComponentId::GROUP_NAME, VLBytes::new(new_meta.clone()));
         let payload = ComponentRegistryComponent::encode_mutation(&delta).unwrap();
         let new_bytes =
             ComponentRegistryComponent::apply_update_payload(&payload, Some(&prior_bytes)).unwrap();
         let new = ComponentRegistryComponent::decode_value(&new_bytes).unwrap();
         assert_eq!(
             new.get(&ComponentId::GROUP_NAME).unwrap().as_slice(),
-            b"new-policy"
+            new_meta.as_slice()
         );
     }
 
@@ -400,14 +548,127 @@ mod tests {
     fn component_registry_apply_batched_delta_atomically() {
         // Bulk-register two custom components in one proposal.
         let delta = TlsMapDelta::<ComponentId, VLBytes>::new()
-            .insert(ComponentId::new(0xC100), VLBytes::new(b"meta1".to_vec()))
-            .insert(ComponentId::new(0xC101), VLBytes::new(b"meta2".to_vec()));
+            .insert(ComponentId::new(0xC100), VLBytes::new(valid_meta_bytes()))
+            .insert(ComponentId::new(0xC101), VLBytes::new(valid_meta_bytes()));
         let payload = ComponentRegistryComponent::encode_mutation(&delta).unwrap();
         let new_bytes = ComponentRegistryComponent::apply_update_payload(&payload, None).unwrap();
         let new = ComponentRegistryComponent::decode_value(&new_bytes).unwrap();
         assert_eq!(new.len(), 2);
         assert!(new.get(&ComponentId::new(0xC100)).is_some());
         assert!(new.get(&ComponentId::new(0xC101)).is_some());
+    }
+
+    // ------------------------------------------------------------------
+    // Registry delta entry-validation (apply + expand must agree)
+    // ------------------------------------------------------------------
+
+    /// Apply and expand must return the same verdict for the same
+    /// delta — they share `validate_registry_delta`, and this pins it.
+    fn assert_registry_delta_rejected_everywhere(delta: TlsMapDelta<ComponentId, VLBytes>) {
+        let payload = ComponentRegistryComponent::encode_mutation(&delta).unwrap();
+        let apply_err = ComponentRegistryComponent::apply_update_payload(&payload, None);
+        assert!(
+            matches!(apply_err, Err(ComponentTypedError::RegistryMutation(_))),
+            "apply must reject, got {apply_err:?}"
+        );
+        let op = AppDataUpdateOperation::Update(payload.into());
+        let expand_err = ComponentRegistryComponent::expand_to_changes(&op, None);
+        assert!(
+            matches!(expand_err, Err(ComponentTypedError::RegistryMutation(_))),
+            "expand must reject, got {expand_err:?}"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn registry_delta_rejects_reserved_range_insert() {
+        // THE poison case: a reserved-range entry accepted into the
+        // dict would fail every subsequent registry load. It must be
+        // rejected at the wire, on both the apply and validate paths.
+        assert_registry_delta_rejected_everywhere(
+            TlsMapDelta::<ComponentId, VLBytes>::new()
+                .insert(ComponentId::new(0xFF00), VLBytes::new(valid_meta_bytes())),
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn registry_delta_rejects_hardcoded_insert() {
+        assert_registry_delta_rejected_everywhere(
+            TlsMapDelta::<ComponentId, VLBytes>::new().insert(
+                ComponentId::SUPER_ADMIN_LIST,
+                VLBytes::new(valid_meta_bytes()),
+            ),
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn registry_delta_rejects_out_of_space_insert() {
+        assert_registry_delta_rejected_everywhere(
+            TlsMapDelta::<ComponentId, VLBytes>::new()
+                .insert(ComponentId::new(0x0001), VLBytes::new(valid_meta_bytes())),
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn registry_delta_rejects_undecodable_metadata_insert() {
+        assert_registry_delta_rejected_everywhere(
+            TlsMapDelta::<ComponentId, VLBytes>::new().insert(
+                ComponentId::new(0xC100),
+                VLBytes::new(vec![0xFF, 0xFF, 0xFF, 0xFF]),
+            ),
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn registry_delta_rejects_immutable_update_and_delete() {
+        // Write-once: immutable-range registry entries can be inserted
+        // but never overwritten or deleted, mirroring
+        // `ComponentRegistry::{set, remove}`.
+        assert_registry_delta_rejected_everywhere(
+            TlsMapDelta::<ComponentId, VLBytes>::new()
+                .update(ComponentId::new(0xBE00), VLBytes::new(valid_meta_bytes())),
+        );
+        assert_registry_delta_rejected_everywhere(
+            TlsMapDelta::<ComponentId, VLBytes>::new().delete(ComponentId::new(0xBE00)),
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn registry_delta_rejects_hardcoded_delete() {
+        assert_registry_delta_rejected_everywhere(
+            TlsMapDelta::<ComponentId, VLBytes>::new().delete(ComponentId::SUPER_ADMIN_LIST),
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn registry_component_rejects_whole_component_remove() {
+        // Deleting the entire COMPONENT_REGISTRY dict slot would strand
+        // the group (the registry's presence is the migration marker
+        // and the policy source). Never legal.
+        let err =
+            ComponentRegistryComponent::expand_to_changes(&AppDataUpdateOperation::Remove, None);
+        assert!(
+            matches!(err, Err(ComponentTypedError::RegistryMutation(_))),
+            "Remove of the registry component must be rejected, got {err:?}"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn registry_delta_valid_mutations_expand_and_apply() {
+        // The happy path still works end-to-end after entry validation:
+        // register a custom component, then observe it in both the
+        // expanded changes and the applied map.
+        let delta = TlsMapDelta::<ComponentId, VLBytes>::new()
+            .insert(ComponentId::new(0xC200), VLBytes::new(valid_meta_bytes()));
+        let payload = ComponentRegistryComponent::encode_mutation(&delta).unwrap();
+
+        let op = AppDataUpdateOperation::Update(payload.clone().into());
+        let changes = ComponentRegistryComponent::expand_to_changes(&op, None).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Insert);
+
+        let new_bytes = ComponentRegistryComponent::apply_update_payload(&payload, None).unwrap();
+        let new = ComponentRegistryComponent::decode_value(&new_bytes).unwrap();
+        assert!(new.get(&ComponentId::new(0xC200)).is_some());
     }
 
     #[xmtp_common::test(unwrap_try = true)]

--- a/crates/xmtp_mls_common/src/app_data/typed.rs
+++ b/crates/xmtp_mls_common/src/app_data/typed.rs
@@ -33,7 +33,7 @@ use xmtp_proto::xmtp::mls::message_contents::ComponentType;
 use crate::{
     app_data::{
         component_id::ComponentId,
-        component_registry::{ComponentOp, ComponentRegistry},
+        component_registry::{ComponentOp, ComponentRegistry, ComponentRegistryError},
         validation::ComponentChange,
     },
     inbox_id::InboxIdError,
@@ -281,6 +281,17 @@ pub enum ComponentTypedError {
     /// [`ComponentType`]: xmtp_proto::xmtp::mls::message_contents::ComponentType
     #[error("component {0} has no registered ComponentType (unspecified)")]
     UnspecifiedType(ComponentId),
+
+    /// A `COMPONENT_REGISTRY` mutation violates the registry's write
+    /// invariants (invalid/reserved/hardcoded id, immutable overwrite,
+    /// or structurally invalid `ComponentMetadata`). The wire path
+    /// enforces the same invariants as [`ComponentRegistry::set`] /
+    /// [`ComponentRegistry::remove`] so a peer cannot land an entry
+    /// that a local writer could not produce — critically, one that
+    /// would poison every subsequent
+    /// [`ComponentRegistry::from_bytes`] load of the group's registry.
+    #[error("registry mutation rejected: {0}")]
+    RegistryMutation(#[from] ComponentRegistryError),
 }
 
 /// Errors surfaced by [`Component::validate_invariant`].


### PR DESCRIPTION
## Problem

Two receive-side holes around the `COMPONENT_REGISTRY` dict entry, found during the pre-v1.11 app-data review:

1. **Steady-state registry writes are not entry-validated.** `ComponentRegistry::validate_entry` runs only in `from_bytes` and the bootstrap validator. A steady-state `AppDataUpdate(COMPONENT_REGISTRY, …)` delta is applied as a raw map operation, so a super admin (or buggy future client) can land a reserved-range or undecodable entry that every receiver *accepts* — after which every subsequent `load_component_registry` fails via strict `from_bytes`, and **every future commit on the group is rejected by every member, permanently** (including the `MIN_SUPPORTED_PROTOCOL_VERSION` floor bump that would otherwise be the remediation lever).

2. **One bad entry poisons the whole registry load.** `from_bytes` rejected the entire snapshot on any invalid entry, so a single entry written by a newer protocol version (or already present in a poisoned group) degrades to "no commit on this group can validate ever again" instead of "that one component is unwritable here."

Because v1.11.0 is the first stable release carrying app-data, its receive-side acceptance behavior becomes the permanent floor contract — these are only free to change before the cut.

## Changes

- **`validate_registry_delta`** (new, `tls_map_components.rs`): every mutation in a `COMPONENT_REGISTRY` delta is validated against the same invariants `ComponentRegistry::{set, remove}` enforce for local writes — `validate_entry` on Insert/Update (id space, reserved, hardcoded, decodable + structurally complete metadata), write-once for immutable-range ids, and id-level checks on Delete. Shared by `ComponentRegistryComponent::apply_update_payload` (authoritative apply-time check) and `::expand_to_changes` (commit-validator path), so the two paths cannot drift. Removing the entire registry component (`AppDataUpdateOperation::Remove`) is also rejected — its presence is the migration marker and the policy source.
- **Tolerant `ComponentRegistry::from_bytes`**: entries failing `validate_entry` are now preserved-but-invisible (kept out of the readable map, so writes against them fall to deny-by-default `NoRegistryEntry`; merged back in `to_bytes` so round-trips never drop peers' data). The outer `TlsMap` decode remains a hard error. `unrecognized_ids()` exposes tolerated entries and `load_component_registry` logs a warning when any are present. `set`/`remove` gain repair semantics (a valid write/delete replaces a broken entry) to keep the two maps disjoint.
- New `ComponentTypedError::RegistryMutation` variant mapping to `ComponentSourceError::MalformedComponentValue` at the dispatch boundary.

The two changes ship together deliberately: a strict-loader release and a tolerant-loader release would diverge on a poisoned group (reject-all vs validate-normally), and the write-side validation is what makes read-side tolerance safe going forward.

## Testing

- New unit coverage: rejection of reserved/hardcoded/out-of-space/undecodable inserts and immutable overwrites **on both the apply and expand paths** (pinned by a shared assertion helper); whole-registry `Remove` rejection; tolerance contract per invalid-entry class (invisible to reads, reported via `unrecognized_ids`, byte-preserving round-trip); mixed valid+invalid snapshots; repair-by-set and repair-by-delete.
- Existing fixtures that fed placeholder bytes as registry metadata were upgraded to real encoded `ComponentMetadata` — that tightening is the point of the change.
- `xmtp_mls_common`: 814/814. `xmtp_mls` full crate suite against the local node: 697/697 (one retry on the known-flaky `should_reconnect`). `just lint-rust` clean.

Part of the pre-v1.11 app-data hardening plan (P0.1 + P0.2): receive-side acceptance changes that must land before the first stable release fields the app-data validators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZpajnDV829SVuW9danrW

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-entry validation on registry delta writes and tolerant registry loads in MLS
> - `ComponentRegistry::from_bytes` now tolerates invalid entries at decode time rather than failing: invalid entries are preserved as unrecognized bytes and hidden from policy lookups (deny-by-default), while valid entries behave normally.
> - `ComponentRegistry::to_bytes` merges unrecognized bytes back during serialization, ensuring load→store round-trips are lossless.
> - A new `validate_registry_delta` function rejects invalid mutations (bad ids, immutable updates/deletes, malformed metadata) during both `apply_update_payload` and `expand_to_changes` for `COMPONENT_REGISTRY` updates.
> - `MetadataUpdate` intent routing in `Group::sync` switches from checking `proposals_enabled + non-empty registry` to using `is_migrated_group`, fixing misrouting for groups with only unrecognized registry entries.
> - Risk: groups that previously failed to load due to invalid registry entries will now load successfully but treat those entries as unregistered (deny-by-default).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bb2398.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->