### PR TITLE
fix: crash on welcome stream after group creator leaves and is re-added

### DIFF
--- a/bindings/mobile/src/mls/tests/test_self_removal.rs
+++ b/bindings/mobile/src/mls/tests/test_self_removal.rs
@@ -233,7 +233,10 @@ async fn test_creator_leave_and_readd_does_not_abort_welcome_stream() {
     // admin to Bo, then drop Alix's own super admin, so the creator is allowed to
     // leave (and so Bo can drive the removal and re-add).
     alix_group.add_super_admin(bo.inbox_id()).await.unwrap();
-    alix_group.remove_super_admin(alix.inbox_id()).await.unwrap();
+    alix_group
+        .remove_super_admin(alix.inbox_id())
+        .await
+        .unwrap();
     alix_group.sync().await.unwrap();
     bo_group.sync().await.unwrap();
 

--- a/bindings/mobile/src/mls/tests/test_self_removal.rs
+++ b/bindings/mobile/src/mls/tests/test_self_removal.rs
@@ -188,6 +188,118 @@ async fn test_membership_state_after_readd() {
     );
 }
 
+/// Regression test for the `group_cursors` startup abort
+/// (`if seq is not null, originator must not be null`).
+///
+/// Unlike the tests above (where the *non-creator* Bo leaves and is re-added),
+/// here the group's **creator** leaves and is re-added. That is the only case
+/// that reproduces the crash: the creator's local group row is *cursorless*
+/// (`sequence_id = NULL, originator_id = NULL`, since a created group never
+/// processes a welcome for itself), whereas a joined group carries an
+/// originator from its first welcome. When the creator is re-welcomed,
+/// `insert_or_replace_group`'s "group already exists" branch writes only
+/// `sequence_id`, leaving `originator_id` NULL — and the next welcome-stream
+/// startup reads that row via `group_cursors()` and aborts (SIGABRT on device).
+///
+/// To see the crash, DISABLE the fix (both parts) in
+/// `crates/xmtp_db/src/encrypted_store/group.rs`:
+///   1. `insert_or_replace_group` update branch: set `sequence_id` only
+///      (remove the co-set of `originator_id`), and
+///   2. `group_cursors`: restore the `orig.expect(...)` (remove the `filter_map`).
+/// With the fix disabled this test panics with
+/// `if seq is not null, originator must not be null`; with the fix it passes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_creator_leave_and_readd_does_not_abort_welcome_stream() {
+    use xmtp_db::prelude::QueryGroup;
+
+    let alix = new_test_client().await;
+    let bo = new_test_client().await;
+
+    // Alix CREATES a group with Bo. Alix's local row for this group is cursorless.
+    let alix_group = alix
+        .conversations()
+        .create_group_by_identity(
+            vec![bo.account_identifier.clone()],
+            FfiCreateGroupOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    // Bo syncs and gets the group.
+    bo.conversations().sync().await.unwrap();
+    let bo_group = bo.conversation(alix_group.id()).unwrap();
+
+    // The creator is a super admin, and a super admin cannot leave. Hand super
+    // admin to Bo, then drop Alix's own super admin, so the creator is allowed to
+    // leave (and so Bo can drive the removal and re-add).
+    alix_group.add_super_admin(bo.inbox_id()).await.unwrap();
+    alix_group.remove_super_admin(alix.inbox_id()).await.unwrap();
+    alix_group.sync().await.unwrap();
+    bo_group.sync().await.unwrap();
+
+    // Alix (now a regular member) leaves the group.
+    alix_group.leave_group().await.unwrap();
+    assert_eq!(
+        alix_group.membership_state().unwrap(),
+        FfiGroupMembershipState::PendingRemove
+    );
+
+    // Drive the event-driven removal: Bo (super admin) publishes the removal
+    // commit via his TaskRunner; Alix syncs it down. Poll until Alix is removed.
+    alix_group.sync().await.unwrap();
+    let mut removed = false;
+    for _ in 0..20 {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        bo_group.sync().await.ok();
+        alix_group.sync().await.ok();
+        if !alix_group.is_active().unwrap() {
+            removed = true;
+            break;
+        }
+    }
+    assert!(removed, "creator should be removed after leaving");
+
+    // Bo re-adds Alix. This delivers a welcome for a group Alix already has
+    // locally as a cursorless row.
+    bo_group
+        .add_members_by_identity(vec![alix.account_identifier.clone()])
+        .await
+        .unwrap();
+    bo_group.sync().await.unwrap();
+
+    // Alix processes the re-add welcome. This is the corrupting write: the
+    // "group already exists" branch sets sequence_id but (pre-fix) leaves
+    // originator_id NULL. (sync_welcomes does not read group_cursors, so this
+    // step itself does not crash.)
+    alix.conversations().sync().await.unwrap();
+
+    // "Stream welcomes": on startup the conversation/welcome stream builds its
+    // known-welcome set via `group_cursors()` (see
+    // `subscriptions::stream_conversations` -> `group_cursors`). Invoke that exact
+    // call here. With the fix disabled it aborts on the corrupted row; with the
+    // fix it returns the healed cursor. We assert it directly because on device
+    // the abort happens on the stream's background task, which a unit test can't
+    // deterministically observe.
+    let cursors = alix
+        .inner_client
+        .context
+        .db()
+        .group_cursors()
+        .expect("welcome-stream startup (group_cursors) must not abort after creator re-add");
+    assert_eq!(
+        cursors.len(),
+        1,
+        "the re-added creator group should yield exactly one welcome cursor"
+    );
+
+    // And end-to-end: actually start the conversation/welcome stream, which is
+    // what runs `group_cursors()` at setup on a real client. Reached only when the
+    // fix is present (pre-fix the assertion above already panicked).
+    let stream_callback = Arc::new(RustStreamCallback::default());
+    let stream = alix.conversations().stream(stream_callback.clone()).await;
+    stream.end_and_wait().await.unwrap();
+}
+
 /// Test that leave request messages are visible and properly decoded.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_leave_request_message_is_visible() {

