### PR TITLE
fix(xmtp_mls): floor pause in the bootstrap validator + golden-vector pin on the synthesis encoder

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/bootstrap_validator.rs
+++ b/crates/xmtp_mls/src/groups/app_data/bootstrap_validator.rs
@@ -56,6 +56,21 @@ use crate::groups::validated_commit::{
 /// via the `#[from]` on `CommitValidationError::Bootstrap`.
 #[derive(Debug, thiserror::Error)]
 pub enum BootstrapValidationError {
+    /// The `MIN_SUPPORTED_PROTOCOL_VERSION` floor seeded by this
+    /// bootstrap exceeds the receiver's version — the bootstrap was
+    /// produced by a newer release whose synthesis encoding this
+    /// version may not reproduce. The caller converts this to
+    /// `CommitValidationError::ProtocolVersionTooLow` so the group
+    /// pauses (defer-and-reprocess after upgrade) instead of failing
+    /// the byte-compare with `Mismatch` — a rejection that above-floor
+    /// members don't share, i.e. a fork. Normally unreachable (the
+    /// step-A legacy floor bump pauses below-floor members before the
+    /// bootstrap arrives); this covers downgrade-between-steps races
+    /// and is the receiver-side half of the rule that any bootstrap
+    /// encoder change must ship with a `PROPOSALS_MIN_PROTOCOL_VERSION`
+    /// bump.
+    #[error("bootstrap seeds minimum supported protocol version {0} above this client's version")]
+    ProtocolVersionTooLow(String),
     /// The canonical subset says this `ComponentId` should be present
     /// among the bootstrap commit's `AppDataUpdate` proposals, but the
     /// commit didn't include one for it.
@@ -296,6 +311,7 @@ pub(crate) fn validate_bootstrap_commit(
     staged_commit: &StagedCommit,
     openmls_group: &OpenMlsGroup,
     proposer: &CommitParticipant,
+    own_version: &str,
 ) -> Result<(), BootstrapValidationError> {
     if !proposer.is_super_admin {
         return Err(BootstrapValidationError::ProposerNotSuperAdmin);
@@ -309,6 +325,29 @@ pub(crate) fn validate_bootstrap_commit(
     // `is_bootstrap_commit` (which only checks the GCE shape + a
     // COMPONENT_REGISTRY write) cannot reach OpenMLS' merge step.
     validate_only_allowed_proposal_types(staged_commit)?;
+
+    // PAUSE BEFORE BYTE-COMPARE: if the bootstrap seeds a floor above
+    // this client's version, it came from a newer release whose
+    // synthesis encoding this version may not reproduce — surfacing
+    // `Mismatch` would be a fork, pausing is recoverable. This check
+    // sits deliberately AFTER the proposer-is-super-admin gate.
+    //
+    // Non-admin injection is not possible here even though the floor is
+    // read before the canonical-subset compare: a bootstrap runs on a
+    // *pre-migration* group, where `proposals_enabled` is false, so the
+    // receive path rejects and never stores any standalone `AppDataUpdate`
+    // proposal (`ProposalsNotEnabled`, mls_sync.rs — the `!proposals_enabled
+    // && type != GroupContextExtensions` gate). A non-admin therefore cannot
+    // pre-stage an `AppDataUpdate(MIN_SUPPORTED_PROTOCOL_VERSION)` for this
+    // commit to reference; every `AppDataUpdate` in a bootstrap commit is an
+    // inline proposal authored by the super-admin committer validated above.
+    // And a super admin who reaches this line could equally pause members
+    // via a legitimate floor bump, so no new trust is extended. Malformed
+    // floor bytes are ignored (fall through to the byte-compare, which judges
+    // them against the synthesized expectation).
+    if let Some(min_version) = bootstrap_floor_exceeding(staged_commit, own_version) {
+        return Err(BootstrapValidationError::ProtocolVersionTooLow(min_version));
+    }
 
     // Expected bytes: sync synthesis over the pre-flip extensions.
     // No identity-update API lookups; the receiver does NOT call the
@@ -373,6 +412,33 @@ fn validate_only_allowed_proposal_types(
         }
     }
     Ok(())
+}
+
+/// Returns the `MIN_SUPPORTED_PROTOCOL_VERSION` floor seeded by this
+/// bootstrap commit's `AppDataUpdate` proposals when it parses as
+/// semver and exceeds `own_version`. Lenient everywhere else (absent
+/// seed, non-UTF-8 bytes, unparseable versions ⇒ `None`) — the
+/// canonical byte-compare downstream is the authority on whether the
+/// seed's bytes are what the pre-flip state demands; this helper only
+/// decides pause-vs-compare.
+fn bootstrap_floor_exceeding(staged_commit: &StagedCommit, own_version: &str) -> Option<String> {
+    use crate::groups::validated_commit::LibXMTPVersion;
+    use openmls::messages::proposals::AppDataUpdateOperation;
+
+    let floor_bytes = staged_commit.queued_proposals().find_map(|queued| {
+        if let Proposal::AppDataUpdate(p) = queued.proposal()
+            && ComponentId::from(p.component_id()) == ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION
+            && let AppDataUpdateOperation::Update(bytes) = p.operation()
+        {
+            Some(bytes.as_slice().to_vec())
+        } else {
+            None
+        }
+    })?;
+    let floor = String::from_utf8(floor_bytes).ok()?;
+    let own = LibXMTPVersion::parse(own_version).ok()?;
+    let floor_version = LibXMTPVersion::parse(&floor).ok()?;
+    (floor_version > own).then_some(floor)
 }
 
 /// Collect every `AppDataUpdate` proposal in a staged commit into a

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -239,12 +239,19 @@ pub struct EnableProposalsOptions {
     /// [`xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`] — the
     /// release where proposals support first ships.
     ///
+    /// Non-test builds clamp the override to
+    /// [`xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`] `<=
+    /// min_version <=` own `pkg_version`: the bootstrap encoder is
+    /// byte-frozen against receivers at or above that constant, so a
+    /// seeded floor below it would reopen the byte-compare fork the
+    /// pause path closes.
+    ///
     /// Use cases:
     /// - Tests that want a synthetic floor (e.g. `"99.0.0"` to force
-    ///   the pause path) or no floor (e.g. `"0.0.0"`).
-    /// - Dev / nightly builds that need to migrate groups without
-    ///   pausing peers running older `pkg_version`s.
-    /// - Staged production rollouts that need a non-default floor.
+    ///   the pause path) or no floor (e.g. `"0.0.0"`) — below-floor
+    ///   values are accepted only in `test` / `test-utils` builds.
+    /// - Staged production rollouts that need a floor above the
+    ///   default.
     pub min_version: Option<String>,
 }
 
@@ -843,6 +850,9 @@ where
     /// Returns an error if:
     /// - `force = false` and not all existing members support proposals
     /// - `min_version` is set to an invalid semver string
+    /// - `min_version` is outside the allowed bounds: above the
+    ///   caller's own `pkg_version`, or — in non-test builds — below
+    ///   [`xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`]
     /// - The group context extension update fails
     pub async fn enable_proposals(
         &self,
@@ -1011,6 +1021,36 @@ where
                         requested: min_version.clone(),
                         own: own_version_str.clone(),
                     });
+                }
+                // Encoder-freeze clamp (lower bound): the bootstrap
+                // encoder is byte-frozen, and receive-side validators
+                // accept its output via strict byte-compare only down
+                // to `PROPOSALS_MIN_PROTOCOL_VERSION`. Seeding a floor
+                // below that constant would drop below-floor receivers
+                // — whose frozen decoder may disagree on the bytes —
+                // back into the byte-compare instead of the pause
+                // path, reopening the fork the floor exists to close.
+                // Refuse, so the effective invariant is
+                // `PROPOSALS_MIN_PROTOCOL_VERSION <= min_version <=
+                // own pkg_version`. Test builds are exempt so
+                // `EnableProposalsOptions::test_default()` can seed a
+                // synthetic below-floor value (`"0.0.0"`) that never
+                // pauses workspace-version peers.
+                #[cfg(not(any(test, feature = "test-utils")))]
+                {
+                    let floor_str = xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION;
+                    let floor_v = LibXMTPVersion::parse(floor_str).map_err(|e| {
+                        GroupError::InvalidMinVersion {
+                            value: floor_str.to_string(),
+                            reason: format!("PROPOSALS_MIN_PROTOCOL_VERSION: {e}"),
+                        }
+                    })?;
+                    if target_v < floor_v {
+                        return Err(GroupError::MinVersionDowngrade {
+                            requested: min_version.clone(),
+                            current: floor_str.to_string(),
+                        });
+                    }
                 }
                 let metadata =
                     xmtp_mls_common::group_mutable_metadata::extract_legacy_group_mutable_metadata(

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -3841,6 +3841,131 @@ async fn test_admin_list_add_unchanged_on_unmigrated_group() {
     );
 }
 
+/// Bootstrap-time pause path: a receiver validating a bootstrap commit
+/// whose seeded `MIN_SUPPORTED_PROTOCOL_VERSION` exceeds its own
+/// version must PAUSE at the bootstrap (`ProtocolVersionTooLow`), not
+/// byte-compare it. Reachable only via a downgrade between the step-A
+/// legacy floor bump and the bootstrap: step-A normally pauses
+/// below-floor members before they ever see step-B.
+///
+/// This test is fully differential for the bootstrap floor check:
+/// without it, the downgraded receiver's byte-compare SUCCEEDS (its
+/// synthesized expectation reads the same floor value from the
+/// pre-flip GMM — value equality, no version comparison) and it merges
+/// the bootstrap, ending migrated-and-unpaused in a group whose floor
+/// it doesn't meet. With the check it ends unmigrated-and-paused, and
+/// reprocesses the bootstrap with upgraded code later.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_downgraded_client_pauses_at_bootstrap_seeding_higher_floor() {
+    use crate::builder::ClientBuilder;
+    use crate::client::Client;
+    use crate::groups::tests::increment_patch_version;
+    use crate::identity::IdentityStrategy;
+    use crate::utils::{DefaultTestClientCreator, VersionInfo, test::register_client};
+    use xmtp_common::tmp_path;
+    use xmtp_cryptography::utils::generate_local_wallet;
+    use xmtp_db::XmtpTestDb;
+    use xmtp_id::InboxOwner;
+    use xmtp_id::associations::test_utils::MockSmartContractSignatureVerifier;
+    use xmtp_proto::api_client::{ApiBuilder, XmtpTestClient};
+
+    // Both clients run one patch above the default so the legacy floor
+    // can be raised to a value the default version doesn't meet.
+    let mut high_version = VersionInfo::default();
+    let bumped = increment_patch_version(high_version.pkg_version()).expect("patch bump");
+    high_version.test_update_version(&bumped);
+
+    let alix =
+        ClientBuilder::new_test_client_with_version(&generate_local_wallet(), high_version.clone())
+            .await;
+
+    // Bo lives on a persistent store so the same identity can be
+    // re-opened at a lower version mid-flow.
+    let bo_wallet = generate_local_wallet();
+    let bo_db_path = tmp_path();
+    let bo_ident = bo_wallet.get_identifier()?;
+    let bo_nonce = 1;
+    let bo_strategy = IdentityStrategy::new(
+        bo_ident.inbox_id(bo_nonce)?,
+        bo_ident.clone(),
+        bo_nonce,
+        None,
+    );
+
+    let bo_store = xmtp_db::TestDb::create_persistent_store(Some(bo_db_path.clone())).await;
+    let bo = Client::builder(bo_strategy.clone())
+        .api_client(DefaultTestClientCreator::create().build()?)
+        .store(bo_store)
+        .default_mls_store()?
+        .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
+        .version(high_version.clone())
+        .build()
+        .await?;
+    register_client(&bo, &bo_wallet).await;
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+    let bo_groups = bo.sync_welcomes().await?;
+    let bo_group = bo_groups
+        .iter()
+        .find(|g| g.group_id == alix_group.group_id)
+        .expect("bo should receive a welcome for alix_group");
+    bo_group.sync().await?;
+
+    // Step-A equivalent, processed by bo at the HIGH version: raise the
+    // legacy GMM floor to `bumped`. Bo meets it — no pause.
+    alix_group.update_group_min_version_to_match_self().await?;
+    bo_group.sync().await?;
+    assert!(
+        bo_group.paused_for_version()?.is_none(),
+        "bo meets the legacy floor pre-downgrade and must not be paused"
+    );
+
+    // The downgrade, BETWEEN the legacy bump and the bootstrap.
+    let bo_group_id = bo_group.group_id;
+    drop(bo);
+    let bo_store = xmtp_db::TestDb::create_persistent_store(Some(bo_db_path)).await;
+    let bo_downgraded = Client::builder(bo_strategy)
+        .api_client(DefaultTestClientCreator::create().build()?)
+        .store(bo_store)
+        .default_mls_store()?
+        .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
+        .version(VersionInfo::default())
+        .build()
+        .await?;
+
+    // Alix migrates. `enable_proposals` skips its own step-A bump (the
+    // current floor already satisfies the test floor), and the
+    // bootstrap synthesis seeds `MIN_SUPPORTED_PROTOCOL_VERSION` from
+    // the GMM attribute — i.e. `bumped`.
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+
+    // The bootstrap is the first commit the downgraded bo processes.
+    let bo_group = bo_downgraded.group(&bo_group_id)?;
+    let _ = bo_group.sync().await;
+
+    assert_eq!(
+        bo_group.paused_for_version()?.as_deref(),
+        Some(bumped.as_str()),
+        "a downgraded receiver must pause AT the bootstrap seeding a floor above \
+         its version, deferring it for post-upgrade reprocessing"
+    );
+    let bo_migrated = bo_group
+        .load_mls_group_with_lock_async(async |g| {
+            Ok::<bool, crate::groups::GroupError>(bo_group.proposals_enabled(&g))
+        })
+        .await?;
+    assert!(
+        !bo_migrated,
+        "the paused bootstrap must NOT have been merged — pre-fix the byte-compare \
+         accepted it and bo ended migrated in a group whose floor it doesn't meet"
+    );
+}
+
 /// XIP §3 welcome-time pause path: when a new member is welcomed into a
 /// fully-migrated group whose AppData dict carries a
 /// `MIN_SUPPORTED_PROTOCOL_VERSION` higher than the joiner's pkg_version,

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -427,6 +427,7 @@ impl ValidatedCommit {
                 openmls_group,
                 immutable_metadata,
                 mutable_metadata,
+                context.version_info().pkg_version(),
             );
         }
 
