### PR TITLE
fix(xmtp_archive): export migrated groups instead of silently dropping them

### DIFF
--- a/crates/xmtp_archive/src/export_stream/group_save.rs
+++ b/crates/xmtp_archive/src/export_stream/group_save.rs
@@ -3,7 +3,10 @@ use openmls::group::MlsGroup;
 use xmtp_db::group::{GroupQueryArgs, StoredGroup};
 use xmtp_db::sql_key_store::SqlKeyStore;
 use xmtp_mls_common::{
-    group_metadata::GroupMetadata, group_mutable_metadata::GroupMutableMetadata,
+    group_metadata::{GroupMetadata, extract_group_metadata},
+    group_mutable_metadata::{
+        GroupMutableMetadata, extensions_are_migrated, merge_dict_into_mutable_metadata_lossy,
+    },
 };
 use xmtp_proto::xmtp::device_sync::{
     backup_element::Element,
@@ -43,11 +46,75 @@ impl BackupRecordProvider for GroupSave {
                     return None;
                 }
                 let group_id = record.id;
-                let mls_group = MlsGroup::load(&storage, &group_id.to_openmls()).ok()??;
-                let immutable = mls_group.extensions().immutable_metadata()?;
+                let mls_group = match MlsGroup::load(&storage, &group_id.to_openmls()) {
+                    Ok(Some(mls_group)) => mls_group,
+                    Ok(None) => {
+                        tracing::warn!(
+                            group_id = %group_id,
+                            "skipping group in backup: no MLS group state found"
+                        );
+                        return None;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            group_id = %group_id,
+                            error = %e,
+                            "skipping group in backup: failed to load MLS group state"
+                        );
+                        return None;
+                    }
+                };
+                let extensions = mls_group.extensions();
 