--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -934,12 +934,24 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                     && (existing_group.sequence_id.is_none()
                         || group.sequence_id > existing_group.sequence_id)
                 {
+                    // Co-set `originator_id` alongside `sequence_id`. The incoming
+                    // (welcome-built) group already carries the correct originator
+                    // (e.g. `Originators::WELCOME_MESSAGES` via `Cursor::v3_welcomes`),
+                    // and the builder invariant guarantees that whenever
+                    // `sequence_id.is_some()` the `originator_id` is also set. Writing
+                    // only `sequence_id` here (the previous behavior) could leave a row
+                    // in the invalid `(sequence_id = NOT NULL, originator_id = NULL)`
+                    // state, which later aborts `group_cursors()`.
                     self.raw_query(|c| {
                         diesel::update(dsl::groups.find(&group.id))
-                            .set(dsl::sequence_id.eq(group.sequence_id))
+                            .set((
+                                dsl::sequence_id.eq(group.sequence_id),
+                                dsl::originator_id.eq(group.originator_id),
+                            ))
                             .execute(c)
                     })?;
                     existing_group.sequence_id = group.sequence_id;
+                    existing_group.originator_id = group.originator_id;
                 }
                 Ok(existing_group)
             }
@@ -956,11 +968,25 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                 .select((dsl::sequence_id, dsl::originator_id))
                 .load::<(Option<i64>, Option<i64>)>(conn)?
                 .into_iter()
-                .map(|(seq, orig)| {
-                    Cursor::new(
-                        seq.expect("Filtered for not null") as u64,
-                        orig.expect("if seq is not null, originator must not be null") as u32,
-                    )
+                .filter_map(|(seq, orig)| match (seq, orig) {
+                    (Some(seq), Some(orig)) => Some(Cursor::new(seq as u64, orig as u32)),
+                    // Defense in depth: a row with a `sequence_id` but a NULL
+                    // `originator_id` violates the builder invariant and previously
+                    // aborted the whole conversation stream on startup (bricking the
+                    // app until local data was wiped). Skip such a row and warn rather
+                    // than crash, so a single half-populated cursor can't take the
+                    // client down. The write-path fix above prevents new rows from
+                    // reaching this state; a heal migration backfills existing ones.
+                    (Some(seq), None) => {
+                        tracing::warn!(
+                            sequence_id = seq,
+                            "group row has sequence_id but NULL originator_id; skipping cursor"
+                        );
+                        None
+                    }
+                    // `sequence_id.is_not_null()` filters these out at the SQL layer;
+                    // handled here only for exhaustiveness.
+                    (None, _) => None,
                 })
                 .collect())
         })
@@ -1717,6 +1743,82 @@ pub(crate) mod tests {
                     .map(|c| c.sequence_id)
                     .collect::<Vec<u64>>()
             );
