### PR TITLE
fix(xmtp_api_d14n,xmtp_mls): harden the bidi lifecycle, reconnect backoff, and catch-up ahead of enablement

### DIFF
--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -2266,8 +2266,15 @@ where
             close_gracefully(wire);
         }
         // Pending waves stay, progress intact: their leases are still owed a
-        // CatchUpComplete, and `reopen` re-issues them alongside the resume
-        // wave that carries any parked resume() waiters.
+        // CatchUpComplete, re-issued alongside the next reopen's resume wave.
+        // But a resume already awaiting catch-up is superseded by this suspend
+        // — the app is going off the network, so it can never reach its live
+        // edge on this transition. Conclude those waiters now instead of
+        // stranding them (and their callers' tasks) for the whole background
+        // sojourn; the next resume parks a fresh waiter.
+        for waiter in self.resume_notify.drain(..) {
+            let _ = waiter.send(());
+        }
         let _ = reply.send(());
         Flow::Continue
     }
@@ -2391,7 +2398,13 @@ where
     /// suspended, outrank any resumes the dial had deferred, and acknowledge.
     fn suspend_preempted(&mut self, ack: oneshot::Sender<()>) {
         self.suspended = true;
+        // Move any dial-deferred resumes into `resume_notify`, then conclude
+        // every parked resume: this suspend supersedes them all (same reason
+        // as [`Self::suspend`]).
         self.park_deferred_resumes();
+        for waiter in self.resume_notify.drain(..) {
+            let _ = waiter.send(());
+        }
         let _ = ack.send(());
     }
 
@@ -4174,6 +4187,9 @@ mod tests {
         });
         tokio::time::sleep(Duration::from_millis(20)).await;
         tokio::time::timeout(WAIT, transport.suspend()).await??;
+        // The deferred resume was superseded by the suspend: its waiter
+        // concludes now, not stranded until some later resume.
+        tokio::time::timeout(WAIT, first_resume).await?.unwrap()?;
         let mut alpha = tokio::time::timeout(WAIT, leased).await?.unwrap()?;
 
         // The stale resume must not resurrect the network.
@@ -4184,8 +4200,7 @@ mod tests {
             "a resume deferred before the suspend must not redial"
         );
 
