### PR TITLE
feat(bindings): unify the app-data FFI surface across mobile, wasm, and node

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1688,12 +1688,32 @@ impl TryFrom<FfiPermissionPolicySet> for PolicySet {
     }
 }
 
+/// Options for [`FfiConversation::update_app_data`]. A record (rather
+/// than a bare `String` parameter) so future knobs can be added
+/// without breaking compiled apps — same pattern as
+/// [`FfiEnableProposalsOptions`].
+///
+/// WARNING: uniffi Records get NO default field values unless the field
+/// carries `#[uniffi(default = ...)]`. Any field added later MUST carry
+/// a uniffi default (and a serde/napi default on the wasm/node
+/// `UpdateAppDataOptions`), or the generated Swift/Kotlin constructors
+/// change and the addition breaks compiled apps.
+#[derive(uniffi::Record, Clone, Default, Debug)]
+pub struct FfiUpdateAppDataOptions {
+    /// The new value for the group's opaque `APP_DATA` string slot.
+    pub value: String,
+}
+
 #[derive(uniffi::Enum, Debug)]
 pub enum FfiMetadataField {
     GroupName,
     Description,
     ImageUrlSquare,
     AppData,
+    // Present on the wasm and node bindings from the start; added here
+    // so the three bindings expose the same field set.
+    MessageExpirationFromNs,
+    MessageExpirationInNs,
 }
 
 impl From<&FfiMetadataField> for MetadataField {
@@ -1703,6 +1723,8 @@ impl From<&FfiMetadataField> for MetadataField {
             FfiMetadataField::Description => MetadataField::Description,
             FfiMetadataField::ImageUrlSquare => MetadataField::GroupImageUrlSquare,
             FfiMetadataField::AppData => MetadataField::AppData,
+            FfiMetadataField::MessageExpirationFromNs => MetadataField::MessageDisappearFromNS,
+            FfiMetadataField::MessageExpirationInNs => MetadataField::MessageDisappearInNS,
         }
     }
 }
