### PR TITLE
fix(bindings,sdks): gate enable_proposals behind a per-language unstable namespace

### DIFF
--- a/bindings/node/src/conversation/metadata.rs
+++ b/bindings/node/src/conversation/metadata.rs
@@ -3,28 +3,6 @@ use napi::bindgen_prelude::Result;
 use napi_derive::napi;
 use xmtp_mls::mls_common::group_metadata::GroupMetadata as XmtpGroupMetadata;
 
-/// Options for [`Conversation::enableProposals`]. Mirrors
-/// [`xmtp_mls::groups::EnableProposalsOptions`].
-#[napi(object)]
-pub struct EnableProposalsOptions {
-  /// Skip the pre-flight key-package capability check. Post-d14n
-  /// every client supports proposals by version floor alone; set
-  /// `true` to bypass the per-member scan in that environment.
-  pub force: Option<bool>,
-  /// Override the `MIN_SUPPORTED_PROTOCOL_VERSION` floor. `None`
-  /// defaults to `xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`.
-  pub min_version: Option<String>,
-}
-
-impl From<EnableProposalsOptions> for xmtp_mls::groups::EnableProposalsOptions {
-  fn from(opts: EnableProposalsOptions) -> Self {
-    xmtp_mls::groups::EnableProposalsOptions {
-      force: opts.force.unwrap_or(false),
-      min_version: opts.min_version,
-    }
-  }
-}
-
 #[napi]
 pub struct GroupMetadata {
   metadata: XmtpGroupMetadata,
@@ -78,23 +56,6 @@ impl Conversation {
       .map_err(ErrorWrapper::from)?;
 
     Ok(())
-  }
-
-  /// Enable AppData-proposal-based metadata updates on this group.
-  ///
-  /// Stages the bootstrap commit that migrates the group's metadata
-  /// from the legacy GroupContextExtensions shape into the OpenMLS
-  /// AppData dictionary. Hard-fails if any member's latest key
-  /// package doesn't advertise `ProposalType::AppDataUpdate`. One-
-  /// way: migrated groups cannot return to the legacy path.
-  #[napi]
-  #[xmtp_common::err_span]
-  pub async fn enable_proposals(&self, options: EnableProposalsOptions) -> Result<()> {
-    let group = self.create_mls_group();
-    group
-      .enable_proposals(options.into())
-      .await
-      .map_err(|e| ErrorWrapper::from(e).into())
   }
 
   /// Whether this group has migrated to AppData-proposal-based

--- a/bindings/node/src/conversation/mod.rs
+++ b/bindings/node/src/conversation/mod.rs
@@ -15,6 +15,7 @@ pub mod messages;
 pub mod metadata;
 pub mod permissions;
 pub mod streams;
+pub mod unstable;
 
 #[napi]
 #[derive(Clone)]

--- a/bindings/node/src/conversation/unstable.rs
+++ b/bindings/node/src/conversation/unstable.rs
@@ -1,0 +1,73 @@
+use crate::{ErrorWrapper, conversation::Conversation};
+use napi::bindgen_prelude::Result;
+use napi_derive::napi;
+
+/// Options for [`UnstableConversation::enableProposals`]. Mirrors
+/// [`xmtp_mls::groups::EnableProposalsOptions`].
+#[napi(object)]
+pub struct EnableProposalsOptions {
+  /// Skip the pre-flight key-package capability check. Post-d14n
+  /// every client supports proposals by version floor alone; set
+  /// `true` to bypass the per-member scan in that environment.
+  pub force: Option<bool>,
+  /// Override the `MIN_SUPPORTED_PROTOCOL_VERSION` floor. `None`
+  /// defaults to `xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`.
+  pub min_version: Option<String>,
+}
+
+impl From<EnableProposalsOptions> for xmtp_mls::groups::EnableProposalsOptions {
+  fn from(opts: EnableProposalsOptions) -> Self {
+    xmtp_mls::groups::EnableProposalsOptions {
+      force: opts.force.unwrap_or(false),
+      min_version: opts.min_version,
+    }
+  }
+}
+
+/// The pre-release surface of a [`Conversation`], reached through
+/// `conversation.unstable`.
+///
+/// Everything here is unstable: the API shape may still change and, in
+/// some cases (see [`UnstableConversation::enable_proposals`]), the
+/// effect is one-way and irreversible. Reaching into `.unstable` is the
+/// deliberate opt-in. When an API graduates it moves onto
+/// [`Conversation`] directly and is removed here, so callers of the
+/// `unstable` form get a compile-time break to migrate against.
+#[napi]
+pub struct UnstableConversation {
+  inner: Conversation,
+}
+
+#[napi]
+impl UnstableConversation {
+  pub fn new(inner: Conversation) -> Self {
+    Self { inner }
+  }
+
+  /// Enable AppData-proposal-based metadata updates on this group.
+  ///
+  /// Stages the bootstrap commit that migrates the group's metadata
+  /// from the legacy GroupContextExtensions shape into the OpenMLS
+  /// AppData dictionary. Hard-fails if any member's latest key package
+  /// doesn't advertise `ProposalType::AppDataUpdate`. One-way:
+  /// migrated groups cannot return to the legacy path.
+  #[napi]
+  #[xmtp_common::err_span]
+  pub async fn enable_proposals(&self, options: EnableProposalsOptions) -> Result<()> {
+    let group = self.inner.create_mls_group();
+    group
+      .enable_proposals(options.into())
+      .await
+      .map_err(|e| ErrorWrapper::from(e).into())
+  }
+}
+
+#[napi]
+impl Conversation {
+  /// Pre-release APIs, gated behind an explicit `.unstable` opt-in.
+  /// See [`UnstableConversation`].
+  #[napi(getter)]
+  pub fn unstable(&self) -> UnstableConversation {
+    UnstableConversation::new(self.clone())
+  }
+}

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -138,6 +138,39 @@ impl From<EnableProposalsOptions> for xmtp_mls::groups::EnableProposalsOptions {
   }
 }
 
