### PR TITLE
fix(xmtp_mls): pause below-floor clients before parsing migrated-group commits

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -75,6 +75,27 @@ pub enum ProcessMessageWithAppDataError<StorageError: std::error::Error> {
     /// (mapped to `CommitResult::Invalid`).
     #[error("failed to decode incoming AppDataUpdate payload: {0}")]
     AppDataDecode(#[from] ComponentSourceError),
+    /// The group's committed `MIN_SUPPORTED_PROTOCOL_VERSION` floor
+    /// exceeds this client's version. Surfaced *before* any
+    /// `AppDataUpdate` payload is dispatched, so a client below the
+    /// floor (most commonly after an app downgrade — pausing normally
+    /// happens at the floor-bump commit itself, but a downgraded
+    /// client never processed one) pauses the group instead of
+    /// rejecting a commit it cannot interpret. Rejecting here is what
+    /// forks a group: peers above the floor accept the commit and
+    /// advance without us.
+    ///
+    /// Converted to `CommitValidationError::ProtocolVersionTooLow` at
+    /// the `mls_sync` boundary so the existing pause machinery
+    /// (`set_group_paused`, held cursor, reprocess-on-upgrade) applies
+    /// unchanged.
+    #[error(
+        "group's minimum supported protocol version {min_version} exceeds this client's version {own_version}"
+    )]
+    ProtocolVersionTooLow {
+        min_version: String,
+        own_version: String,
+    },
 }
 
 /// Walk a stream of `(ComponentId, &AppDataUpdateOperation)` tuples and
@@ -190,15 +211,41 @@ where
 /// Callers replace `mls_group.process_message(provider, message)` with
 /// `process_message_with_app_data(mls_group, provider, message)` and get
 /// back the same `ProcessedMessage` they used to.