@@ -2344,9 +2366,13 @@ pub struct FfiInboxCapabilities {
 
 /// A generic membership/capability snapshot for a group. Mirrors
 /// [`xmtp_mls::groups::GroupMembershipCapabilities`]. Callers filter it — e.g.
-/// the proposal migration is complete when `context_extensions` contains
-/// `AppDataDictionary`, and an inbox blocks migration when one of its
-/// installations' `supported_extensions` does not.
+/// an inbox blocks the proposal migration when one of its
+/// installations' `supported_extensions` lacks `AppDataDictionary`.
+///
+/// To ask "is this group migrated?", use
+/// [`FfiConversation::proposals_enabled`] instead of scanning
+/// `context_extensions` — the marker extension is an internal
+/// protocol detail and the semantic bool is the stable contract.
 #[derive(uniffi::Record, Clone, Debug)]
 pub struct FfiGroupMembershipCapabilities {
     pub context_extensions: Vec<FfiMlsExtensionType>,
@@ -2945,8 +2971,8 @@ impl FfiConversation {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn update_app_data(&self, app_data: String) -> Result<(), FfiError> {
-        self.inner.update_app_data(app_data).await?;
+    pub async fn update_app_data(&self, options: FfiUpdateAppDataOptions) -> Result<(), FfiError> {
+        self.inner.update_app_data(options.value).await?;
         Ok(())
     }
 
@@ -2954,6 +2980,22 @@ impl FfiConversation {
     pub fn app_data(&self) -> Result<String, FfiError> {
         let app_data = self.inner.app_data()?;
         Ok(app_data)
+    }
+
+    /// Whether this group has migrated to AppData-proposal-based
+    /// metadata updates (the `AppDataDictionary` group-context
+    /// extension is present). `false` means the group is still on
+    /// the legacy GroupContextExtensions path.
+    ///
+    /// Prefer this semantic bool over scanning
+    /// [`FfiGroupMembershipCapabilities::context_extensions`] for
+    /// `AppDataDictionary` — the capabilities snapshot answers
+    /// "which members block migration", not "is this group migrated",
+    /// and the marker extension is an internal protocol detail.
+    /// Mirrors `proposalsEnabled` on the wasm and node bindings.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub fn proposals_enabled(&self) -> Result<bool, FfiError> {
+        Ok(self.inner.is_proposals_enabled()?)
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/bindings/mobile/src/mls/tests/group_management.rs
+++ b/bindings/mobile/src/mls/tests/group_management.rs
@@ -1,6 +1,7 @@
 //! Tests for group creation, permissions, metadata, membership, listing, and pagination
 
 use super::*;
+use crate::FfiUpdateAppDataOptions;
 
 use xmtp_proto::types::GroupId;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -332,7 +333,9 @@ async fn test_app_data_permission_update() {
     // Verify bola cannot update app_data (not an admin)
     bola_group
         .conversation
-        .update_app_data("bola's data".to_string())
+        .update_app_data(FfiUpdateAppDataOptions {
+            value: "bola's data".to_string(),
+        })
         .await
         .unwrap_err();
 
@@ -364,7 +367,9 @@ async fn test_app_data_permission_update() {
     // Now bola CAN update app_data
     bola_group
         .conversation
-        .update_app_data("bola's data".to_string())
+        .update_app_data(FfiUpdateAppDataOptions {
+            value: "bola's data".to_string(),
+        })
         .await
         .unwrap();
 

--- a/bindings/node/src/conversation/metadata.rs
+++ b/bindings/node/src/conversation/metadata.rs
@@ -125,14 +125,25 @@ impl Conversation {
 
   #[napi]
   #[xmtp_common::err_span]
-  pub async fn update_app_data(&self, app_data: String) -> Result<()> {
+  pub async fn update_app_data(&self, options: UpdateAppDataOptions) -> Result<()> {
     let group = self.create_mls_group();
 
     group
-      .update_app_data(app_data)
+      .update_app_data(options.value)
       .await
       .map_err(ErrorWrapper::from)?;
 
     Ok(())
   }
+}
+
+/// Options for [`Conversation::updateAppData`]. An object (rather than
+/// a bare string parameter) so future knobs can be added without
+/// breaking callers — same pattern as [`EnableProposalsOptions`].
+/// New fields must be `Option` so the generated TS type stays non-breaking.
+#[napi(object)]
+#[derive(Clone, Default)]
+pub struct UpdateAppDataOptions {
+  /// The new value for the group's opaque `APP_DATA` string slot.
+  pub value: String,
 }

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -171,6 +171,17 @@ impl UnstableConversation {
   }
 }
 
+/// Options for [`Conversation::updateAppData`]. An object (rather than
+/// a bare string parameter) so future knobs can be added without
+/// breaking callers — same pattern as [`EnableProposalsOptions`].
+/// New fields must be `Option` + `#[serde(default)]` to stay non-breaking.
+#[derive(Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateAppDataOptions {
+  /// The new value for the group's opaque `APP_DATA` string slot.
+  pub value: String,
+}
 #[derive(Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -737,14 +748,11 @@ impl Conversation {
   }
 
   #[wasm_bindgen(js_name = updateAppData)]
-  pub async fn update_app_data(
-    &self,
-    #[wasm_bindgen(js_name = appData)] app_data: String,
-  ) -> Result<(), JsError> {
+  pub async fn update_app_data(&self, options: UpdateAppDataOptions) -> Result<(), JsError> {
     let group = self.to_mls_group();
 
     group
-      .update_app_data(app_data)
+      .update_app_data(options.value)
       .await
       .map_err(ErrorWrapper::js)?;
 

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -42,6 +42,7 @@ import uniffi.xmtpv3.FfiMessageDisappearingSettings
 import uniffi.xmtpv3.FfiMetadataField
 import uniffi.xmtpv3.FfiPermissionUpdateType
 import uniffi.xmtpv3.FfiSortBy
+import uniffi.xmtpv3.FfiUpdateAppDataOptions
 import java.util.Date
 
 class Group(
@@ -616,7 +617,7 @@ class Group(
     suspend fun updateAppData(appData: String) =
         withContext(Dispatchers.IO) {
             try {
-                libXMTPGroup.updateAppData(appData)
+                libXMTPGroup.updateAppData(FfiUpdateAppDataOptions(value = appData))
             } catch (e: Exception) {
                 throw XMTPException("Permission denied: Unable to update group app data", e)
             }
@@ -636,17 +637,33 @@ class Group(
         get() = UnstableGroup(libXMTPGroup)
 
     /**
+     * Whether this group has migrated to AppData-proposal-based metadata
+     * updates. `false` means the group is still on the legacy
+     * GroupContextExtensions path. Prefer this semantic bool over scanning
+     * [membershipCapabilities] for the marker extension.
+     */
+    suspend fun proposalsEnabled(): Boolean =
+        withContext(Dispatchers.IO) {
+            try {
+                libXMTPGroup.proposalsEnabled()
+            } catch (e: Exception) {
+                throw XMTPException("Unable to read proposals enabled state on group", e)
+            }
+        }
+
+    /**
      * Snapshot this group's membership capabilities: the group context's
      * extension types plus, per member inbox and installation, the extension
      * types each advertises.
      *
      * These are generic facts you filter to a specific question. For the
-     * proposal (app-data-dictionary) migration: the group is migrated when
-     * [GroupMembershipCapabilities.contextExtensions] contains
-     * [org.xmtp.android.library.libxmtp.MlsExtensionType.AppDataDictionary],
-     * and an inbox blocks migration when one of its installations'
+     * proposal (app-data-dictionary) migration: use [proposalsEnabled] to ask
+     * "is this group migrated" — this snapshot answers the other question: an
+     * inbox blocks migration when one of its installations'
      * [org.xmtp.android.library.libxmtp.InstallationCapabilities.supportedExtensions]
-     * does not. Pair with [UnstableGroup.enableProposals].
+     * does not contain
+     * [org.xmtp.android.library.libxmtp.MlsExtensionType.AppDataDictionary].
+     * Pair with [UnstableGroup.enableProposals].
      */
     suspend fun membershipCapabilities(): GroupMembershipCapabilities =
         withContext(Dispatchers.IO) {

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/libxmtp/GroupMembershipCapabilities.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/libxmtp/GroupMembershipCapabilities.kt
@@ -104,11 +104,12 @@ class InboxCapabilities(
  * A generic membership/capability snapshot for a group.
  *
  * Reports raw facts rather than answers. For the proposal (app-data-dictionary)
- * migration specifically: the group is already migrated when [contextExtensions]
- * contains [MlsExtensionType.AppDataDictionary], it's eligible to migrate when
- * every installation's [InstallationCapabilities.supportedExtensions] contains
- * it, and the inboxes blocking migration are those with an installation that
- * doesn't.
+ * migration specifically: to ask whether the group is already migrated, prefer
+ * [org.xmtp.android.library.Group.proposalsEnabled] over scanning
+ * [contextExtensions] for [MlsExtensionType.AppDataDictionary]. The snapshot's
+ * job is eligibility: the group can migrate when every installation's
+ * [InstallationCapabilities.supportedExtensions] contains that extension, and
+ * the inboxes blocking migration are those with an installation that doesn't.
  *
  * Read it with [org.xmtp.android.library.Group.membershipCapabilities]; drive
  * the upgrade with [org.xmtp.android.library.UnstableGroup.enableProposals]

--- a/sdks/ios/Sources/XMTPiOS/Group.swift
+++ b/sdks/ios/Sources/XMTPiOS/Group.swift
@@ -235,7 +235,9 @@ public struct Group: Identifiable, Equatable, Hashable {
 	}
 
 	public func updateAppData(appData: String) async throws {
-		try await ffiGroup.updateAppData(appData: appData)
+		try await ffiGroup.updateAppData(
+			options: FfiUpdateAppDataOptions(value: appData)
+		)
 	}
 
 	/// Pre-release APIs, grouped under ``UnstableGroup`` and gated behind
@@ -248,16 +250,25 @@ public struct Group: Identifiable, Equatable, Hashable {
 		UnstableGroup(ffiGroup: ffiGroup)
 	}
 
+	/// Whether this group has migrated to AppData-proposal-based metadata
+	/// updates. `false` means the group is still on the legacy
+	/// GroupContextExtensions path. Prefer this semantic bool over scanning
+	/// ``membershipCapabilities()`` for the marker extension.
+	public func proposalsEnabled() throws -> Bool {
+		try ffiGroup.proposalsEnabled()
+	}
+
 	/// Snapshot this group's membership capabilities: the group context's
 	/// extension types plus, per member inbox and installation, the extension
 	/// types each advertises.
 	///
 	/// These are generic facts you filter to a specific question. For the
-	/// proposal (app-data-dictionary) migration: the group is migrated when
-	/// ``GroupMembershipCapabilities/contextExtensions`` contains
-	/// ``MlsExtensionType/appDataDictionary``, and an inbox blocks migration
-	/// when one of its installations' ``InstallationCapabilities/supportedExtensions``
-	/// does not. Pair with ``UnstableGroup/enableProposals(force:minVersion:)``.
+	/// proposal (app-data-dictionary) migration: use ``proposalsEnabled()``
+	/// to ask "is this group migrated" — this snapshot answers the other
+	/// question: an inbox blocks migration when one of its installations'
+	/// ``InstallationCapabilities/supportedExtensions`` does not contain
+	/// ``MlsExtensionType/appDataDictionary``. Pair with
+	/// ``UnstableGroup/enableProposals(force:minVersion:)``.
 	public func membershipCapabilities() async throws -> GroupMembershipCapabilities {
 		try await GroupMembershipCapabilities(ffi: ffiGroup.membershipCapabilities())
 	}

--- a/sdks/ios/Sources/XMTPiOS/Libxmtp/GroupMembershipCapabilities.swift
+++ b/sdks/ios/Sources/XMTPiOS/Libxmtp/GroupMembershipCapabilities.swift
@@ -88,11 +88,13 @@ public struct InboxCapabilities {
 /// A generic membership/capability snapshot for a group.
 ///
 /// Reports raw facts rather than answers. For the proposal
-/// (app-data-dictionary) migration specifically: the group is already
-/// migrated when ``contextExtensions`` contains ``MlsExtensionType/appDataDictionary``,
-/// it's eligible to migrate when every installation's
-/// ``InstallationCapabilities/supportedExtensions`` contains it, and the
-/// inboxes blocking migration are those with an installation that doesn't.
+/// (app-data-dictionary) migration specifically: to ask whether the group is
+/// already migrated, prefer ``Group/proposalsEnabled()`` over scanning
+/// ``contextExtensions`` for ``MlsExtensionType/appDataDictionary``. The
+/// snapshot's job is eligibility: the group can migrate when every
+/// installation's ``InstallationCapabilities/supportedExtensions`` contains
+/// that extension, and the inboxes blocking migration are those with an
+/// installation that doesn't.
 ///
 /// Read it with ``Group/membershipCapabilities()``; drive the upgrade with
 /// ``UnstableGroup/enableProposals(force:minVersion:)`` (via

--- a/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -1356,6 +1356,21 @@ public protocol FfiConversationProtocol: AnyObject, Sendable {
     func processStreamedConversationMessage(envelopeBytes: Data) async throws  -> [FfiMessage]
     
     /**
+     * Whether this group has migrated to AppData-proposal-based
+     * metadata updates (the `AppDataDictionary` group-context
+     * extension is present). `false` means the group is still on
+     * the legacy GroupContextExtensions path.
+     *
+     * Prefer this semantic bool over scanning
+     * [`FfiGroupMembershipCapabilities::context_extensions`] for
+     * `AppDataDictionary` — the capabilities snapshot answers
+     * "which members block migration", not "is this group migrated",
+     * and the marker extension is an internal protocol detail.
+     * Mirrors `proposalsEnabled` on the wasm and node bindings.
+     */
+    func proposalsEnabled() throws  -> Bool
+    
+    /**
      * Publish all unpublished messages
      */
     func publishMessages() async throws 
@@ -1390,7 +1405,7 @@ public protocol FfiConversationProtocol: AnyObject, Sendable {
     
     func sync() async throws 
     
-    func updateAppData(appData: String) async throws 
+    func updateAppData(options: FfiUpdateAppDataOptions) async throws 
     
     func updateConsentState(state: FfiConsentState) throws 
     
@@ -1933,6 +1948,27 @@ open func processStreamedConversationMessage(envelopeBytes: Data)async throws  -
 }
     
     /**
+     * Whether this group has migrated to AppData-proposal-based
+     * metadata updates (the `AppDataDictionary` group-context
+     * extension is present). `false` means the group is still on
+     * the legacy GroupContextExtensions path.
+     *
+     * Prefer this semantic bool over scanning
+     * [`FfiGroupMembershipCapabilities::context_extensions`] for
+     * `AppDataDictionary` — the capabilities snapshot answers
+     * "which members block migration", not "is this group migrated",
+     * and the marker extension is an internal protocol detail.
+     * Mirrors `proposalsEnabled` on the wasm and node bindings.
+     */
+open func proposalsEnabled()throws  -> Bool  {
+    return try  FfiConverterBool.lift(try rustCallWithError(FfiConverterTypeFfiError_lift) {
+    uniffi_xmtpv3_fn_method_fficonversation_proposals_enabled(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+    /**
      * Publish all unpublished messages
      */
 open func publishMessages()async throws   {
@@ -2147,13 +2183,13 @@ open func sync()async throws   {
         )
 }
     
-open func updateAppData(appData: String)async throws   {
+open func updateAppData(options: FfiUpdateAppDataOptions)async throws   {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_xmtpv3_fn_method_fficonversation_update_app_data(
                     self.uniffiCloneHandle(),
-                    FfiConverterString.lower(appData)
+                    FfiConverterTypeFfiUpdateAppDataOptions_lower(options)
                 )
             },
             pollFunc: ffi_xmtpv3_rust_future_poll_void,
@@ -7921,9 +7957,13 @@ public func FfiConverterTypeFfiForkRecoveryOpts_lower(_ value: FfiForkRecoveryOp
 /**
  * A generic membership/capability snapshot for a group. Mirrors
  * [`xmtp_mls::groups::GroupMembershipCapabilities`]. Callers filter it — e.g.
- * the proposal migration is complete when `context_extensions` contains
- * `AppDataDictionary`, and an inbox blocks migration when one of its
- * installations' `supported_extensions` does not.
+ * an inbox blocks the proposal migration when one of its
+ * installations' `supported_extensions` lacks `AppDataDictionary`.
+ *
+ * To ask "is this group migrated?", use
+ * [`FfiConversation::proposals_enabled`] instead of scanning
+ * `context_extensions` — the marker extension is an internal
+ * protocol detail and the semantic bool is the stable contract.
  */
 public struct FfiGroupMembershipCapabilities: Equatable, Hashable {
     public var contextExtensions: [FfiMlsExtensionType]
@@ -10026,6 +10066,68 @@ public func FfiConverterTypeFfiTransactionReference_lift(_ buf: RustBuffer) thro
 #endif
 public func FfiConverterTypeFfiTransactionReference_lower(_ value: FfiTransactionReference) -> RustBuffer {
     return FfiConverterTypeFfiTransactionReference.lower(value)
+}
+
+
+/**
+ * Options for [`FfiConversation::update_app_data`]. A record (rather
+ * than a bare `String` parameter) so future knobs can be added
+ * without breaking compiled apps — same pattern as
+ * [`FfiEnableProposalsOptions`].
+ */
+public struct FfiUpdateAppDataOptions: Equatable, Hashable {
+    /**
+     * The new value for the group's opaque `APP_DATA` string slot.
+     */
+    public var value: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * The new value for the group's opaque `APP_DATA` string slot.
+         */value: String) {
+        self.value = value
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension FfiUpdateAppDataOptions: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiUpdateAppDataOptions: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiUpdateAppDataOptions {
+        return
+            try FfiUpdateAppDataOptions(
+                value: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiUpdateAppDataOptions, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.value, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiUpdateAppDataOptions_lift(_ buf: RustBuffer) throws -> FfiUpdateAppDataOptions {
+    return try FfiConverterTypeFfiUpdateAppDataOptions.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiUpdateAppDataOptions_lower(_ value: FfiUpdateAppDataOptions) -> RustBuffer {
+    return FfiConverterTypeFfiUpdateAppDataOptions.lower(value)
 }
 
 
@@ -12735,6 +12837,8 @@ public enum FfiMetadataField: Equatable, Hashable {
     case description
     case imageUrlSquare
     case appData
+    case messageExpirationFromNs
+    case messageExpirationInNs
 
 
 
@@ -12764,6 +12868,10 @@ public struct FfiConverterTypeFfiMetadataField: FfiConverterRustBuffer {
         
         case 4: return .appData
         
+        case 5: return .messageExpirationFromNs
+        
+        case 6: return .messageExpirationInNs
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
@@ -12786,6 +12894,14 @@ public struct FfiConverterTypeFfiMetadataField: FfiConverterRustBuffer {
         
         case .appData:
             writeInt(&buf, Int32(4))
+        
+        
+        case .messageExpirationFromNs:
+            writeInt(&buf, Int32(5))
+        
+        
+        case .messageExpirationInNs:
+            writeInt(&buf, Int32(6))
         
         }
     }
@@ -16931,6 +17047,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_fficonversation_process_streamed_conversation_message() != 45021) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_xmtpv3_checksum_method_fficonversation_proposals_enabled() != 59452) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xmtpv3_checksum_method_fficonversation_publish_messages() != 1758) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -16970,7 +17089,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_fficonversation_sync() != 52433) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_method_fficonversation_update_app_data() != 2749) {
+    if (uniffi_xmtpv3_checksum_method_fficonversation_update_app_data() != 309) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonversation_update_consent_state() != 39794) {

--- a/sdks/js/browser-sdk/src/WorkerConversation.ts
+++ b/sdks/js/browser-sdk/src/WorkerConversation.ts
@@ -78,7 +78,7 @@ export class WorkerConversation {
   }
 
   async updateAppData(appData: string) {
-    return this.#group.updateAppData(appData);
+    return this.#group.updateAppData({ value: appData });
   }
 
   get isActive() {

--- a/sdks/js/node-sdk/src/Group.ts
+++ b/sdks/js/node-sdk/src/Group.ts
@@ -95,7 +95,7 @@ export class Group<ContentTypes = unknown> extends Conversation<ContentTypes> {
    * @param appData The new app data for the group
    */
   async updateAppData(appData: string) {
-    return this.#conversation.updateAppData(appData);
+    return this.#conversation.updateAppData({ value: appData });
   }
 
   /**


### PR DESCRIPTION
## Problem

Three inconsistencies in the app-data FFI surface, from the pre-v1.11 review — each one bakes divergent app expectations across platforms the moment the first stable release ships:

1. **Migration introspection was split disjointly**: wasm/node exposed `proposalsEnabled()` but not `membershipCapabilities()`; mobile exposed the capabilities snapshot but no boolean — and its docs told apps to detect migration by scanning `contextExtensions` for `AppDataDictionary`, coupling iOS/Android apps to an internal MLS extension identity.
2. **`updateAppData` took a bare `String`** on all three bindings — no way to ever add a parameter without a breaking signature change.
3. **The `MetadataField` enums disagreed**: mobile's `FfiMetadataField` was missing the `MessageExpirationFromNs`/`InNs` variants wasm/node have.

## Changes

- Mobile gains `proposals_enabled()` (same core call as wasm/node); the `membershipCapabilities` docs now steer apps to the semantic bool for the "is this group migrated?" question and reserve the capabilities snapshot for "which members block migration".
- `updateAppData` takes an options record on all three bindings (`FfiUpdateAppDataOptions` / `UpdateAppDataOptions { value }`), the same growable pattern as `EnableProposalsOptions`. The **public Swift/Kotlin SDK signatures are unchanged** (`updateAppData(appData: String)` — the wrappers construct the options internally), so no app-facing break anywhere.
- `FfiMetadataField` gains the two `MessageExpiration*` variants, mapped to the core `MessageDisappear*` fields — all three bindings now expose the same field set.
- Checked-in iOS uniffi bindings (`xmtpv3.swift`) regenerated via `sdks/ios/dev/bindings` (nix). Android Kotlin bindings are generated at build time and need no checked-in update.

## Testing

`xmtpv3` + `bindings_node` suites: 153/153. `just wasm check` and `cargo check` green across all three bindings. In-repo mobile tests updated to the options struct (no external consumers exist — verified in the P1.1 sweep).

Part of the pre-v1.11 app-data hardening plan (P1.4 + P1.5 + P1.6). Siblings: #3863–#3869.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZpajnDV829SVuW9danrW

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify `updateAppData` FFI surface across mobile, WASM, and Node bindings
> - Replaces the bare `String` parameter in `updateAppData` with an `UpdateAppDataOptions`/`FfiUpdateAppDataOptions` options object across all bindings (mobile, WASM, Node). Public SDK APIs for iOS, Android, and JS are unchanged.
> - Adds a `proposalsEnabled()` method to the mobile FFI, iOS SDK, and Android SDK to expose whether a group uses AppData-proposal-based metadata updates.
> - Adds `messageExpirationFromNs` and `messageExpirationInNs` variants to `FfiMetadataField` in the mobile bindings, mapping to the underlying disappear-from/in fields.
> - Behavioral Change: callers using the raw FFI or native addon directly (not via the SDK wrappers) must update `updateAppData` call sites to pass an options object.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74bc001.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->