-                let immutable_metadata = GroupMetadata::try_from(immutable.metadata()).ok()?;
-                let mutable_metadata = GroupMutableMetadata::try_from(&mls_group).ok()?;
+                // Capability-aware reads: migrated (post-bootstrap)
+                // groups no longer carry the legacy `ImmutableMetadata`
+                // / `GroupMutableMetadata` extensions — their metadata
+                // lives in the AppData dictionary. Reading the legacy
+                // extensions only would silently drop every migrated
+                // group from the backup (conversation loss on restore).
+                // Skips below are logged, never silent: a group that
+                // fails BOTH sources is corrupt and worth a log line.
+                let immutable_metadata = extract_group_metadata(extensions)
+                    .inspect_err(|e| {
+                        tracing::warn!(
+                            group_id = %group_id,
+                            error = %e,
+                            "skipping group in backup: unreadable group metadata"
+                        );
+                    })
+                    .ok()?;
+                let mutable_metadata = if extensions_are_migrated(extensions) {
+                    let mut base = GroupMutableMetadata::new(
+                        std::collections::HashMap::new(),
+                        Vec::new(),
+                        Vec::new(),
+                    );
+                    // Per-field degrade, never per-group: a malformed
+                    // component loses that one field, not the whole
+                    // group. Dropping the group here would orphan its
+                    // (unconditionally exported) messages, and the
+                    // restore's foreign-key check would abort the
+                    // entire import over one corrupt component.
+                    for e in merge_dict_into_mutable_metadata_lossy(&mut base, extensions) {
+                        tracing::warn!(
+                            group_id = %group_id,
+                            error = %e,
+                            "skipping malformed metadata component in backup; \
+                             group still exported"
+                        );
+                    }
+                    base
+                } else {
+                    GroupMutableMetadata::try_from(&mls_group)
+                        .inspect_err(|e| {
+                            tracing::warn!(
+                                group_id = %group_id,
+                                error = %e,
+                                "skipping group in backup: unreadable legacy metadata"
+                            );
+                        })
+                        .ok()?
+                };
 
                 Some(BackupElement {
                     element: Some(Element::Group(GroupSave::new(

--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -285,34 +285,10 @@ pub(crate) fn component_type(id: ComponentId) -> Option<ComponentType> {
     }
 }
 
-/// Single source of truth for the `MetadataField` ↔ `ComponentId` bijection
-/// over the Bytes-typed mutable-metadata family. Both lookup helpers below
-/// and `merge_app_data_into_mutable_metadata` derive from this table.
-const METADATA_FIELD_COMPONENT_MAP: &[(MetadataField, ComponentId)] = &[
-    (MetadataField::GroupName, ComponentId::GROUP_NAME),
-    (MetadataField::Description, ComponentId::GROUP_DESCRIPTION),
-    (
-        MetadataField::GroupImageUrlSquare,
-        ComponentId::GROUP_IMAGE_URL,
-    ),
-    (
-        MetadataField::MessageDisappearFromNS,
-        ComponentId::MESSAGE_DISAPPEAR_FROM_NS,
-    ),
-    (
-        MetadataField::MessageDisappearInNS,
-        ComponentId::MESSAGE_DISAPPEAR_IN_NS,
-    ),
-    (
-        MetadataField::MinimumSupportedProtocolVersion,
-        ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION,
-    ),
-    (
-        MetadataField::CommitLogSigner,
-        ComponentId::COMMIT_LOG_SIGNER,
-    ),
-    (MetadataField::AppData, ComponentId::APP_DATA),
-];
+/// Re-export of the `MetadataField` ↔ `ComponentId` bijection, moved
+/// to `xmtp_mls_common` (single source of truth shared with the
+/// dict↔legacy merge and the archive exporter).
+pub(crate) use xmtp_mls_common::group_mutable_metadata::METADATA_FIELD_COMPONENT_MAP;
 
 /// Map a [`MetadataField`] string to its corresponding `ComponentId`.
 ///
@@ -781,63 +757,24 @@ pub(crate) fn merge_app_data_into_mutable_metadata_from_extensions(
     if !super::is_migrated_extensions(extensions) {
         return Ok(());
     }
-    let Some(ext) = extensions.app_data_dictionary() else {
-        return Ok(());
-    };
-    let dict = ext.dictionary();
-
-    for (field, id) in METADATA_FIELD_COMPONENT_MAP {
-        if let Some(bytes) = dict.get(&id.as_u16()) {
-            // Each typed `Component`'s wire shape decides how the dict
-            // bytes round-trip back into the legacy
-            // `GroupMutableMetadata.attributes` string map:
-            //
-            // - `MESSAGE_DISAPPEAR_*` are 8-byte BE `i64` on the wire;
-            //   format as a base-10 string for the legacy reader.
-            // - `COMMIT_LOG_SIGNER` is the raw 32-byte private key on
-            //   the wire; hex-encode for the legacy reader.
-            // - All other metadata-attribute components are UTF-8.
-            let legacy_value = match *id {
-                ComponentId::MESSAGE_DISAPPEAR_FROM_NS | ComponentId::MESSAGE_DISAPPEAR_IN_NS => {
-                    let arr: [u8; 8] = bytes.try_into().map_err(|_| {
-                        ComponentSourceError::MalformedComponentValue {
-                            component_id: *id,
-                            reason: format!("expected 8 bytes (BE i64), got {}", bytes.len()),
-                        }
-                    })?;
-                    i64::from_be_bytes(arr).to_string()
-                }
-                ComponentId::COMMIT_LOG_SIGNER => hex::encode(bytes),
-                _ => std::str::from_utf8(bytes)
-                    .map_err(|e| ComponentSourceError::MalformedComponentValue {
-                        component_id: *id,
-                        reason: format!("non-UTF-8 bytes: {e}"),
-                    })?
-                    .to_string(),
-            };
-            base.attributes
-                .insert(field.as_str().to_string(), legacy_value);
-        }
-    }
-
-    // ADMIN_LIST / SUPER_ADMIN_LIST overlay: on migrated groups the
-    // dict is authoritative; decode the `TlsSet<InboxId>` and
-    // hex-encode each id back to string form for the base GMM.
-    for (component_id, list) in [
-        (ComponentId::ADMIN_LIST, &mut base.admin_list),
-        (ComponentId::SUPER_ADMIN_LIST, &mut base.super_admin_list),
-    ] {
-        if let Some(bytes) = dict.get(&component_id.as_u16()) {
-            let set = TlsSet::<InboxId>::tls_deserialize_exact(bytes).map_err(|e| {
-                ComponentSourceError::MalformedComponentValue {
-                    component_id,
-                    reason: format!("invalid TlsSet<InboxId>: {e}"),
-                }
-            })?;
-            *list = set.iter().map(|id| id.to_hex()).collect();
-        }
-    }
-    Ok(())
+    // The merge body lives in `xmtp_mls_common` so crates below
+    // `xmtp_mls` in the dependency graph (the archive exporter) can
+    // reuse it; only the (test-override-aware) migration gate above
+    // stays here. Map the per-component error back to
+    // `MalformedComponentValue` so this function's error shape (which
+    // callers and tests match on, and `component_id()` extracts from)
+    // is unchanged by the move.
+    xmtp_mls_common::group_mutable_metadata::merge_dict_into_mutable_metadata(base, extensions)
+        .map_err(|e| match e {
+            GroupMutableMetadataError::MalformedComponent {
+                component_id: Some(component_id),
+                reason,
+            } => ComponentSourceError::MalformedComponentValue {
+                component_id,
+                reason,
+            },
+            other => ComponentSourceError::GroupMutableMetadata(other),
+        })
 }
 
 // ============================================================================

--- a/crates/xmtp_mls/src/worker/device_sync/archive.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/archive.rs
@@ -562,4 +562,100 @@ mod tests {
         let result = insert_importer(&mut importer, &alix.context).await;
         assert!(result.is_ok());
     }
+
+    /// Migrated (post-bootstrap) groups must survive the backup
+    /// round-trip. The bootstrap commit strips the legacy
+    /// `ImmutableMetadata` / `GroupMutableMetadata` extensions, and the
+    /// exporter used to read only those — so every migrated group was
+    /// silently omitted from the archive (`filter_map` + `?`), i.e.
+    /// conversation loss on restore. The exporter is now
+    /// capability-aware and reads the AppData dictionary on migrated
+    /// groups.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_archive_includes_migrated_groups() {
+        use crate::groups::EnableProposalsOptions;
+
+        tester!(alix, disable_workers);
+        tester!(bo, disable_workers);
+
+        let alix_group = alix
+            .create_group_with_members(&[bo.inbox_id()], None, None)
+            .await?;
+        alix_group.send_message(b"hi", Default::default()).await?;
+
+        // Migrate, then set metadata POST-migration so the exported
+        // values can only have come from the AppData dict.
+        alix_group
+            .enable_proposals(EnableProposalsOptions::test_default())
+            .await?;
+        alix_group
+            .update_group_name("post-migration name".to_string())
+            .await?;
+        alix_group
+            .update_group_description("post-migration description".to_string())
+            .await?;
+        alix_group
+            .update_group_image_url_square("https://example.com/post-migration.png".to_string())
+            .await?;
+
+        // A second, unmigrated group in the same archive pins the
+        // mixed legacy+migrated export: both read paths must produce
+        // restorable groups side by side.
+        let legacy_group = alix
+            .create_group_with_members(&[bo.inbox_id()], None, None)
+            .await?;
+        legacy_group
+            .update_group_name("legacy name".to_string())
+            .await?;
+
+        let key = vec![7; 32];
+        let opts = ArchiveOptions {
+            start_ns: None,
+            end_ns: None,
+            elements: vec![
+                BackupElementSelection::Messages,
+                BackupElementSelection::Consent,
+            ],
+            exclude_disappearing_messages: false,
+        };
+        let export = {
+            let mut file = vec![];
+            let mut exporter = ArchiveExporter::new(opts, alix.db(), &key);
+            exporter.read_to_end(&mut file).await?;
+            file
+        };
+
+        // Fresh installation of the same inbox restores from the
+        // archive only (workers disabled, no welcome sync).
+        tester!(alix2, from: alix);
+        let reader = Box::pin(BufReader::new(Cursor::new(export)));
+        let mut importer = ArchiveImporter::load(reader, &key).await?;
+        insert_importer(&mut importer, &alix2.context).await?;
+
+        let restored = alix2.db().find_group(&alix_group.group_id)?;
+        assert!(
+            restored.is_some(),
+            "migrated group missing from restored archive — the exporter \
+             dropped it (pre-fix behavior: legacy-extension read on a \
+             migrated group)"
+        );
+
+        // Presence isn't enough: the metadata written after migration
+        // must round-trip through the archive, or per-field loss in
+        // the exporter's dict read would go unnoticed.
+        let restored_group = alix2.group(&alix_group.group_id)?;
+        assert_eq!(restored_group.group_name()?, "post-migration name");
+        assert_eq!(
+            restored_group.group_description()?,
+            "post-migration description"
+        );
+        assert_eq!(
+            restored_group.group_image_url_square()?,
+            "https://example.com/post-migration.png"
+        );
+
+        // The legacy group in the same archive restores alongside it.
+        let restored_legacy = alix2.group(&legacy_group.group_id)?;
+        assert_eq!(restored_legacy.group_name()?, "legacy name");
+    }
 }

--- a/crates/xmtp_mls_common/src/group_mutable_metadata.rs
+++ b/crates/xmtp_mls_common/src/group_mutable_metadata.rs
@@ -396,6 +396,215 @@ pub fn extract_legacy_group_mutable_metadata(
         .try_into()
 }
 
+/// Single source of truth for the `MetadataField` ↔ `ComponentId`
+/// bijection over the Bytes/String-typed mutable-metadata family. The
+/// dict↔legacy merge below and the lookup helpers in
+/// `xmtp_mls::groups::app_data::component_source` all derive from this
+/// table.
+pub const METADATA_FIELD_COMPONENT_MAP: &[(
+    MetadataField,
+    super::app_data::component_id::ComponentId,
+)] = &[
+    (
+        MetadataField::GroupName,
+        super::app_data::component_id::ComponentId::GROUP_NAME,
+    ),
+    (
+        MetadataField::Description,
+        super::app_data::component_id::ComponentId::GROUP_DESCRIPTION,
+    ),
+    (
+        MetadataField::GroupImageUrlSquare,
+        super::app_data::component_id::ComponentId::GROUP_IMAGE_URL,
+    ),
+    (
+        MetadataField::MessageDisappearFromNS,
+        super::app_data::component_id::ComponentId::MESSAGE_DISAPPEAR_FROM_NS,
+    ),
+    (
+        MetadataField::MessageDisappearInNS,
+        super::app_data::component_id::ComponentId::MESSAGE_DISAPPEAR_IN_NS,
+    ),
+    (
+        MetadataField::MinimumSupportedProtocolVersion,
+        super::app_data::component_id::ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION,
+    ),
+    (
+        MetadataField::CommitLogSigner,
+        super::app_data::component_id::ComponentId::COMMIT_LOG_SIGNER,
+    ),
+    (
+        MetadataField::AppData,
+        super::app_data::component_id::ComponentId::APP_DATA,
+    ),
+];
+
+/// Production migration predicate over raw extensions: the group is
+/// post-bootstrap iff the AppData dictionary carries the
+/// `COMPONENT_REGISTRY` entry (the bootstrap commit's first write).
+///
+/// `xmtp_mls::groups::app_data::is_migrated_extensions` layers a
+/// test-only registry override on top of this; use that one inside
+/// `xmtp_mls`. This variant exists for crates below `xmtp_mls` in the
+/// dependency graph (e.g. the archive exporter).
+pub fn extensions_are_migrated(extensions: &Extensions<GroupContext>) -> bool {
+    extensions
+        .app_data_dictionary()
+        .map(|ext| {
+            ext.dictionary()
+                .get(&super::app_data::component_id::ComponentId::COMPONENT_REGISTRY.as_u16())
+                .is_some()
+        })
+        .unwrap_or(false)
+}
+
+/// Overlay the AppData dictionary's metadata components onto `base` —
+/// the dict→legacy direction of the capability-aware read paths.
+///
+/// **Ungated**: callers decide migration state before calling (the
+/// `xmtp_mls` wrapper gates on its test-override-aware
+/// `is_migrated_extensions`; the archive exporter gates on
+/// [`extensions_are_migrated`]). No-op when the extensions carry no
+/// AppData dictionary.
+///
+/// Value translation per component family:
+/// - `MESSAGE_DISAPPEAR_*`: 8-byte BE `i64` on the wire → base-10
+///   string for the legacy reader.
+/// - `COMMIT_LOG_SIGNER`: raw 32 key bytes → hex string.
+/// - Every other metadata attribute: UTF-8 passthrough.
+/// - `ADMIN_LIST` / `SUPER_ADMIN_LIST`: `TlsSet<InboxId>` → hex-string
+///   lists (dict is authoritative on migrated groups).
+pub fn merge_dict_into_mutable_metadata(
+    base: &mut GroupMutableMetadata,
+    extensions: &Extensions<GroupContext>,
+) -> Result<(), GroupMutableMetadataError> {
+    use super::app_data::component_id::ComponentId;
+
+    let Some(ext) = extensions.app_data_dictionary() else {
+        return Ok(());
+    };
+    let dict = ext.dictionary();
+
+    for (field, id) in METADATA_FIELD_COMPONENT_MAP {
+        if let Some(bytes) = dict.get(&id.as_u16()) {
+            let legacy_value = decode_metadata_component(*id, bytes)?;
+            base.attributes
+                .insert(field.as_str().to_string(), legacy_value);
+        }
+    }
+
+    for (component_id, list) in [
+        (ComponentId::ADMIN_LIST, &mut base.admin_list),
+        (ComponentId::SUPER_ADMIN_LIST, &mut base.super_admin_list),
+    ] {
+        if let Some(bytes) = dict.get(&component_id.as_u16()) {
+            *list = decode_inbox_id_list(component_id, bytes)?;
+        }
+    }
+    Ok(())
+}
+
+/// Best-effort variant of [`merge_dict_into_mutable_metadata`] that
+/// degrades per-field instead of failing per-group: every component
+/// that decodes is applied to `base`, every component that doesn't is
+/// skipped, and the errors are returned so the caller can log them
+/// (empty vec = clean merge).
+///
+/// Exists for the archive exporter, where one malformed component must
+/// not drop the whole group from a backup — the group's messages are
+/// exported unconditionally, so a missing group row orphans them and
+/// aborts the entire restore on a foreign-key violation. Non-export
+/// callers that want fail-fast semantics keep using the strict variant
+/// above.
+pub fn merge_dict_into_mutable_metadata_lossy(
+    base: &mut GroupMutableMetadata,
+    extensions: &Extensions<GroupContext>,
+) -> Vec<GroupMutableMetadataError> {
+    use super::app_data::component_id::ComponentId;
+
+    let Some(ext) = extensions.app_data_dictionary() else {
+        return Vec::new();
+    };
+    let dict = ext.dictionary();
+    let mut errors = Vec::new();
+
+    for (field, id) in METADATA_FIELD_COMPONENT_MAP {
+        if let Some(bytes) = dict.get(&id.as_u16()) {
+            match decode_metadata_component(*id, bytes) {
+                Ok(legacy_value) => {
+                    base.attributes
+                        .insert(field.as_str().to_string(), legacy_value);
+                }
+                Err(e) => errors.push(e),
+            }
+        }
+    }
+
+    for (component_id, list) in [
+        (ComponentId::ADMIN_LIST, &mut base.admin_list),
+        (ComponentId::SUPER_ADMIN_LIST, &mut base.super_admin_list),
+    ] {
+        if let Some(bytes) = dict.get(&component_id.as_u16()) {
+            match decode_inbox_id_list(component_id, bytes) {
+                Ok(ids) => *list = ids,
+                Err(e) => errors.push(e),
+            }
+        }
+    }
+    errors
+}
+
+/// Decode one Bytes/String-family component's wire bytes into its
+/// legacy string value, per the translation rules documented on
+/// [`merge_dict_into_mutable_metadata`]. Shared by the strict and
+/// lossy merge variants so both apply identical translations.
+fn decode_metadata_component(
+    id: super::app_data::component_id::ComponentId,
+    bytes: &[u8],
+) -> Result<String, GroupMutableMetadataError> {
+    use super::app_data::component_id::ComponentId;
+
+    match id {
+        ComponentId::MESSAGE_DISAPPEAR_FROM_NS | ComponentId::MESSAGE_DISAPPEAR_IN_NS => {
+            let arr: [u8; 8] =
+                bytes
+                    .try_into()
+                    .map_err(|_| GroupMutableMetadataError::MalformedComponent {
+                        component_id: Some(id),
+                        reason: format!("expected 8 bytes (BE i64), got {}", bytes.len()),
+                    })?;
+            Ok(i64::from_be_bytes(arr).to_string())
+        }
+        ComponentId::COMMIT_LOG_SIGNER => Ok(hex::encode(bytes)),
+        _ => Ok(std::str::from_utf8(bytes)
+            .map_err(|e| GroupMutableMetadataError::MalformedComponent {
+                component_id: Some(id),
+                reason: format!("non-UTF-8 bytes: {e}"),
+            })?
+            .to_string()),
+    }
+}
+
+/// Decode an `ADMIN_LIST` / `SUPER_ADMIN_LIST` component's wire bytes
+/// (`TlsSet<InboxId>`) into the legacy hex-string list form. Shared by
+/// the strict and lossy merge variants.
+fn decode_inbox_id_list(
+    component_id: super::app_data::component_id::ComponentId,
+    bytes: &[u8],
+) -> Result<Vec<String>, GroupMutableMetadataError> {
+    use super::inbox_id::InboxId;
+    use super::tls_set::TlsSet;
+    use tls_codec::Deserialize as _;
+
+    let set = TlsSet::<InboxId>::tls_deserialize_exact(bytes).map_err(|e| {
+        GroupMutableMetadataError::MalformedComponent {
+            component_id: Some(component_id),
+            reason: format!("invalid TlsSet<InboxId>: {e}"),
+        }
+    })?;
+    Ok(set.iter().map(|id| id.to_hex()).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -431,5 +640,67 @@ mod tests {
 
         let bad_metadata = GroupMutableMetadata::new(bad_attributes, vec![], vec![]);
         assert!(bad_metadata.commit_log_signer().is_none());
+    }
+
+    #[xmtp_common::test]
+    fn test_lossy_merge_applies_good_fields_and_reports_bad_ones() {
+        use super::super::app_data::component_id::ComponentId;
+        use openmls::extensions::{AppDataDictionary, AppDataDictionaryExtension};
+        use openmls::group::GroupContext;
+
+        // One valid component (GROUP_NAME), two malformed ones
+        // (MESSAGE_DISAPPEAR_FROM_NS with the wrong byte width,
+        // ADMIN_LIST with bytes that aren't a TlsSet<InboxId>).
+        let mut dict = AppDataDictionary::new();
+        let _ = dict.insert(ComponentId::GROUP_NAME.as_u16(), b"Good Name".to_vec());
+        let _ = dict.insert(
+            ComponentId::MESSAGE_DISAPPEAR_FROM_NS.as_u16(),
+            vec![0x01; 3],
+        );
+        let _ = dict.insert(ComponentId::ADMIN_LIST.as_u16(), vec![0xff, 0xff, 0xff]);
+        let extensions: Extensions<GroupContext> =
+            Extensions::from_vec(vec![Extension::AppDataDictionary(
+                AppDataDictionaryExtension::new(dict),
+            )])
+            .unwrap();
+
+        // The strict variant fails on the first malformed component.
+        let mut strict_base = GroupMutableMetadata::new(HashMap::new(), vec![], vec![]);
+        assert!(merge_dict_into_mutable_metadata(&mut strict_base, &extensions).is_err());
+
+        // The lossy variant applies the good field, leaves the bad
+        // ones untouched, and reports both errors with their ids.
+        let mut base = GroupMutableMetadata::new(HashMap::new(), vec![], vec![]);
+        let errors = merge_dict_into_mutable_metadata_lossy(&mut base, &extensions);
+
+        assert_eq!(
+            base.attributes
+                .get(MetadataField::GroupName.as_str())
+                .map(String::as_str),
+            Some("Good Name"),
+        );
+        assert!(
+            !base
+                .attributes
+                .contains_key(MetadataField::MessageDisappearFromNS.as_str())
+        );
+        assert!(base.admin_list.is_empty());
+
+        let error_ids: Vec<_> = errors
+            .iter()
+            .map(|e| match e {
+                GroupMutableMetadataError::MalformedComponent { component_id, .. } => {
+                    component_id.unwrap()
+                }
+                other => panic!("expected MalformedComponent, got: {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            error_ids,
+            vec![
+                ComponentId::MESSAGE_DISAPPEAR_FROM_NS,
+                ComponentId::ADMIN_LIST
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Problem

The archive exporter read group metadata exclusively from the legacy `ImmutableMetadata` / `GroupMutableMetadata` group-context extensions, inside a `filter_map` with `?`. The app-data bootstrap commit strips exactly those extensions — so **every migrated group silently vanished from device-sync backups**, with no error and no log line. An archive written after migrating is missing those conversations on restore: silent data loss, found during the pre-v1.11 app-data review.

## Changes

- **Capability-aware exporter** (`xmtp_archive/src/export_stream/group_save.rs`): immutable metadata via `extract_group_metadata` (already capability-aware since #3612); mutable metadata via the dict merge on migrated groups, legacy extension otherwise. Groups that fail to read are now skipped with a `tracing::warn!` carrying the group id — never silently.
- **Merge logic moved down to `xmtp_mls_common`** so the archive crate (which cannot depend on `xmtp_mls` — dependency direction) reuses the exact same code the live read paths use, rather than a drifting copy: `merge_dict_into_mutable_metadata`, the production migration predicate `extensions_are_migrated`, and the `METADATA_FIELD_COMPONENT_MAP` bijection now live in `group_mutable_metadata.rs`. `component_source.rs` delegates, keeping its test-override-aware migration gate and mapping the moved function's per-component error back to `ComponentSourceError::MalformedComponentValue` so the error shape callers and tests match on is unchanged.

Scope note (per the hardening plan): the archive proto stays legacy-shaped — migrated groups round-trip their legacy-representable subset (name, description, image, app_data, disappearing settings, admin lists, creator). Custom app-data components are out of scope for v1.11 (future app-data-native archive format).

## Testing

- New regression test `test_archive_includes_migrated_groups`: create → migrate → rename post-migration (so the exported name can only come from the dict) → export → restore on a fresh installation of the same inbox (workers disabled, no network sync) → the group is present. **Mutation-verified**: forcing the exporter back onto the legacy-only branch makes the test fail on every retry; restored, it passes.
- Existing error-shape test (`merge_with_malformed_field_surfaces_error_not_silent_loss`) still passes — the delegation preserves `MalformedComponentValue` exactly.
- Full `xmtp_mls` + `xmtp_mls_common` + `xmtp_archive` suites against the local node: 1505/1505 (known flake `should_reconnect` retried). fmt clean.

Part of the pre-v1.11 app-data hardening plan (P1.2). Siblings: #3863–#3867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZpajnDV829SVuW9danrW

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix backup export to include migrated groups instead of silently dropping them
> - Previously, `BackupRecordProvider::backup_records` in [group_save.rs](https://github.com/xmtp/libxmtp/pull/3868/files#diff-d290f107f0b3a0aeea5bb881c96460e88df9da34b91c84d7d2623bd0f814a914) used `?` propagation inside `filter_map`, which silently dropped groups whose metadata was stored in the AppData dictionary (migrated groups).
> - For migrated groups, metadata is now read from the AppData dictionary via a new `merge_dict_into_mutable_metadata_lossy` function; per-component decode failures are logged but do not drop the group from the export.
> - Adds `extensions_are_migrated`, `merge_dict_into_mutable_metadata`, and `merge_dict_into_mutable_metadata_lossy` helpers to [group_mutable_metadata.rs](https://github.com/xmtp/libxmtp/pull/3868/files#diff-ed696106212fb67c35890c8338ccfd437eff9d62595cc6d1b73139430893a8ed) as the shared source of truth for migration-aware metadata decoding.
> - Adds an integration test in [archive.rs](https://github.com/xmtp/libxmtp/pull/3868/files#diff-009339e0af57f89865f1763abb73f1be9f5122f41953cedcc60aabdc3e0c5d38) verifying that migrated group metadata round-trips correctly through archive export and restore alongside legacy groups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2ebc66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->