-        // A later, explicit resume brings everything back — including the
-        // parked waiter from before the suspend.
+        // A later, explicit resume brings the wire back.
         let second_resume = tokio::spawn({
             let transport = transport.clone();
             async move { transport.resume().await }
@@ -4194,7 +4209,6 @@ mod tests {
         let resume = server.next_mutate().await;
         server.send(catchup_complete(resume.mutate_id));
         tokio::time::timeout(WAIT, second_resume).await?.unwrap()?;
-        tokio::time::timeout(WAIT, first_resume).await?.unwrap()?;
         assert!(matches!(
             recv(&mut alpha).await,
             Some(LeaseEvent::CatchUpComplete)

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -3184,6 +3184,109 @@ mod tests {
         );
     }
 
+    /// A lease over the cap that is STILL catching up when the wire dies is
+    /// re-issued *whole* on reopen — re-chunked into fresh bounded waves, no
+    /// topic dropped — and reports caught-up only once its LAST reopened chunk
+    /// completes. Deterministic coverage for the chunking x reconnect x
+    /// completion interaction the property test otherwise carries alone.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn an_over_cap_lease_still_catching_up_survives_a_wire_death() {
+        // Cap 2: a 3-topic lease chunks into 2 + 1.
+        let (transport, servers) = transport_capped(2, usize::MAX);
+        let topics: Vec<(Topic, u64)> = (0..3u32)
+            .map(|i| (group_topic(&i.to_le_bytes()), 0))
+            .collect();
+        let mut lease = transport.lease(topics, DEFAULT_LEASE_DEPTH).await?;
+
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        let second = server.next_mutate().await;
+        assert_eq!(first.adds.len() + second.adds.len(), 3);
+        // Ack only the FIRST chunk, then kill the wire: the lease is still
+        // catching up (its second chunk never completed).
+        server.send(catchup_complete(first.mutate_id));
+        drop(server);
+
+        // Reopen re-issues the WHOLE lease, re-chunked into fresh 2 + 1 waves.
+        let mut reconnect = wait_for_server(&servers).await;
+        let resume_a = reconnect.next_mutate().await;
+        let resume_b = reconnect.next_mutate().await;
+        assert_eq!(
+            resume_a.adds.len() + resume_b.adds.len(),
+            3,
+            "the whole lease is re-issued after the death, not just the unfinished chunk"
+        );
+        for id in [resume_a.mutate_id, resume_b.mutate_id] {
+            assert!(
+                id != first.mutate_id && id != second.mutate_id,
+                "reissued chunks carry fresh wave ids"
+            );
+        }
+
+        // Completing only the first reopened chunk must NOT catch it up.
+        reconnect.send(catchup_complete(resume_a.mutate_id));
+        let quiet = tokio::time::timeout(Duration::from_millis(200), lease.next()).await;
+        assert!(
+            quiet.is_err(),
+            "a re-chunked lease stays catching-up until its LAST reopened chunk completes"
+        );
+        // The last reopened chunk catches it up — exactly once.
+        reconnect.send(catchup_complete(resume_b.mutate_id));
+        assert!(matches!(
+            recv(&mut lease).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+    }
+
+    /// Suspending then resuming a lease over the cap re-subscribes it across
+    /// multiple bounded frames, and `resume()` resolves only once every resumed
+    /// chunk has completed — the chunking x suspend/resume interaction.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn an_over_cap_lease_survives_suspend_and_resume() {
+        let (transport, servers) = transport_capped(2, usize::MAX);
+        let topics: Vec<(Topic, u64)> = (0..3u32)
+            .map(|i| (group_topic(&i.to_le_bytes()), 0))
+            .collect();
+        let mut lease = transport.lease(topics, DEFAULT_LEASE_DEPTH).await?;
+
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+        let second = server.next_mutate().await;
+        server.send(catchup_complete(first.mutate_id));
+        server.send(catchup_complete(second.mutate_id));
+        assert!(matches!(
+            recv(&mut lease).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
+
+        // Suspend parks the wire; resume re-opens and re-subscribes the whole
+        // lease, chunked into bounded frames again.
+        transport.suspend().await?;
+        drop(server);
+        let mut resume = tokio::spawn({
+            let transport = transport.clone();
+            async move { transport.resume().await }
+        });
+
+        let mut reconnect = wait_for_server(&servers).await;
+        let resume_a = reconnect.next_mutate().await;
+        let resume_b = reconnect.next_mutate().await;
+        assert_eq!(
+            resume_a.adds.len() + resume_b.adds.len(),
+            3,
+            "the whole lease is re-subscribed on resume, chunked into bounded frames"
+        );
+        // resume() resolves only once EVERY resumed chunk has completed.
+        reconnect.send(catchup_complete(resume_a.mutate_id));
+        let pending = tokio::time::timeout(Duration::from_millis(200), &mut resume).await;
+        assert!(
+            pending.is_err(),
+            "resume() must not resolve until every resumed chunk is caught up"
+        );
+        reconnect.send(catchup_complete(resume_b.mutate_id));
+        tokio::time::timeout(WAIT, resume).await?.unwrap()?;
+    }
+
     /// A lease whose topics exceed the BYTE budget (not the count cap) still
     /// splits into bounded frames — the guarantee holds regardless of topic
     /// identifier length, not just topic count.

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -633,11 +633,23 @@ where
     /// that dying drain with the fresh wire; the resume wave re-serves
     /// anything the drain discarded, so nothing is lost.
     pub async fn suspend(&self) -> Result<(), TransportError> {
+        self.enqueue_suspend()?
+            .await
+            .map_err(|_| TransportError::Closed)
+    }
+
+    /// Push a suspend command without awaiting its ack, returning the reply
+    /// channel to await later. Splitting the enqueue (a synchronous push onto
+    /// the unbounded command channel) from the await lets the process-level
+    /// lifecycle fan-out push the command under the same lock that orders the
+    /// suspend flag, so a concurrent resume cannot interleave its command send
+    /// between that flag flip and this one.
+    pub fn enqueue_suspend(&self) -> Result<oneshot::Receiver<()>, TransportError> {
         let (reply, response) = oneshot::channel();
         self.cmds
             .send(Cmd::Suspend { reply })
             .map_err(|_| TransportError::Closed)?;
-        response.await.map_err(|_| TransportError::Closed)
+        Ok(response)
     }
 
     /// Come back onto the network after [`Self::suspend`]: re-opens with the
@@ -655,11 +667,21 @@ where
     /// connection's own watchdog detects the stale wire and the transport
     /// reconnects transparently.
     pub async fn resume(&self) -> Result<(), TransportError> {
+        self.enqueue_resume()?
+            .await
+            .map_err(|_| TransportError::Closed)
+    }
+
+    /// Push a resume command without awaiting its catch-up, returning the reply
+    /// channel to await later. The enqueue counterpart of [`Self::suspend`]'s
+    /// [`Self::enqueue_suspend`] — see it for why the push is split from the
+    /// await.
+    pub fn enqueue_resume(&self) -> Result<oneshot::Receiver<()>, TransportError> {
         let (reply, response) = oneshot::channel();
         self.cmds
             .send(Cmd::Resume { reply })
             .map_err(|_| TransportError::Closed)?;
-        response.await.map_err(|_| TransportError::Closed)
+        Ok(response)
     }
 }
 

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -258,6 +258,13 @@ const RECONNECT_INITIAL_DELAY: std::time::Duration = std::time::Duration::from_m
 /// full extra base of jitter ([`LedgerTask::arm_reconnect`]) to de-sync a
 /// fleet, so the effective wait tops out near twice this.
 const RECONNECT_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(30);
+/// How long a wire must stay up before its death resets the backoff to the
+/// floor. A wire that opens and dies inside this window is flapping, so its
+/// backoff keeps growing instead — this stops an accept-then-immediately-close
+/// server (an overloaded node RSTing right after accept) from pinning a client
+/// at the reconnect floor. Only an open that *proves stable* earns the reset; a
+/// bare accept no longer does.
+const MIN_STABLE_UPTIME: std::time::Duration = std::time::Duration::from_secs(10);
 /// How long a graceful close (half-close, then drain inbound to completion)
 /// may take before the connection is dropped outright. After a half-close the
 /// server finishes any in-flight catch-up waves before closing with `OK`
@@ -1965,6 +1972,7 @@ async fn run_ledger<B: TransportBinding>(
         conn: None,
         reconnect_delay: RECONNECT_INITIAL_DELAY,
         reconnect_at: tokio::time::Instant::now(),
+        wire_opened_at: None,
         suspended: initially_suspended,
         wire_opens: 0,
         resume_notify: Vec::new(),
@@ -2003,6 +2011,10 @@ where
     /// sleep from `reconnect_delay` each loop iteration would let a steady
     /// stream of commands postpone the reconnect forever.
     reconnect_at: tokio::time::Instant,
+    /// When the current wire opened, or `None` between wires. A wire that dies
+    /// having been up at least [`MIN_STABLE_UPTIME`] resets the backoff to the
+    /// floor; a shorter-lived one is flapping and keeps it growing.
+    wire_opened_at: Option<tokio::time::Instant>,
     /// `suspend()`ed: the wire stays down on purpose — no lazy open for new
     /// leases, no reconnect backoff — until `resume()` clears it.
     suspended: bool,
@@ -2129,7 +2141,9 @@ where
             match self.open_preemptibly(mutate0).await {
                 OpenOutcome::Opened(wire) => {
                     self.conn = Some(wire);
-                    self.reconnect_delay = RECONNECT_INITIAL_DELAY;
+                    // Backoff resets on stable death, not on open: a bare accept
+                    // doesn't prove the wire works ([`Self::wire_died`]).
+                    self.wire_opened_at = Some(tokio::time::Instant::now());
                     self.wire_opens += 1;
                     tracing::info!(
                         topics = topics.len(),
@@ -2334,6 +2348,19 @@ where
     fn wire_died(&mut self) -> Flow {
         self.outbox.clear();
         drop(self.conn.take());
+        // A wire that proved stable resets the backoff to the floor so the
+        // reconnect is prompt; one that died inside `MIN_STABLE_UPTIME` is
+        // flapping — grow the backoff so an accept-then-close server can't pin
+        // us at the floor. Only surviving resets it; a bare open never did.
+        let stable = self
+            .wire_opened_at
+            .take()
+            .is_some_and(|opened| opened.elapsed() >= MIN_STABLE_UPTIME);
+        self.reconnect_delay = if stable {
+            RECONNECT_INITIAL_DELAY
+        } else {
+            (self.reconnect_delay * 2).min(RECONNECT_MAX_DELAY)
+        };
         let retry_in = self.arm_reconnect();
         if !self.ledger.leases.is_empty() {
             tracing::warn!(
@@ -2425,7 +2452,8 @@ where
         match self.open_preemptibly(initial).await {
             OpenOutcome::Opened(wire) => {
                 self.conn = Some(wire);
-                self.reconnect_delay = RECONNECT_INITIAL_DELAY;
+                // Backoff resets on stable death, not on open ([`wire_died`]).
+                self.wire_opened_at = Some(tokio::time::Instant::now());
                 self.wire_opens += 1;
                 tracing::info!(
                     reconnects = self.wire_opens.saturating_sub(1),

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport_props.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport_props.rs
@@ -710,10 +710,12 @@ async fn run_schedule(ops: Vec<Op>, chunk_cap: usize, chunk_bytes: usize) {
 
 proptest! {
     #![proptest_config(ProptestConfig {
+        // Default raised for the delicate chunked-completion accounting; set
+        // PROPTEST_CASES=1 for a fast local run, or higher in a nightly lane.
         cases: std::env::var("PROPTEST_CASES")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(16),
+            .unwrap_or(32),
         ..ProptestConfig::default()
     })]
 

--- a/crates/xmtp_mls/src/subscriptions/catch_up.rs
+++ b/crates/xmtp_mls/src/subscriptions/catch_up.rs
@@ -379,6 +379,13 @@ where
         let mut seen = seeds.seen;
 
         let api = self.context.api().api_client.clone();
+        // Defensive: `subs` always carries the welcome topic (pushed above), so
+        // it is never empty — but an empty set would seed an adds-nothing open
+        // frame that never earns a `CatchUpComplete`, stalling the run until the
+        // watchdog fires. Nothing owed means nothing to catch up.
+        if subs.is_empty() {
+            return Ok(AttemptEnd::Complete);
+        }
         // Chunk the subscription set so a very large account never opens with
         // one oversized frame; the overflow chunks ride the follow-up queue
         // below as their own waves.

--- a/crates/xmtp_mls/src/subscriptions/catch_up.rs
+++ b/crates/xmtp_mls/src/subscriptions/catch_up.rs
@@ -503,15 +503,21 @@ where
         // Bounded-sync half-close (XIP-83): we are done sending; the server
         // finishes and closes its side. Everything owed has already arrived
         // and been attempted, so from here the run is complete no matter how
-        // gracefully the wire goes down.
-        if conn.finish().await.is_ok() {
-            let drain = async { while conn.next().await.is_some() {} };
-            if tokio::time::timeout(POST_FINISH_DRAIN, drain)
-                .await
-                .is_err()
-            {
-                tracing::debug!("catch-up peer did not close after the half-close; dropping");
+        // gracefully the wire goes down. Time-box the whole close — the
+        // half-close send AND the drain: `finish()` blocks on the connection's
+        // command channel, which a wedged actor (parked emitting into a full
+        // event channel) could hold forever, so the courtesy close must never
+        // outlast the run (mirrors the transport's `close_gracefully` budget).
+        let close = async {
+            if conn.finish().await.is_ok() {
+                while conn.next().await.is_some() {}
             }
+        };
+        if tokio::time::timeout(POST_FINISH_DRAIN, close)
+            .await
+            .is_err()
+        {
+            tracing::debug!("catch-up half-close did not settle in time; dropping the wire");
         }
         Ok(AttemptEnd::Complete)
     }

--- a/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
+++ b/crates/xmtp_mls/src/subscriptions/router_callbacks.rs
@@ -309,17 +309,21 @@ where
 /// suspended defers its backend's capability discovery to the resume
 /// re-open; see [`settle_lifecycle`] for how a refusal there still latches.
 pub async fn suspend_bidi_streams() -> Result<()> {
-    let wires: Vec<_> = {
+    // Enqueue each transport's command UNDER the same lock that flips the
+    // process flag, so a concurrent resume can't interleave its command send
+    // between our flag flip and ours — the actor then sees Suspend/Resume in
+    // the order the lock ordered the flags, not in scheduler order. The push is
+    // synchronous; only the reply await below runs outside the lock.
+    let (wires, pending): (Vec<_>, Vec<_>) = {
         let mut shared = SHARED_WIRES.lock();
         shared.suspend_requested = true;
         shared
             .transports
             .iter()
-            .map(|(host, t)| (host.clone(), t.clone()))
-            .collect()
+            .map(|(host, t)| ((host.clone(), t.clone()), t.enqueue_suspend()))
+            .unzip()
     };
-    let results = futures::future::join_all(wires.iter().map(|(_, t)| t.suspend())).await;
-    settle_lifecycle(&wires, results)
+    settle_lifecycle(&wires, await_lifecycle_acks(pending).await)
 }
 
 /// Bring the shared bidi wires back (`willEnterForeground`), resolving once
@@ -333,17 +337,34 @@ pub async fn suspend_bidi_streams() -> Result<()> {
 /// ([`suspend_bidi_streams`]), so transports created from here on are born
 /// live again. A no-op when no transport was ever opened.
 pub async fn resume_bidi_streams() -> Result<()> {
-    let wires: Vec<_> = {
+    // Enqueue under the flag lock, same as [`suspend_bidi_streams`]: the
+    // command order must match the flag order under all interleavings.
+    let (wires, pending): (Vec<_>, Vec<_>) = {
         let mut shared = SHARED_WIRES.lock();
         shared.suspend_requested = false;
         shared
             .transports
             .iter()
-            .map(|(host, t)| (host.clone(), t.clone()))
-            .collect()
+            .map(|(host, t)| ((host.clone(), t.clone()), t.enqueue_resume()))
+            .unzip()
     };
-    let results = futures::future::join_all(wires.iter().map(|(_, t)| t.resume())).await;
-    settle_lifecycle(&wires, results)
+    settle_lifecycle(&wires, await_lifecycle_acks(pending).await)
+}
+
+/// Await every enqueued lifecycle reply, mapping a dropped sender (a closed
+/// transport) to `Closed`. The command pushes already happened under the
+/// registry lock ([`suspend_bidi_streams`]); only this await runs outside it,
+/// so a slow catch-up on one destination never delays another's command.
+async fn await_lifecycle_acks(
+    pending: Vec<std::result::Result<tokio::sync::oneshot::Receiver<()>, TransportError>>,
+) -> Vec<std::result::Result<(), TransportError>> {
+    futures::future::join_all(pending.into_iter().map(|reply| async move {
+        match reply {
+            Ok(rx) => rx.await.map_err(|_| TransportError::Closed),
+            Err(e) => Err(e),
+        }
+    }))
+    .await
 }
 
 /// Fold a lifecycle fan-out's results, driving EVERY destination before


### PR DESCRIPTION
Pre-enablement hardening for the XIP-83 bidi surface, from a fresh adversarial re-review of the now-merged transport + catch-up + lifecycle code (the interaction bugs that per-PR reviews miss). Bidi still ships **default-OFF** (`XMTP_BIDI_STREAMS_ENABLED`), so none of these block a release — they harden the fleet behavior that matters the moment the flag is flipped. Six atomic commits, one per finding.

## The two that matter most for enablement

- **Order the lifecycle command with the suspend flag under one lock** (`#1`, medium). `suspend_bidi_streams`/`resume_bidi_streams` set the process `suspend_requested` flag under the registry lock but sent each transport's `Cmd::Suspend`/`Cmd::Resume` *after* dropping it. On a multi-threaded runtime a concurrent suspend+resume could race between lock-release and their sends, delivering the commands to a transport opposite to the flag — a wire left **live while backgrounded** (battery) or **parked while foregrounded** (no delivery). Now the synchronous command push (`enqueue_suspend`/`enqueue_resume`) happens inside the same locked section as the flag; only the reply await runs outside.

- **Grow the reconnect backoff on a flapping wire** (`#2`, medium, pre-existing). The backoff reset to the 100 ms floor the instant a wire *opened*, before any frame. A server that accepts then immediately closes (an overloaded node RSTing after accept) pinned every client at the floor forever, amplifying load against the struggling backend. Now only a wire that stays up ≥ `MIN_STABLE_UPTIME` resets the backoff; one that dies inside that window is flapping and keeps backing off. The explicit `resume()` reset is unchanged.

## Latent hardening

- **Guard the catch-up open against an empty subscription set** (`#3`, low). An empty `subs` would seed an adds-nothing open frame that never earns a `CatchUpComplete`, stalling ~90 s → `Exhausted`. Unreachable today (the welcome topic is always present), but the safety sat far from the open; short-circuit it to `Complete`.

- **Time-box the catch-up half-close** (`#4`, low). `catch_up_attempt` awaited `conn.finish()` with no deadline; a wedged actor could hang it. Wrap the half-close and drain under one budget, matching the transport's own `close_gracefully`.

- **Conclude a superseded resume waiter on suspend** (`#5`, low). A `resume()` awaiting catch-up that a `suspend()` preempts was left parked until some *later* resume, stranding the caller (and its task) for the whole background sojourn. A suspend supersedes pending resumes; conclude them at the suspend instead.

## Coverage

- **Chunking × reconnect and × suspend/resume** (`#6`, test). The multi-wave-per-lease chunking across a wire death or suspend/resume was exercised only by the property test (16-case default); every scripted lifecycle test used the production cap, so none chunked. Adds two deterministic tests at a shrunk cap (over-cap lease survives a wire death; survives a suspend/resume), and raises the property test's default case count.

## Verification

- Both affected crates compile; `clippy` clean; `cargo fmt` clean.
- All 239 transport scripted tests pass (incl. the two new chunking tests and the updated preempt test); catch-up + lifecycle tests pass against the live node; property model passes with the transport changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden bidi transport lifecycle with reconnect backoff, suspend/resume ordering, and catch-up fixes
> - Reconnect backoff in `LedgerTask.wire_died` now resets to the floor only if the wire stayed up for at least `MIN_STABLE_UPTIME` (10s); short-lived flaps continue to grow the backoff instead.
> - `Transport.enqueue_suspend` and `enqueue_resume` allow callers to enqueue lifecycle commands under the `SHARED_WIRES` lock and await acknowledgment outside it, closing a race where a resume could be enqueued between a flag flip and its suspend command.
> - Pending `resume()` waiters are now resolved immediately when a suspend is processed (both in the normal handler and when a suspend preempts an in-flight dial).
> - `CatchUp::catch_up_to_live` returns early when the subscription set is empty (avoiding a stalled frame) and enforces a timeout on the post-finish drain to prevent indefinite blocking on a wedged connection.
> - Behavioral Change: over-cap leases that were still catching up on wire death are now fully re-issued in fresh chunks on reopen rather than resuming mid-stream.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a238169.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->