### PR TITLE
fix(xmtp_api_d14n): keep commit-log on the retained v3 service after cutover

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -29,7 +29,10 @@ filter = 'test(/\btest_can_stream_group_messages_for_updates/)'
 retries = 3
 [profile.ci-d14n]
 slow-timeout = "90sec"
-default-filter = "not (test(/\\w*commit_log*/))"
+# Commit-log tests are excluded on d14n because the pure d14n test client no-ops
+# commit-log — except the migration round-trip, which routes commit-log to the
+# live v3 node and so is meaningful (and only compiles) on this lane.
+default-filter = "not (test(/\\w*commit_log*/)) | test(migration_client_commit_log_round_trips_through_v3)"
 # inherits = "ci" not supported until latest nextest release
 failure-output = "never"
 fail-fast = false

--- a/crates/xmtp_api_d14n/src/queries/combined.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined.rs
@@ -210,22 +210,27 @@ where
             .await
     }
 
+    // Commit-log (fork detection) is deliberately not part of d14n's network
+    // ordering; it stays on a centralized v3-shaped service that is kept running
+    // through and past the cutover. So — unlike every other call — commit-log
+    // does NOT follow `choose_client`: a migrated client whose reads/writes go
+    // to xmtpd must keep publishing and reading its commit log on v3, or fork
+    // detection silently dies the moment it crosses the cutover (the d14n
+    // client's commit-log methods are deliberate no-ops). Route to v3
+    // unconditionally. No `write_with_refresh`: this service never emits the
+    // migration-rejection signal that reroutes writes to xmtpd.
     async fn publish_commit_log(
         &self,
         request: mls_v1::BatchPublishCommitLogRequest,
     ) -> Result<(), Self::Error> {
-        self.write_with_refresh(|| {
-            let value = request.clone();
-            async move { self.choose_client().await?.publish_commit_log(value).await }
-        })
-        .await
+        self.v3_client.publish_commit_log(request).await
     }
 
     async fn query_commit_log(
         &self,
         request: mls_v1::BatchQueryCommitLogRequest,
     ) -> Result<mls_v1::BatchQueryCommitLogResponse, Self::Error> {
-        self.choose_client().await?.query_commit_log(request).await
+        self.v3_client.query_commit_log(request).await
     }
 
     async fn get_newest_group_message(

--- a/crates/xmtp_api_d14n/src/queries/combined/test_client.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/test_client.rs
@@ -52,7 +52,8 @@ where
     }
 }
 
-impl<V3, R, W> XmtpTestClientExt for MigrationClient<V3, ReadWriteClient<R, W>, Arc<dyn CursorStore>>
+impl<V3, R, W> XmtpTestClientExt
+    for MigrationClient<V3, ReadWriteClient<R, W>, Arc<dyn CursorStore>>
 where
     V3: XmtpTestClient,
     R: XmtpTestClient<Builder = W::Builder>,

--- a/crates/xmtp_api_d14n/src/queries/combined/tests.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/tests.rs
@@ -299,3 +299,42 @@ async fn is_d14n_returns_true_after_migration() {
 
     assert!(client.is_d14n()?);
 }
