### PR TITLE
fix(xmtp_api_d14n,xmtp_mls): harden the bidi wire for permanent enablement

### DIFF
--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -181,7 +181,9 @@ const WITHHELD_FRAMES_CAP: usize = 512;
 /// to [`RECONNECT_MAX_DELAY`]. Reconnection is never given up on — an offline
 /// process resumes when the network returns.
 const RECONNECT_INITIAL_DELAY: std::time::Duration = std::time::Duration::from_millis(100);
-/// Ceiling for the reconnect backoff.
+/// Ceiling for the exponential reconnect base. The armed delay adds up to a
+/// full extra base of jitter ([`LedgerTask::arm_reconnect`]) to de-sync a
+/// fleet, so the effective wait tops out near twice this.
 const RECONNECT_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(30);
 /// How long a graceful close (half-close, then drain inbound to completion)
 /// may take before the connection is dropped outright. After a half-close the
@@ -2121,18 +2123,32 @@ where
         Flow::Continue
     }
 
+    /// Arm the next reconnect at a jittered deadline and return the chosen
+    /// delay (for logging). The exponential base ([`Self::reconnect_delay`])
+    /// is the floor; a random offset of up to one more base spreads the
+    /// attempt across `[delay, 2·delay)`. A server restart releases every
+    /// client's wire in the same instant, so without this spread the whole
+    /// fleet would reconnect in lockstep and re-stampede the backend on each
+    /// backoff step — the jitter de-syncs them (same rationale as the stream
+    /// watchdog's `XMTP_STREAM_WATCHDOG_RECONNECT_JITTER_MS`).
+    fn arm_reconnect(&mut self) -> std::time::Duration {
+        let delay = self.reconnect_delay + xmtp_common::time::rand_offset(self.reconnect_delay);
+        self.reconnect_at = tokio::time::Instant::now() + delay;
+        delay
+    }
+
     /// The wire ended (server close or transport failure). Leases survive:
     /// the dead-wire select arm reconnects with a resume wave (module docs)
     /// — no stream ever observes the flap.
     fn wire_died(&mut self) -> Flow {
         self.outbox.clear();
         drop(self.conn.take());
-        self.reconnect_at = tokio::time::Instant::now() + self.reconnect_delay;
+        let retry_in = self.arm_reconnect();
         if !self.ledger.leases.is_empty() {
             tracing::warn!(
                 leases = self.ledger.leases.len(),
                 interrupted_waves = self.ledger.pending_waves.len(),
-                retry_in_ms = self.reconnect_delay.as_millis() as u64,
+                retry_in_ms = retry_in.as_millis() as u64,
                 "bidi transport: wire died; reconnecting from last-seen positions"
             );
         }
@@ -2214,7 +2230,7 @@ where
             // Unreachable — every leased topic is either in the resume adds
             // or owned by a re-issue — but never send an adds-nothing frame;
             // retry on the normal backoff instead.
-            self.reconnect_at = tokio::time::Instant::now() + self.reconnect_delay;
+            self.arm_reconnect();
             return AfterReopen::Proceed;
         };
         match self.open_preemptibly(initial).await {
@@ -2276,9 +2292,12 @@ where
                     tracing::error!("bidi transport: reconnect refused ({e}); closing");
                     return AfterReopen::Shutdown;
                 }
-                tracing::warn!("bidi transport: reconnect failed ({e}); backing off");
                 self.reconnect_delay = (self.reconnect_delay * 2).min(RECONNECT_MAX_DELAY);
-                self.reconnect_at = tokio::time::Instant::now() + self.reconnect_delay;
+                let retry_in = self.arm_reconnect();
+                tracing::warn!(
+                    retry_in_ms = retry_in.as_millis() as u64,
+                    "bidi transport: reconnect failed ({e}); backing off"
+                );
                 // Resumes deferred mid-dial were concurrent with this attempt
                 // and it failed for all of them: park their waiters on the
                 // scheduled retry. Replaying them would grant each the

--- a/crates/xmtp_api_d14n/src/queries/d14n/connection.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/connection.rs
@@ -130,8 +130,19 @@ impl BidiBinding for D14nBinding {
             Some(Response::Envelopes(envelopes)) => {
                 extract(envelopes.envelopes, envelopes.mutate_id)
             }
-            // A future-revision arm: informational frames are safe to skip.
-            None => Inbound::Skip,
+            // An unset response case: a frame kind a newer server added
+            // (prost decodes an unknown oneof tag as `None`), or an empty
+            // frame. Skipping keeps the wire alive, but warn so a mandatory
+            // frame a future server sends WITHOUT gating it behind a
+            // `Started.capabilities` bit surfaces in metrics instead of being
+            // dropped invisibly — the XIP-83 forward-compat contract is that
+            // any new response frame a client must act on is capability-gated.
+            None => {
+                tracing::warn!(
+                    "d14n bidi subscription dropping an unknown or unset response frame"
+                );
+                Inbound::Skip
+            }
         }
     }
 }

--- a/crates/xmtp_api_d14n/src/queries/v3/connection.rs
+++ b/crates/xmtp_api_d14n/src/queries/v3/connection.rs
@@ -79,8 +79,17 @@ impl BidiBinding for V3Binding {
                 welcome: messages.welcome_messages,
                 mutate_id: messages.mutate_id,
             },