+/// The pre-release surface of a [`Conversation`], reached through
+/// `conversation.unstable`.
+///
+/// Everything here is unstable: the API shape may still change and, in
+/// some cases (see [`UnstableConversation::enable_proposals`]), the
+/// effect is one-way and irreversible. Reaching into `.unstable` is the
+/// deliberate opt-in. When an API graduates it moves onto
+/// [`Conversation`] directly and is removed here, so callers of the
+/// `unstable` form get a compile-time break to migrate against.
+#[wasm_bindgen]
+pub struct UnstableConversation {
+  inner: Conversation,
+}
+
+#[wasm_bindgen]
+impl UnstableConversation {
+  /// Enable AppData-proposal-based metadata updates on this group.
+  ///
+  /// Stages the bootstrap commit that migrates the group's metadata
+  /// from the legacy GroupContextExtensions shape into the OpenMLS
+  /// AppData dictionary. Hard-fails if any member's latest key package
+  /// doesn't advertise `ProposalType::AppDataUpdate`. One-way:
+  /// migrated groups cannot return to the legacy path.
+  #[wasm_bindgen(js_name = enableProposals)]
+  pub async fn enable_proposals(&self, options: EnableProposalsOptions) -> Result<(), JsError> {
+    let group = self.inner.to_mls_group();
+    group
+      .enable_proposals(options.into())
+      .await
+      .map_err(ErrorWrapper::js)
+  }
+}
+
 #[derive(Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -675,20 +708,13 @@ impl Conversation {
     Ok(())
   }
 