@@ -792,6 +793,7 @@ impl ValidatedCommit {
         openmls_group: &OpenMlsGroup,
         immutable_metadata: GroupMetadata,
         mutable_metadata: GroupMutableMetadata,
+        own_version: &str,
     ) -> Result<Self, CommitValidationError> {
         reject_psk_proposals(staged_commit)?;
 
@@ -811,11 +813,25 @@ impl ValidatedCommit {
         )?
         .ok_or(CommitValidationError::ProposerNotFound)?;
 
+        // A bootstrap seeding a floor above this client pauses the
+        // group (same variant the steady-state floor checks emit, so
+        // the pause machinery in `mls_sync` applies) rather than
+        // surfacing as an opaque byte-compare `Mismatch` — which
+        // above-floor members wouldn't share, i.e. a fork.
         super::app_data::bootstrap_validator::validate_bootstrap_commit(
             staged_commit,
             openmls_group,
             &gce_proposer,
-        )?;
+            own_version,
+        )
+        .map_err(|e| {
+            match e {
+            super::app_data::bootstrap_validator::BootstrapValidationError::ProtocolVersionTooLow(
+                min_version,
+            ) => CommitValidationError::ProtocolVersionTooLow(min_version),
+            other => other.into(),
+        }
+        })?;
 
         Ok(Self {
             actor,

--- a/crates/xmtp_mls_common/src/app_data/migration.rs
+++ b/crates/xmtp_mls_common/src/app_data/migration.rs
@@ -519,6 +519,17 @@ pub struct CanonicalBootstrapExpectation {
 /// Compute the [`CanonicalBootstrapExpectation`] from a pre-flip
 /// group's state. **Sync, fully local** — no API calls — so every
 /// honest receiver produces bit-identical output.
+///
+/// **ENCODING FREEZE.** The `strict` map this produces is byte-compared
+/// by every fielded validator against incoming bootstrap commits, and
+/// groups migrate lazily — so for any input an already-shipped receiver
+/// can encounter, this encoding is permanent. The
+/// `golden_bootstrap_synthesis_*` tests pin it byte-for-byte. An
+/// encoder change is only shippable together with a
+/// `PROPOSALS_MIN_PROTOCOL_VERSION` bump (below-floor receivers pause
+/// via the floor check in `validate_bootstrap_commit` instead of
+/// byte-comparing), and the old expectation logic must keep validating
+/// bootstraps produced by older senders.
 pub fn synthesize_canonical_subset_for_validation(
     mls_group: &OpenMlsGroup,
 ) -> Result<CanonicalBootstrapExpectation, MigrationError> {
@@ -1692,6 +1703,185 @@ mod tests {
             err,
             MigrationError::InvalidFailedInstallationLength(16)
         ));
+    }
+
+    /// Format one strict entry as a stable, diffable line.
+    fn strict_lines(subset: &CanonicalBootstrapExpectation) -> Vec<String> {
+        subset
+            .strict
+            .iter()
+            .map(|(id, (op, bytes))| format!("{id} {op:?} {}", hex::encode(bytes)))
+            .collect()
+    }
+
+    /// A fully-populated legacy fixture: every metadata attribute set,
+    /// non-empty admin/super-admin lists. Fixed values only — the
+    /// golden tests below pin the synthesis encoder's exact output.
+    fn golden_gmm() -> crate::group_mutable_metadata::GroupMutableMetadata {
+        use crate::group_mutable_metadata::MetadataField;
+        let mut attributes = std::collections::HashMap::new();
+        attributes.insert(
+            MetadataField::GroupName.to_string(),
+            "Golden Group".to_string(),
+        );
+        attributes.insert(
+            MetadataField::Description.to_string(),
+            "golden description".to_string(),
+        );
+        attributes.insert(
+            MetadataField::GroupImageUrlSquare.to_string(),
+            "https://example.com/golden.png".to_string(),
+        );
+        attributes.insert(
+            MetadataField::AppData.to_string(),
+            "golden-app-data".to_string(),
+        );
+        attributes.insert(
+            MetadataField::MinimumSupportedProtocolVersion.to_string(),
+            "1.11.0".to_string(),
+        );
+        attributes.insert(
+            MetadataField::MessageDisappearFromNS.to_string(),
+            "1000000000".to_string(),
+        );
+        attributes.insert(
+            MetadataField::MessageDisappearInNS.to_string(),
+            "2000000000".to_string(),
+        );
+        attributes.insert(
+            MetadataField::CommitLogSigner.to_string(),
+            hex::encode([0xAB; 32]),
+        );
+        crate::group_mutable_metadata::GroupMutableMetadata::new(
+            attributes,
+            vec![hex_inbox(0x22)],
+            vec![hex_inbox(0x33)],
+        )
+    }
+
+    /// GOLDEN VECTORS — the strict byte-compare surface of the
+    /// bootstrap synthesis encoder, pinned byte-for-byte.
+    ///
+    /// Every fielded validator re-synthesizes these exact bytes from
+    /// pre-flip group state and byte-compares them against incoming
+    /// bootstrap commits (`bootstrap_validator.rs`), and groups migrate
+    /// lazily — so this encoding must never change for inputs that old
+    /// receivers can see. If this test fails, you have changed the
+    /// bootstrap wire encoding: that is only shippable together with a
+    /// `PROPOSALS_MIN_PROTOCOL_VERSION` bump (below-floor receivers
+    /// then pause instead of byte-comparing — see the floor check in
+    /// `validate_bootstrap_commit`), and the old expectation code must
+    /// keep validating bootstraps produced by older senders. Do NOT
+    /// simply re-pin the hex to make the test pass.
+    #[test]
+    fn golden_bootstrap_synthesis_group() {
+        let exts = build_test_extensions(
+            golden_gmm(),
+            minimal_default_policy_set(),
+            empty_membership(),
+            plain_group_metadata(),
+        );
+        let subset = synthesize_canonical_subset_from_extensions(&exts).unwrap();
+
+        let expected: Vec<String> = [
+            // SUPER_ADMIN_LIST (0x8001): TlsSet<InboxId>, one element
+            // (vlen 0x22=34, then TLS-framed versioned InboxId).
+            "0x8001 Update 2200003333333333333333333333333333333333333333333333333333333333333333",
+            // ADMIN_LIST (0x8002): TlsSet<InboxId>, one element.
+            "0x8002 Update 2200002222222222222222222222222222222222222222222222222222222222222222",
+            // GROUP_NAME (0x8004): utf-8 passthrough.
+            "0x8004 Update 476f6c64656e2047726f7570",
+            // GROUP_DESCRIPTION (0x8005)
+            "0x8005 Update 676f6c64656e206465736372697074696f6e",
+            // GROUP_IMAGE_URL (0x8006)
+            "0x8006 Update 68747470733a2f2f6578616d706c652e636f6d2f676f6c64656e2e706e67",
+            // MESSAGE_DISAPPEAR_FROM_NS (0x8007): 8-byte BE i64 1_000_000_000.
+            "0x8007 Update 000000003b9aca00",
+            // MESSAGE_DISAPPEAR_IN_NS (0x8008): 8-byte BE i64 2_000_000_000.
+            "0x8008 Update 0000000077359400",
+            // APP_DATA (0x8009)
+            "0x8009 Update 676f6c64656e2d6170702d64617461",
+            // MIN_SUPPORTED_PROTOCOL_VERSION (0x800A): utf-8 "1.11.0".
+            "0x800A Update 312e31312e30",
+            // COMMIT_LOG_SIGNER (0x800B): raw 32 key bytes.
+            "0x800B Update abababababababababababababababababababababababababababababababab",
+            // CREATOR_INBOX_ID (0xBFFE): versioned InboxId (varint v0 + 32 bytes).
+            "0xBFFE Update 001111111111111111111111111111111111111111111111111111111111111111",
+            // CONVERSATION_TYPE (0xBFFF): BE i32, Group = 1.
+            "0xBFFF Update 00000001",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        assert_eq!(
+            strict_lines(&subset),
+            expected,
+            "bootstrap synthesis encoder output changed — see the doc comment \
+             on this test before touching the pins"
+        );
+    }
+
+    /// DM + oneshot variant of [`golden_bootstrap_synthesis_group`] —
+    /// covers the optional strict seeds (DM_MEMBERS, ONESHOT_MESSAGE)
+    /// the plain-group vector can't. Same freeze rules apply.
+    #[test]
+    fn golden_bootstrap_synthesis_dm_with_oneshot() {
+        let dm_members = crate::group_metadata::DmMembers {
+            member_one_inbox_id: hex_inbox(0x22),
+            member_two_inbox_id: hex_inbox(0x33),
+        };
+        // Empty proto: zero encoded bytes, but the presence-gated seed
+        // still appears in strict — a stable pin that doesn't depend
+        // on OneshotMessage's inner shape.
+        let oneshot =
+            xmtp_proto::xmtp::mls::message_contents::OneshotMessage { message_type: None };
+        let metadata = crate::group_metadata::GroupMetadata::new(
+            xmtp_db::group::ConversationType::Dm,
+            hex_inbox(0x22),
+            Some(dm_members),
+            Some(oneshot),
+        );
+        let exts = build_test_extensions(
+            golden_gmm(),
+            minimal_default_policy_set(),
+            empty_membership(),
+            metadata,
+        );
+        let subset = synthesize_canonical_subset_from_extensions(&exts).unwrap();
+
+        let expected: Vec<String> = [
+            "0x8001 Update 2200003333333333333333333333333333333333333333333333333333333333333333",
+            "0x8002 Update 2200002222222222222222222222222222222222222222222222222222222222222222",
+            "0x8004 Update 476f6c64656e2047726f7570",
+            "0x8005 Update 676f6c64656e206465736372697074696f6e",
+            "0x8006 Update 68747470733a2f2f6578616d706c652e636f6d2f676f6c64656e2e706e67",
+            "0x8007 Update 000000003b9aca00",
+            "0x8008 Update 0000000077359400",
+            "0x8009 Update 676f6c64656e2d6170702d64617461",
+            "0x800A Update 312e31312e30",
+            "0x800B Update abababababababababababababababababababababababababababababababab",
+            // ONESHOT_MESSAGE (0xBFFC): prost encoding of the empty
+            // proto — zero bytes, seed present.
+            "0xBFFC Update ",
+            // DM_MEMBERS (0xBFFD): TlsSet<InboxId> of both members
+            // (two-byte vlen 0x4044 = 68, elements in sorted order).
+            "0xBFFD Update 40440000222222222222222222222222222222222222222222222222222222222222222200003333333333333333333333333333333333333333333333333333333333333333",
+            // CREATOR_INBOX_ID (0xBFFE): versioned InboxId.
+            "0xBFFE Update 002222222222222222222222222222222222222222222222222222222222222222",
+            // CONVERSATION_TYPE (0xBFFF): BE i32, Dm = 2.
+            "0xBFFF Update 00000002",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        assert_eq!(
+            strict_lines(&subset),
+            expected,
+            "bootstrap synthesis encoder output changed — see the doc comment \
+             on golden_bootstrap_synthesis_group before touching the pins"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Two related gaps around the bootstrap (migration) commit, from the pre-v1.11 app-data review:

1. `validate_bootstrap_and_build` had **no version check at all**. A bootstrap produced by a newer release — one whose synthesis encoding this version can't reproduce — fails the byte-compare with `Mismatch`, a non-retryable rejection that above-floor members don't share: a fork.
2. Nothing pinned the bootstrap synthesis encoder's byte output. Receivers byte-compare their locally synthesized expectation against incoming bootstraps, and groups migrate lazily over years — so the encoder is effectively frozen from the first stable release onward, with no test making that freeze visible to the next engineer who touches it.

## Changes

- **Floor pause in `validate_bootstrap_commit`**: after the proposer-is-super-admin gate and the allowed-proposal-types check, extract the bootstrap's seeded `MIN_SUPPORTED_PROTOCOL_VERSION` and return the new `BootstrapValidationError::ProtocolVersionTooLow` when it exceeds the client's version; `validate_bootstrap_and_build` remaps it to `CommitValidationError::ProtocolVersionTooLow` so the standard pause machinery (held cursor, `set_group_paused`, reprocess after upgrade) applies. Placement matters: the floor value is read from the commit's own proposals, so the check sits deliberately **after** the super-admin gate — pausing on non-admin input would let any member freeze a group, while a super admin who reaches this line could equally pause members via a legitimate floor bump (no new trust extended). Malformed floor bytes fall through to the byte-compare. The client version is threaded from `context.version_info()` so cross-version tests can override it.
- **Golden vectors**: `golden_bootstrap_synthesis_group` and `golden_bootstrap_synthesis_dm_with_oneshot` pin the strict byte-compare surface of `synthesize_canonical_subset_from_extensions` byte-for-byte (hex) over fully-populated fixtures — every metadata attribute, admin/super-admin lists, DM members, oneshot, both conversation types. An **ENCODING FREEZE** doc block on the synthesis entry point states the rule the floor check enables: an encoder change is only shippable together with a `PROPOSALS_MIN_PROTOCOL_VERSION` bump, and old expectation logic must keep validating old senders' bootstraps.

Together these make the frozen encoder *evolvable*: below-floor receivers pause instead of byte-comparing, and the golden tests make any accidental encoding change loudly visible instead of silently forking migrated groups.

## Testing

- New differential integration test `test_downgraded_client_pauses_at_bootstrap_seeding_higher_floor`: a member processes the legacy floor bump at a high version, downgrades (persistent-store rebuild at a lower version), then meets the bootstrap. Without the check, its byte-compare **accepts** the bootstrap (its synthesized expectation contains the same floor value — value equality, no version comparison) and it ends migrated-and-unpaused in a group whose floor it doesn't meet; with the check it pauses at the bootstrap, unmigrated, deferring it for post-upgrade reprocessing. **Mutation-verified**: with the floor check neutralized the test fails 4/4 retries; restored, it passes.
- Golden vectors generated from the actual encoder output (not hand-derived) and re-verified; existing canonical-subset tests untouched and green.
- Full `xmtp_mls` + `xmtp_mls_common` suites against the local node: 1502/1502 (known flake `should_reconnect` retried). Changed files clean under clippy 1.97; the two remaining flags on this machine are pre-existing trunk debt (`identity.rs` unused_mut, `mls_sync.rs` needless_return) untouched to keep the diff minimal.

Part of the pre-v1.11 app-data hardening plan (P0.5). Sibling of #3863 (registry entry validation + tolerant loads) and #3864 (steady-state floor guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZpajnDV829SVuW9danrW

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Floor pause in bootstrap validator when seeded version exceeds receiver's version
> - `validate_bootstrap_commit` now checks for a `MIN_SUPPORTED_PROTOCOL_VERSION` floor in staged proposals and returns `ProtocolVersionTooLow` if the seeded floor exceeds the receiver's own version, pausing processing instead of proceeding to the canonical byte-compare.
> - `enable_proposals` rejects `min_version` values below `PROPOSALS_MIN_PROTOCOL_VERSION` in non-test builds with `MinVersionDowngrade`.
> - Pins the exact encoded output of `synthesize_canonical_subset_for_validation` via golden tests for both group and DM-with-oneshot bootstrap cases to guard against unintended encoding changes.
> - Behavioral Change: downgraded clients bootstrapping into a group where a higher floor was seeded will now pause (setting `paused_for_version`) rather than proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b31aa5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->