### PR TITLE
feat(bindings_node): return catch-up counts as number (not BigInt) + completed flag

### DIFF
--- a/bindings/node/src/client/catch_up.rs
+++ b/bindings/node/src/client/catch_up.rs
@@ -1,21 +1,29 @@
 use crate::{ErrorWrapper, client::Client};
-use napi::bindgen_prelude::{BigInt, Result};
+use napi::bindgen_prelude::Result;
 use napi_derive::napi;
 
 /// Counts of what a single `catchUpToLive` run brought into the local store.
 #[napi(object)]
 pub struct CatchUpSummary {
   /// Messages newly persisted during this run.
-  pub messages: BigInt,
+  pub messages: u32,
   /// Conversations newly joined during this run.
-  pub conversations: BigInt,
+  pub conversations: u32,
+  /// Whether the run reached the live edge. Always `true` here — the node
+  /// binding has no caller deadline (see `catchUpToLive`).
+  pub completed: bool,
 }
 
 impl From<xmtp_mls::subscriptions::catch_up::CatchUpSummary> for CatchUpSummary {
   fn from(summary: xmtp_mls::subscriptions::catch_up::CatchUpSummary) -> Self {
+    // Saturate rather than let `as u32` wrap: a single catch-up run persisting
+    // more than u32::MAX items is unreachable in practice, but clamping keeps a
+    // pathological count honest and monotonic instead of wrapping it toward
+    // zero.
     Self {
-      messages: BigInt::from(summary.messages),
-      conversations: BigInt::from(summary.conversations),
+      messages: u32::try_from(summary.messages).unwrap_or(u32::MAX),
+      conversations: u32::try_from(summary.conversations).unwrap_or(u32::MAX),
+      completed: summary.completed,
     }
   }
 }


### PR DESCRIPTION
Stacked on #3881 (base branch `tyler/lifecycle-catchup-hardening`) — review/merge that first.

Returns the node `catchUpToLive` counts as `number` (napi `u32`) instead of `BigInt`, and adds the `completed` flag (now that core `CatchUpSummary` carries it, from #3881).

`BigInt` is a permanent tax on every JS/TS consumer — it can't be mixed with `number`, breaks `JSON.stringify`, and is awkward in TS — while a single catch-up run's counts comfortably fit a `number`. Doing this before the release avoids a breaking type change for every agent codebase later.

### Verification
- Full napi release build succeeds (`just node check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change `CatchUpSummary` counts from BigInt to u32 and add `completed` flag in Node bindings
> - Changes `messages` and `conversations` fields in the Node-exposed `CatchUpSummary` from `BigInt` to `u32` (JS number), making them easier to consume in JavaScript.
> - Adds a `completed` boolean field indicating whether the catch-up run reached the live edge.
> - Counts exceeding `u32::MAX` are clamped to `4294967295` rather than represented as arbitrarily large integers.
> - Behavioral Change: JS consumers receiving these values will get plain numbers instead of BigInt; any code that handled BigInt will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43f67a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->