-  /// Enable AppData-proposal-based metadata updates on this group.
-  ///
-  /// Stages the bootstrap commit that migrates the group's metadata
-  /// from the legacy GroupContextExtensions shape into the OpenMLS
-  /// AppData dictionary. Hard-fails if any member's latest key
-  /// package doesn't advertise `ProposalType::AppDataUpdate`. One-
-  /// way: migrated groups cannot return to the legacy path.
-  #[wasm_bindgen(js_name = enableProposals)]
-  pub async fn enable_proposals(&self, options: EnableProposalsOptions) -> Result<(), JsError> {
-    let group = self.to_mls_group();
-    group
-      .enable_proposals(options.into())
-      .await
-      .map_err(ErrorWrapper::js)
+  /// Pre-release APIs, gated behind an explicit `.unstable` opt-in.
+  /// See [`UnstableConversation`].
+  #[wasm_bindgen(getter)]
+  pub fn unstable(&self) -> UnstableConversation {
+    UnstableConversation {
+      inner: self.clone(),
+    }
   }
 
   /// Whether this group has migrated to AppData-proposal-based

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -623,39 +623,17 @@ class Group(
         }
 
     /**
-     * Migrate this group's metadata from the legacy GroupContextExtensions
-     * shape onto OpenMLS `AppDataUpdate` proposals. After this returns
-     * successfully, subsequent metadata writes (group name, description,
-     * image URL, admin list, permissions) flow through the proposal-based
-     * path instead of GCE commits.
-     *
-     * @param force Skip the pre-flight key-package capability check.
-     *   Post-d14n every client supports proposals by version floor
-     *   alone, so the per-member scan stops adding signal. Set `true`
-     *   to bypass it. Callers using this MUST be confident every
-     *   member is at `>= minVersion`. Defaults to `false`.
-     * @param minVersion Override the `MIN_SUPPORTED_PROTOCOL_VERSION`
-     *   floor. `null` defaults to libxmtp's
-     *   `PROPOSALS_MIN_PROTOCOL_VERSION` — the release where proposals
-     *   support first ships.
-     *
-     * Hard-fails if `force == false` and any member's latest key
-     * package doesn't advertise `ProposalType.AppDataUpdate`. The
-     * migration is one-way — a migrated group cannot return to the
-     * legacy path.
+     * Pre-release APIs, grouped under [UnstableGroup]. The `@UnstableApi`
+     * opt-in is applied once here, so every function on [UnstableGroup] is
+     * covered without a per-function annotation. Call sites must
+     * `@OptIn(UnstableApi::class)`; when a function graduates it moves onto
+     * [Group] and the opt-in stops resolving, forcing a migration.
      */
-    suspend fun enableProposals(
-        force: Boolean = false,
-        minVersion: String? = null,
-    ) = withContext(Dispatchers.IO) {
-        try {
-            libXMTPGroup.enableProposals(
-                FfiEnableProposalsOptions(force = force, minVersion = minVersion),
-            )
-        } catch (e: Exception) {
-            throw XMTPException("Unable to enable proposals on group", e)
-        }
-    }
+    @UnstableApi(
+        "APIs on Group.unstable are pre-release: shapes may change and some (e.g. enableProposals) are one-way and irreversible.",
+    )
+    val unstable: UnstableGroup
+        get() = UnstableGroup(libXMTPGroup)
 
     /**
      * Snapshot this group's membership capabilities: the group context's
@@ -668,7 +646,7 @@ class Group(
      * [org.xmtp.android.library.libxmtp.MlsExtensionType.AppDataDictionary],
      * and an inbox blocks migration when one of its installations'
      * [org.xmtp.android.library.libxmtp.InstallationCapabilities.supportedExtensions]
-     * does not. Pair with [enableProposals].
+     * does not. Pair with [UnstableGroup.enableProposals].
      */
     suspend fun membershipCapabilities(): GroupMembershipCapabilities =
         withContext(Dispatchers.IO) {

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/UnstableApi.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/UnstableApi.kt
@@ -1,0 +1,16 @@
+package org.xmtp.android.library
+
+/**
+ * Opt-in marker for pre-release ("unstable") APIs. The API shape may
+ * still change and, in some cases, the effect is one-way and
+ * irreversible. Call sites must acknowledge with
+ * `@OptIn(UnstableApi::class)`; when an API graduates the marker is
+ * dropped from it and — once the marker itself is removed — the opt-in
+ * fails to compile, forcing a migration to the stable form.
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class UnstableApi(
+    val message: String,
+)

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/UnstableGroup.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/UnstableGroup.kt
@@ -1,0 +1,61 @@
+package org.xmtp.android.library
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import uniffi.xmtpv3.FfiConversation
+import uniffi.xmtpv3.FfiEnableProposalsOptions
+
+/**
+ * Pre-release ("unstable") surface for a [Group], reached through
+ * `group.unstable`.
+ *
+ * Everything here is unstable: the API shape may still change and, in
+ * some cases (see [enableProposals]), the effect is one-way and
+ * irreversible. Adding a function here needs no per-function annotation —
+ * the class-level `@UnstableApi` covers every member, and the opt-in
+ * requirement follows an `UnstableGroup` instance even if it escapes the
+ * `group.unstable` accessor. When an API graduates it moves onto [Group]
+ * directly and is removed here, so callers of the `unstable` form get a
+ * compile-time break to migrate against.
+ */
+@UnstableApi(
+    "APIs on Group.unstable are pre-release: shapes may change and some (e.g. enableProposals) are one-way and irreversible.",
+)
+class UnstableGroup(
+    private val libXMTPGroup: FfiConversation,
+) {
+    /**
+     * Migrate this group's metadata from the legacy GroupContextExtensions
+     * shape onto OpenMLS `AppDataUpdate` proposals. After this returns
+     * successfully, subsequent metadata writes (group name, description,
+     * image URL, admin list, permissions) flow through the proposal-based
+     * path instead of GCE commits.
+     *
+     * @param force Skip the pre-flight key-package capability check.
+     *   Post-d14n every client supports proposals by version floor
+     *   alone, so the per-member scan stops adding signal. Set `true`
+     *   to bypass it. Callers using this MUST be confident every
+     *   member is at `>= minVersion`. Defaults to `false`.
+     * @param minVersion Override the `MIN_SUPPORTED_PROTOCOL_VERSION`
+     *   floor. `null` defaults to libxmtp's
+     *   `PROPOSALS_MIN_PROTOCOL_VERSION` — the release where proposals
+     *   support first ships.
+     *
+     * Hard-fails if `force == false` and any member's latest key
+     * package doesn't advertise `ProposalType.AppDataUpdate`. The
+     * migration is one-way — a migrated group cannot return to the
+     * legacy path.
+     */
+    suspend fun enableProposals(
+        force: Boolean = false,
+        minVersion: String? = null,
+    ) = withContext(Dispatchers.IO) {
+        try {
+            libXMTPGroup.enableProposals(
+                FfiEnableProposalsOptions(force = force, minVersion = minVersion),
+            )
+        } catch (e: Exception) {
+            throw XMTPException("Unable to enable proposals on group", e)
+        }
+    }
+}

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/libxmtp/GroupMembershipCapabilities.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/libxmtp/GroupMembershipCapabilities.kt
@@ -111,7 +111,8 @@ class InboxCapabilities(
  * doesn't.
  *
  * Read it with [org.xmtp.android.library.Group.membershipCapabilities]; drive
- * the upgrade with [org.xmtp.android.library.Group.enableProposals].
+ * the upgrade with [org.xmtp.android.library.UnstableGroup.enableProposals]
+ * (via `group.unstable`, opting in with `@OptIn(UnstableApi::class)`).
  */
 class GroupMembershipCapabilities(
     private val ffi: FfiGroupMembershipCapabilities,

--- a/sdks/ios/Sources/XMTPiOS/Group.swift
+++ b/sdks/ios/Sources/XMTPiOS/Group.swift
@@ -238,31 +238,14 @@ public struct Group: Identifiable, Equatable, Hashable {
 		try await ffiGroup.updateAppData(appData: appData)
 	}
 
-	/// Migrate this group's metadata from the legacy GroupContextExtensions
-	/// shape onto OpenMLS `AppDataUpdate` proposals. After this returns
-	/// successfully, subsequent metadata writes (group name, description,
-	/// image URL, admin list, permissions) flow through the proposal-based
-	/// path instead of GCE commits.
-	///
-	/// - Parameters:
-	///   - force: Skip the pre-flight key-package capability check.
-	///     Post-d14n every client supports proposals by version floor
-	///     alone, so the per-member scan stops adding signal. Set
-	///     `true` to bypass it. Callers using this MUST be confident
-	///     every member is at `>= minVersion`. Defaults to `false`.
-	///   - minVersion: Override the `MIN_SUPPORTED_PROTOCOL_VERSION`
-	///     floor. `nil` defaults to libxmtp's
-	///     `PROPOSALS_MIN_PROTOCOL_VERSION` — the release where
-	///     proposals support first ships.
-	///
-	/// Hard-fails with `ProposalsNotSupported` if `force == false` and
-	/// any member's latest key package doesn't advertise
-	/// `ProposalType::AppDataUpdate`. The migration is one-way — a
-	/// migrated group cannot return to the legacy path.
-	public func enableProposals(force: Bool = false, minVersion: String? = nil) async throws {
-		try await ffiGroup.enableProposals(
-			options: FfiEnableProposalsOptions(force: force, minVersion: minVersion)
-		)
+	/// Pre-release APIs, grouped under ``UnstableGroup`` and gated behind
+	/// `@_spi(Unstable)` — they are not part of the stable API surface for
+	/// the v1.11 cut. Reach them via `@_spi(Unstable) import XMTPiOS`.
+	/// Opting in once here covers every function on ``UnstableGroup``; when
+	/// one graduates it moves onto `Group` and the `.unstable` access
+	/// breaks at compile time, forcing a migration.
+	@_spi(Unstable) public var unstable: UnstableGroup {
+		UnstableGroup(ffiGroup: ffiGroup)
 	}
 
 	/// Snapshot this group's membership capabilities: the group context's
@@ -274,7 +257,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 	/// ``GroupMembershipCapabilities/contextExtensions`` contains
 	/// ``MlsExtensionType/appDataDictionary``, and an inbox blocks migration
 	/// when one of its installations' ``InstallationCapabilities/supportedExtensions``
-	/// does not. Pair with ``enableProposals(force:minVersion:)``.
+	/// does not. Pair with ``UnstableGroup/enableProposals(force:minVersion:)``.
 	public func membershipCapabilities() async throws -> GroupMembershipCapabilities {
 		try await GroupMembershipCapabilities(ffi: ffiGroup.membershipCapabilities())
 	}

--- a/sdks/ios/Sources/XMTPiOS/Libxmtp/GroupMembershipCapabilities.swift
+++ b/sdks/ios/Sources/XMTPiOS/Libxmtp/GroupMembershipCapabilities.swift
@@ -95,7 +95,8 @@ public struct InboxCapabilities {
 /// inboxes blocking migration are those with an installation that doesn't.
 ///
 /// Read it with ``Group/membershipCapabilities()``; drive the upgrade with
-/// ``Group/enableProposals(force:minVersion:)``.
+/// ``UnstableGroup/enableProposals(force:minVersion:)`` (via
+/// `@_spi(Unstable) import XMTPiOS`).
 public struct GroupMembershipCapabilities {
 	let ffi: FfiGroupMembershipCapabilities
 

--- a/sdks/ios/Sources/XMTPiOS/UnstableGroup.swift
+++ b/sdks/ios/Sources/XMTPiOS/UnstableGroup.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Pre-release ("unstable") surface for a ``Group``, reached through
+/// `group.unstable` and gated behind `@_spi(Unstable)`.
+///
+/// Everything here is unstable: the API shape may still change and, in
+/// some cases (see ``enableProposals(force:minVersion:)``), the effect is
+/// one-way and irreversible. Adding a function here needs no per-function
+/// annotation — the `@_spi(Unstable)` gate on `Group.unstable` covers the
+/// whole type. When an API graduates it moves onto ``Group`` directly and
+/// is removed here, so callers of the `unstable` form get a compile-time
+/// break to migrate against.
+@_spi(Unstable) public struct UnstableGroup {
+	let ffiGroup: FfiConversation
+
+	/// Migrate this group's metadata from the legacy GroupContextExtensions
+	/// shape onto OpenMLS `AppDataUpdate` proposals. After this returns
+	/// successfully, subsequent metadata writes (group name, description,
+	/// image URL, admin list, permissions) flow through the proposal-based
+	/// path instead of GCE commits.
+	///
+	/// - Parameters:
+	///   - force: Skip the pre-flight key-package capability check.
+	///     Post-d14n every client supports proposals by version floor
+	///     alone, so the per-member scan stops adding signal. Set
+	///     `true` to bypass it. Callers using this MUST be confident
+	///     every member is at `>= minVersion`. Defaults to `false`.
+	///   - minVersion: Override the `MIN_SUPPORTED_PROTOCOL_VERSION`
+	///     floor. `nil` defaults to libxmtp's
+	///     `PROPOSALS_MIN_PROTOCOL_VERSION` — the release where
+	///     proposals support first ships.
+	///
+	/// Hard-fails with `ProposalsNotSupported` if `force == false` and
+	/// any member's latest key package doesn't advertise
+	/// `ProposalType::AppDataUpdate`. The migration is one-way — a
+	/// migrated group cannot return to the legacy path.
+	public func enableProposals(force: Bool = false, minVersion: String? = nil) async throws {
+		try await ffiGroup.enableProposals(
+			options: FfiEnableProposalsOptions(force: force, minVersion: minVersion)
+		)
+	}
+}


### PR DESCRIPTION
## Problem

`enableProposals()` is a one-way, irreversible per-group migration: the moment any app calls it, that group's cohort is permanently on the app-data format and every pre-1.11 member is paused until upgrade. It must not sit on the **stable** API surface for the v1.11 cut until the app-data hardening work (#3863–#3865 plus the remaining product fixes) has landed and been re-reviewed.

But first-party apps (convos-ios / convos-android) still need a way to call it — so hiding it outright is wrong. The first revision of this PR did exactly that on mobile (`internal` / non-`public`), which **removes** the capability from every downstream consumer, and merely **renamed** it on JS (`unstableEnableProposals`), which gives no compile-time signal when it graduates.

## Change

One consistent model across all four bindings: an **`unstable` namespace** that groups pre-release functions under a single opt-in. The function keeps its **real, final name**; promotion to stable is a **compile-time break** for callers of the gated form (the function moves out of the namespace). New unstable functions — the custom-component-id internals landing next — accrete onto the same namespace with **no per-function annotation**.

| Binding | Gate (applied once) | Call site |
| --- | --- | --- |
| node | `conversation.unstable` namespace object (`UnstableConversation`, `#[napi(getter)]`) | `conversation.unstable.enableProposals(opts)` |
| wasm | same (`#[wasm_bindgen(getter)]`) | `conversation.unstable.enableProposals(opts)` |
| iOS | `@_spi(Unstable) public var unstable: UnstableGroup` | `@_spi(Unstable) import XMTPiOS` → `group.unstable.enableProposals(...)` |
| Android | `@UnstableApi val unstable: UnstableGroup` (`@RequiresOptIn` marker, mirrors existing `DelicateApi`) | `@OptIn(UnstableApi::class)` → `group.unstable.enableProposals(...)` |

- **node**: new `bindings/node/src/conversation/unstable.rs` holding `UnstableConversation` + the `EnableProposalsOptions` it consumes, plus a `#[napi(getter)] unstable` on `Conversation`.
- **wasm**: `UnstableConversation` + `#[wasm_bindgen(getter)] unstable`, inline in `conversation.rs` (matching that binding's single-file layout).
- **iOS**: new `UnstableGroup.swift`; a single `@_spi(Unstable)` on the `Group.unstable` accessor gates the whole type — adding functions needs no per-function attribute.
- **Android**: new `UnstableGroup.kt` + `UnstableApi.kt` (`@RequiresOptIn(level = ERROR)` marker); the marker is applied **once** on the `Group.unstable` accessor, not per function.
- Doc links that referenced `Group.enableProposals` now point at `UnstableGroup.enableProposals`.
- Core `MlsGroup::enable_proposals`, the mobile FFI, and the read surfaces (`proposalsEnabled`, `membershipCapabilities`) are unchanged.

**Promotion, when the hardening lands:** move `enableProposals` off the `unstable` namespace onto the primary type (all four). Each move is a compile-time break for existing opt-in callers.

## Testing

- `cargo check -p bindings_node` ✅, `cargo check -p bindings_wasm --target wasm32-unknown-unknown` ✅, clippy `-Dwarnings` ✅ on both (native + wasm32), fmt clean.
- No in-repo references to the old `unstableEnableProposals` name; no bare `Group.enableProposals` references remain.
- iOS/Android are visibility/namespace-only changes that mirror existing patterns; **not compiled locally** (no Xcode/Gradle+nix in this env) — CI validates the mobile lanes. No Swift/Kotlin code call sites reference the moved symbol (only doc links, now updated).

Part of the pre-v1.11 app-data hardening plan (P1.1 / D5). Supersedes the rename/hide approach in the first revision of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate `enableProposals` behind a per-language unstable namespace across Node, WASM, Android, and iOS SDKs
> - Moves `enableProposals` off the stable `Conversation`/`Group` surface and onto a new `unstable` accessor (`conversation.unstable.enableProposals` / `group.unstable.enableProposals`) in all SDK bindings.
> - Introduces `UnstableConversation` (Node, WASM) and `UnstableGroup` (Android, iOS) types that hold the actual implementation.
> - Each platform uses its idiomatic opt-in mechanism: `@_spi(Unstable)` on iOS, `@RequiresOptIn` (`@UnstableApi`) on Android, and a plain getter on Node/WASM.
> - Behavioral Change: callers using `enableProposals` directly on `Conversation` or `Group` will have a compile/runtime break and must migrate to the `unstable` accessor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfd88ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->