### PR TITLE
test(xmtp_mls,xmtp_api_d14n): live v3↔d14n coexistence over a real MigrationClient

### DIFF
--- a/crates/xmtp_api_d14n/src/queries/combined.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined.rs
@@ -27,6 +27,11 @@ mod streams;
 mod to_dyn_api;
 mod xmtp_query;
 
+xmtp_common::if_test! {
+    mod test_client;
+    pub use test_client::*;
+}
+
 static ERROR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(xmtp_configuration::D14N_MIGRATION_MSG_REGEX).expect("static regex must be valid")
 });

--- a/crates/xmtp_api_d14n/src/queries/combined/test_client.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/test_client.rs
@@ -1,0 +1,94 @@
+//! `XmtpTestClient` impl that builds a real [`MigrationClient`] against a live
+//! backend, so tests can exercise the v3↔d14n cutover client end to end (the
+//! object production actually ships — see [`MigrationClient`]). The v3 side
+//! dials xmtp-node-go; the d14n side is a [`ReadWriteClient`] over xmtpd +
+//! gateway, matching the pure-d14n test client's transport shape.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use xmtp_configuration::PAYER_WRITE_FILTER;
+use xmtp_proto::api::{Client, IsConnectedCheck};
+use xmtp_proto::prelude::{ApiBuilder, XmtpTestClient};
+
+use super::MigrationClient;
+use crate::protocol::{CursorStore, NoCursorStore};
+use crate::{ReadWriteClient, ReadWriteClientBuilder, XmtpTestClientExt};
+
+/// Builder for a test [`MigrationClient`]: a v3 builder, a d14n read/write
+/// builder, and the shared cursor store that carries the cutover state.
+pub struct MigrationClientBuilder<V3B, D14nB, Store> {
+    v3: V3B,
+    xmtpd: D14nB,
+    store: Store,
+}
+
+impl<V3B, D14nB, Store> MigrationClientBuilder<V3B, D14nB, Store> {
+    pub fn new(v3: V3B, xmtpd: D14nB, store: Store) -> Self {
+        Self { v3, xmtpd, store }
+    }
+}
+
+impl<V3, R, W> XmtpTestClient for MigrationClient<V3, ReadWriteClient<R, W>, Arc<dyn CursorStore>>
+where
+    V3: XmtpTestClient,
+    R: XmtpTestClient<Builder = W::Builder>,
+    W: XmtpTestClient,
+    W::Builder: Clone,
+{
+    type Builder = MigrationClientBuilder<
+        V3::Builder,
+        ReadWriteClientBuilder<R::Builder, W::Builder>,
+        Arc<dyn CursorStore>,
+    >;
+
+    fn create() -> Self::Builder {
+        let v3 = <V3 as XmtpTestClient>::create();
+        let rw = ReadWriteClient::builder()
+            .read(<R as XmtpTestClient>::create())
+            .write(<W as XmtpTestClient>::create())
+            .filter(PAYER_WRITE_FILTER);
+        MigrationClientBuilder::new(v3, rw, Arc::new(NoCursorStore))
+    }
+}
+
+impl<V3, R, W> XmtpTestClientExt for MigrationClient<V3, ReadWriteClient<R, W>, Arc<dyn CursorStore>>
+where
+    V3: XmtpTestClient,
+    R: XmtpTestClient<Builder = W::Builder>,
+    W: XmtpTestClient,
+    W::Builder: Clone,
+{
+    fn with_cursor_store(store: Arc<dyn CursorStore>) -> <Self as XmtpTestClient>::Builder {
+        let mut b = <Self as XmtpTestClient>::create();
+        b.store = store;
+        b
+    }
+}
+
+impl<V3B, BRead, BWrite> ApiBuilder
+    for MigrationClientBuilder<V3B, ReadWriteClientBuilder<BRead, BWrite>, Arc<dyn CursorStore>>
+where
+    V3B: ApiBuilder,
+    V3B::Output: Client + IsConnectedCheck + Clone + 'static,
+    BRead: ApiBuilder,
+    BWrite: ApiBuilder,
+    ReadWriteClient<BRead::Output, BWrite::Output>: Client + IsConnectedCheck + Clone + 'static,
+{
+    type Output = MigrationClient<
+        V3B::Output,
+        ReadWriteClient<BRead::Output, BWrite::Output>,
+        Arc<dyn CursorStore>,
+    >;
+    // The v3 grpc builder carries the only fallible-on-connect step; the
+    // read/write build and `MigrationClient::new` (a local SCW-verifier setup)
+    // are infallible in tests, so they unwrap.
+    type Error = <V3B as ApiBuilder>::Error;
+
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        let v3 = self.v3.build()?;
+        let xmtpd =
+            <ReadWriteClientBuilder<BRead, BWrite> as ApiBuilder>::build(self.xmtpd).unwrap();
+        Ok(MigrationClient::new(v3, xmtpd, self.store).unwrap())
+    }
+}