+        })
+    }
+
+    /// Regression test for the `group_cursors` abort
+    /// (`if seq is not null, originator must not be null`).
+    ///
+    /// A group can legitimately exist locally with no cursor (the creator /
+    /// local-create path stores `sequence_id = NULL, originator_id = NULL`). When a
+    /// welcome for that same, already-existing group is later processed,
+    /// `insert_or_replace_group` takes its "group already exists" update branch. That
+    /// update must co-set `originator_id` with `sequence_id`; otherwise the row lands
+    /// in the invalid `(sequence_id = NOT NULL, originator_id = NULL)` state that
+    /// aborts `group_cursors()` on the next conversation-stream startup.
+    #[xmtp_common::test]
+    fn test_insert_or_replace_group_update_preserves_originator() {
+        with_connection(|conn| {
+            // 1. Cursorless group created locally (both fields NULL — valid).
+            let group = generate_group(None);
+            assert!(group.sequence_id.is_none());
+            assert!(group.originator_id.is_none());
+            group.store(conn).unwrap();
+
+            // 2. A welcome for the same group arrives carrying a real v3 welcome
+            //    cursor (seq set, originator = WELCOME_MESSAGES = 11).
+            let incoming = StoredGroup {
+                sequence_id: Some(5),
+                originator_id: Some(Originators::WELCOME_MESSAGES as i64),
+                ..group.clone()
+            };
+            conn.insert_or_replace_group(incoming).unwrap();
+
+            // 3. The stored row must keep the invariant: seq set => originator set.
+            let stored: StoredGroup = conn.fetch(&group.id).ok().flatten().unwrap();
+            assert_eq!(stored.sequence_id, Some(5));
+            assert_eq!(
+                stored.originator_id,
+                Some(Originators::WELCOME_MESSAGES as i64),
+                "update path must co-set originator_id with sequence_id"
+            );
+
+            // 4. group_cursors() (run on conversation-stream startup) must not abort.
+            let cursors = conn.group_cursors().unwrap();
+            assert_eq!(cursors.len(), 1);
+            assert_eq!(cursors[0].sequence_id, 5);
+            assert_eq!(cursors[0].originator_id, Originators::WELCOME_MESSAGES);
+        })
+    }
+
+    /// Defense in depth: even if a legacy / half-populated row already exists with
+    /// `sequence_id` set but `originator_id` NULL (users may be in this state in the
+    /// wild since the originator-id migration), `group_cursors()` must not abort the
+    /// stream. It should skip the bad row instead of `.expect()`-panicking.
+    #[xmtp_common::test]
+    fn test_group_cursors_skips_row_with_null_originator() {
+        with_connection(|conn| {
+            // A healthy cursor'd group.
+            let good = generate_group_with_welcome(None, Some(30));
+            good.store(conn).unwrap();
+
+            // A cursorless group, then force the invalid state directly via a raw
+            // UPDATE that sets sequence_id only (mimicking the pre-fix write path and
+            // legacy data). Deliberately bypasses the builder invariant.
+            let bad = generate_group(None);
+            bad.store(conn).unwrap();
+            conn.raw_query(|c| {
+                diesel::update(dsl::groups.find(&bad.id))
+                    .set(dsl::sequence_id.eq(Some(7i64)))
+                    .execute(c)
+            })
+            .unwrap();
+
+            // Must not panic; the bad row is skipped, the good one is returned.
+            let cursors = conn.group_cursors().unwrap();
+            assert_eq!(cursors.len(), 1);
+            assert_eq!(cursors[0].sequence_id, 30);
+            assert_eq!(cursors[0].originator_id, Originators::WELCOME_MESSAGES);
         })
     }
 


### PR DESCRIPTION
Notice before the second commit, our new test would have the following error which re-produced as a crash on android and iOS when a group creator re-joined a group after leaving and then streamed welcomes:

```
'mls::tests::test_self_removal::test_creator_leave_and_readd_does_not_abort_welcome_stream' (68653) panicked at crates/xmtp_db/src/encrypted_store/group.rs:962:30:
>     if seq is not null, originator must not be null
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix crash in `group_cursors()` when group creator leaves and is re-added
> - When updating an existing group with a newer welcome, `insert_or_replace_group` now writes `originator_id` alongside `sequence_id`, preventing rows where `sequence_id` is set but `originator_id` is NULL.
> - `group_cursors()` no longer panics on such rows; it skips them with a warning log instead of calling `expect()` on a missing value.
> - Two regression tests are added: one verifying `originator_id` is persisted on update, and one confirming `group_cursors()` skips NULL-originator rows without panicking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04ba332.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->