### PR TITLE
test(sdks/js): fix two residual delivery races in the JS test poll conversions

### DIFF
--- a/sdks/js/browser-sdk/test/DeviceSync.test.ts
+++ b/sdks/js/browser-sdk/test/DeviceSync.test.ts
@@ -11,6 +11,12 @@ import { createRegisteredClient, createSigner } from "@test/helpers";
 // on loaded CI runners.
 const WAIT = { timeout: 30_000, interval: 1000 };
 
+// The request→archive→import round trip crosses two background-worker hops
+// (one worker builds and uploads the archive, the other downloads and
+// imports it), so give it a much larger budget than the single-hop waits
+// and pace the retries so the workers aren't flooded with requests.
+const ROUND_TRIP_WAIT = { timeout: 90_000, interval: 3000 };
+
 describe("DeviceSync", () => {
   it("should sync consent across installations", async () => {
     const { signer: boSigner } = createSigner();
@@ -199,18 +205,20 @@ describe("DeviceSync", () => {
       expect(state.installations.length).toBe(2);
     }, WAIT);
 
-    await client2.sendSyncRequest(
-      {
-        elements: [],
-        excludeDisappearingMessages: false,
-      },
-      HistorySyncUrls.local,
-    );
-
-    // client1's worker answers the request with an archive; client2's worker
-    // imports it. Poll the whole round trip until the group and its messages
-    // materialize on client2.
+    // The sync request is a one-shot message into the device sync group: if
+    // it goes out before client1's worker has joined, client1 can never
+    // decrypt it and no archive ever comes back. Re-issue the request on
+    // each attempt, then poll the whole round trip — client1's worker
+    // answers with an archive, client2's worker imports it — until the
+    // group and its messages materialize on client2.
     const messagesOnClient2 = await vi.waitFor(async () => {
+      await client2.sendSyncRequest(
+        {
+          elements: [],
+          excludeDisappearingMessages: false,
+        },
+        HistorySyncUrls.local,
+      );
       await client1.syncAllDeviceSyncGroups();
       await client2.syncAllDeviceSyncGroups();
       await client2.conversations.syncAll();
@@ -219,7 +227,7 @@ describe("DeviceSync", () => {
       const msgs = await c!.messages();
       expect(msgs.length).toBeGreaterThan(0);
       return msgs;
-    }, WAIT);
+    }, ROUND_TRIP_WAIT);
 
     const client1MessageCount = (await group.messages()).length;
     const containsMessage = messagesOnClient2.some((m) => m.id === msgId);

--- a/sdks/js/browser-sdk/test/Preferences.test.ts
+++ b/sdks/js/browser-sdk/test/Preferences.test.ts
@@ -129,9 +129,10 @@ describe("Preferences", () => {
     const group = await client.conversations.createGroup([client2.inboxId!]);
     const stream = await client.preferences.streamConsent();
 
-    // Consume the stream in the background and wait for each update's batch
-    // to arrive before issuing the next update — batch boundaries stay
-    // deterministic without pacing on fixed sleeps.
+    // Consume the stream in the background. Background workers can emit
+    // their own consent batches at any time, so batch counts and indices
+    // aren't stable — wait for and assert on the content of the updates
+    // we issue instead.
     const batches: Consent[][] = [];
     const consumed = (async () => {
       for await (const updates of stream) {
@@ -139,8 +140,28 @@ describe("Preferences", () => {
       }
     })();
 
+    const observed = (
+      entityType: ConsentEntityType,
+      entity: string,
+      state: ConsentState,
+    ) =>
+      batches
+        .flat()
+        .some(
+          (u) =>
+            u.entityType === entityType &&
+            u.entity === entity &&
+            u.state === state,
+        );
+
     await group.updateConsentState(ConsentState.Denied);
-    await vi.waitFor(() => expect(batches.length).toBe(1), WAIT);
+    await vi.waitFor(
+      () =>
+        expect(
+          observed(ConsentEntityType.GroupId, group.id, ConsentState.Denied),
+        ).toBe(true),
+      WAIT,
+    );
 
     await client.preferences.setConsentStates([
       {
@@ -149,7 +170,13 @@ describe("Preferences", () => {
         state: ConsentState.Allowed,
       },
     ]);
-    await vi.waitFor(() => expect(batches.length).toBe(2), WAIT);
+    await vi.waitFor(
+      () =>
+        expect(
+          observed(ConsentEntityType.GroupId, group.id, ConsentState.Allowed),
+        ).toBe(true),
+      WAIT,
+    );
 
     await client.preferences.setConsentStates([
       {
@@ -163,26 +190,31 @@ describe("Preferences", () => {
         state: ConsentState.Allowed,
       },
     ]);
-    await vi.waitFor(() => expect(batches.length).toBe(3), WAIT);
+    // the two-entry update is delivered together in a single batch
+    await vi.waitFor(
+      () =>
+        expect(
+          batches.some(
+            (b) =>
+              b.some(
+                (u) =>
+                  u.entityType === ConsentEntityType.GroupId &&
+                  u.entity === group.id &&
+                  u.state === ConsentState.Denied,
+              ) &&
+              b.some(
+                (u) =>
+                  u.entityType === ConsentEntityType.InboxId &&
+                  u.entity === client2.inboxId &&
+                  u.state === ConsentState.Allowed,
+              ),
+          ),
+        ).toBe(true),
+      WAIT,
+    );
 
     await stream.end();
     await consumed;
-
-    expect(batches[0].length).toBe(1);
-    expect(batches[0][0].state).toBe(ConsentState.Denied);
-    expect(batches[0][0].entity).toBe(group.id);
-    expect(batches[0][0].entityType).toBe(ConsentEntityType.GroupId);
-    expect(batches[1].length).toBe(1);
-    expect(batches[1][0].state).toBe(ConsentState.Allowed);
-    expect(batches[1][0].entity).toBe(group.id);
-    expect(batches[1][0].entityType).toBe(ConsentEntityType.GroupId);
-    expect(batches[2].length).toBe(2);
-    expect(batches[2][0].state).toBe(ConsentState.Denied);
-    expect(batches[2][0].entity).toBe(group.id);
-    expect(batches[2][0].entityType).toBe(ConsentEntityType.GroupId);
-    expect(batches[2][1].state).toBe(ConsentState.Allowed);
-    expect(batches[2][1].entity).toBe(client2.inboxId);
-    expect(batches[2][1].entityType).toBe(ConsentEntityType.InboxId);
   });
 
   it("should stream preferences", async () => {

--- a/sdks/js/node-sdk/test/DeviceSync.test.ts
+++ b/sdks/js/node-sdk/test/DeviceSync.test.ts
@@ -11,6 +11,12 @@ import { createRegisteredClient, createSigner } from "@test/helpers";
 // on loaded CI runners.
 const WAIT = { timeout: 30_000, interval: 1000 };
 
+// The request→archive→import round trip crosses two background-worker hops
+// (one worker builds and uploads the archive, the other downloads and
+// imports it), so give it a much larger budget than the single-hop waits
+// and pace the retries so the workers aren't flooded with requests.
+const ROUND_TRIP_WAIT = { timeout: 90_000, interval: 3000 };
+
 describe("DeviceSync", () => {
   it("should sync consent across installations", async () => {
     const { signer: boSigner } = createSigner();
@@ -195,18 +201,20 @@ describe("DeviceSync", () => {
       expect(state.installations.length).toBe(2);
     }, WAIT);
 
-    await client2.sendSyncRequest(
-      {
-        elements: [],
-        excludeDisappearingMessages: false,
-      },
-      HistorySyncUrls.local,
-    );
-
-    // client1's worker answers the request with an archive; client2's worker
-    // imports it. Poll the whole round trip until the group and its messages
-    // materialize on client2.
+    // The sync request is a one-shot message into the device sync group: if
+    // it goes out before client1's worker has joined, client1 can never
+    // decrypt it and no archive ever comes back. Re-issue the request on
+    // each attempt, then poll the whole round trip — client1's worker
+    // answers with an archive, client2's worker imports it — until the
+    // group and its messages materialize on client2.
     const messagesOnClient2 = await vi.waitFor(async () => {
+      await client2.sendSyncRequest(
+        {
+          elements: [],
+          excludeDisappearingMessages: false,
+        },
+        HistorySyncUrls.local,
+      );
       await client1.syncAllDeviceSyncGroups();
       await client2.syncAllDeviceSyncGroups();
       await client2.conversations.syncAll();
@@ -215,7 +223,7 @@ describe("DeviceSync", () => {
       const msgs = await c!.messages();
       expect(msgs.length).toBeGreaterThan(0);
       return msgs;
-    }, WAIT);
+    }, ROUND_TRIP_WAIT);
 
     const client1MessageCount = (await group.messages()).length;
     const containsMessage = messagesOnClient2.some((m) => m.id === msgId);

--- a/sdks/js/node-sdk/test/Preferences.test.ts
+++ b/sdks/js/node-sdk/test/Preferences.test.ts
@@ -123,9 +123,10 @@ describe("Preferences", () => {
     const group = await client.conversations.createGroup([client2.inboxId]);
     const stream = await client.preferences.streamConsent();
 
-    // Consume the stream in the background and wait for each update's batch
-    // to arrive before issuing the next update — batch boundaries stay
-    // deterministic without pacing on fixed sleeps.
+    // Consume the stream in the background. Background workers can emit
+    // their own consent batches at any time, so batch counts and indices
+    // aren't stable — wait for and assert on the content of the updates
+    // we issue instead.
     const batches: Consent[][] = [];
     const consumed = (async () => {
       for await (const updates of stream) {
@@ -133,8 +134,28 @@ describe("Preferences", () => {
       }
     })();
 
+    const observed = (
+      entityType: ConsentEntityType,
+      entity: string,
+      state: ConsentState,
+    ) =>
+      batches
+        .flat()
+        .some(
+          (u) =>
+            u.entityType === entityType &&
+            u.entity === entity &&
+            u.state === state,
+        );
+
     group.updateConsentState(ConsentState.Denied);
-    await vi.waitFor(() => expect(batches.length).toBe(1), WAIT);
+    await vi.waitFor(
+      () =>
+        expect(
+          observed(ConsentEntityType.GroupId, group.id, ConsentState.Denied),
+        ).toBe(true),
+      WAIT,
+    );
 
     await client.preferences.setConsentStates([
       {
@@ -143,7 +164,13 @@ describe("Preferences", () => {
         state: ConsentState.Allowed,
       },
     ]);
-    await vi.waitFor(() => expect(batches.length).toBe(2), WAIT);
+    await vi.waitFor(
+      () =>
+        expect(
+          observed(ConsentEntityType.GroupId, group.id, ConsentState.Allowed),
+        ).toBe(true),
+      WAIT,
+    );
 
     await client.preferences.setConsentStates([
       {
@@ -157,26 +184,31 @@ describe("Preferences", () => {
         state: ConsentState.Allowed,
       },
     ]);
-    await vi.waitFor(() => expect(batches.length).toBe(3), WAIT);
+    // the two-entry update is delivered together in a single batch
+    await vi.waitFor(
+      () =>
+        expect(
+          batches.some(
+            (b) =>
+              b.some(
+                (u) =>
+                  u.entityType === ConsentEntityType.GroupId &&
+                  u.entity === group.id &&
+                  u.state === ConsentState.Denied,
+              ) &&
+              b.some(
+                (u) =>
+                  u.entityType === ConsentEntityType.InboxId &&
+                  u.entity === client2.inboxId &&
+                  u.state === ConsentState.Allowed,
+              ),
+          ),
+        ).toBe(true),
+      WAIT,
+    );
 
     await stream.end();
     await consumed;
-
-    expect(batches[0].length).toBe(1);
-    expect(batches[0][0].state).toBe(ConsentState.Denied);
-    expect(batches[0][0].entity).toBe(group.id);
-    expect(batches[0][0].entityType).toBe(ConsentEntityType.GroupId);
-    expect(batches[1].length).toBe(1);
-    expect(batches[1][0].state).toBe(ConsentState.Allowed);
-    expect(batches[1][0].entity).toBe(group.id);
-    expect(batches[1][0].entityType).toBe(ConsentEntityType.GroupId);
-    expect(batches[2].length).toBe(2);
-    expect(batches[2][0].state).toBe(ConsentState.Denied);
-    expect(batches[2][0].entity).toBe(group.id);
-    expect(batches[2][0].entityType).toBe(ConsentEntityType.GroupId);
-    expect(batches[2][1].state).toBe(ConsentState.Allowed);
-    expect(batches[2][1].entity).toBe(client2.inboxId);
-    expect(batches[2][1].entityType).toBe(ConsentEntityType.InboxId);
   });
 
   it("should stream preferences", async () => {


### PR DESCRIPTION
Follow-up to #3891 fixing two residual races its poll conversions left behind, both caught by CI runs today (#3872's rerun and this PR's own first run).

## streamConsent: batch-count equality can overshoot

`should stream consent updates` waits on `expect(batches.length).toBe(n)` — exact equality on a counter that only grows. Background workers can emit their own consent batches at any time (the failing run logged worker sync activity mid-test), so the count can skip past `n` between polls; once it does, the equality can never match again and the `waitFor` times out. Observed as `expected 5 to be 3` after 31s on node-sdk shard 1.

Fixed by making the waits content-based:

- After each issued update, poll until that update's `(entityType, entity, state)` appears anywhere in the stream — extra worker batches can't break it.
- The final two-entry `setConsentStates` polls for a **single batch** containing both entries, preserving the batched-delivery semantic the old `batches[2].length === 2` assertion was checking.
- The exact-index assertions (`batches[0][0]…`) are gone: batch indices aren't stable under worker traffic, and everything they verified is covered by the content waits.

## sendSyncRequest: the one-shot fix #3891 missed

#3891 established that device-sync messages are one-shot: published before the peer installation has joined the sync group, they are undecryptable for it forever. It moved `sendSyncArchive` and the consent update inside the retry loops — but left `sendSyncRequest` issued once, outside the poll. Lose that join race and client1's worker never sees the request, no archive ever comes back, and the round-trip poll times out no matter how long it retries. Observed as `expected undefined to be truthy` at 30s on **both** node-sdk shards in this PR's first run.

Fixed by re-issuing the request on each poll attempt, same pattern as the archive test. Multiple requests are harmless: the poll exits on the first successful import, and the message-identity assertion was already conditional on counts matching.

Both fixes applied identically to node-sdk and browser-sdk.

## Verification

- node-sdk `Preferences.test.ts`: 3 consecutive runs against the local backend, 5/5 each.
- node-sdk `DeviceSync.test.ts`: 3 consecutive runs, 3/3 each.
- `yarn eslint` and `tsc` clean on all four files; `just lint-treefmt` reports 0 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix delivery races in JS SDK device sync and consent streaming tests
> - Replaces single-shot `sendSyncRequest` calls with retry-inside-poll logic in `DeviceSync` tests for both browser and node SDKs, re-issuing the request on each `vi.waitFor` attempt to handle async group joins.
> - Adds a `ROUND_TRIP_WAIT` constant (90s timeout, 3s interval) to account for the two-hop background-worker round trip in device sync tests.
> - Replaces batch-count and index-based assertions in `Preferences` streaming tests with content-based checks using an `observed()` helper, tolerating unstable batch boundaries from background workers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ae5065.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->