--- a/crates/xmtp_api_d14n/src/test/definitions.rs
+++ b/crates/xmtp_api_d14n/src/test/definitions.rs
@@ -2,7 +2,7 @@
 //! "creators" are test clients that can be used with [`XmtpTestClient`]
 
 use crate::{
-    D14nClient, ReadWriteClient, TrackedStatsClient, V3Client,
+    D14nClient, MigrationClient, ReadWriteClient, TrackedStatsClient, V3Client,
     protocol::{CursorStore, NoCursorStore},
 };
 use std::sync::Arc;
@@ -105,4 +105,22 @@ xmtp_common::if_v3! {
     pub type DefaultTestClientCreator = FeatureSwitchedTestClientCreator;
 }
 
-// TODO: combined_migration client. i.e 'if_combined_client!'
+/// A built test client that speaks through the `MigrationClient` cutover path:
+/// v3 (xmtp-node-go) before cutover, xmtpd (read/write over gateway) after.
+/// This is the object production ships, so live tests use it to prove the
+/// v3↔d14n handoff works end to end.
+pub type TestMigrationClient = TrackedStatsClient<
+    MigrationClient<GrpcClient, ReadWriteClient<GrpcClient, GrpcClient>, Arc<dyn CursorStore>>,
+>;
+
+/// Creator for a `MigrationClient` wired to the local docker stack (v3
+/// node-go + xmtpd + gateway). Unlike [`FeatureSwitchedTestClientCreator`],
+/// this does not switch on the `d14n` feature — it always builds the dual
+/// backend so a test can drive the cutover itself via the cursor store.
+pub type LocalOnlyMigrationClientCreator = TrackedStatsClient<
+    MigrationClient<
+        LocalNodeGoClient,
+        ReadWriteClient<LocalXmtpdClient, LocalGatewayClient>,
+        Arc<dyn CursorStore>,
+    >,
+>;

--- a/crates/xmtp_mls/src/lib.rs
+++ b/crates/xmtp_mls/src/lib.rs
@@ -19,6 +19,8 @@ pub mod utils;
 pub mod worker;
 pub use definitions::*;
 
+#[cfg(all(test, not(target_arch = "wasm32"), feature = "d14n"))]
+mod migration_tests;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test;
 #[cfg(test)]

--- a/crates/xmtp_mls/src/migration_tests.rs
+++ b/crates/xmtp_mls/src/migration_tests.rs
@@ -1,0 +1,62 @@
+//! Live integration test for the v3↔d14n [`MigrationClient`] — the coexistence
+//! client production actually ships (holds both a v3 and an xmtpd backend and
+//! picks between them at a cutover). The rest of the suite runs on a *pure* v3
+//! or *pure* d14n client selected at compile time; nothing exercises the real
+//! migration client end to end. This test does: it builds an MLS client whose
+//! API is the migration client, pre-migrated to the d14n side, and drives a
+//! full group-message round-trip through it against the live xmtpd backend.
+//!
+//! Only the d14n (post-cutover) side is driven here. The v3 (pre-cutover)
+//! selection is covered by the migration unit tests in
+//! `xmtp_api_d14n::queries::combined::tests`; it can't be driven against the
+//! local stack because the test node-go does not serve `FetchD14nCutover`, so
+//! `choose_client`'s forced first refresh would error before it could route to
+//! v3. See `ClientBuilder::local_migration`.
+//!
+//! d14n-only and native-only.
+#![allow(clippy::unwrap_used)]
+
+use alloy::signers::local::PrivateKeySigner;
+use xmtp_cryptography::utils::generate_local_wallet;
+use xmtp_id::associations::test_utils::MockSmartContractSignatureVerifier;
+
+use crate::Client;
+use crate::groups::send_message_opts::SendMessageOpts;
+use crate::utils::test::{MigrationXmtpClient, identity_setup, register_client};
+
+/// Build a registered MLS client whose API is the migration client, pre-set to
+/// the migrated (d14n) side so every call routes to xmtpd.
+async fn migrated_migration_client(owner: &PrivateKeySigner) -> MigrationXmtpClient {
+    let client = Client::builder(identity_setup(owner.clone()))
+        .temp_store()
+        .await
+        .local_migration()
+        .default_mls_store()
+        .unwrap()
+        .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
+        .build()
+        .await
+        .unwrap();
+    register_client(&client, owner.clone()).await;
+    client
+}
+
+/// Two migration clients, both migrated to d14n, exchange a group message end to
+/// end — proving the real cutover client registers, publishes, and reads over
+/// the live xmtpd backend.
+#[xmtp_common::test(unwrap_try = true)]
+async fn migration_client_delivers_a_group_message_on_the_d14n_backend() {
+    let alix = migrated_migration_client(&generate_local_wallet()).await;
+    let bo = migrated_migration_client(&generate_local_wallet()).await;
+
+    let group = alix.create_group(None, None)?;
+    group.add_members(&[bo.inbox_id()]).await?;
+
+    const MSG: &[u8] = b"hello over d14n through the migration client";
+    group.send_message(MSG, SendMessageOpts::default()).await?;
+
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&group.group_id)?;
+    let last = bo_group.test_last_message_bytes().await?;
+    assert_eq!(last.unwrap(), MSG);
+}