+/// `own_version` is the client's pkg_version (threaded from the caller's
+/// context rather than read from a constant so cross-version tests can
+/// override it).
 pub(crate) fn process_message_with_app_data<Provider: OpenMlsProvider>(
     mls_group: &mut OpenMlsGroup,
     provider: &Provider,
     message: impl Into<ProtocolMessage>,
+    own_version: &str,
 ) -> Result<ProcessedMessage, ProcessMessageWithAppDataError<Provider::StorageError>> {
     let unverified = mls_group.unprotect_message(provider, message)?;
 
     let app_data_updates: Option<AppDataUpdates> = match unverified.committed_proposals() {
         Some(proposals) => {
+            // PAUSE BEFORE PARSE: if the group's committed floor already
+            // exceeds this client's version, do not attempt to interpret
+            // this commit at all — its app-data payloads may use wire
+            // formats introduced after this version, and a referenced
+            // proposal this client refused to store earlier would surface
+            // as `MissingAppDataUpdates`. Either way the failure is a
+            // non-retryable rejection, i.e. a fork, since above-floor
+            // peers accept the commit. Deliberately fires for every
+            // commit on a below-floor group (not just ones whose
+            // app-data proposals resolved) and reads ONLY the pre-commit
+            // dict — committed, already-validated state. It must never
+            // consider the commit's own proposals: a same-commit floor
+            // bump has not passed the super-admin policy check yet, and
+            // pausing on unvalidated input would let any member freeze
+            // the group for everyone. Application messages are
+            // unaffected (`committed_proposals()` is `None` for them).
+            if let Some(min_version) = committed_floor_exceeding(mls_group, own_version) {
+                return Err(ProcessMessageWithAppDataError::ProtocolVersionTooLow {
+                    min_version,
+                    own_version: own_version.to_string(),
+                });
+            }
             // Collect owned (id, operation) tuples so the iterator doesn't
             // borrow `mls_group` — `accumulate_app_data_updates` needs `&mls_group`
             // and we'd otherwise conflict with the pending-proposal lookup below.
@@ -542,6 +589,54 @@ pub(crate) fn load_component_registry(
     load_component_registry_from_extensions(mls_group.extensions())
 }
 
+/// Returns the group's committed `MIN_SUPPORTED_PROTOCOL_VERSION` floor
+/// when it exceeds `own_version`, reading ONLY the pre-commit AppData
+/// dict — committed, already-validated state.
+///
+/// This is the shared trigger for the "pause, don't fork" guards on the
+/// receive paths ([`process_message_with_app_data`] before dispatch;
+/// `ValidatedCommit::from_staged_commit` before interpreting migrated
+/// group state). It is deliberately blind to any floor bump carried by
+/// the commit currently being processed: that proposal has not passed
+/// the super-admin policy check yet, and a pause triggered by
+/// unvalidated input would let any member freeze the group permanently.
+/// The commit that *raises* the floor pauses below-floor receivers
+/// through the post-policy check at the end of commit validation
+/// instead. Consequence for protocol evolution: a release introducing
+/// a new wire format must land the group-floor bump in a *strictly
+/// earlier* commit than the first commit using that format.
+///
+/// Lenient on malformed state (non-UTF-8 floor bytes, unparseable
+/// semver ⇒ `None`), mirroring `enforce_min_version_monotonicity`'s
+/// treatment of malformed priors: garbage must never brick the group.
+pub(crate) fn committed_floor_exceeding(
+    mls_group: &OpenMlsGroup,
+    own_version: &str,
+) -> Option<String> {
+    committed_floor_exceeding_in_extensions(mls_group.extensions(), own_version)
+}
+
+/// Extensions-only variant of [`committed_floor_exceeding`], split out
+/// (like [`load_component_registry_from_extensions`]) so unit tests can
+/// exercise the parse-and-compare logic without materializing an
+/// `OpenMlsGroup`.
+pub(crate) fn committed_floor_exceeding_in_extensions(
+    extensions: &openmls::extensions::Extensions<openmls::group::GroupContext>,
+    own_version: &str,
+) -> Option<String> {
+    use super::validated_commit::LibXMTPVersion;
+
+    let bytes = extensions
+        .app_data_dictionary()?
+        .dictionary()
+        .get(&ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION.as_u16())?
+        .to_vec();
+    let floor = String::from_utf8(bytes).ok()?;
+    let own = LibXMTPVersion::parse(own_version).ok()?;
+    let floor_version = LibXMTPVersion::parse(&floor).ok()?;
+    (floor_version > own).then_some(floor)
+}
+
 /// Extensions-only variant of [`load_component_registry`]. Mirrors the
 /// [`is_migrated_group`] / [`is_migrated_extensions`] split so unit
 /// tests can exercise the registry-decode path without materializing
@@ -670,6 +765,110 @@ mod tests {
                 assert!(is_migrated_extensions(&exts));
             })
             .await;
+    }
+
+    // ========================================================================
+    // committed_floor_exceeding_in_extensions
+    // ========================================================================
+    //
+    // The shared trigger for the pause-before-parse guards. Two properties
+    // are load-bearing: (1) it fires strictly on floor > own — equal or
+    // lower floors must not pause; (2) it is lenient on garbage — malformed
+    // floor bytes must read as "no floor", never as an error that could
+    // wedge the group.
+
+    #[test]
+    fn floor_above_own_version_fires() {
+        let exts = extensions_with_dict(&[(
+            ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION.as_u16(),
+            b"2.0.0".to_vec(),
+        )]);
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&exts, "1.11.0"),
+            Some("2.0.0".to_string())
+        );
+        // Prerelease floors order correctly under semver: 1.11.0-dev
+        // exceeds 1.10.0 but not 1.11.0.
+        let exts = extensions_with_dict(&[(
+            ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION.as_u16(),
+            b"1.11.0-dev".to_vec(),
+        )]);
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&exts, "1.10.0"),
+            Some("1.11.0-dev".to_string())
+        );
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&exts, "1.11.0"),
+            None
+        );
+    }
+
+    #[test]
+    fn floor_at_or_below_own_version_does_not_fire() {
+        let exts = extensions_with_dict(&[(
+            ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION.as_u16(),
+            b"1.11.0".to_vec(),
+        )]);
+        // Equal: not paused — the floor is inclusive.
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&exts, "1.11.0"),
+            None
+        );
+        // Above: not paused.
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&exts, "1.12.0"),
+            None
+        );
+    }
+
+    #[test]
+    fn missing_floor_or_dict_does_not_fire() {
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&empty_extensions(), "1.11.0"),
+            None
+        );
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&extensions_with_dict(&[]), "1.11.0"),
+            None
+        );
+        // Dict present with other components but no floor entry.
+        let exts = extensions_with_dict(&[(ComponentId::GROUP_NAME.as_u16(), b"name".to_vec())]);
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&exts, "1.11.0"),
+            None
+        );
+    }
+
+    #[test]
+    fn malformed_floor_is_lenient() {
+        // Non-UTF-8 bytes → no floor, never an error.
+        let exts = extensions_with_dict(&[(
+            ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION.as_u16(),
+            vec![0xFF, 0xFE],
+        )]);
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&exts, "1.11.0"),
+            None
+        );
+        // Unparseable semver → no floor.
+        let exts = extensions_with_dict(&[(
+            ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION.as_u16(),
+            b"not-a-version".to_vec(),
+        )]);
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&exts, "1.11.0"),
+            None
+        );
+        // Own version unparseable (shouldn't happen in a real build) →
+        // skip the guard rather than pausing on garbage.
+        let exts = extensions_with_dict(&[(
+            ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION.as_u16(),
+            b"2.0.0".to_vec(),
+        )]);
+        assert_eq!(
+            committed_floor_exceeding_in_extensions(&exts, "garbage"),
+            None
+        );
     }
 
     // ========================================================================

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -255,6 +255,13 @@ impl RetryableError for GroupMessageProcessingError {
                 // Decode failures are wire-format violations from the
                 // peer — retrying won't help.
                 super::app_data::ProcessMessageWithAppDataError::AppDataDecode(_) => false,
+                // Resolved by upgrading, not by retrying. In practice
+                // this variant never reaches here: the call sites remap
+                // it to `CommitValidation(ProtocolVersionTooLow)` so
+                // the pause machinery in `post_process_message` fires.
+                super::app_data::ProcessMessageWithAppDataError::ProtocolVersionTooLow {
+                    ..
+                } => false,
             },
             Self::MergeStagedCommit(err) => err.is_retryable(),
             Self::ProcessIntent(err) => err.is_retryable(),