-            // A future-revision arm: informational frames are safe to skip.
-            None => Inbound::Skip,
+            // An unset response case: a frame kind a newer server added
+            // (prost decodes an unknown oneof tag as `None`), or an empty
+            // frame. Skipping keeps the wire alive, but warn so a mandatory
+            // frame a future server sends WITHOUT gating it behind a
+            // `Started.capabilities` bit surfaces in metrics instead of being
+            // dropped invisibly — the XIP-83 forward-compat contract is that
+            // any new response frame a client must act on is capability-gated.
+            None => {
+                tracing::warn!("bidi subscription dropping an unknown or unset response frame");
+                Inbound::Skip
+            }
         }
     }
 }

--- a/crates/xmtp_mls/src/subscriptions/catch_up.rs
+++ b/crates/xmtp_mls/src/subscriptions/catch_up.rs
@@ -48,8 +48,12 @@
 //! is never skipped past and a later query-path sync retries it. The cost is
 //! symmetric too: a repeat call re-requests the tail since the last durable
 //! advance and drops the already-stored copies at the seed's seen-set.
-//! Welcome cursors DO advance (the welcome pipeline advances them on every
-//! processed welcome, streamed or not).
+//! Welcomes are the same on this path: they are processed with the cursor
+//! increment OFF (`process_new_welcome(.., false, ..)`), so the streamed and
+//! catch-up arms do NOT advance the durable welcome cursor either — a
+//! re-processed welcome is dropped by group-existence dedup (the seed's
+//! `known_welcomes_above`), not by the cursor. Only the legacy full-sync
+//! fallback advances the welcome cursor.
 //!
 //! ## Fallback
 //!


### PR DESCRIPTION
Three atomic, low-risk hardening changes ahead of turning XIP-83 bidi streams on by default. Bidi ships default-OFF (`XMTP_BIDI_STREAMS_ENABLED`), so none of these are release-blockers — they harden the wire for the eventual permanent enablement. Reviewed by commit; each is independent and file-disjoint.

## 1. Warn when the bidi wire drops an unknown response frame (`znkpnkwp`)
The inbound `handle` skipped an unknown or unset response oneof case **silently**, unlike the unknown-*version* arm which already warns. A future server that ships a mandatory response frame WITHOUT gating it behind a `Started.capabilities` bit would then have its data dropped invisibly — the wire stays up while correctness quietly degrades. Both the v3 and d14n bindings now warn on that arm, so the XIP-83 forward-compat contract (a new response frame a client must act on is capability-gated) is caught by a metric instead of going unnoticed. Behavior is otherwise unchanged (`Skip`), and the arm only fires on an unknown-future case or a genuinely empty frame — never in steady state.

## 2. Jitter the reconnect backoff to de-sync a fleet (`xtvvzlnt`)
A server restart releases every client's wire in the same instant; the pure-exponential backoff then had them all reconnect in lockstep and re-stampede the backend on each step. The armed delay now adds up to a full extra base of random spread — `delay ∈ [base, 2·base)` — via one `arm_reconnect` helper used by all three backoff sites (the same de-sync the stream watchdog already applies through `rand_offset`). Correctness is unchanged: the full reconnect suite and the ordering property test pass through the new helper.

## 3. Correct the catch-up welcome-cursor comment (`znukxxmq`)
`catch_up`'s module docs claimed the streamed/catch-up welcome path advances the durable welcome cursor. It does not: welcomes there are processed with the cursor increment off (`process_new_welcome(.., false, ..)`) and deduped on group existence (`known_welcomes_above`), so only the legacy full-sync fallback advances the welcome cursor. Comment-only.

## Testing
- `cargo clippy --all-features --all-targets` clean on all three changed files (the only workspace warnings are pre-existing lints in untouched files, surfaced by a newer-than-CI local toolchain).
- 58/58 bidi transport + connection tests pass, including the full reconnect suite and the ledger ordering property test — all now flowing through the new `arm_reconnect` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AVuJ7VAgen2fFhtJQ6zid


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden bidi wire reconnect scheduling with jitter and warn on unknown frames
> - Adds `LedgerTask.arm_reconnect()` in [bidi_transport.rs](https://github.com/xmtp/libxmtp/pull/3873/files#diff-d4217bbd27403da346b2451dab35cab51079f0ccb533baa2a2248a7fa3dbe458) to compute a jittered reconnect delay (base + up to one base of random offset), replacing direct assignment of `reconnect_at` in all reconnect paths.
> - All reconnect scheduling (wire death, failed reopen, no-op outbound) now uses the jittered delay and logs the exact retry interval in milliseconds.
> - Unknown or unset response frames in `D14nBinding.handle` and `V3Binding.handle` now emit a `tracing::warn!` before returning `Inbound::Skip` instead of silently skipping.
> - Updates [catch_up.rs](https://github.com/xmtp/libxmtp/pull/3873/files#diff-0f712bac68b7d394bd934c86f442148b513550fc9fd3df1d726880379c954003) docs to clarify that welcomes processed during catch-up do not advance the durable welcome cursor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f24cd0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->