--- a/crates/xmtp_mls/src/utils/test/definitions.rs
+++ b/crates/xmtp_mls/src/utils/test/definitions.rs
@@ -13,6 +13,16 @@ pub type FullXmtpClient = Client<TestXmtpMlsContext>;
 pub type ClientTester = Tester<PrivateKeySigner, FullXmtpClient>;
 pub type TestMlsGroup = crate::groups::MlsGroup<TestXmtpMlsContext>;
 
+/// A test client whose API is the v3↔d14n [`MigrationClient`](xmtp_api_d14n::MigrationClient)
+/// — the coexistence object production ships. Unlike [`TestClient`], its backend is not
+/// feature-switched: it always holds both, and a test drives the cutover via the cursor
+/// store. Used by the live coexistence test to prove messaging works through the real
+/// migration client.
+pub type MigrationTestClient = xmtp_api_d14n::TestMigrationClient;
+pub type MigrationXmtpMlsContext =
+    Arc<XmtpMlsLocalContext<MigrationTestClient, xmtp_db::DefaultStore, TestMlsStorage>>;
+pub type MigrationXmtpClient = Client<MigrationXmtpMlsContext>;
+
 /// A Test client
 /// This client switches its backend based on feature flag.
 /// default: V3 , Local
@@ -23,6 +33,9 @@ pub type TestClient = xmtp_api_d14n::TestClient;
 
 /// Test client that is local only, but still switches between d14n/v3 clients on feature flag
 pub type LocalOnlyTestClientCreator = xmtp_api_d14n::LocalOnlyTestClientCreator;
+
+/// Local-only creator for the v3↔d14n `MigrationClient` (does not feature-switch).
+pub type LocalOnlyMigrationClientCreator = xmtp_api_d14n::LocalOnlyMigrationClientCreator;
 
 /// Test client that is dev only, but still switches between d14n/v3 clients on feature flag
 pub type DevOnlyTestClientCreator = xmtp_api_d14n::DevOnlyTestClientCreator;

--- a/crates/xmtp_mls/src/utils/test/mod.rs
+++ b/crates/xmtp_mls/src/utils/test/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 use std::{sync::Arc, time::Duration};
 use tokio::sync::Notify;
 use xmtp_api_d14n::XmtpTestClientExt;
-use xmtp_api_d14n::protocol::XmtpQuery;
+use xmtp_api_d14n::protocol::{CursorStore, XmtpQuery};
 use xmtp_common::time::Expired;
 use xmtp_db::XmtpMlsStorageProvider;
 use xmtp_db::{ConnectionExt, DbConnection, XmtpTestDb};
@@ -50,6 +50,20 @@ impl<A, S> ClientBuilder<A, S> {
     pub fn local(self) -> ClientBuilder<TestClient, S> {
         let s = Arc::new(SqliteCursorStore::new(self.store.as_ref().unwrap().db()));
         let a = LocalOnlyTestClientCreator::with_cursor_store(s);
+        let api_client = a.build().unwrap();
+        self.api_client(api_client)
+    }
+
+    /// Wire a `MigrationClient` (the v3↔d14n cutover client production ships)
+    /// onto this builder, pre-set to the migrated (d14n) side so a live test can
+    /// exercise real messaging through it against xmtpd. The pre-cutover (v3)
+    /// selection is covered by the migration unit tests; it can't be driven
+    /// locally because the test node-go does not serve `FetchD14nCutover`, so
+    /// `choose_client`'s first-call refresh would error before it could pick v3.
+    pub fn local_migration(self) -> ClientBuilder<MigrationTestClient, S> {
+        let s = Arc::new(SqliteCursorStore::new(self.store.as_ref().unwrap().db()));
+        s.set_has_migrated(true).unwrap();
+        let a = LocalOnlyMigrationClientCreator::with_cursor_store(s);
         let api_client = a.build().unwrap();
         self.api_client(api_client)
     }
@@ -117,7 +131,7 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
     }
 }
 
