### PR TITLE
ci: per-workflow sticky disks, drop nix-fast-build, gradle cache disk

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -4,11 +4,22 @@ inputs:
   github-token:
     description: "GitHub token for Nix installation"
     required: true
+  disk-key:
+    description: >-
+      Per-workflow namespace for the /nix sticky disk; pass the workflow file
+      stem (e.g. test-workspace). Required on Linux. Keep the value a literal:
+      reset-sticky-disks.yml greps workflows for `disk-key:` to enumerate disks.
+    required: false
+    default: ""
   cachix-auth-token:
     description: "Cachix auth token for xmtp cache"
     required: false
   sccache:
     description: "Enable sccache with GitHub Actions cache backend"
+    required: false
+    default: "false"
+  gradle-disk:
+    description: "Mount the shared repo-wide sticky disk at ~/.gradle (Linux); enable in jobs that run Gradle"
     required: false
     default: "false"
   docker-builder:
@@ -18,9 +29,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Persistent /nix sticky disk, one per (repo, OS, arch); must mount
-    # before Nix installs. Concurrent jobs clone the last snapshot;
-    # Cachix backfills anything a lost commit race drops.
+    # Persistent /nix sticky disk, one per (repo, workflow, OS, arch); must
+    # mount before Nix installs. Per-workflow keys stop concurrent workflows
+    # from overwriting each other's commits (last write wins per disk, so the
+    # slowest workflow used to decide what the shared disk kept). Concurrent
+    # jobs within a workflow still race, but they build near-identical
+    # closures and Cachix backfills anything a lost commit drops.
+    - name: Require disk-key on Linux
+      if: ${{ runner.os == 'Linux' && inputs.disk-key == '' }}
+      run: |
+        echo "::error::setup-nix needs a disk-key input on Linux (the workflow file stem, e.g. test-workspace)"
+        exit 1
+      shell: bash
     - name: Prepare /nix mount point
       if: ${{ runner.os == 'Linux' }}
       run: |
@@ -31,15 +51,28 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       uses: useblacksmith/stickydisk@v1
       with:
-        key: ${{ github.repository }}-nix-${{ runner.os }}-${{ runner.arch }}
+        key: ${{ github.repository }}-nix-${{ inputs.disk-key }}-${{ runner.os }}-${{ runner.arch }}
         path: /nix
         # Untrusted PR jobs never commit — a malicious PR could persist
         # tampered store paths that release builds later consume. Trusted
         # events (push/tag/dispatch/schedule) commit on-change.
         commit: ${{ !startsWith(github.event_name, 'pull_request') && 'on-change' || 'false' }}
-    # Posts run in reverse order: registered after the mount = runs right
+    # Gradle wrapper dist + dependency/transform caches for Android jobs.
+    # One disk repo-wide (not per workflow): contents are append-only
+    # downloads, so a lost commit race just re-downloads a few jars.
+    # Must be registered before the busy-process cleanup below so the cleanup
+    # post (which kills gradle/kotlin daemons) runs before this unmounts.
+    - name: Mount ~/.gradle sticky disk
+      if: ${{ inputs.gradle-disk == 'true' && runner.os == 'Linux' }}
+      uses: useblacksmith/stickydisk@v1
+      with:
+        key: ${{ github.repository }}-gradle-${{ runner.os }}-${{ runner.arch }}
+        path: ~/.gradle
+        commit: ${{ !startsWith(github.event_name, 'pull_request') && 'on-change' || 'false' }}
+    # Posts run in reverse order: registered after the mounts = runs right
     # before unmount+commit. Store-binary daemons (gradle/kotlin/adb) hold
-    # /nix busy; spare cachix daemon, its own post stops it. See convos-releases#31.
+    # /nix and ~/.gradle busy; spare cachix daemon, its own post stops it.
+    # See convos-releases#31.
     # action-post-run exec()s its `run` input as a bare executable (no
     # shell), so the script must live in a file.
     - name: Write /nix busy-process cleanup script
@@ -48,8 +81,11 @@ runs:
         cat > "$RUNNER_TEMP/nix-unmount-cleanup.sh" << 'EOF'
         #!/usr/bin/env bash
         keep="$(pgrep -f 'cachix daemon' || true)"
-        for pid in $(sudo fuser -M -m /nix 2>/dev/null); do
-          echo "$keep" | grep -qx "$pid" || sudo kill -9 "$pid" 2>/dev/null
+        # fuser -M no-ops when the path is not a mount point (gradle-disk off)
+        for mnt in /nix "$HOME/.gradle"; do
+          for pid in $(sudo fuser -M -m "$mnt" 2>/dev/null); do
+            echo "$keep" | grep -qx "$pid" || sudo kill -9 "$pid" 2>/dev/null
+          done
         done
         sleep 2
         exit 0