+
+/// Commit-log (fork detection) must stay on the retained centralized v3 service
+/// even after the client has migrated to d14n. With `has_migrated = true` every
+/// other call routes to the xmtpd client, but `publish_commit_log` /
+/// `query_commit_log` must still hit v3 — the d14n mock has no expectations, so
+/// a call wrongly routed there panics.
+#[xmtp_common::test(unwrap_try = true)]
+async fn commit_log_stays_on_v3_after_migration() {
+    use xmtp_proto::mls_v1::{BatchPublishCommitLogRequest, BatchQueryCommitLogRequest};
+
+    let store = InMemoryCursorStore::new();
+    store.set_has_migrated(true)?;
+
+    // v3 mock counts every request and answers with an empty (default-decoding)
+    // body; d14n mock is left bare so any commit-log call routed to it panics.
+    let v3_calls = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let v3 = {
+        let calls = v3_calls.clone();
+        let mut mock = MockNetworkClient::new();
+        mock.expect_request().returning(move |_req, _path, _body| {
+            calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(http::Response::new(prost::bytes::Bytes::new()))
+        });
+        TestNetworkClient::from_mock(mock)
+    };
+    let d14n = TestNetworkClient::new();
+
+    let client = build_test_client(v3, d14n, store);
+
+    client
+        .publish_commit_log(BatchPublishCommitLogRequest::default())
+        .await?;
+    client
+        .query_commit_log(BatchQueryCommitLogRequest::default())
+        .await?;
+
+    // Both calls reached v3, never the migrated (d14n) client.
+    assert_eq!(v3_calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+}

--- a/crates/xmtp_mls/src/migration_tests.rs
+++ b/crates/xmtp_mls/src/migration_tests.rs
@@ -6,12 +6,18 @@
 //! API is the migration client, pre-migrated to the d14n side, and drives a
 //! full group-message round-trip through it against the live xmtpd backend.
 //!
-//! Only the d14n (post-cutover) side is driven here. The v3 (pre-cutover)
-//! selection is covered by the migration unit tests in
-//! `xmtp_api_d14n::queries::combined::tests`; it can't be driven against the
-//! local stack because the test node-go does not serve `FetchD14nCutover`, so
-//! `choose_client`'s forced first refresh would error before it could route to
-//! v3. See `ClientBuilder::local_migration`.
+//! Two things are exercised here, both with the client parked on one side of
+//! the cutover (so neither needs the transition itself):
+//!   - the d14n (post-cutover) side, via a full group-message round-trip; and
+//!   - commit-log routing, which must keep going to the retained v3 service even
+//!     after migration — proven by a live publish→query round-trip that only
+//!     round-trips against node-go, never xmtpd's commit-log no-op.
+//!
+//! The cutover *transition* isn't driven: the pre-cutover selection is covered
+//! by the migration unit tests in `xmtp_api_d14n::queries::combined::tests`, and
+//! it can't run against the local stack because the test node-go does not serve
+//! `FetchD14nCutover`, so `choose_client`'s forced first refresh would error
+//! before it could route to v3. See `ClientBuilder::local_migration`.
 //!
 //! d14n-only and native-only.
 #![allow(clippy::unwrap_used)]
@@ -21,6 +27,7 @@ use xmtp_cryptography::utils::generate_local_wallet;
 use xmtp_id::associations::test_utils::MockSmartContractSignatureVerifier;
 
 use crate::Client;
+use crate::context::XmtpSharedContext;
 use crate::groups::send_message_opts::SendMessageOpts;
 use crate::utils::test::{MigrationXmtpClient, identity_setup, register_client};
 
@@ -59,4 +66,81 @@ async fn migration_client_delivers_a_group_message_on_the_d14n_backend() {
     let bo_group = bo.group(&group.group_id)?;
     let last = bo_group.test_last_message_bytes().await?;
     assert_eq!(last.unwrap(), MSG);
+}
+
+/// A migrated client sends every ordinary call to xmtpd — but commit-log (fork
+/// detection) must keep going to the retained v3 service, never to xmtpd (whose
+/// commit-log methods are deliberate no-ops). This drives a real publish→query
+/// commit-log round-trip through a *migrated* migration client and asserts the
+/// entry comes back: had commit-log wrongly followed the cutover to xmtpd, the
+/// publish would hit the d14n no-op and the query would return empty. It's the
+/// live counterpart to the `commit_log_stays_on_v3_after_migration` mock unit
+/// test in `xmtp_api_d14n::queries::combined::tests`.
+#[xmtp_common::test(unwrap_try = true)]
+async fn migration_client_commit_log_round_trips_through_v3() {
+    use openmls::prelude::{OpenMlsCrypto, SignatureScheme};
+    use openmls_traits::OpenMlsProvider;
+    use prost::Message;
+    use rand::RngExt;
+    use xmtp_proto::mls_v1::{PublishCommitLogRequest, QueryCommitLogRequest};
+    use xmtp_proto::xmtp::identity::associations::RecoverableEd25519Signature;
+    use xmtp_proto::xmtp::mls::message_contents::PlaintextCommitLogEntry;
+
+    let alix = migrated_migration_client(&generate_local_wallet()).await;
+
+    // The local node's commit log isn't cleared between runs; use a fresh random
+    // group_id so this test never collides with a previous iteration.
+    let group_id: Vec<u8> = (0..20).map(|_| rand::rng().random_range(0..=255)).collect();
+
+    let entry = PlaintextCommitLogEntry {
+        group_id: group_id.clone(),
+        commit_sequence_id: 1,
+        last_epoch_authenticator: vec![1, 2, 3, 4],
+        commit_result: 1, // Success
+        applied_epoch_number: 1,
+        applied_epoch_authenticator: vec![5, 6, 7, 8],
+    };
+
+    // The backend requires a signature; sign the serialized entry with an ad-hoc
+    // ed25519 key (unrelated to the client's identity, which lives on xmtpd).
+    let provider = alix.context.mls_provider();
+    let crypto = provider.crypto();
+    let (private_key_bytes, _) = crypto.signature_key_gen(SignatureScheme::ED25519)?;
+    let private_key = xmtp_cryptography::Secret::new(private_key_bytes.clone());
+    let public_key = xmtp_cryptography::signature::to_public_key(&private_key)?.to_vec();
+    let serialized = entry.encode_to_vec();
+    let signature = crypto.sign(SignatureScheme::ED25519, &serialized, &private_key_bytes)?;
+
+    alix.context
+        .api()
+        .publish_commit_log(vec![PublishCommitLogRequest {
+            group_id: group_id.clone(),
+            serialized_commit_log_entry: serialized,
+            signature: Some(RecoverableEd25519Signature {
+                bytes: signature,
+                public_key,
+            }),
+        }])
+        .await?;
+
+    let responses = alix
+        .context
+        .api()
+        .query_commit_log(vec![QueryCommitLogRequest {
+            group_id: group_id.clone(),
+            ..Default::default()
+        }])
+        .await?;
+
+    // A non-empty result means the round-trip landed on live node-go (v3); a
+    // client that routed commit-log to xmtpd would see the no-op and get nothing.
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].commit_log_entries.len(), 1);
+    let returned = PlaintextCommitLogEntry::decode(
+        responses[0].commit_log_entries[0]
+            .serialized_commit_log_entry
+            .as_slice(),
+    )?;
+    assert_eq!(returned.group_id, group_id);
+    assert_eq!(returned.commit_sequence_id, 1);
 }