@@ -295,6 +302,29 @@ impl RetryableError for GroupMessageProcessingError {
 }
 
 impl GroupMessageProcessingError {
+    /// Route an app-data processing failure into this error type.
+    ///
+    /// The pre-dispatch floor guard in `process_message_with_app_data`
+    /// surfaces as the same `ProtocolVersionTooLow` commit-validation
+    /// error the validator's post-policy floor check emits, so
+    /// `post_process_message` pauses the group (held cursor,
+    /// `set_group_paused`) instead of treating it like a wire-format
+    /// rejection that advances past the commit. Every other variant
+    /// wraps as `OpenMlsProcessMessageWithAppData`, same as `From`.
+    /// Use this instead of `?`'s implicit conversion at call sites
+    /// that can see commits from newer protocol versions.
+    fn from_app_data_processing(
+        err: super::app_data::ProcessMessageWithAppDataError<sql_key_store::SqlKeyStoreError>,
+    ) -> Self {
+        match err {
+            super::app_data::ProcessMessageWithAppDataError::ProtocolVersionTooLow {
+                min_version,
+                ..
+            } => Self::CommitValidation(CommitValidationError::ProtocolVersionTooLow(min_version)),
+            other => other.into(),
+        }
+    }
+
     pub(crate) fn commit_result(&self) -> CommitResult {
         use super::app_data::ProcessMessageWithAppDataError;
         match self {
@@ -1134,6 +1164,7 @@ where
                 mls_group,
                 &provider,
                 message.clone(),
+                self.context.version_info().pkg_version(),
             ));
             // Roll back: sync with the server before committing.
             Ok::<TransactionOutcome<()>, StorageError>(Rollback)
@@ -1143,7 +1174,9 @@ where
                 .map(TransactionOutcome::into_continued)
                 .inspect_err(|e| tracing::debug!("immutable process message failed {}", e))?;
         }