@@ -101,9 +137,6 @@ runs:
     - name: Setup sccache
       if: ${{ inputs.sccache == 'true' }}
       uses: mozilla-actions/sccache-action@v0.0.9
-    - name: Install nix-fast-build
-      run: nix profile add github:Mic92/nix-fast-build
-      shell: bash
     - name: Configure sccache env
       if: ${{ inputs.sccache == 'true' }}
       run: |

--- a/.github/workflows/cross-test.yml
+++ b/.github/workflows/cross-test.yml
@@ -109,6 +109,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: cross-test
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"

--- a/.github/workflows/fh-cache.yml
+++ b/.github/workflows/fh-cache.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: fh-cache
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Install omnix
@@ -51,6 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: fh-cache
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build validation service image

--- a/.github/workflows/ignored-tests-tracker.yml
+++ b/.github/workflows/ignored-tests-tracker.yml
@@ -43,6 +43,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: ignored-tests-tracker
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/lint-android.yml
+++ b/.github/workflows/lint-android.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: lint-android
+          gradle-disk: "true"
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - name: Build Android bindings (required for lint)

--- a/.github/workflows/lint-config.yml
+++ b/.github/workflows/lint-config.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: lint-config
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - name: Lint config files (TOML, Nix, shell)

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: lint-js
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - name: Install dependencies

--- a/.github/workflows/lint-node.yml
+++ b/.github/workflows/lint-node.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: lint-node
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - name: Install dependencies

--- a/.github/workflows/lint-wasm.yml
+++ b/.github/workflows/lint-wasm.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: lint-wasm
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/lint-workspace.yml
+++ b/.github/workflows/lint-workspace.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: lint-workspace
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "true"

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: ./.github/actions/setup-release-tools
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: release-android
+          gradle-disk: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 

--- a/.github/workflows/release-browser-sdk.yml
+++ b/.github/workflows/release-browser-sdk.yml
@@ -94,6 +94,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: release-browser-sdk
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 

--- a/.github/workflows/release-kotlin-bindings-nix.yml
+++ b/.github/workflows/release-kotlin-bindings-nix.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: release-kotlin-bindings-nix
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build jniLibs

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -94,6 +94,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: release-node-sdk
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -84,6 +84,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: release-node
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
@@ -112,6 +113,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: release-node
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
@@ -136,6 +138,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: release-node
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -81,17 +81,18 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: release-wasm
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build wasm-bindings
-        run: nix-fast-build --flake .#packages.x86_64-linux.wasm-bindings
+        run: nix build .#packages.x86_64-linux.wasm-bindings
 
       - name: Upload build output
         uses: actions/upload-artifact@v7
         with:
           name: wasm_build
-          path: result-/dist
+          path: result/dist
           retention-days: 1
 
   publish:

--- a/.github/workflows/reset-sticky-disks.yml
+++ b/.github/workflows/reset-sticky-disks.yml
@@ -7,21 +7,55 @@ on:
     - cron: "0 0 1 */2 *"
   workflow_dispatch:
 jobs:
