### PR TITLE
fix(xmtp_mls_common): enforce UTF-8 on String-component apply so committed values stay readable

### DIFF
--- a/crates/xmtp_mls_common/src/app_data/components/metadata_attributes.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/metadata_attributes.rs
@@ -136,6 +136,17 @@ macro_rules! passthrough_string_component {
                 payload: &[u8],
                 _prior: Option<&[u8]>,
             ) -> Result<Vec<u8>, ComponentTypedError> {
+                // Validate UTF-8 before accepting the bytes into the
+                // dict. Without this, a peer could land a value every
+                // receiver ACCEPTS at commit time but none can READ
+                // back (`decode_value` requires UTF-8) — an
+                // accepted-but-unreadable component. Mirrors the
+                // `be_i64_component!` family's validate-then-passthrough
+                // shape, and matches the type-aware fallback for
+                // unknown String-typed ids, which already rejects
+                // non-UTF-8 — so known-impl and unknown-id receivers
+                // agree.
+                let _ = decode_utf8(Self::ID, payload)?;
                 apply_passthrough(payload)
             }
 
@@ -143,6 +154,10 @@ macro_rules! passthrough_string_component {
                 op: &AppDataUpdateOperation,
                 _prior: Option<&[u8]>,
             ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+                // Keep the validator's verdict in lockstep with apply.
+                if let AppDataUpdateOperation::Update(payload) = op {
+                    let _ = decode_utf8(Self::ID, payload.as_slice())?;
+                }
                 expand_passthrough(op)
             }
         }
@@ -302,6 +317,44 @@ mod tests {
             }
             other => panic!("expected MalformedValue, got {other:?}"),
         }
+    }
+
+    /// Apply/read symmetry: bytes the read path can't decode must be
+    /// rejected at APPLY time too. Pre-fix, `apply_update_payload` was
+    /// a raw passthrough — a peer could land a value every receiver
+    /// accepted at commit time but none could read back.
+    #[xmtp_common::test(unwrap_try = true)]
+    fn string_component_apply_rejects_non_utf8() {
+        let err = AppDataComponent::apply_update_payload(&[0xff, 0xfe, 0xfd], None).unwrap_err();
+        match err {
+            ComponentTypedError::MalformedValue { component_id, .. } => {
+                assert_eq!(component_id, ComponentId::APP_DATA);
+            }
+            other => panic!("expected MalformedValue, got {other:?}"),
+        }
+        // Valid UTF-8 still passes through byte-identical.
+        let ok = AppDataComponent::apply_update_payload("héllo".as_bytes(), None).unwrap();
+        assert_eq!(ok, "héllo".as_bytes());
+    }
+
+    /// Same symmetry on the validator's expansion path — apply and
+    /// expand must agree so every honest receiver returns the same
+    /// verdict regardless of which stage sees the payload first.
+    #[xmtp_common::test(unwrap_try = true)]
+    fn string_component_expand_rejects_non_utf8() {
+        let op = AppDataUpdateOperation::Update(vec![0xff, 0xfe, 0xfd].into());
+        let err = GroupNameComponent::expand_to_changes(&op, None).unwrap_err();
+        match err {
+            ComponentTypedError::MalformedValue { component_id, .. } => {
+                assert_eq!(component_id, ComponentId::GROUP_NAME);
+            }
+            other => panic!("expected MalformedValue, got {other:?}"),
+        }
+        // Remove never carries bytes and stays valid.
+        let changes =
+            GroupNameComponent::expand_to_changes(&AppDataUpdateOperation::Remove, None).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Delete);
     }
 
     #[xmtp_common::test(unwrap_try = true)]


### PR DESCRIPTION
## Problem

The String-typed metadata components (`GROUP_NAME`, `GROUP_DESCRIPTION`, `GROUP_IMAGE_URL`, `APP_DATA`, `MIN_SUPPORTED_PROTOCOL_VERSION`) validated UTF-8 on **read** (`decode_value`) but not on **apply**: `apply_update_payload` was a raw passthrough. A peer could commit non-UTF-8 bytes that every receiver accepts into the dict at commit time — and then no receiver can read the value back (`MalformedValue` on every subsequent read). An accepted-but-unreadable component, found in the pre-v1.11 wire-format review.

The asymmetry was also version-divergent: the type-aware fallback used for *unknown* String-typed component ids already rejects non-UTF-8 at dispatch, so a client with the typed impl accepted bytes that a client without it rejected.

## Change

`passthrough_string_component!` now validates UTF-8 in both `apply_update_payload` and `expand_to_changes` (Update arm), mirroring the `be_i64_component!` family's validate-then-passthrough shape. Apply and the validator's expansion stay in lockstep, and the known-impl path now agrees with the type-aware fallback. Legitimate senders are unaffected — `encode_mutation` takes a `String`, so they can only produce valid UTF-8.

Acceptance-tightening note: this changes what v1.11 receivers accept (rejects payloads that were previously accepted-but-unreadable), which is only free before the first stable release fields these validators — the same reasoning as the rest of the hardening set.

## Testing

New pins: `string_component_apply_rejects_non_utf8` (rejects garbage, passes valid UTF-8 byte-identical) and `string_component_expand_rejects_non_utf8` (same verdict on the validator path; `Remove` unaffected). Differential by construction — both fail against the pre-fix passthrough. Full `xmtp_mls_common` + `xmtp_mls` suites against the local node: 1501/1501 (known flake `should_reconnect` retried).

Part of the pre-v1.11 app-data hardening plan (P1.3). Siblings: #3863–#3868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZpajnDV829SVuW9danrW

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce UTF-8 validation in `passthrough_string_component` apply and expand
> - String-typed MLS components now validate payloads as UTF-8 in both `apply_update_payload` and `expand_to_changes`, returning `MalformedValue` on invalid bytes instead of accepting raw byte sequences.
> - The fix is applied inside the `passthrough_string_component` macro in [metadata_attributes.rs](https://github.com/xmtp/libxmtp/pull/3869/files#diff-8d22387053032391f57a49904f5f719eaf2c6f0ffc9be4c79d7c1763eb321a14), so all String components (e.g. `GroupNameComponent`) get the behavior automatically.
> - Behavioral Change: previously, non-UTF-8 bytes were silently accepted and stored; they now produce an error at apply/expand time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35e11a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->