### PR TITLE
test(xmtp_mls): run concurrent DM-invite streaming on native d14n

### DIFF
--- a/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -649,7 +649,9 @@ mod test {
     #[case::onehundred_dms(100)]
     #[xmtp_common::test]
     #[awt]
-    #[cfg_attr(all(feature = "d14n"), ignore)]
+    // Runs on native d14n (verified); still skipped on d14n+wasm, where 100
+    // concurrent streaming clients are impractical (matches the heavy group tests).
+    #[cfg_attr(all(feature = "d14n", target_arch = "wasm32"), ignore)]
     async fn test_many_concurrent_dm_invites(#[future] alix: ClientTester, #[case] dms: usize) {
         let alix_inbox_id = Arc::new(alix.inbox_id().to_string());
         let mut clients = vec![];


### PR DESCRIPTION
## What

Enables `test_many_concurrent_dm_invites` (concurrent DM-invite streaming, 5 and 100 clients) on the **native d14n** backend. It was ignored on *all* d14n via `#[cfg_attr(all(feature = "d14n"), ignore)]` with no rationale; the ignore is now narrowed to `d14n + wasm` (matching the heavy group tests), so native d14n gains the coverage.

Verified both cases pass on d14n, twice: 5-DM ~2s, 100-DM ~30s (against a 120s budget).

## Scope: this phase is deliberately small

**Phase 3 of 3** (Phase 1: [#3888](https://github.com/xmtp/libxmtp/pull/3888), Phase 2: [#3889](https://github.com/xmtp/libxmtp/pull/3889)). The original sketch was "port the streaming-internals test modules to d14n." Investigation showed that gap is mostly illusory, so I did **not** churn out low-value twins:

- **bidi is already twinned** — `bidi_tests` (v3 wire) ↔ `d14n_bidi_tests` (d14n wire); the two backends have distinct wire types, correctly separated.
- **`stream_router_tests` / `router_callbacks_tests` / `bidi_fuzz_tests`** drive **backend-agnostic** shared code (the transport ledger, router) through v3-shaped harnesses. `d14n_bidi_tests` already proves the d14n wire feeds that shared code, so twinning them would re-test the same logic through a differently-shaped harness — churn, not coverage.
- **Most heavy group/commit-log tests already run on native d14n** — they're ignored only on `d14n + wasm`, not native.
- The **one** test genuinely ignored on native d14n was `test_many_concurrent_dm_invites`, and it passes. That's this PR.

Separately noted (not addressed here): the `ci-d14n` `not (test(/commit_log/))` exclusion is *correct* as-is — the pure d14n test client no-ops commit-log, so those tests can only pass through a migration-backed client. Lifting it would build on the Phase 1 harness + Phase 2 routing fix, a coherent future PR.

## Verification

- Both cases pass on native d14n (verified twice); fmt clean; v3 behavior unchanged (the attr was inactive on v3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run `test_many_concurrent_dm_invites` on native targets with the `d14n` feature
> The test was previously skipped whenever the `d14n` feature was enabled, regardless of target. The `cfg` ignore attribute in [stream_conversations.rs](https://github.com/xmtp/libxmtp/pull/3890/files#diff-3c411407849c20e140c5378758ec78ce4372139f3d13778c5ad4617623f99922) is narrowed so the test only skips on `wasm32` with `d14n` enabled, allowing it to run on native targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c35c26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->