-        let processed_message = processed_message.expect("Was just set to Some")?;
+        let processed_message = processed_message
+            .expect("Was just set to Some")
+            .map_err(GroupMessageProcessingError::from_app_data_processing)?;
 
         // Reload the mlsgroup to clear the it's internal cache
         mls_group.reload(provider.storage())?;
@@ -1205,6 +1238,27 @@ where
                 Some(validated_commit)
             }
             ProcessedMessageContent::ProposalMessage(queued_proposal) => {
+                // Floor-first: if this migrated group's committed protocol floor
+                // exceeds our version, pause BEFORE validating or storing the
+                // proposal — exactly as the commit branch does above, and without
+                // advancing the cursor. Post-migration metadata updates are
+                // published propose-then-commit, so a below-floor client that
+                // instead rejected-and-skipped a new-format standalone proposal
+                // here would later be unable to stage the commit that references
+                // it (the proposal would be missing from the store) and fork.
+                // Holding the cursor before the proposal lets it replay after the
+                // client upgrades and the group un-pauses.
+                //
+                // This reads only committed group-context state (the pre-commit
+                // dictionary), never the arriving proposal, so it cannot be used
+                // by a member to freeze a group.
+                if let Some(min_version) = super::app_data::committed_floor_exceeding(
+                    mls_group,
+                    self.context.version_info().pkg_version(),
+                ) {
+                    return Err(CommitValidationError::ProtocolVersionTooLow(min_version).into());
+                }
+
                 // Reject Add/Remove proposals if proposals are not enabled on this group.
                 // GCE proposals are exempt because enable_proposals() uses them to bootstrap
                 // proposal support — they must be allowed through to flip the flag on.
@@ -1379,7 +1433,9 @@ where
                 mls_group,
                 &provider,
                 message.clone(),
-            )?;
+                self.context.version_info().pkg_version(),
+            )
+            .map_err(GroupMessageProcessingError::from_app_data_processing)?;
             let identifier = self.process_external_message(
                 mls_group,
                 processed_message,
@@ -2258,6 +2314,24 @@ where
                     let mut error_cause = None;
                     let (next_intent_state, internal_message_id) = match result {
                         Err(err) => {
+                            // Floor-first (own-intent path): a below-floor client
+                            // processing its OWN commit on a migrated group must
+                            // PAUSE, not fold the failure into a terminal `Error`.
+                            // Folding would commit the cursor advance above (past
+                            // its own commit) and leave the intent `Error` — forking
+                            // from peers who merged the commit, with no upgrade-based
+                            // recovery. Roll the transaction back (undoing the cursor
+                            // advance) so the error reaches `post_process_message`'s
+                            // pause arm, exactly like the external-commit path, and
+                            // the intent stays for revalidation after upgrade.
+                            if matches!(
+                                err.processing_error,
+                                GroupMessageProcessingError::CommitValidation(
+                                    CommitValidationError::ProtocolVersionTooLow(_)
+                                )
+                            ) {
+                                return Err(err.processing_error);
+                            }
                             if err.processing_error.is_retryable() {
                                 // Rollback the transaction so that we can retry
                                 return Err(err.processing_error);

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -921,6 +921,7 @@ async fn test_merge_staged_commit_logged_rejects_non_advancing_authenticator()
             &mut group_copy,
             &provider,
             commit_envelope.message.clone(),
+            bo.context.version_info().pkg_version(),
         ));
         Ok::<TransactionOutcome<()>, StorageError>(Rollback)
     });

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -4027,6 +4027,129 @@ async fn test_steady_state_pause_on_min_version_bump_via_app_data_update() {
     );
 }
 