--- a/sdks/js/browser-sdk/test/streams.test.ts
+++ b/sdks/js/browser-sdk/test/streams.test.ts
@@ -400,7 +400,9 @@ describe("createStream", () => {
         retryAttempts: 1,
       });
 
-      await vi.waitFor(() => expect(onFailSpy).toHaveBeenCalled(), { timeout: 10_000 });
+      await vi.waitFor(() => expect(onFailSpy).toHaveBeenCalled(), {
+        timeout: 10_000,
+      });
       await stream.end();
     });
 
@@ -425,10 +427,9 @@ describe("createStream", () => {
       });
 
       // onRetry should be called with (currentAttempt, maxAttempts)
-      await vi.waitFor(
-        () => expect(onRetrySpy).toHaveBeenCalledWith(1, 3),
-        { timeout: 10_000 },
-      );
+      await vi.waitFor(() => expect(onRetrySpy).toHaveBeenCalledWith(1, 3), {
+        timeout: 10_000,
+      });
       await stream.end();
     });
 
@@ -454,10 +455,9 @@ describe("createStream", () => {
         retryAttempts: 3,
       });
 
-      await vi.waitFor(
-        () => expect(onRestartSpy).toHaveBeenCalledTimes(1),
-        { timeout: 10_000 },
-      );
+      await vi.waitFor(() => expect(onRestartSpy).toHaveBeenCalledTimes(1), {
+        timeout: 10_000,
+      });
       await stream.end();
     });
 
@@ -625,7 +625,9 @@ describe("createStream", () => {
       });
 
       // onFail should be called when the stream fails via the onFail callback
-      await vi.waitFor(() => expect(onFailSpy).toHaveBeenCalled(), { timeout: 10_000 });
+      await vi.waitFor(() => expect(onFailSpy).toHaveBeenCalled(), {
+        timeout: 10_000,
+      });
       await stream.end();
     });
 
@@ -800,10 +802,9 @@ describe("createStream", () => {
         onValue: onValueSpy,
       });
 
-      await vi.waitFor(
-        () => expect(onValueSpy).toHaveBeenCalledWith("test"),
-        { timeout: 10_000 },
-      );
+      await vi.waitFor(() => expect(onValueSpy).toHaveBeenCalledWith("test"), {
+        timeout: 10_000,
+      });
       await stream.end();
     });
   });


### PR DESCRIPTION
## What

Fixes a latent correctness bug in the shipping `MigrationClient`: **commit-log (fork detection) silently dies the moment a client crosses the v3→d14n cutover.**

Commit-log is deliberately *not* part of d14n's network ordering — the plan keeps a centralized v3-shaped commit-log service running through and past the cutover ("basically keep that part of v3 running"). But `MigrationClient` routed `publish_commit_log` / `query_commit_log` through `choose_client`, so a migrated client's commit-log calls followed its reads/writes to xmtpd — where the commit-log methods are deliberate no-ops (`publish` drops, `query` returns empty). Fork detection would go dark at migration with no error.

