### PR TITLE
fix(xmtp_mls): make MissingSequenceId retryable so membership adds survive identity-propagation races

### DIFF
--- a/crates/xmtp_mls/src/groups/error.rs
+++ b/crates/xmtp_mls/src/groups/error.rs
@@ -90,7 +90,8 @@ pub enum GroupError {
     UserLimitExceeded,
     /// Sequence ID not found.
     ///
-    /// Missing sequence ID in local database. Not retryable.
+    /// No sequence ID for an inbox after an identity-update refresh —
+    /// its registration hasn't propagated yet. Retryable.
     #[error("SequenceId not found in local db")]
     MissingSequenceId,
     /// Addresses not found.
@@ -612,13 +613,19 @@ impl RetryableError for GroupError {
             Self::DeleteMessage(e) => e.is_retryable(),
             Self::DeviceSync(e) => e.is_retryable(),
             Self::MergePendingCommit(e) => e.is_retryable(),
+            // Only emitted when a fresh `load_identity_updates` network
+            // refresh still has no sequence id for an inbox — i.e. its
+            // registration hasn't propagated to reads yet. Retrying re-runs
+            // the fetch, so the miss is transient; classifying it
+            // non-retryable permanently failed sync-group membership adds
+            // that raced a new installation's identity propagation.
+            Self::MissingSequenceId => true,
             Self::NotFound(_)
             | Self::UserLimitExceeded
             | Self::InvalidGroupMembership
             | Self::Intent(_)
             | Self::CreateMessage(_)
             | Self::TlsError(_)
-            | Self::MissingSequenceId
             | Self::AddressNotFound(_)
             | Self::InvalidExtension(_)
             | Self::Signature(_)
@@ -655,5 +662,19 @@ impl crate::worker::NeedsDbReconnect for GroupError {
             Self::DeviceSync(d) => d.needs_db_reconnect(),
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[xmtp_common::test]
+    fn missing_sequence_id_is_retryable() {
+        // Regression lock: while non-retryable, a membership add racing a
+        // new installation's identity propagation burned all publish
+        // attempts instantly and permanently failed the sync-group add
+        // (surfaced as the DeviceSync sendSyncRequest CI failures).
+        assert!(GroupError::MissingSequenceId.is_retryable());
     }
 }


### PR DESCRIPTION
Root-cause fix for the node-sdk `DeviceSync > sendSyncRequest` CI failures that repeatedly blocked #3872 (and hit an unrelated test-only PR identically): the round trip either converges in seconds or never converges at all, no matter how long the client polls.

## Mechanics

`GroupError::MissingSequenceId` is only emitted in the membership-update paths (`get_membership_update_intent`, and the `UpdateGroupMembership` publish path) **immediately after a fresh `load_identity_updates` network refresh**: the `(None, _)` arm means the network still has no identity update for an inbox — i.e. a just-registered installation whose registration hasn't propagated to reads yet. That is transient by definition; retrying re-runs the fetch.

It was classified **non-retryable**, which turns the race into a permanent failure through the intent machinery:

1. `publish_intents` wraps intent-data production in `retry_async!(Retry::default(), …)` (5 retries with backoff) — but the retry loop exits immediately on a non-retryable error, so the propagation window is never re-probed.
2. Each failed publish cycle increments the intent's `publish_attempts`; at `MAX_INTENT_PUBLISH_ATTEMPTS` (**3**) the intent is moved to `Error` via `set_group_intent_error_and_fail_msg` — permanently.
3. A client actively syncing (as the JS test does every ~3s) burns those 3 attempts within seconds of the race being lost. After that, the sync-group membership add is dead: the new installation can never decrypt anything in the sync group, and no later request, sync, or timeout budget recovers it. This is user-reachable — a freshly added device losing this race has device sync silently never complete.

## Fix

Reclassify `MissingSequenceId` as retryable (with the rationale in a comment at the match arm, and the variant's doc corrected). Each publish cycle now genuinely re-probes: up to 6 fetch attempts with backoff per cycle, 3 cycles — instead of 3 instant failures. The existing `MAX_INTENT_PUBLISH_ATTEMPTS` ceiling is untouched, so there is no retry-storm risk; the change only makes the attempts that were already budgeted actually re-run the identity fetch.

A regression test locks the classification with the failure mode documented.

## Follow-up candidates (out of scope here)

- `get_sync_group` persists the sync-group row **before** `add_missing_installations`; if that add fails (any error, including this one after its retries are exhausted), the `Some(...)` branch on subsequent calls never re-attempts the add — a permanently under-membered sync group. Self-healing that branch deserves its own change.
- `publish_attempts` counts retryable failures toward the permanent cap; arguably only non-retryable failures should consume lifetime attempts.

## Verification

- `groups::error::tests::missing_sequence_id_is_retryable` passes.
- Full v3 suite against the local backend.
- CI-exact `just lint-rust` and `just lint-treefmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark `GroupError::MissingSequenceId` as retryable to handle identity-propagation races
> Previously, `MissingSequenceId` was treated as non-retryable, causing group membership additions to fail permanently when an inbox lacked a sequence ID due to an in-flight identity update. The fix reclassifies it as retryable in [`GroupError::is_retryable`](https://github.com/xmtp/libxmtp/pull/3895/files#diff-3092c03be9a98f95252ffd3a9b58177bc1f8597a79a2505a0aac3bfc2689338d) and adds a unit test to assert the new behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0066280.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->