+  # Disks are keyed per workflow (see setup-nix). Enumerate the keys from
+  # the workflow files themselves so new workflows are reset automatically.
+  enumerate:
+    name: Enumerate disk keys
+    runs-on: ubuntu-latest
+    outputs:
+      keys: ${{ steps.list.outputs.keys }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Collect disk-key values from workflows
+        id: list
+        run: |
+          keys=$(grep -rhoP 'disk-key:\s*\K[A-Za-z0-9_-]+' .github/workflows | sort -u | jq -Rnc '[inputs]')
+          echo "keys=$keys" >> "$GITHUB_OUTPUT"
+          echo "Found nix disk keys: $keys"
   reset-nix-disks:
-    name: Delete Nix store sticky disks
-    runs-on: ${{ matrix.runner }}
+    name: Delete nix-${{ matrix.key }} (X64)
+    needs: enumerate
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
-        # Disk namespace is per-arch: deletion must run on a matching-arch
-        # runner. arch must match runner.arch in the setup-nix disk key.
-        include:
-          - arch: X64
-            runner: blacksmith-2vcpu-ubuntu-2404
-          - arch: ARM64
-            runner: blacksmith-2vcpu-ubuntu-2404-arm
+        key: ${{ fromJSON(needs.enumerate.outputs.keys) }}
     steps:
-      - name: Delete ${{ github.repository }}-nix-Linux-${{ matrix.arch }}
+      # Rarely-run workflows may have no disk yet; don't fail the reset on those.
+      - name: Delete ${{ github.repository }}-nix-${{ matrix.key }}-Linux-X64
         uses: useblacksmith/stickydisk-delete@v1
+        continue-on-error: true
         with:
-          delete-key: ${{ github.repository }}-nix-Linux-${{ matrix.arch }}
+          delete-key: ${{ github.repository }}-nix-${{ matrix.key }}-Linux-X64
+  # Single repo-wide Gradle cache disk (see setup-nix gradle-disk input).
+  reset-gradle-disk:
+    name: Delete gradle disk (X64)
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Delete ${{ github.repository }}-gradle-Linux-X64
+        uses: useblacksmith/stickydisk-delete@v1
+        continue-on-error: true
+        with:
+          delete-key: ${{ github.repository }}-gradle-Linux-X64
+  # Disk namespace is per-arch: deletion must run on a matching-arch runner.
+  # fh-cache is the only workflow with a Linux ARM job; extend this list if
+  # more workflows grow ARM jobs.
+  reset-nix-disks-arm:
+    name: Delete nix-fh-cache (ARM64)
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    steps:
+      - name: Delete ${{ github.repository }}-nix-fh-cache-Linux-ARM64
+        uses: useblacksmith/stickydisk-delete@v1
+        continue-on-error: true
+        with:
+          delete-key: ${{ github.repository }}-nix-fh-cache-Linux-ARM64

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-android
+          gradle-disk: "true"
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -33,6 +35,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-android
+          gradle-disk: "true"
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/test-bindings-check.yml
+++ b/.github/workflows/test-bindings-check.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-bindings-check
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "true"
@@ -34,6 +35,8 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-bindings-check
+          gradle-disk: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "true"

--- a/.github/workflows/test-browser-sdk.yml
+++ b/.github/workflows/test-browser-sdk.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-browser-sdk
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/test-keepalive-probe.yml
+++ b/.github/workflows/test-keepalive-probe.yml
@@ -11,8 +11,9 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-keepalive-probe
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"
       - name: Check keepalive-probe compiles
-        run: nix-fast-build --no-nom --flake .#cargo-clippy.x86_64-linux.keepalive-probe
+        run: nix build --no-link .#cargo-clippy.x86_64-linux.keepalive-probe

--- a/.github/workflows/test-node-sdk.yml
+++ b/.github/workflows/test-node-sdk.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-node-sdk
           docker-builder: "true"
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-node
           docker-builder: "true"
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/test-wasm.yml
+++ b/.github/workflows/test-wasm.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-wasm
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-workspace
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -24,10 +25,10 @@ jobs:
       - name: Run tests (v3 + d14n with coverage)
         # use `nix build` instead of `nix flake check` because we need the resulting coverage
         run: |
-          nix-fast-build --no-nom --flake .#nextest.x86_64-linux.v3 --out-link v3 --option sandbox relaxed
-          nix-fast-build --no-nom --flake .#nextest.x86_64-linux.d14n --out-link d14n --option sandbox relaxed
+          nix build .#nextest.x86_64-linux.v3 --out-link v3 --option sandbox relaxed
+          nix build .#nextest.x86_64-linux.d14n --out-link d14n --option sandbox relaxed
       - name: merge coverage files
-        run: nix run nixpkgs#lcov -- --add-tracefile v3-/coverage --add-tracefile d14n-/coverage --output-file lcov.info
+        run: nix run nixpkgs#lcov -- --add-tracefile v3/coverage --add-tracefile d14n/coverage --output-file lcov.info
       - name: Upload coverage
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -11,8 +11,9 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
+          disk-key: test-xdbg
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"
       - name: Check xdbg compiles
-        run: nix-fast-build --no-nom --flake .#cargo-clippy.x86_64-linux.xdbg
+        run: nix build --no-link .#cargo-clippy.x86_64-linux.xdbg

--- a/bindings/node/node.just
+++ b/bindings/node/node.just
@@ -40,8 +40,8 @@ test: install (_prepare-dist "--features test-utils")
 # tests using built with nix. closer to ci but no local incremental compilation.
 test-ci:
     rm -rf dist
-    nix run github:Mic92/nix-fast-build -- --no-nom --flake .#packages.{{ nix_system }}.node-bindings-test
-    cp -r result-/dist dist
+    nix build .#packages.{{ nix_system }}.node-bindings-test
+    cp -r result/dist dist
     yarn vitest run
 
 # Build Node.js NAPI bindings (alias)

--- a/bindings/wasm/wasm.just
+++ b/bindings/wasm/wasm.just
@@ -57,8 +57,8 @@ nix-test: nix-test-v3 nix-test-d14n
 
 # CI version of wasm tests (no local incremental compilation, but uses cachix)
 test-ci:
-    nix run github:Mic92/nix-fast-build -- --no-nom --skip-cached --flake .#nextest.{{ nix_system }}.wasm-v3 --option sandbox relaxed
-    nix run github:Mic92/nix-fast-build -- --no-nom --skip-cached --flake .#nextest.{{ nix_system }}.wasm-d14n --option sandbox relaxed
+    nix build --no-link .#nextest.{{ nix_system }}.wasm-v3 --option sandbox relaxed
+    nix build --no-link .#nextest.{{ nix_system }}.wasm-d14n --option sandbox relaxed
 
 # WASM JS integration tests
 [script("bash")]


### PR DESCRIPTION
## Summary

Three related CI cache changes:

**Drop nix-fast-build.** Its parallel-eval benefit was negligible for our builds and it costs an extra install on every job. All invocations are now plain `nix build` (workflows + `wasm.just`/`node.just` test-ci recipes), and the install step is gone from `setup-nix`. Out-link references updated for the naming difference (`v3-/coverage` → `v3/coverage`, `result-/dist` → `result/dist`); clippy-only checks use `--no-link`.

**Per-workflow /nix sticky disks.** The single per-(repo, OS, arch) disk meant every concurrent workflow raced on the last-write-wins commit — the slowest workflow decided what the disk kept, so on main most workflows ran against a disk missing their store paths. The disk key now includes a per-workflow namespace via a new `disk-key` input on `setup-nix` (the workflow file stem), with a runtime guard failing Linux jobs that omit it (composite-action `required:` is not enforced by the runner, and `github.workflow` resolves to the *caller* inside reusable workflows, so an explicit input is the only reliable identity). `reset-sticky-disks.yml` now enumerates `disk-key:` values from the workflow files at runtime, so new workflows are reset automatically.

**Gradle cache sticky disk for Android.** The android jobs re-downloaded the gradle wrapper dist (~130MB) plus all dependencies on every run — no caching existed. `setup-nix` grows a `gradle-disk` input that mounts a sticky disk at `~/.gradle`, enabled in lint-android, test-android, test-bindings-check (check-android), and release-android. One disk repo-wide rather than per-workflow: the contents are append-only downloads, so a lost commit race just re-fetches a few jars. The disk is registered before the busy-process cleanup so gradle/kotlin daemons are killed before it unmounts, and the cleanup script now sweeps both `/nix` and `~/.gradle`.

## Rollout note

Every new disk key starts empty, so the first post-merge round of CI repopulates from Cachix and will be slow once per workflow.

## Validation

- actionlint: no new findings vs main (pre-existing runner-label/shellcheck noise unchanged)
- `nix fmt -- --fail-on-change` clean on touched paths
- reset enumerate grep verified locally: yields exactly the 24 expected keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-workflow sticky disk keys, a shared Gradle cache disk, and drop `nix-fast-build`
> - The [setup-nix action](.github/actions/setup-nix/action.yml) now requires a `disk-key` input on Linux, which is incorporated into the `/nix` sticky disk key so each workflow gets its own isolated disk rather than sharing one.
> - A new `gradle-disk` flag mounts a shared `~/.gradle` sticky disk for Android/Gradle workflows; the unmount cleanup script is extended to release both mounts.
> - All workflows are updated to pass their own `disk-key`; Android workflows (`lint-android`, `release-android`, `test-android`, `test-bindings-check`) also set `gradle-disk: "true"`.
> - `nix-fast-build` is removed throughout: build steps now use `nix build` (with `--no-link` or explicit `--out-link`), and artifact paths change from `result-/…` to `result/…`.
> - The [reset-sticky-disks workflow](.github/workflows/reset-sticky-disks.yml) now dynamically enumerates per-workflow disk keys by grepping workflow files, and adds jobs to reset the shared Gradle disk and ARM64 fh-cache disk.
> - Behavioral Change: any Linux job using `setup-nix` without a `disk-key` will now hard-fail early; artifact copy paths referencing `result-/dist` or similar must be updated to `result/dist`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07ca049.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->