+/// Downgrade safety: pausing normally happens at the floor-*bump* commit
+/// (the post-policy `ProtocolVersionTooLow` check), but a client that
+/// processed the bump while ABOVE the floor and then downgrades never
+/// took that pause — its DB holds a migrated group whose committed
+/// floor exceeds its (new, lower) version, with `paused_for_version`
+/// unset. The next sync must pause the group from the committed dict
+/// floor (the pause-before-parse guards) rather than surface commit
+/// processing errors: a non-retryable rejection here is a fork, since
+/// above-floor peers accept the same commits.
+///
+/// Emulates the downgrade by re-opening the same persistent store with
+/// a client built at a lower pkg_version, mirroring the restart pattern
+/// in `test::builder::identity_persistence_test`. The post-bump commit
+/// in this test uses a format both versions understand, so it pins the
+/// end state (paused, at the right floor, no error) rather than
+/// distinguishing which floor check fired first; the guard ordering
+/// (pre-dispatch, before any payload is interpreted) is pinned by the
+/// unit tests on `committed_floor_exceeding_in_extensions` plus the
+/// guard's placement in `process_message_with_app_data`.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_downgraded_client_pauses_on_migrated_group_with_higher_floor() {
+    use crate::builder::ClientBuilder;
+    use crate::client::Client;
+    use crate::groups::tests::increment_patch_version;
+    use crate::identity::IdentityStrategy;
+    use crate::utils::{DefaultTestClientCreator, VersionInfo, test::register_client};
+    use xmtp_common::tmp_path;
+    use xmtp_cryptography::utils::generate_local_wallet;
+    use xmtp_db::XmtpTestDb;
+    use xmtp_id::InboxOwner;
+    use xmtp_id::associations::test_utils::MockSmartContractSignatureVerifier;
+    use xmtp_proto::api_client::{ApiBuilder, XmtpTestClient};
+
+    // Both clients start one patch above the default version so the
+    // floor can be raised to a value the default version doesn't meet.
+    let mut high_version = VersionInfo::default();
+    let bumped = increment_patch_version(high_version.pkg_version()).expect("patch bump");
+    high_version.test_update_version(&bumped);
+
+    let alix =
+        ClientBuilder::new_test_client_with_version(&generate_local_wallet(), high_version.clone())
+            .await;
+
+    // Bo lives on a persistent store so the same identity can be
+    // re-opened at a lower version below.
+    let bo_wallet = generate_local_wallet();
+    let bo_db_path = tmp_path();
+    let bo_ident = bo_wallet.get_identifier()?;
+    let bo_nonce = 1;
+    let bo_inbox_id = bo_ident.inbox_id(bo_nonce)?;
+    let bo_strategy = IdentityStrategy::new(bo_inbox_id.clone(), bo_ident.clone(), bo_nonce, None);
+
+    let bo_store = xmtp_db::TestDb::create_persistent_store(Some(bo_db_path.clone())).await;
+    let bo = Client::builder(bo_strategy.clone())
+        .api_client(DefaultTestClientCreator::create().build()?)
+        .store(bo_store)
+        .default_mls_store()?
+        .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
+        .version(high_version.clone())
+        .build()
+        .await?;
+    register_client(&bo, &bo_wallet).await;
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+    let bo_groups = bo.sync_welcomes().await?;
+    let bo_group = bo_groups
+        .iter()
+        .find(|g| g.group_id == alix_group.group_id)
+        .expect("bo should receive a welcome for alix_group");
+    bo_group.sync().await?;
+
+    // Migrate with the 0.0.0 test floor so nobody pauses at bootstrap.
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+    bo_group.sync().await?;
+
+    // Raise the floor to the bumped version. Bo — at that same version —
+    // processes the bump WITHOUT pausing: he meets the floor.
+    alix_group.update_group_min_version(&bumped).await?;
+    bo_group.sync().await?;
+    assert!(
+        bo_group.paused_for_version()?.is_none(),
+        "bo meets the floor pre-downgrade and must not be paused"
+    );
+
+    // Traffic lands after the bump; the downgraded client below will
+    // meet this commit as the first thing it processes.
+    alix_group
+        .update_group_name("post-bump name".to_string())
+        .await?;
+
+    // The downgrade: re-open bo's store with a client at the DEFAULT
+    // (lower) pkg_version.
+    let bo_group_id = bo_group.group_id;
+    drop(bo);
+    let bo_store = xmtp_db::TestDb::create_persistent_store(Some(bo_db_path)).await;
+    let bo_downgraded = Client::builder(bo_strategy)
+        .api_client(DefaultTestClientCreator::create().build()?)
+        .store(bo_store)
+        .default_mls_store()?
+        .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
+        .version(VersionInfo::default())
+        .build()
+        .await?;
+
+    let bo_group = bo_downgraded.group(&bo_group_id)?;
+    // The sync may surface the pause as a per-message outcome; the
+    // assertion below is the contract, not the sync result.
+    let _ = bo_group.sync().await;
+
+    assert_eq!(
+        bo_group.paused_for_version()?.as_deref(),
+        Some(bumped.as_str()),
+        "a downgraded client below the committed floor must pause the group \
+         (deferring all commits for post-upgrade reprocessing), never surface \
+         processing errors that would advance past peers"
+    );
+}
+
 /// Pause recovery: a client that's been pinned to `paused_for_version`
 /// gets the flag cleared once their `pkg_version` catches up. Without
 /// this sweep a paused group could stay paused indefinitely on quiet

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -371,6 +371,27 @@ impl ValidatedCommit {
         // and route into `validate_bootstrap_and_build`, which uses
         // these pre-flip values as the canonical source.
         let is_migrated = super::app_data::is_migrated_extensions(extensions);
+        // PAUSE BEFORE PARSE: when the group's committed floor already
+        // exceeds this client's version, every migrated-state read
+        // below (dict-seeded metadata, registry loads, per-proposal
+        // dispatch) may encounter wire formats introduced after this
+        // version — and any error they raise is a non-retryable
+        // rejection, i.e. a fork against above-floor peers. Surface
+        // the version gap first so the group pauses and the commit is
+        // reprocessed after upgrade. Deliberately reads only the
+        // pre-commit dict (committed, already-validated state) — the
+        // commit that *raises* the floor is instead paused by the
+        // post-policy check at the end of this function, after its
+        // super-admin permission has been verified. See
+        // `committed_floor_exceeding` for the full rationale.
+        if is_migrated
+            && let Some(min_version) = super::app_data::committed_floor_exceeding(
+                openmls_group,
+                context.version_info().pkg_version(),
+            )
+        {
+            return Err(CommitValidationError::ProtocolVersionTooLow(min_version));
+        }
         let immutable_metadata: GroupMetadata = if is_migrated {
             // ComponentSourceError → GroupMutableMetadataError →
             // CommitValidationError::GroupMutableMetadata is the


### PR DESCRIPTION
## Problem

On migrated groups, a client whose version is below the group's committed `MIN_SUPPORTED_PROTOCOL_VERSION` floor could still attempt to interpret incoming commits. Both receive stages choke on anything a newer protocol version wrote:

- The apply path (`process_message_with_app_data` → `accumulate_app_data_updates`) dispatches every `AppDataUpdate` payload before any validation; unknown formats surface as non-retryable `AppDataDecode`. A commit referencing a standalone proposal the client earlier refused to store surfaces as `MissingAppDataUpdates`.
- The validate path (`ValidatedCommit::from_staged_commit`) reads dict-seeded metadata and the registry, and dispatches per-proposal expansion, all before the floor comparison at the tail of the function.

Every one of those failures is a non-retryable rejection — a **fork**, because above-floor peers accept the same commit. The main victim is a **downgraded client**: pausing normally happens at the floor-*bump* commit, but a client that processed the bump while above the floor and then rolled back never took that pause, and its next sync walks straight into the dispatch errors.

## Change

New shared guard `committed_floor_exceeding[_in_extensions]` (`groups/app_data/mod.rs`): returns the committed floor from the **pre-commit AppData dict** when it exceeds the client's version. Wired in two places:

- `process_message_with_app_data`: fires for every commit on a below-floor group, before any payload is dispatched or referenced proposal resolved. Surfaces as a new `ProcessMessageWithAppDataError::ProtocolVersionTooLow`, remapped at the `mls_sync` call sites (`GroupMessageProcessingError::from_app_data_processing`) into `CommitValidation(ProtocolVersionTooLow)` so the existing pause machinery — held cursor, `set_group_paused`, defer-and-reprocess after upgrade — applies unchanged. Application messages are unaffected. The client's version is threaded in as a parameter so cross-version tests can override it.
- `ValidatedCommit::from_staged_commit`: same check at the top of the migrated branch, before any dict-seeded metadata read, registry load, or proposal dispatch.

### Why the guard reads only committed state (design note)

An earlier design draft moved the *post-commit* floor check (tail of `from_staged_commit`) up before app-data validation. That would have been a **non-admin permanent-pause DoS**: the post-commit floor overlay includes same-commit `AppDataUpdate(0x800A)` proposals that have not yet passed the super-admin policy check, so any member could pause every receiver forever with floor=999.0.0. The tail check's position is load-bearing (policy first, floor after) and stays exactly where it is — it remains what pauses receivers at the floor-bump commit itself. The new guards never read same-commit proposals.

Protocol convention this establishes (docs to follow in the hardening docs change): a release introducing a new wire format must land the group-floor bump in a **strictly earlier** commit than the first commit using that format, and the floor-bump commit itself must contain nothing format-novel.

## Testing

- Unit battery on `committed_floor_exceeding_in_extensions`: fires strictly on floor > own (including semver prerelease ordering: `1.11.0-dev` exceeds `1.10.0`, not `1.11.0`); equal/lower/missing floors inert; malformed floor bytes or unparseable versions are lenient (`None`) so garbage can never wedge a group.
- New integration test `test_downgraded_client_pauses_on_migrated_group_with_higher_floor`: bo participates in a migrated group at a bumped version, processes a floor raise to that version unpaused, then is re-opened over the same persistent store at the default (lower) version — his next sync pauses the group at the committed floor with no processing error. (The post-bump commit uses formats both versions understand, so this pins the end state; a differential future-format harness is follow-on work with the cross-version CI.)
- Existing pause suite unchanged and green (`test_welcome_on_migrated_group_pauses_below_min_version`, `test_steady_state_pause_on_min_version_bump_via_app_data_update`, monotonicity tests).
- Full `xmtp_mls` crate suite against the local node: 702/702 (known flake `should_reconnect` retried). Changed files are clean under clippy 1.97; `lint-rust` failures on this machine are pre-existing trunk debt flagged by the newer local toolchain (`identity.rs:842` unused_mut, `mls_sync.rs:2894` needless_return, 8 `useless_borrows_in_formatting` in xmtp_db/xmtp_api_d14n) — untouched here to keep the diff minimal; happy to sweep those in a separate hygiene PR.

Part of the pre-v1.11 app-data hardening plan (P0.3 + P0.4, revised): receive-side acceptance changes that must land before the first stable release fields the app-data validators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZpajnDV829SVuW9danrW

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pause below-floor clients before parsing migrated-group commits in MLS sync
> - Adds a `committed_floor_exceeding` helper in [app_data/mod.rs](https://github.com/xmtp/libxmtp/pull/3864/files#diff-f0cc46ebb4d5cc3d18a7be0c2cab862e1d491117402b03370c19b1ca6dadcf3d) that reads `MIN_SUPPORTED_PROTOCOL_VERSION` from the committed AppData dictionary and compares it to the client's version.
> - `process_message_with_app_data` now accepts the client's `pkg_version` and returns a new `ProtocolVersionTooLow` error early, before decoding any AppDataUpdate payloads, when the committed floor exceeds the client version.
> - `ValidatedCommit::from_staged_commit` in [validated_commit.rs](https://github.com/xmtp/libxmtp/pull/3864/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6) checks the committed floor before reading migrated state, returning `CommitValidationError::ProtocolVersionTooLow` to pause the group without advancing the cursor.
> - `Group::sync` in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/3864/files#diff-160aadcd7de477c1116260a79601a0548842f3bd91bf16bd8443debb66ce6684) maps `ProtocolVersionTooLow` errors into the commit-validation pause path for both external commits/proposals and own-commit processing; the error is classified as non-retryable.
> - Behavioral Change: clients whose `pkg_version` is below a group's committed minimum will now pause (rather than error or retry) when processing commits from that group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a7a93f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->