### PR TITLE
feat(sdks): seed suspended on background launch (iOS) + correct stream-lifecycle docs

### DIFF
--- a/sdks/android/library/src/main/java/org/xmtp/android/library/StreamLifecycle.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/StreamLifecycle.kt
@@ -52,15 +52,15 @@ data class CatchUpSummary(
  *   so a naive launch-per-callback could complete out of order and strand the
  *   wire live-while-backgrounded; the loop instead converges to the last intent.
  *
- * **Known limitation — background launch.** Registration seeds the desired state
- * from [ProcessLifecycleOwner]'s current state, so a process created in the
- * background starts suspended. But a stream opened *after* that while still
- * backgrounded opens a fresh live wire the model can't see (no lifecycle
- * transition fires), so it can sit live-while-backgrounded until the next
- * foreground/background cycle. Backgrounds that only catch up — the normal
- * pattern — are unaffected, since [Client.catchUpToLive] uses its own
- * connection, not this wire. The complete fix is for the shared transport to
- * honor a suspend requested before it is first opened (a libxmtp follow-on).
+ * **Background launch.** Registration seeds the desired state from
+ * [ProcessLifecycleOwner]'s current state, so a process created in the background
+ * starts suspended. A stream opened *after* that while still backgrounded is born
+ * parked too: the seeded suspend records the intent on the shared transport
+ * (suspend-before-open latch), so its first lease opens parked rather than
+ * dialing a live wire. Backgrounds that only catch up — the normal pattern — use
+ * their own connection ([Client.catchUpToLive]), not this wire. (Narrow residual:
+ * the seed runs a few async hops after registration; a stream opened inside that
+ * cold-start window can still be born live — see [enableIfNeeded].)
  */
 internal object StreamLifecycleManager {
     private val lock = Any()

--- a/sdks/ios/Sources/XMTPiOS/StreamLifecycle.swift
+++ b/sdks/ios/Sources/XMTPiOS/StreamLifecycle.swift
@@ -50,16 +50,17 @@ public struct CatchUpSummary: Sendable {
 ///   reconciler instead re-checks the desired state after every applied op and
 ///   issues a correcting op if it changed, converging to the last intent.
 ///
-/// **Known limitation — background launch.** State is seeded to foreground and
-/// only reacts to *transitions*; a process launched straight into the
-/// background (silent push / `BGTask`) fires no `didEnterBackground`, so if it
-/// opens live streams and never foregrounds, the wire can stay live in the
-/// background. We can't seed from `UIApplication.shared.applicationState`
-/// without breaking app-extension builds (`.shared` is extension-unavailable).
-/// Backgrounds that only catch up — the normal pattern — are unaffected, since
-/// ``Client/catchUpToLive(timeoutMs:)`` uses its own connection, not this wire.
-/// The complete fix is for the shared transport to honor a suspend requested
-/// before it is first opened (a libxmtp follow-on).
+/// **Background launch.** A process launched straight into the background
+/// (silent push / `BGTask`) fires no `didEnterBackground`, so registration seeds
+/// the backgrounded case explicitly by reading the current application state
+/// (see `launchedInBackground()`) — foreground is already the default. A stream
+/// opened while still backgrounded is then born parked by the shared transport's
+/// suspend-before-open latch, so it never opens a live wire in the background.
+/// Because XMTPiOS is usable from app-extension targets — where
+/// `UIApplication.shared` is compile-time unavailable — the state read is dynamic
+/// and app-process-only; in an extension it is skipped (there is no app lifecycle
+/// to seed from, and ``Client/catchUpToLive(timeoutMs:)`` uses its own
+/// connection, not this wire).
 final class StreamLifecycleManager: @unchecked Sendable {
 	static let shared = StreamLifecycleManager()
 
@@ -77,8 +78,10 @@ final class StreamLifecycleManager: @unchecked Sendable {
 	func enableIfNeeded() {
 		#if canImport(UIKit)
 			lock.lock()
-			defer { lock.unlock() }
-			guard !isRegistered else { return }
+			if isRegistered {
+				lock.unlock()
+				return
+			}
 			isRegistered = true
 
 			let center = NotificationCenter.default
@@ -96,6 +99,44 @@ final class StreamLifecycleManager: @unchecked Sendable {
 			) { [weak self] _ in
 				self?.setDesired(live: true)
 			}
+			lock.unlock()
+
+			// A process launched straight into the background fires no
+			// `didEnterBackground`; seed the backgrounded case so a stream opened
+			// before any foreground is born parked. `setDesired` takes the lock,
+			// so this must run after unlocking. `nil` (can't tell / app extension)
+			// leaves the foreground default.
+			if launchedInBackground() == true {
+				setDesired(live: false)
+			}
+		#endif
+	}
+
+	/// Whether the host app is currently backgrounded, or `nil` when it can't be
+	/// determined — an app extension (no app-level lifecycle to seed from) or an
+	/// unexpected runtime shape. XMTPiOS is usable from extension targets, where
+	/// `UIApplication.shared` is compile-time unavailable, so this reads the
+	/// shared application and its state dynamically and only in the app process.
+	/// Any failure returns `nil`, leaving the foreground default — it can never
+	/// regress a normally-foregrounded app.
+	private func launchedInBackground() -> Bool? {
+		#if canImport(UIKit)
+			guard
+				Bundle.main.bundleURL.pathExtension != "appex",
+				let appClass = NSClassFromString("UIApplication")
+			else { return nil }
+			// Read `+[UIApplication sharedApplication].applicationState` dynamically
+			// through the ObjC runtime, so nothing references the
+			// extension-unavailable `.shared` at compile time.
+			let selector = NSSelectorFromString("sharedApplication")
+			guard
+				(appClass as AnyObject).responds(to: selector),
+				let shared = (appClass as AnyObject).perform(selector)?.takeUnretainedValue(),
+				let state = (shared as AnyObject).value(forKey: "applicationState") as? Int
+			else { return nil }
+			return state == 2 // UIApplication.State.background
+		#else
+			return nil
 		#endif
 	}
 


### PR DESCRIPTION
Seeds a `suspend` at `StreamLifecycleManager` registration when the iOS app launched straight into the background, closing the "launched-into-background" gap where a stream opened while backgrounded would open a live wire and run in the background indefinitely. Android already did this; this brings iOS to parity using the Rust `suspend_requested` latch that already landed.

Because XMTPiOS is usable from app-extension targets (where `UIApplication.shared` is compile-time unavailable), the app-state read is done dynamically via the ObjC runtime, app-process-only, and is nil-safe: any failure leaves the foreground default, so it can never regress a normally-foregrounded app.

Also corrects the now-stale "known limitation" doc comments on **both** iOS and Android that described the (already-landed) suspend-before-open fix as an unlanded follow-on — Android's was outright false (it claimed a backgrounded stream opens a live wire, when its own seed already parks it).

SDK-only; no binding changes. Independent of the other two PRs in this stack.

### Verification
- `swift build` — 399/399, clean
- SwiftLint + SwiftFormat — no new violations
- Android change is doc-only

### Reviewer note
The dynamic `applicationState` read in `launchedInBackground()` is worth an eyeball for App Store review comfort — it's isolated to that helper and degrades safely (returns `nil` → no seed → prior behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed iOS `StreamLifecycleManager` to suspended state on background launch
> - When `enableIfNeeded` is first called in a backgrounded app process, it now immediately calls `setDesired(live: false)` to seed the desired state to suspended before any foreground transition occurs.
> - Adds `launchedInBackground()` helper in [StreamLifecycle.swift](https://github.com/xmtp/libxmtp/pull/3880/files#diff-5c9b42f47cc560e374ebdd786bb372e6fb42374c87a7f32c034d34002027172b) that detects app background state at runtime via ObjC runtime lookup and KVC, avoiding direct `UIApplication.shared` references that would break app extensions.
> - In app extensions or when state is undetermined, no seeding occurs and the default foreground desired state is preserved.
> - Fixes the lock-holding issue in `enableIfNeeded` so the class lock is released before post-registration seeding.
> - Updates the equivalent Android [StreamLifecycle.kt](https://github.com/xmtp/libxmtp/pull/3880/files#diff-b14f0378e1c0236f155e8114343ccfaa7769afab6fff4ec17149fbab5be98bff) doc comment to describe the same seeded-suspend latch behavior with a cold-start window caveat.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8064f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->