### PR TITLE
test(sdks/js): poll for convergence instead of pacing with fixed sleeps

### DIFF
--- a/sdks/js/browser-sdk/test/Conversations.test.ts
+++ b/sdks/js/browser-sdk/test/Conversations.test.ts
@@ -262,6 +262,11 @@ describe("Conversations", () => {
     await client1.conversations.createGroup([client2.inboxId!]);
     await client1.conversations.createDm(client3.inboxId!);
 
+    // Settle before subscribing: the fixed sleep lets the server index the
+    // creation-time fanout so the subscription cursor starts after it. This
+    // is a server-side race with no client-observable condition — do NOT
+    // replace with client syncs, which trigger worker activity that injects
+    // extra messages into the stream.
     await sleep(2000);
 
     const stream = await client1.conversations.streamAllMessages();
@@ -306,6 +311,11 @@ describe("Conversations", () => {
     await client1.conversations.createGroup([client3.inboxId!]);
     await client1.conversations.createDm(client4.inboxId!);
 
+    // Settle before subscribing: the fixed sleep lets the server index the
+    // creation-time fanout so the subscription cursor starts after it. This
+    // is a server-side race with no client-observable condition — do NOT
+    // replace with client syncs, which trigger worker activity that injects
+    // extra messages into the stream.
     await sleep(2000);
 
     const stream = await client1.conversations.streamAllGroupMessages();
@@ -357,6 +367,11 @@ describe("Conversations", () => {
     await client1.conversations.createGroup([client3.inboxId!]);
     await client1.conversations.createDm(client4.inboxId!);
 
+    // Settle before subscribing: the fixed sleep lets the server index the
+    // creation-time fanout so the subscription cursor starts after it. This
+    // is a server-side race with no client-observable condition — do NOT
+    // replace with client syncs, which trigger worker activity that injects
+    // extra messages into the stream.
     await sleep(2000);
 
     const stream = await client1.conversations.streamAllDmMessages();

--- a/sdks/js/browser-sdk/test/DeviceSync.test.ts
+++ b/sdks/js/browser-sdk/test/DeviceSync.test.ts
@@ -1,13 +1,15 @@
 import { ConsentEntityType, ConsentState } from "@xmtp/wasm-bindings";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { HistorySyncUrls } from "@/constants";
 import { uuid } from "@/utils/uuid";
-import {
-  createRegisteredClient,
-  createSigner,
-  sleep,
-  waitFor,
-} from "@test/helpers";
+import { createRegisteredClient, createSigner } from "@test/helpers";
+
+// Device sync hands work to background workers on both installations, so
+// cross-installation visibility converges rather than completing on any
+// single sync call. Poll (re-triggering the syncs) until the expected state
+// appears instead of pacing with fixed sleeps — a fixed sleep loses the race
+// on loaded CI runners.
+const WAIT = { timeout: 30_000, interval: 1000 };
 
 describe("DeviceSync", () => {
   it("should sync consent across installations", async () => {
@@ -32,23 +34,26 @@ describe("DeviceSync", () => {
       dbPath: `./test-${uuid()}.db3`,
     });
 
-    const state = await alix2.preferences.fetchInboxState();
-    expect(state.installations.length).toBe(2);
+    // the new installation's registration propagates asynchronously
+    await vi.waitFor(async () => {
+      const state = await alix2.preferences.fetchInboxState();
+      expect(state.installations.length).toBe(2);
+    }, WAIT);
 
     // sync the DM on alix so conversation is pushed
     await dm.sync();
-    await sleep(1000);
     await alix.conversations.syncAll();
-    await sleep(1000);
 
-    // alix2 syncs so it has the DM
-    await alix2.conversations.sync();
-    await sleep(1000);
+    // alix2 syncs until it has the DM; re-trigger the sender side too
+    const dm2 = await vi.waitFor(async () => {
+      await alix.conversations.syncAll();
+      await alix2.conversations.sync();
+      const c = await alix2.conversations.getConversationById(dm.id);
+      expect(c).toBeTruthy();
+      return c!;
+    }, WAIT);
 
-    const dm2Initial = await alix2.conversations.getConversationById(dm.id);
-    expect(dm2Initial).not.toBeNull();
-
-    const consentOnAlix2Before = await dm2Initial!.consentState();
+    const consentOnAlix2Before = await dm2.consentState();
     expect(
       consentOnAlix2Before === ConsentState.Unknown ||
         consentOnAlix2Before === ConsentState.Allowed,
@@ -60,32 +65,35 @@ describe("DeviceSync", () => {
     expect(consentState).toBe(ConsentState.Denied);
 
     await alix.preferences.sync();
-    await sleep(1000);
-    await alix2.preferences.sync();
-    await sleep(1000);
 
-    const dm2 = await alix2.conversations.getConversationById(dm.id);
-    expect(dm2).not.toBeNull();
-
-    const consentState2 = await dm2!.consentState();
-    expect(consentState2).toBe(ConsentState.Denied);
+    // The consent update is published into the device sync group once — if
+    // that happens before alix2 has joined, alix2 can never decrypt it.
+    // Re-issue the update on each attempt (after toggling, so the write is
+    // never a no-op) and re-sync both sides until it lands on alix2.
+    await vi.waitFor(async () => {
+      await dm.updateConsentState(ConsentState.Allowed);
+      await dm.updateConsentState(ConsentState.Denied);
+      await alix.preferences.sync();
+      await alix2.preferences.sync();
+      expect(await dm2.consentState()).toBe(ConsentState.Denied);
+    }, WAIT);
 
     // update consent back to allowed on alix2
     await alix2.preferences.setConsentStates([
       {
         entityType: ConsentEntityType.GroupId,
-        entity: dm2!.id,
+        entity: dm2.id,
         state: ConsentState.Allowed,
       },
     ]);
 
     const convoState = await alix2.preferences.getConsentState(
       ConsentEntityType.GroupId,
-      dm2!.id,
+      dm2.id,
     );
     expect(convoState).toBe(ConsentState.Allowed);
 
-    const updatedConsentState = await dm2!.consentState();
+    const updatedConsentState = await dm2.consentState();
     expect(updatedConsentState).toBe(ConsentState.Allowed);
   });
 
@@ -99,41 +107,26 @@ describe("DeviceSync", () => {
     const group = await alix.conversations.createGroup([bo.inboxId!]);
     const msgFromAlix = await group.sendText("hello from alix");
 
-    await sleep(1000);
-
     // create second installation for alix
     const alix2 = await createRegisteredClient(alixSigner, {
       dbPath: `./test-${uuid()}.db3`,
     });
 
-    await sleep(1000);
-
-    await alix.syncAllDeviceSyncGroups();
-    await alix.sendSyncArchive(
-      "123",
-      {
-        elements: [],
-        excludeDisappearingMessages: false,
-      },
-      HistorySyncUrls.local,
-    );
-    await sleep(1000);
-
     await bo.conversations.syncAll();
     const boGroup = await bo.conversations.getConversationById(group.id);
-    expect(boGroup).not.toBeNull();
+    expect(boGroup).toBeTruthy();
     await boGroup!.sendText("hello from bo");
 
-    await alix.conversations.syncAll();
-    await alix2.conversations.syncAll();
-
-    const group2Before = await alix2.conversations.getConversationById(
-      group.id,
-    );
-    expect(group2Before).not.toBeNull();
-
-    const messagesBefore = await group2Before!.messages();
-    expect(messagesBefore.length).toBe(2);
+    // bo's send commits alix2 into the group; poll until the welcome and
+    // the post-join messages land on alix2
+    await vi.waitFor(async () => {
+      await alix.conversations.syncAll();
+      await alix2.conversations.syncAll();
+      const c = await alix2.conversations.getConversationById(group.id);
+      expect(c).toBeTruthy();
+      const msgs = await c!.messages();
+      expect(msgs.length).toBe(2);
+    }, WAIT);
 
     // list available archives - may fail in some environments
     try {
@@ -143,28 +136,30 @@ describe("DeviceSync", () => {
       // listAvailableArchives may not be fully supported in all test environments
     }
 
-    // The archive payload propagates to alix2 over the network asynchronously,
-    // so a single device-sync pass can race ahead of delivery and leave
-    // processSyncArchive unable to find the payload (DeviceSyncError::MissingPayload).
-    // Re-sync the device-sync groups and retry until the pinned payload arrives.
-    await waitFor(
-      async () => {
-        await alix.syncAllDeviceSyncGroups();
-        await alix2.syncAllDeviceSyncGroups();
-        try {
-          await alix2.processSyncArchive("123");
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 30000, interval: 1000 },
-    );
-    await sleep(1000);
+    // The archive announcement is a one-shot message into the device sync
+    // group: if it goes out before alix2 has joined, alix2 can never decrypt
+    // it and no amount of later syncing recovers it. Re-send the archive on
+    // each attempt (fresh announcement into whatever sync groups now
+    // connect the two installations) and retry the import until the pinned
+    // payload arrives (processSyncArchive throws MissingPayload until then).
+    await vi.waitFor(async () => {
+      await alix.syncAllDeviceSyncGroups();
+      await alix.sendSyncArchive(
+        "123",
+        {
+          elements: [],
+          excludeDisappearingMessages: false,
+        },
+        HistorySyncUrls.local,
+      );
+      await alix2.syncAllDeviceSyncGroups();
+      await alix2.processSyncArchive("123");
+    }, WAIT);
+
     await alix2.conversations.syncAll();
 
     const group2After = await alix2.conversations.getConversationById(group.id);
-    expect(group2After).not.toBeNull();
+    expect(group2After).toBeTruthy();
 
     const messagesAfter = await group2After!.messages();
     // verify we received messages from the archive sync
@@ -198,8 +193,11 @@ describe("DeviceSync", () => {
       dbPath: `./test-${uuid()}.db3`,
     });
 
-    const state = await client2.preferences.fetchInboxState();
-    expect(state.installations.length).toBe(2);
+    // the new installation's registration propagates asynchronously
+    await vi.waitFor(async () => {
+      const state = await client2.preferences.fetchInboxState();
+      expect(state.installations.length).toBe(2);
+    }, WAIT);
 
     await client2.sendSyncRequest(
       {
@@ -209,27 +207,24 @@ describe("DeviceSync", () => {
       HistorySyncUrls.local,
     );
 
-    await client1.syncAllDeviceSyncGroups();
-    await sleep(1000);
-    await client2.syncAllDeviceSyncGroups();
-    await sleep(1000);
-
-    // sync conversations to get the group on client2
-    await client2.conversations.syncAll();
-    await sleep(1000);
+    // client1's worker answers the request with an archive; client2's worker
+    // imports it. Poll the whole round trip until the group and its messages
+    // materialize on client2.
+    const messagesOnClient2 = await vi.waitFor(async () => {
+      await client1.syncAllDeviceSyncGroups();
+      await client2.syncAllDeviceSyncGroups();
+      await client2.conversations.syncAll();
+      const c = await client2.conversations.getConversationById(group.id);
+      expect(c).toBeTruthy();
+      const msgs = await c!.messages();
+      expect(msgs.length).toBeGreaterThan(0);
+      return msgs;
+    }, WAIT);
 
     const client1MessageCount = (await group.messages()).length;
-    const group2 = await client2.conversations.getConversationById(group.id);
-    expect(group2).not.toBeNull();
-
-    const messagesOnClient2 = await group2!.messages();
     const containsMessage = messagesOnClient2.some((m) => m.id === msgId);
-    const client2MessageCount = messagesOnClient2.length;
 
-    // verify client2 has the group and some messages
-    expect(client2MessageCount).toBeGreaterThan(0);
-
-    if (client1MessageCount === client2MessageCount) {
+    if (client1MessageCount === messagesOnClient2.length) {
       expect(containsMessage).toBe(true);
     }
   });

--- a/sdks/js/browser-sdk/test/Dm.test.ts
+++ b/sdks/js/browser-sdk/test/Dm.test.ts
@@ -6,10 +6,15 @@ import {
   type GroupUpdated,
   type MessageDisappearingSettings,
 } from "@xmtp/wasm-bindings";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { DecodedMessage } from "@/DecodedMessage";
 import { metadataFieldName } from "@/utils/metadata";
 import { createRegisteredClient, createSigner, sleep } from "@test/helpers";
+
+// Background workers (self-remove, disappearing messages) complete
+// asynchronously; poll until the expected state appears instead of pacing
+// with fixed sleeps — a fixed sleep loses the race on loaded CI runners.
+const WAIT = { timeout: 30_000, interval: 1000 };
 
 describe("Dm", () => {
   it("should have a topic", async () => {
@@ -161,7 +166,11 @@ describe("Dm", () => {
     const client2 = await createRegisteredClient(signer2);
     const dm = await client1.conversations.createDm(client2.inboxId!);
 
-    // wait a second to exclude GroupUpdated message
+    // Settle before subscribing: the fixed sleep lets the server index the
+    // creation-time fanout so the subscription cursor starts after it. This
+    // is a server-side race with no client-observable condition — do NOT
+    // replace with client syncs, which trigger worker activity that injects
+    // extra messages into the stream.
     await sleep(1000);
 
     const streamedMessages: unknown[] = [];
@@ -249,11 +258,11 @@ describe("Dm", () => {
     });
     expect(await dm2.isMessageDisappearingEnabled()).toBe(true);
 
-    // wait for the messages to be deleted
-    await sleep(2000);
-
-    // verify that the messages are deleted
-    expect((await dm.messages()).length).toBe(1);
+    // poll until the disappearing-messages worker deletes the expired
+    // messages
+    await vi.waitFor(async () => {
+      expect((await dm.messages()).length).toBe(1);
+    }, WAIT);
 
     // verify that the messages are deleted on the other client
     expect((await dm2.messages()).length).toBe(1);

--- a/sdks/js/browser-sdk/test/Group.test.ts
+++ b/sdks/js/browser-sdk/test/Group.test.ts
@@ -12,7 +12,7 @@ import {
   type GroupUpdated,
   type MessageDisappearingSettings,
 } from "@xmtp/wasm-bindings";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { DecodedMessage } from "@/DecodedMessage";
 import {
   contentTypeGroupUpdated,
@@ -25,6 +25,11 @@ import {
   sleep,
   TestCodec,
 } from "@test/helpers";
+
+// Background workers (self-remove, disappearing messages) complete
+// asynchronously; poll until the expected state appears instead of pacing
+// with fixed sleeps — a fixed sleep loses the race on loaded CI runners.
+const WAIT = { timeout: 30_000, interval: 1000 };
 
 describe("Group", () => {
   it("should have a topic", async () => {
@@ -447,11 +452,14 @@ describe("Group", () => {
     await group.sync();
 
     // With event-driven self-remove, client1 (super-admin) processes the
-    // request via the worker, adding a removal GroupUpdated commit. Wait for it
-    // up front so message ordering and counts below are deterministic.
+    // request via the worker, adding a removal GroupUpdated commit. Wait for
+    // it up front (poll until the member is gone) so message ordering and
+    // counts below are deterministic.
     await client1.conversations.syncAll();
-    await sleep(4000);
-    await group.sync();
+    await vi.waitFor(async () => {
+      await group.sync();
+      expect((await group.members()).length).toBe(1);
+    }, WAIT);
 
     const textMessageId = await group.sendText("gm");
     await group.sendMarkdown("# gm");
@@ -800,11 +808,11 @@ describe("Group", () => {
     });
     expect(await group2.isMessageDisappearingEnabled()).toBe(true);
 
-    // wait for the messages to be deleted
-    await sleep(2000);
-
-    // verify that the messages are deleted
-    expect((await group.messages()).length).toBe(1);
+    // poll until the disappearing-messages worker deletes the expired
+    // messages
+    await vi.waitFor(async () => {
+      expect((await group.messages()).length).toBe(1);
+    }, WAIT);
 
     // verify that the messages are deleted on the other client
     expect((await group2.messages()).length).toBe(1);
@@ -1022,14 +1030,14 @@ describe("Group", () => {
 
     // messages and welcomes must be synced
     await client2.conversations.syncAll();
-    await client1.conversations.syncAll();
 
-    // wait for worker to process the removal request
-    await sleep(4000);
-
-    await group2.sync();
-
-    expect(await group2.isActive()).toBe(false);
+    // client1's worker processes the removal request; poll until the removal
+    // commit reaches client2
+    await vi.waitFor(async () => {
+      await client1.conversations.syncAll();
+      await group2.sync();
+      expect(await group2.isActive()).toBe(false);
+    }, WAIT);
     expect(await group2.isPendingRemoval()).toBe(true);
 
     expect(await group.members()).toHaveLength(1);

--- a/sdks/js/browser-sdk/test/Preferences.test.ts
+++ b/sdks/js/browser-sdk/test/Preferences.test.ts
@@ -1,17 +1,22 @@
 import {
   ConsentEntityType,
   ConsentState,
+  type Consent,
   type UserPreferenceUpdate,
 } from "@xmtp/wasm-bindings";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { uuid } from "@/utils/uuid";
 import {
   createClient,
   createRegisteredClient,
   createSigner,
-  sleep,
   waitFor,
 } from "@test/helpers";
+
+// Preference updates propagate through background sync-group workers;
+// poll until the expected state appears instead of pacing with fixed
+// sleeps — a fixed sleep loses the race on loaded CI runners.
+const WAIT = { timeout: 30_000, interval: 1000 };
 
 describe("Preferences", () => {
   it("should return the correct inbox state", async () => {
@@ -124,10 +129,19 @@ describe("Preferences", () => {
     const group = await client.conversations.createGroup([client2.inboxId!]);
     const stream = await client.preferences.streamConsent();
 
-    await sleep(1000);
-    await group.updateConsentState(ConsentState.Denied);
+    // Consume the stream in the background and wait for each update's batch
+    // to arrive before issuing the next update — batch boundaries stay
+    // deterministic without pacing on fixed sleeps.
+    const batches: Consent[][] = [];
+    const consumed = (async () => {
+      for await (const updates of stream) {
+        batches.push(updates);
+      }
+    })();
 
-    await sleep(1000);
+    await group.updateConsentState(ConsentState.Denied);
+    await vi.waitFor(() => expect(batches.length).toBe(1), WAIT);
+
     await client.preferences.setConsentStates([
       {
         entity: group.id,
@@ -135,8 +149,8 @@ describe("Preferences", () => {
         state: ConsentState.Allowed,
       },
     ]);
+    await vi.waitFor(() => expect(batches.length).toBe(2), WAIT);
 
-    await sleep(1000);
     await client.preferences.setConsentStates([
       {
         entity: group.id,
@@ -149,35 +163,26 @@ describe("Preferences", () => {
         state: ConsentState.Allowed,
       },
     ]);
+    await vi.waitFor(() => expect(batches.length).toBe(3), WAIT);
 
-    setTimeout(() => {
-      void stream.end();
-    }, 2000);
+    await stream.end();
+    await consumed;
 
-    let count = 0;
-    for await (const updates of stream) {
-      count++;
-      if (count === 1) {
-        expect(updates.length).toBe(1);
-        expect(updates[0].state).toBe(ConsentState.Denied);
-        expect(updates[0].entity).toBe(group.id);
-        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
-      } else if (count === 2) {
-        expect(updates.length).toBe(1);
-        expect(updates[0].state).toBe(ConsentState.Allowed);
-        expect(updates[0].entity).toBe(group.id);
-        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
-      } else if (count === 3) {
-        expect(updates.length).toBe(2);
-        expect(updates[0].state).toBe(ConsentState.Denied);
-        expect(updates[0].entity).toBe(group.id);
-        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
-        expect(updates[1].state).toBe(ConsentState.Allowed);
-        expect(updates[1].entity).toBe(client2.inboxId);
-        expect(updates[1].entityType).toBe(ConsentEntityType.InboxId);
-      }
-    }
-    expect(count).toBe(3);
+    expect(batches[0].length).toBe(1);
+    expect(batches[0][0].state).toBe(ConsentState.Denied);
+    expect(batches[0][0].entity).toBe(group.id);
+    expect(batches[0][0].entityType).toBe(ConsentEntityType.GroupId);
+    expect(batches[1].length).toBe(1);
+    expect(batches[1][0].state).toBe(ConsentState.Allowed);
+    expect(batches[1][0].entity).toBe(group.id);
+    expect(batches[1][0].entityType).toBe(ConsentEntityType.GroupId);
+    expect(batches[2].length).toBe(2);
+    expect(batches[2][0].state).toBe(ConsentState.Denied);
+    expect(batches[2][0].entity).toBe(group.id);
+    expect(batches[2][0].entityType).toBe(ConsentEntityType.GroupId);
+    expect(batches[2][1].state).toBe(ConsentState.Allowed);
+    expect(batches[2][1].entity).toBe(client2.inboxId);
+    expect(batches[2][1].entityType).toBe(ConsentEntityType.InboxId);
   });
 
   it("should stream preferences", async () => {

--- a/sdks/js/browser-sdk/test/streams.test.ts
+++ b/sdks/js/browser-sdk/test/streams.test.ts
@@ -213,10 +213,11 @@ describe("createStream", () => {
         onError: onErrorSpy,
       });
 
-      await sleep(50);
+      await vi.waitFor(
+        () => expect(onErrorSpy).toHaveBeenCalledWith(mutatorError),
+        { timeout: 10_000 },
+      );
       await stream.end();
-
-      expect(onErrorSpy).toHaveBeenCalledWith(mutatorError);
     });
 
     it("should call onError when async mutator rejects", async () => {
@@ -239,10 +240,11 @@ describe("createStream", () => {
         onError: onErrorSpy,
       });
 
-      await sleep(100);
+      await vi.waitFor(
+        () => expect(onErrorSpy).toHaveBeenCalledWith(mutatorError),
+        { timeout: 10_000 },
+      );
       await stream.end();
-
-      expect(onErrorSpy).toHaveBeenCalledWith(mutatorError);
     });
   });
 
@@ -262,10 +264,11 @@ describe("createStream", () => {
         onError: onErrorSpy,
       });
 
-      await sleep(50);
+      await vi.waitFor(
+        () => expect(onErrorSpy).toHaveBeenCalledWith(streamError),
+        { timeout: 10_000 },
+      );
       await stream.end();
-
-      expect(onErrorSpy).toHaveBeenCalledWith(streamError);
     });
 
     it("should throw StreamInvalidRetryAttemptsError when retryAttempts < 0 and retryOnFail is true", async () => {
@@ -352,7 +355,15 @@ describe("createStream", () => {
         retryAttempts: 1,
       });
 
-      await sleep(100);
+      await vi.waitFor(
+        () =>
+          expect(
+            onErrorSpy.mock.calls
+              .map((call) => call[0])
+              .some((e) => e instanceof StreamFailedError),
+          ).toBe(true),
+        { timeout: 10_000 },
+      );
       await stream.end();
 
       // Find the StreamFailedError
@@ -389,10 +400,8 @@ describe("createStream", () => {
         retryAttempts: 1,
       });
 
-      await sleep(100);
+      await vi.waitFor(() => expect(onFailSpy).toHaveBeenCalled(), { timeout: 10_000 });
       await stream.end();
-
-      expect(onFailSpy).toHaveBeenCalled();
     });
 
     it("should call onRetry when retrying", async () => {
@@ -415,11 +424,12 @@ describe("createStream", () => {
         retryAttempts: 3,
       });
 
-      await sleep(100);
-      await stream.end();
-
       // onRetry should be called with (currentAttempt, maxAttempts)
-      expect(onRetrySpy).toHaveBeenCalledWith(1, 3);
+      await vi.waitFor(
+        () => expect(onRetrySpy).toHaveBeenCalledWith(1, 3),
+        { timeout: 10_000 },
+      );
+      await stream.end();
     });
 
     it("should call onRestart when stream restarts successfully", async () => {
@@ -444,10 +454,11 @@ describe("createStream", () => {
         retryAttempts: 3,
       });
 
-      await sleep(100);
+      await vi.waitFor(
+        () => expect(onRestartSpy).toHaveBeenCalledTimes(1),
+        { timeout: 10_000 },
+      );
       await stream.end();
-
-      expect(onRestartSpy).toHaveBeenCalledTimes(1);
     });
 
     it("should fail after max retry attempts with StreamFailedError", async () => {
@@ -466,7 +477,15 @@ describe("createStream", () => {
         retryAttempts: 2,
       });
 
-      await sleep(200);
+      await vi.waitFor(
+        () =>
+          expect(
+            onErrorSpy.mock.calls
+              .map((call) => call[0])
+              .some((e) => e instanceof StreamFailedError),
+          ).toBe(true),
+        { timeout: 10_000 },
+      );
       await stream.end();
 
       // Should have received StreamFailedError at the end
@@ -539,10 +558,16 @@ describe("createStream", () => {
         retryAttempts: 3,
       });
 
-      await sleep(100);
+      // onRetry fires a retryDelay after onError — wait for both before
+      // ending the stream, or end() cancels the pending retry
+      await vi.waitFor(
+        () => {
+          expect(onErrorSpy).toHaveBeenCalledWith(new Error("Initial failure"));
+          expect(onRetrySpy).toHaveBeenCalled();
+        },
+        { timeout: 10_000 },
+      );
       await stream.end();
-
-      expect(onErrorSpy).toHaveBeenCalledWith(new Error("Initial failure"));
       expect(onRetrySpy).toHaveBeenCalled();
     });
 
@@ -599,11 +624,9 @@ describe("createStream", () => {
         retryAttempts: 3,
       });
 
-      await sleep(200);
-      await stream.end();
-
       // onFail should be called when the stream fails via the onFail callback
-      expect(onFailSpy).toHaveBeenCalled();
+      await vi.waitFor(() => expect(onFailSpy).toHaveBeenCalled(), { timeout: 10_000 });
+      await stream.end();
     });
 
     it("should call onEnd and streamCloser after successful retry", async () => {
@@ -630,7 +653,12 @@ describe("createStream", () => {
         retryAttempts: 3,
       });
 
-      await sleep(100);
+      // wait for the retry to succeed (second streamFunction call) so the
+      // stream closer exists before ending
+      await vi.waitFor(
+        () => expect(mockStreamFunction).toHaveBeenCalledTimes(2),
+        { timeout: 10_000 },
+      );
       await stream.end();
 
       expect(streamCloserSpy).toHaveBeenCalledTimes(1);
@@ -716,7 +744,15 @@ describe("createStream", () => {
         retryAttempts: 0,
       });
 
-      await sleep(100);
+      await vi.waitFor(
+        () =>
+          expect(
+            onErrorSpy.mock.calls
+              .map((call) => call[0])
+              .some((e) => e instanceof StreamFailedError),
+          ).toBe(true),
+        { timeout: 10_000 },
+      );
       await stream.end();
 
       // With 0 retry attempts, it should fail immediately
@@ -764,10 +800,11 @@ describe("createStream", () => {
         onValue: onValueSpy,
       });
 
-      await sleep(50);
+      await vi.waitFor(
+        () => expect(onValueSpy).toHaveBeenCalledWith("test"),
+        { timeout: 10_000 },
+      );
       await stream.end();
-
-      expect(onValueSpy).toHaveBeenCalledWith("test");
     });
   });
 });

--- a/sdks/js/node-sdk/test/Conversations.test.ts
+++ b/sdks/js/node-sdk/test/Conversations.test.ts
@@ -258,6 +258,11 @@ describe("Conversations", () => {
     await client1.conversations.createGroup([client2.inboxId]);
     await client1.conversations.createDm(client3.inboxId);
 
+    // Settle before subscribing: the fixed sleep lets the server index the
+    // creation-time fanout so the subscription cursor starts after it. This
+    // is a server-side race with no client-observable condition — do NOT
+    // replace with client syncs, which trigger worker activity that injects
+    // extra messages into the stream.
     await sleep(2000);
 
     const stream = await client1.conversations.streamAllMessages();
@@ -302,6 +307,11 @@ describe("Conversations", () => {
     await client1.conversations.createGroup([client3.inboxId]);
     await client1.conversations.createDm(client4.inboxId);
 
+    // Settle before subscribing: the fixed sleep lets the server index the
+    // creation-time fanout so the subscription cursor starts after it. This
+    // is a server-side race with no client-observable condition — do NOT
+    // replace with client syncs, which trigger worker activity that injects
+    // extra messages into the stream.
     await sleep(2000);
 
     const stream = await client1.conversations.streamAllGroupMessages();
@@ -353,6 +363,11 @@ describe("Conversations", () => {
     await client1.conversations.createGroup([client3.inboxId]);
     await client1.conversations.createDm(client4.inboxId);
 
+    // Settle before subscribing: the fixed sleep lets the server index the
+    // creation-time fanout so the subscription cursor starts after it. This
+    // is a server-side race with no client-observable condition — do NOT
+    // replace with client syncs, which trigger worker activity that injects
+    // extra messages into the stream.
     await sleep(2000);
 
     const stream = await client1.conversations.streamAllDmMessages();

--- a/sdks/js/node-sdk/test/DeviceSync.test.ts
+++ b/sdks/js/node-sdk/test/DeviceSync.test.ts
@@ -1,8 +1,15 @@
 import { ConsentEntityType, ConsentState } from "@xmtp/node-bindings";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { HistorySyncUrls } from "@/constants";
 import { uuid } from "@/utils/uuid";
-import { createRegisteredClient, createSigner, sleep } from "@test/helpers";
+import { createRegisteredClient, createSigner } from "@test/helpers";
+
+// Device sync hands work to background workers on both installations, so
+// cross-installation visibility converges rather than completing on any
+// single sync call. Poll (re-triggering the syncs) until the expected state
+// appears instead of pacing with fixed sleeps — a fixed sleep loses the race
+// on loaded CI runners.
+const WAIT = { timeout: 30_000, interval: 1000 };
 
 describe("DeviceSync", () => {
   it("should sync consent across installations", async () => {
@@ -28,23 +35,26 @@ describe("DeviceSync", () => {
       dbPath: `./test-${uuid()}.db3`,
     });
 
-    const state = await alix2.preferences.fetchInboxState();
-    expect(state.installations.length).toBe(2);
+    // the new installation's registration propagates asynchronously
+    await vi.waitFor(async () => {
+      const state = await alix2.preferences.fetchInboxState();
+      expect(state.installations.length).toBe(2);
+    }, WAIT);
 
     // sync the DM on alix so conversation is pushed
     await dm.sync();
-    await sleep(1000);
     await alix.conversations.syncAll();
-    await sleep(1000);
 
-    // alix2 syncs so it has the DM
-    await alix2.conversations.sync();
-    await sleep(1000);
+    // alix2 syncs until it has the DM; re-trigger the sender side too
+    const dm2 = await vi.waitFor(async () => {
+      await alix.conversations.syncAll();
+      await alix2.conversations.sync();
+      const c = await alix2.conversations.getConversationById(dm.id);
+      expect(c).toBeTruthy();
+      return c!;
+    }, WAIT);
 
-    const dm2Initial = await alix2.conversations.getConversationById(dm.id);
-    expect(dm2Initial).not.toBeNull();
-
-    const consentOnAlix2Before = dm2Initial!.consentState();
+    const consentOnAlix2Before = dm2.consentState();
     expect(
       consentOnAlix2Before === ConsentState.Unknown ||
         consentOnAlix2Before === ConsentState.Allowed,
@@ -55,33 +65,34 @@ describe("DeviceSync", () => {
     const consentState = dm.consentState();
     expect(consentState).toBe(ConsentState.Denied);
 
-    await alix.preferences.sync();
-    await sleep(1000);
-    await alix2.preferences.sync();
-    await sleep(1000);
-
-    const dm2 = await alix2.conversations.getConversationById(dm.id);
-    expect(dm2).not.toBeNull();
-
-    const consentState2 = dm2!.consentState();
-    expect(consentState2).toBe(ConsentState.Denied);
+    // The consent update is published into the device sync group once — if
+    // that happens before alix2 has joined, alix2 can never decrypt it.
+    // Re-issue the update on each attempt (after toggling, so the write is
+    // never a no-op) and re-sync both sides until it lands on alix2.
+    await vi.waitFor(async () => {
+      dm.updateConsentState(ConsentState.Allowed);
+      dm.updateConsentState(ConsentState.Denied);
+      await alix.preferences.sync();
+      await alix2.preferences.sync();
+      expect(dm2.consentState()).toBe(ConsentState.Denied);
+    }, WAIT);
 
     // update consent back to allowed on alix2
     await alix2.preferences.setConsentStates([
       {
         entityType: ConsentEntityType.GroupId,
-        entity: dm2!.id,
+        entity: dm2.id,
         state: ConsentState.Allowed,
       },
     ]);
 
     const convoState = await alix2.preferences.getConsentState(
       ConsentEntityType.GroupId,
-      dm2!.id,
+      dm2.id,
     );
     expect(convoState).toBe(ConsentState.Allowed);
 
-    const updatedConsentState = dm2!.consentState();
+    const updatedConsentState = dm2.consentState();
     expect(updatedConsentState).toBe(ConsentState.Allowed);
   });
 
@@ -96,57 +107,54 @@ describe("DeviceSync", () => {
     const group = await alix.conversations.createGroup([bo.inboxId]);
     const msgFromAlix = await group.sendText("hello from alix");
 
-    await sleep(1000);
-
     // create second installation for alix
     const alix2 = await createRegisteredClient(alixSigner, {
       dbPath: `./test-${uuid()}.db3`,
     });
 
-    await sleep(1000);
-
-    await alix.syncAllDeviceSyncGroups();
-    await alix.sendSyncArchive(
-      "123",
-      {
-        elements: [],
-        excludeDisappearingMessages: false,
-      },
-      HistorySyncUrls.local,
-    );
-    await sleep(1000);
-
     await bo.conversations.syncAll();
     const boGroup = await bo.conversations.getConversationById(group.id);
-    expect(boGroup).not.toBeNull();
+    expect(boGroup).toBeTruthy();
     await boGroup!.sendText("hello from bo");
 
-    await alix.conversations.syncAll();
-    await alix2.conversations.syncAll();
+    // bo's send commits alix2 into the group; poll until the welcome and
+    // the post-join messages land on alix2
+    const group2Before = await vi.waitFor(async () => {
+      await alix.conversations.syncAll();
+      await alix2.conversations.syncAll();
+      const c = await alix2.conversations.getConversationById(group.id);
+      expect(c).toBeTruthy();
+      const msgs = await c!.messages();
+      expect(msgs.length).toBe(2);
+      return c!;
+    }, WAIT);
 
-    const group2Before = await alix2.conversations.getConversationById(
-      group.id,
-    );
-    expect(group2Before).not.toBeNull();
+    // The archive announcement is a one-shot message into the device sync
+    // group: if it goes out before alix2 has joined, alix2 can never decrypt
+    // it and no amount of later syncing recovers it. Re-send the archive on
+    // each attempt (fresh announcement into whatever sync groups now
+    // connect the two installations) and retry the import until the pinned
+    // payload arrives (processSyncArchive throws MissingPayload until then).
+    await vi.waitFor(async () => {
+      await alix.syncAllDeviceSyncGroups();
+      await alix.sendSyncArchive(
+        "123",
+        {
+          elements: [],
+          excludeDisappearingMessages: false,
+        },
+        HistorySyncUrls.local,
+      );
+      await alix2.syncAllDeviceSyncGroups();
+      const archives = alix2.listAvailableArchives(7);
+      expect(archives).toBeDefined();
+      await alix2.processSyncArchive("123");
+    }, WAIT);
 
-    const messagesBefore = await group2Before!.messages();
-    expect(messagesBefore.length).toBe(2);
-
-    await sleep(1000);
-    await alix.syncAllDeviceSyncGroups();
-    await sleep(1000);
-    await alix2.syncAllDeviceSyncGroups();
-
-    // list available archives
-    const archives = alix2.listAvailableArchives(7);
-    expect(archives).toBeDefined();
-
-    await alix2.processSyncArchive("123");
-    await sleep(1000);
     await alix2.conversations.syncAll();
 
     const group2After = await alix2.conversations.getConversationById(group.id);
-    expect(group2After).not.toBeNull();
+    expect(group2After).toBeTruthy();
 
     const messagesAfter = await group2After!.messages();
     // verify we received messages from the archive sync
@@ -181,8 +189,11 @@ describe("DeviceSync", () => {
       dbPath: `./test-${uuid()}.db3`,
     });
 
-    const state = await client2.preferences.fetchInboxState();
-    expect(state.installations.length).toBe(2);
+    // the new installation's registration propagates asynchronously
+    await vi.waitFor(async () => {
+      const state = await client2.preferences.fetchInboxState();
+      expect(state.installations.length).toBe(2);
+    }, WAIT);
 
     await client2.sendSyncRequest(
       {
@@ -192,27 +203,24 @@ describe("DeviceSync", () => {
       HistorySyncUrls.local,
     );
 
-    await client1.syncAllDeviceSyncGroups();
-    await sleep(1000);
-    await client2.syncAllDeviceSyncGroups();
-    await sleep(1000);
-
-    // sync conversations to get the group on client2
-    await client2.conversations.syncAll();
-    await sleep(1000);
+    // client1's worker answers the request with an archive; client2's worker
+    // imports it. Poll the whole round trip until the group and its messages
+    // materialize on client2.
+    const messagesOnClient2 = await vi.waitFor(async () => {
+      await client1.syncAllDeviceSyncGroups();
+      await client2.syncAllDeviceSyncGroups();
+      await client2.conversations.syncAll();
+      const c = await client2.conversations.getConversationById(group.id);
+      expect(c).toBeTruthy();
+      const msgs = await c!.messages();
+      expect(msgs.length).toBeGreaterThan(0);
+      return msgs;
+    }, WAIT);
 
     const client1MessageCount = (await group.messages()).length;
-    const group2 = await client2.conversations.getConversationById(group.id);
-    expect(group2).not.toBeNull();
-
-    const messagesOnClient2 = await group2!.messages();
     const containsMessage = messagesOnClient2.some((m) => m.id === msgId);
-    const client2MessageCount = messagesOnClient2.length;
 
-    // verify client2 has the group and some messages
-    expect(client2MessageCount).toBeGreaterThan(0);
-
-    if (client1MessageCount === client2MessageCount) {
+    if (client1MessageCount === messagesOnClient2.length) {
       expect(containsMessage).toBe(true);
     }
   });

--- a/sdks/js/node-sdk/test/Dm.test.ts
+++ b/sdks/js/node-sdk/test/Dm.test.ts
@@ -7,9 +7,14 @@ import {
   type GroupUpdated,
   type MessageDisappearingSettings,
 } from "@xmtp/node-bindings";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { DecodedMessage } from "@/DecodedMessage";
 import { createRegisteredClient, createSigner, sleep } from "@test/helpers";
+
+// Background workers (self-remove, disappearing messages) complete
+// asynchronously; poll until the expected state appears instead of pacing
+// with fixed sleeps — a fixed sleep loses the race on loaded CI runners.
+const WAIT = { timeout: 30_000, interval: 1000 };
 
 describe("Dm", () => {
   it("should have a topic", async () => {
@@ -162,7 +167,11 @@ describe("Dm", () => {
     const client2 = await createRegisteredClient(signer2);
     const dm = await client1.conversations.createDm(client2.inboxId);
 
-    // wait a second to exclude GroupUpdated message
+    // Settle before subscribing: the fixed sleep lets the server index the
+    // creation-time fanout so the subscription cursor starts after it. This
+    // is a server-side race with no client-observable condition — do NOT
+    // replace with client syncs, which trigger worker activity that injects
+    // extra messages into the stream.
     await sleep(1000);
 
     const streamedMessages: unknown[] = [];
@@ -250,11 +259,11 @@ describe("Dm", () => {
     });
     expect(dm2.isMessageDisappearingEnabled()).toBe(true);
 
-    // wait for the messages to be deleted
-    await sleep(2000);
-
-    // verify that the messages are deleted
-    expect((await dm.messages()).length).toBe(1);
+    // poll until the disappearing-messages worker deletes the expired
+    // messages
+    await vi.waitFor(async () => {
+      expect((await dm.messages()).length).toBe(1);
+    }, WAIT);
 
     // verify that the messages are deleted on the other client
     expect((await dm2.messages()).length).toBe(1);

--- a/sdks/js/node-sdk/test/Group.test.ts
+++ b/sdks/js/node-sdk/test/Group.test.ts
@@ -15,7 +15,7 @@ import {
   type GroupUpdated,
   type MessageDisappearingSettings,
 } from "@xmtp/node-bindings";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { DecodedMessage } from "@/DecodedMessage";
 import {
   createRegisteredClient,
@@ -23,6 +23,11 @@ import {
   sleep,
   TestCodec,
 } from "@test/helpers";
+
+// Background workers (self-remove, disappearing messages) complete
+// asynchronously; poll until the expected state appears instead of pacing
+// with fixed sleeps — a fixed sleep loses the race on loaded CI runners.
+const WAIT = { timeout: 30_000, interval: 1000 };
 
 describe("Group", () => {
   it("should have a topic", async () => {
@@ -397,11 +402,14 @@ describe("Group", () => {
     await group.sync();
 
     // With event-driven self-remove, client1 (super-admin) processes the
-    // request via the worker, adding a removal GroupUpdated commit. Wait for it
-    // up front so message ordering and counts below are deterministic.
+    // request via the worker, adding a removal GroupUpdated commit. Wait for
+    // it up front (poll until the member is gone) so message ordering and
+    // counts below are deterministic.
     await client1.conversations.syncAll();
-    await sleep(4000);
-    await group.sync();
+    await vi.waitFor(async () => {
+      await group.sync();
+      expect((await group.members()).length).toBe(1);
+    }, WAIT);
 
     const textMessageId = await group.sendText("gm");
     await group.sendMarkdown("# gm");
@@ -791,11 +799,11 @@ describe("Group", () => {
     });
     expect(group2.isMessageDisappearingEnabled()).toBe(true);
 
-    // wait for the messages to be deleted
-    await sleep(2000);
-
-    // verify that the messages are deleted
-    expect((await group.messages()).length).toBe(1);
+    // poll until the disappearing-messages worker deletes the expired
+    // messages
+    await vi.waitFor(async () => {
+      expect((await group.messages()).length).toBe(1);
+    }, WAIT);
 
     // verify that the messages are deleted on the other client
     expect((await group2.messages()).length).toBe(1);
@@ -1011,14 +1019,14 @@ describe("Group", () => {
 
     // messages and welcomes must be synced
     await client2.conversations.syncAll();
-    await client1.conversations.syncAll();
 
-    // wait for worker to process the removal request
-    await sleep(4000);
-
-    await group2.sync();
-
-    expect(group2.isActive).toBe(false);
+    // client1's worker processes the removal request; poll until the removal
+    // commit reaches client2
+    await vi.waitFor(async () => {
+      await client1.conversations.syncAll();
+      await group2.sync();
+      expect(group2.isActive).toBe(false);
+    }, WAIT);
     expect(group2.isPendingRemoval()).toBe(true);
 
     expect(await group.members()).toHaveLength(1);

--- a/sdks/js/node-sdk/test/Preferences.test.ts
+++ b/sdks/js/node-sdk/test/Preferences.test.ts
@@ -1,9 +1,10 @@
 import {
   ConsentEntityType,
   ConsentState,
+  type Consent,
   type UserPreferenceUpdate,
 } from "@xmtp/node-bindings";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { uuid } from "@/utils/uuid";
 import {
   createClient,
@@ -11,6 +12,11 @@ import {
   createSigner,
   sleep,
 } from "@test/helpers";
+
+// Preference updates propagate through background sync-group workers;
+// poll until the expected state appears instead of pacing with fixed
+// sleeps — a fixed sleep loses the race on loaded CI runners.
+const WAIT = { timeout: 30_000, interval: 1000 };
 
 describe("Preferences", () => {
   it("should return the correct inbox state", async () => {
@@ -117,10 +123,19 @@ describe("Preferences", () => {
     const group = await client.conversations.createGroup([client2.inboxId]);
     const stream = await client.preferences.streamConsent();
 
-    await sleep(1000);
-    group.updateConsentState(ConsentState.Denied);
+    // Consume the stream in the background and wait for each update's batch
+    // to arrive before issuing the next update — batch boundaries stay
+    // deterministic without pacing on fixed sleeps.
+    const batches: Consent[][] = [];
+    const consumed = (async () => {
+      for await (const updates of stream) {
+        batches.push(updates);
+      }
+    })();
 
-    await sleep(1000);
+    group.updateConsentState(ConsentState.Denied);
+    await vi.waitFor(() => expect(batches.length).toBe(1), WAIT);
+
     await client.preferences.setConsentStates([
       {
         entity: group.id,
@@ -128,8 +143,8 @@ describe("Preferences", () => {
         state: ConsentState.Allowed,
       },
     ]);
+    await vi.waitFor(() => expect(batches.length).toBe(2), WAIT);
 
-    await sleep(1000);
     await client.preferences.setConsentStates([
       {
         entity: group.id,
@@ -142,35 +157,26 @@ describe("Preferences", () => {
         state: ConsentState.Allowed,
       },
     ]);
+    await vi.waitFor(() => expect(batches.length).toBe(3), WAIT);
 
-    setTimeout(() => {
-      void stream.end();
-    }, 2000);
+    await stream.end();
+    await consumed;
 
-    let count = 0;
-    for await (const updates of stream) {
-      count++;
-      if (count === 1) {
-        expect(updates.length).toBe(1);
-        expect(updates[0].state).toBe(ConsentState.Denied);
-        expect(updates[0].entity).toBe(group.id);
-        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
-      } else if (count === 2) {
-        expect(updates.length).toBe(1);
-        expect(updates[0].state).toBe(ConsentState.Allowed);
-        expect(updates[0].entity).toBe(group.id);
-        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
-      } else if (count === 3) {
-        expect(updates.length).toBe(2);
-        expect(updates[0].state).toBe(ConsentState.Denied);
-        expect(updates[0].entity).toBe(group.id);
-        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
-        expect(updates[1].state).toBe(ConsentState.Allowed);
-        expect(updates[1].entity).toBe(client2.inboxId);
-        expect(updates[1].entityType).toBe(ConsentEntityType.InboxId);
-      }
-    }
-    expect(count).toBe(3);
+    expect(batches[0].length).toBe(1);
+    expect(batches[0][0].state).toBe(ConsentState.Denied);
+    expect(batches[0][0].entity).toBe(group.id);
+    expect(batches[0][0].entityType).toBe(ConsentEntityType.GroupId);
+    expect(batches[1].length).toBe(1);
+    expect(batches[1][0].state).toBe(ConsentState.Allowed);
+    expect(batches[1][0].entity).toBe(group.id);
+    expect(batches[1][0].entityType).toBe(ConsentEntityType.GroupId);
+    expect(batches[2].length).toBe(2);
+    expect(batches[2][0].state).toBe(ConsentState.Denied);
+    expect(batches[2][0].entity).toBe(group.id);
+    expect(batches[2][0].entityType).toBe(ConsentEntityType.GroupId);
+    expect(batches[2][1].state).toBe(ConsentState.Allowed);
+    expect(batches[2][1].entity).toBe(client2.inboxId);
+    expect(batches[2][1].entityType).toBe(ConsentEntityType.InboxId);
   });
 
   it("should stream preferences", async () => {
@@ -198,6 +204,9 @@ describe("Preferences", () => {
       dbPath: `./test-${uuid()}.db3`,
     });
 
+    // This test's exact-count assertion depends on the precise sync cadence
+    // below: fewer cycles under-deliver, extra cycles make the workers emit
+    // additional preference updates. Keep the original fixed pacing.
     await client3.conversations.syncAll();
     await sleep(1000);
     await client1.conversations.syncAll();


### PR DESCRIPTION
The JS SDK tests paced cross-installation and background-worker convergence with bare `sleep()` calls — sync, nap a second, assert. On loaded CI runners the fixed nap loses the race: `DeviceSync.test.ts`'s request round-trip failed three consecutive CI runs on #3872 this way (and identically on an unrelated two-file PR), while passing locally solo and as the full shard. This PR replaces every race-guard sleep across both SDKs with `vi.waitFor` polls that re-trigger the relevant syncs until the expected state appears, and keeps the sleeps that are genuinely semantic.

## Converted (node-sdk + browser-sdk)

- **DeviceSync** — full rewrite. Every cross-installation wait polls the whole round trip (re-triggering both sides' syncs), including the CI-failing `sendSyncRequest` test.
- **Group** — the two 4-second "wait for the self-removal worker" naps poll for the observable outcome instead (member gone / `isActive` false); the disappearing-messages wait polls for the deletion.
- **Dm** — disappearing-messages wait polls for the deletion.
- **Preferences** — `streamConsent` now consumes the stream in the background and waits for each batch before issuing the next update: batch boundaries become deterministic instead of timing-shaped.
- **streams.test.ts** (browser) — 13 fixed naps before spy assertions become `vi.waitFor` on the assertion itself.

## Latent bugs the sleeps were hiding

- `expect(x).not.toBeNull()` **passes when `x` is `undefined`** — which is why the CI failure surfaced as a confusing `TypeError: Cannot read properties of undefined` two lines later instead of a clean assertion. The polls assert `toBeTruthy()`.
- Device-sync **archive announcements and consent updates are one-shot messages** into the sync group: sent before the second installation has joined, they are undecryptable for it forever, and no amount of later syncing recovers them. The fixed sleeps only ever papered over this join race. The tests now re-issue the send inside the retry loop (`sendSyncArchive` re-sent per attempt; the consent update re-toggled per attempt), which converges deterministically.
- The new-installation `fetchInboxState().installations.length` check raced registration propagation with no wait at all; it polls now.

## Deliberately kept as sleeps

- `sleep(10)` timestamp separators between sends (they create time gaps, not waits).
- The `retryDelay` elapsed-time measurement in streams.test.ts (the sleep is the measurement window).
- Pre-subscription settling sleeps in `Conversations`/`Dm` stream tests: they cover a **server-side** indexing race with no client-observable condition. Replacing them with client syncs triggers worker activity that injects extra messages into the streams (verified: it breaks the message-identity assertions), so a poll is the wrong tool there.
- `streamPreferences`' fixed sync cadence: its exact-count assertion depends on the cadence (fewer cycles under-deliver, extra cycles make the workers emit more updates).

## Verification

- node-sdk suite: **183/183, three consecutive full runs** against the local backend; the rewritten DeviceSync file additionally 5/5 in isolation.
- `yarn lint` (type-aware, both SDKs): clean — the one warning is pre-existing in `browser-sdk/src/index.ts`.
- browser-sdk changes mirror the node semantics exactly; CI's playwright lanes validate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace fixed sleeps with `vi.waitFor` polling in JS SDK tests
> - Replaces fixed-duration `sleep` calls in browser and node SDK tests with `vi.waitFor` polling loops that repeatedly trigger sync operations until expected states are observed.
> - Affected test areas include device sync, group membership, disappearing messages, consent preferences, and stream callbacks across both [browser-sdk](https://github.com/xmtp/libxmtp/pull/3891/files#diff-10ac94463881f9278b205ab4313a5a45f325e97ae3bae684d7ef010d7542f0a7) and [node-sdk](https://github.com/xmtp/libxmtp/pull/3891/files#diff-63649a3cff28b3ce6ff145d040935d14b5057e2804795bea5cab334878b69c74) test suites.
> - Some tests also re-trigger operations (e.g. re-sending device archives, toggling consent) within the polling loop to drive convergence rather than waiting passively.
> - A small number of existing sleeps before stream subscriptions are intentionally preserved with explanatory comments to avoid race conditions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 831450d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->