-fn identity_setup(owner: impl InboxOwner) -> IdentityStrategy {
+pub fn identity_setup(owner: impl InboxOwner) -> IdentityStrategy {
     let nonce = 1;
     let ident = owner.get_identifier().unwrap();
     let inbox_id = ident.inbox_id(nonce).unwrap();


### PR DESCRIPTION
## What

First live coverage of the **`MigrationClient`** — the v3↔d14n cutover client production actually ships. Every other test client is a *pure* v3 or *pure* d14n client, selected at compile time by `--features d14n`; nothing ever assembled or exercised the dual-backend migration client against a real backend. This adds the test-harness to build one and a live test that drives real MLS messaging through it.

This is **Phase 1 of 3** toward "both v3 and d14n work in the codebase, proven live." Follow-ups (separate PRs): route commit-log to the retained centralized v3 service, and streaming-internals d14n parity.

## Commits

1. **`feat(xmtp_api_d14n)`** — a `MigrationClient` test-client creator (`XmtpTestClient`/`XmtpTestClientExt`/`ApiBuilder` impls) that assembles a real migration client over a live v3 node + xmtpd read/write pair. Exposes `TestMigrationClient` + `LocalOnlyMigrationClientCreator`; resolves the pre-existing `combined_migration client` TODO.
2. **`test(xmtp_mls)`** — `ClientBuilder::local_migration` + a `MigrationXmtpClient` context, and a live test: two migration clients (pre-migrated to d14n) create a group, add a member, send, and receive — end to end over live xmtpd.

```
PASS [1.198s] migration_client_delivers_a_group_message_on_the_d14n_backend
```

## Scope note: the pre-cutover (v3) side is unit-covered, not live

The test drives only the **d14n (post-cutover)** side, because that side is deterministic: `has_migrated=true` makes `choose_client` early-return xmtpd with no network fetch. The **v3 (pre-cutover)** side can't be driven against the local stack — the test node-go returns `Unimplemented` for `xmtp.migration.api.v1.D14nMigrationApi/FetchD14nCutover`, so `choose_client`'s forced first-call cutover refresh errors before it can route to v3. That selection logic stays covered by the migration unit tests in `xmtp_api_d14n::queries::combined::tests`.

(Worth flagging separately: a production migration client whose v3 backend fails to serve `FetchD14nCutover` would error on *every* call pre-migration — a resilience question, not addressed here.)

## Verification

- `xmtp_api_d14n --features test-utils`, `xmtp_mls --features d14n --tests`, and `xmtp_mls --tests` (v3 lane) all compile; clippy + fmt clean.
- The live test passes against the local docker stack.
- Additive and test-only — no production code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live v3↔d14n coexistence integration test over a real `MigrationClient`
> - Adds a `MigrationClientBuilder` and `XmtpTestClient`/`ApiBuilder` impls in a new test-only [`test_client.rs`](https://github.com/xmtp/libxmtp/pull/3888/files#diff-e38d69659704238b12313de180fd9bd9ee19ad8079c0bc5ff1329d2129621287) module, wiring v3 and d14n read/write backends with the payer write filter.
> - Adds a `local_migration()` method to `ClientBuilder` in [`utils/test/mod.rs`](https://github.com/xmtp/libxmtp/pull/3888/files#diff-a2e2f008a422b23fea48b2b42db58bd5188957240ea98875023bbeb423660182) that builds a `MigrationTestClient` pre-configured to route to the d14n backend via a migrated `SqliteCursorStore`.
> - Adds an end-to-end integration test in [`migration_tests.rs`](https://github.com/xmtp/libxmtp/pull/3888/files#diff-0c978bc1e6025087ff991e8abb25e7f4952581e6f35dfa7e2c7fa15b59170346) that creates two migrated clients, forms a group, sends a message, and asserts the recipient reads it over the xmtpd backend.
> - Introduces test type aliases (`TestMigrationClient`, `MigrationXmtpClient`, etc.) in both `xmtp_api_d14n` and `xmtp_mls` to support typed construction against local/dev infrastructure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24b7402.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->