## Fix

Route commit-log to the v3 client **unconditionally**, independent of cutover state — the one surface that must never follow the cutover. Also drop `write_with_refresh` for it: the retained service never emits the migration-rejection signal that reroutes writes to xmtpd.

```rust
async fn publish_commit_log(&self, request) -> Result<(), Self::Error> {
    self.v3_client.publish_commit_log(request).await   // was: choose_client()
}
async fn query_commit_log(&self, request) -> Result<..., Self::Error> {
    self.v3_client.query_commit_log(request).await     // was: choose_client()
}
```

## Tests

**Mock unit test** (`commit_log_stays_on_v3_after_migration`): with `has_migrated = true` (so every *other* call routes to xmtpd), both commit-log calls must still hit v3. The d14n mock is left bare, so a wrongly-routed call panics — verified this test **fails on the old routing** and passes on the fix.

**Live integration test** (`migration_client_commit_log_round_trips_through_v3`): drives a real publish→query commit-log round-trip through a **migrated** migration client against the local backend, and asserts the entry comes back. Registration and messaging go to xmtpd (migrated); commit-log must go to live node-go (v3). Had it wrongly followed the cutover, the publish would hit xmtpd's no-op and the query would return empty — so a non-empty round-trip *is* the proof the routing holds against a real backend. This is the live counterpart to the mock unit test; verified passing on the d14n backend.

The `ci-d14n` `not (test(/commit_log/))` exclusion is **narrowed** to let this one migration test run — it is the only commit-log test that is meaningful (and only compiles) on the d14n lane, since the pure d14n test client no-ops commit-log. The blanket exclusion for the rest of the commit-log suite stays.

## Scope

**Phase 2 of 3** (Phase 1: [#3888](https://github.com/xmtp/libxmtp/pull/3888), now merged). The live test uses the migration test harness from #3888 (`local_migration`, `MigrationXmtpClient`); this PR is rebased onto `main` now that #3888 has landed. Lifting the exclusion for the *full* commit-log suite through migration-backed clients remains a separate future change.

## Note: bundled formatting

This PR edits `.config/nextest.toml`, which makes the whole-tree `lint-config` (treefmt) job run — it's path-gated and had been skipped on the PRs that introduced two small pre-existing drifts. Both are folded in here so the check passes:
- `combined/test_client.rs` — a one-line rustfmt wrap (satisfies both `cargo fmt` and treefmt);
- `sdks/js/browser-sdk/test/streams.test.ts` — a prettier reflow (from #3891). treefmt's prettier is the JS SDKs' formatter of record, and `lint-js` runs eslint only, so this doesn't conflict with JS linting.

## Verification

- `xmtp_api_d14n` + `xmtp_mls` compile under `--features d14n`; clippy + fmt clean.
- Mock unit test passes (and fails on the pre-fix routing — not vacuous).
- Live test passes on the d14n backend.
- Confirmed the `ci-d14n` filter selects exactly one commit-log test (the migration one) and still excludes the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix commit-log routing to always use the retained v3 service after cutover in `MigrationClient`
> - `publish_commit_log` and `query_commit_log` in [`MigrationClient`](https://github.com/xmtp/libxmtp/pull/3889/files#diff-81eb95c7dae50c6e7081bce354acedcbfd70985a830f1cdd69661b5f764d5571) previously used dynamic client selection (`choose_client`/`write_with_refresh`); they now unconditionally route to the v3 client.
> - A new unit test (`commit_log_stays_on_v3_after_migration`) verifies that both methods call only the v3 mock when `has_migrated=true`.
> - A new integration test (`migration_client_commit_log_round_trips_through_v3`) in [`migration_tests.rs`](https://github.com/xmtp/libxmtp/pull/3889/files#diff-0c978bc1e6025087ff991e8abb25e7f4952581e6f35dfa7e2c7fa15b59170346) publishes and queries a signed `PlaintextCommitLogEntry` end-to-end through the v3 client.
> - The `ci-d14n` nextest profile in [`.config/nextest.toml`](https://github.com/xmtp/libxmtp/pull/3889/files#diff-3e429424057e0b2a83fafc6e8942f4c05b63f4d977548e51535f8d86be8f9613) is updated to exclude general commit-log tests but explicitly include the new round-trip integration test.
> - Behavioral Change: after migration cutover, commit-log traffic no longer fans out to the d14n client under any condition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82ec3e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->