### PR TITLE
ci: sticky-disk Docker layer caching for compose-built backend images

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "Enable sccache with GitHub Actions cache backend"
     required: false
     default: "false"
+  docker-builder:
+    description: "Set up Blacksmith buildx builder with sticky-disk Docker layer caching"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -57,6 +61,15 @@ runs:
       uses: webiny/action-post-run@3.1.0
       with:
         run: bash ${{ runner.temp }}/nix-unmount-cleanup.sh
+    # Buildx builder backed by a sticky-disk layer cache (per Dockerfile,
+    # shared repo-wide, LWW commits). Speeds up compose-built backend
+    # images (validation service, anvil).
+    - name: Setup Blacksmith Docker builder
+      if: ${{ inputs.docker-builder == 'true' && runner.os == 'Linux' }}
+      uses: useblacksmith/setup-docker-builder@v1
+      with:
+        # Prune cap so stale layers don't grow the disk unbounded.
+        max-cache-size-mb: "10240"
     # Single-user install, works with pre-populated /nix. Stay on 2.31.x:
     # 2.34.4 breaks patches (https://github.com/nixos/nix/issues/15619).
     - name: Install Nix (Linux)

--- a/.github/workflows/ignored-tests-tracker.yml
+++ b/.github/workflows/ignored-tests-tracker.yml
@@ -43,6 +43,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
+          docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: taiki-e/install-action@just
@@ -32,6 +33,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/test-browser-sdk.yml
+++ b/.github/workflows/test-browser-sdk.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/test-node-sdk.yml
+++ b/.github/workflows/test-node-sdk.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          docker-builder: "true"
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - name: Install dependencies

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          docker-builder: "true"
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - name: Install dependencies

--- a/.github/workflows/test-wasm.yml
+++ b/.github/workflows/test-wasm.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"


### PR DESCRIPTION
## Summary
- `just backend up` rebuilds the validation-service image (`local.Dockerfile`, full-repo context, `pull_policy: never`) and anvil image from scratch in every test job — no layer cache
- New opt-in `docker-builder` input on `setup-nix` wires up `useblacksmith/setup-docker-builder@v1` (buildx builder backed by a sticky-disk layer cache, scoped per Dockerfile per repo, LWW commits)
- Enabled for the 8 jobs that start the backend (test-workspace, test-node, test-node-sdk, test-browser-sdk, test-wasm, test-android ×2, ignored-tests-tracker)

Follow-up to #3883.

## Known caveat
`setup-docker-builder` has no per-event commit control, so PR jobs write to the shared layer cache. Blast radius is limited to test-infra images (`local.Dockerfile`/`anvil.Dockerfile`) — the released image builds from a different Dockerfile and layer caches are per-Dockerfile.

## Test plan
- [ ] First run: builder mounts, images build, cache commits
- [ ] Second run: compose build steps hit cached layers (compare "Start backend" step time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sticky-disk Docker layer caching to CI workflows via Blacksmith builder
> Adds a `docker-builder` input to the [setup-nix composite action](https://github.com/xmtp/libxmtp/pull/3885/files#diff-d6d03b00722cea2a21415f2e41951abebd36b521b485d7e4fc9fbb4a3c0195dc) that provisions a Blacksmith Docker buildx builder with a 10GB sticky-disk cache on Linux runners. All affected CI workflows (Android, Node, Browser SDK, WASM, workspace, ignored-tests tracker) opt in by passing `docker-builder: "true"` to the action.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c5a7bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->