### PR TITLE
ci: warm sticky disks with build-dep closures on trusted runs

### DIFF
--- a/.github/workflows/cross-test.yml
+++ b/.github/workflows/cross-test.yml
@@ -148,6 +148,15 @@ jobs:
             --profile "$PROFILE" \
             --sample-size "$SAMPLE_SIZE"
 
+      # Warms the current-tree driver's cargo deps only. The per-version
+      # xdbg binaries the driver builds are realized as goal outputs (so
+      # they land on the disk); their build closures are fixed-sha, stay
+      # substitutable from Cachix, and would only bloat the disk.
+      - name: Warm sticky disk with build deps
+        env:
+          KIND: ${{ matrix.kind }}
+        run: dev/ci/warm-deps ".#${KIND}-test"
+
       # xdbg's NDJSON log files are named "YYYY-MM-DD HH:MM:SS.json".
       # actions/upload-artifact rejects filenames with `:`, `<`, `>`, etc.
       # Rename to ISO-safe form before upload so the archive succeeds.

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Build ${{ matrix.target }}
         run: nix build .#node-bindings-${{ matrix.target }} -L
 
+      - name: Warm sticky disk with build deps
+        run: dev/ci/warm-deps .#node-bindings-${{ matrix.target }}
+
       - name: Upload binding
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Build wasm-bindings
         run: nix build .#packages.x86_64-linux.wasm-bindings
 
+      - name: Warm sticky disk with build deps
+        run: dev/ci/warm-deps .#packages.x86_64-linux.wasm-bindings
+
       - name: Upload build output
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/test-keepalive-probe.yml
+++ b/.github/workflows/test-keepalive-probe.yml
@@ -17,3 +17,5 @@ jobs:
           sccache: "false"
       - name: Check keepalive-probe compiles
         run: nix build --no-link .#cargo-clippy.x86_64-linux.keepalive-probe
+      - name: Warm sticky disk with build deps
+        run: dev/ci/warm-deps .#cargo-clippy.x86_64-linux.keepalive-probe

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -27,6 +27,8 @@ jobs:
         run: |
           nix build .#nextest.x86_64-linux.v3 --out-link v3 --option sandbox relaxed
           nix build .#nextest.x86_64-linux.d14n --out-link d14n --option sandbox relaxed
+      - name: Warm sticky disk with build deps
+        run: dev/ci/warm-deps .#nextest.x86_64-linux.v3 .#nextest.x86_64-linux.d14n
       - name: merge coverage files
         run: nix run nixpkgs#lcov -- --add-tracefile v3/coverage --add-tracefile d14n/coverage --output-file lcov.info
       - name: Upload coverage

--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -17,3 +17,5 @@ jobs:
           sccache: "false"
       - name: Check xdbg compiles
         run: nix build --no-link .#cargo-clippy.x86_64-linux.xdbg
+      - name: Warm sticky disk with build deps
+        run: dev/ci/warm-deps .#cargo-clippy.x86_64-linux.xdbg

--- a/bindings/node/node.just
+++ b/bindings/node/node.just
@@ -41,6 +41,7 @@ test: install (_prepare-dist "--features test-utils")
 test-ci:
     rm -rf dist
     nix build .#packages.{{ nix_system }}.node-bindings-test
+    ../../dev/ci/warm-deps .#packages.{{ nix_system }}.node-bindings-test
     cp -r result/dist dist
     yarn vitest run
 

--- a/bindings/wasm/wasm.just
+++ b/bindings/wasm/wasm.just
@@ -59,6 +59,7 @@ nix-test: nix-test-v3 nix-test-d14n
 test-ci:
     nix build --no-link .#nextest.{{ nix_system }}.wasm-v3 --option sandbox relaxed
     nix build --no-link .#nextest.{{ nix_system }}.wasm-d14n --option sandbox relaxed
+    ../../dev/ci/warm-deps .#nextest.{{ nix_system }}.wasm-v3 .#nextest.{{ nix_system }}.wasm-d14n
 
 # WASM JS integration tests
 [script("bash")]

--- a/dev/ci/warm-deps
+++ b/dev/ci/warm-deps
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Warm the /nix sticky disk with the build-time dep closure of the given
+# flake attrs. When a PR already built and pushed a derivation to Cachix,
+# the later main run substitutes just the goal output, so the deps (cargo
+# artifacts, toolchains) never land in the local store — and trusted runs
+# are the only ones that commit the disk (see .github/actions/setup-nix).
+# Realizing the closure keeps the disk hot for the next real rebuild.
+set -euo pipefail
+
+# Mirror the setup-nix commit gate: only trusted (non-PR) CI events commit
+# the disk. Locally GITHUB_EVENT_NAME is unset — nothing to warm.
+case "${GITHUB_EVENT_NAME:-}" in
+"" | pull_request*)
+    echo "warm-deps: sticky disk will not commit on this run; skipping"
+    exit 0
+    ;;
+esac
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "warm-deps: no sticky disk on $(uname -s); skipping"
+    exit 0
+fi
+
+for attr in "$@"; do
+    echo "warm-deps: realizing dep closure of ${attr}"
+    drv="$(nix path-info --derivation "${attr}")"
+    nix-store --query --requisites --include-outputs "${drv}" \
+        | xargs nix-store --realise >/dev/null
+done

--- a/sdks/js/dev/bindings
+++ b/sdks/js/dev/bindings
@@ -24,6 +24,12 @@ build_and_stage() {
 build_and_stage node-bindings-test node
 build_and_stage wasm-bindings-test wasm
 
+# Keep the CI sticky disk hot even when the builds above were cache hits
+# (no-op locally and on PRs).
+"${ROOT}/dev/ci/warm-deps" \
+  "${ROOT}#packages.${nix_system}.node-bindings-test" \
+  "${ROOT}#packages.${nix_system}.wasm-bindings-test"
+
 echo "JS bindings staged:"
 echo "  node: ${ROOT}/bindings/node/dist"
 echo "  wasm: ${ROOT}/bindings/wasm/dist"


### PR DESCRIPTION
## Summary

Follow-up to #3898. Sticky disks only commit on trusted (non-PR) events — but those are exactly the runs most likely to get a full Cachix hit, because the just-merged PR already built and pushed the identical derivation. `nix build` then substitutes only the tiny goal output (test results, bindings dist) and never realizes the cargo dep closure into `/nix`, so the disk stays cold for the one thing it exists to hold, and every subsequent PR pulls deps over the network from Cachix instead of finding them locally.

**Fix:** new `dev/ci/warm-deps` helper — after the build, realize the goal derivation's full dependency closure (`nix-store --query --requisites --include-outputs | nix-store --realise`) so the deps are present when the disk commits. Paths already on the disk are skipped, so steady-state cost is just the delta since the last commit. The script self-gates: it no-ops on PR events (mirroring the setup-nix commit gate), locally (`GITHUB_EVENT_NAME` unset), and on non-Linux runners (no sticky disk).

Wired into every pure-`nix build` job:

- `test-workspace` (nextest v3 + d14n), `test-xdbg`, `test-keepalive-probe`, `cross-test`
- `release-wasm`, `release-node` build-linux
- `wasm.just`/`node.just` `test-ci` recipes (test-wasm, test-node)
- `sdks/js/dev/bindings` (test-node-sdk, test-browser-sdk, SDK releases — this script's own comment notes it's a "100% cache hit" when the binding jobs already built)

Devshell-based jobs (lints, android, ignored-tests-tracker) are not affected: `nix develop` must realize the shell closure locally, so they self-warm.

## Notes

- If a dep path is missing from every cache, `nix-store --realise` builds it locally — same behavior as the pre-cache-hit world, and the result then lands on the disk and in Cachix.
- First trusted run per workflow downloads the full closure from Cachix; after that it's incremental.

## Validation

- shellcheck clean on `dev/ci/warm-deps`; PR-event and local no-op paths exercised
- closure query verified transitively complete against a known derivation
- actionlint: no new findings vs main; treefmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warm sticky Nix store disks with build-dep closures on trusted CI runs
> - Adds a new [`dev/ci/warm-deps`](https://github.com/xmtp/libxmtp/pull/3899/files#diff-ab41778816a9d5cab6a221441833d09b9b75443ee5733cf33a2101868fdf1bb1) script that accepts one or more flake attributes and realizes their full build-time dependency closures via `nix-store` to keep the sticky `/nix` store disk hot.
> - The script is a no-op on pull requests, non-Linux environments, or when `GITHUB_EVENT_NAME` is unset, so it only runs on trusted Linux CI events.
> - Calls to `warm-deps` are added to multiple workflows and `just` recipes, covering nextest, node bindings, wasm bindings, and clippy targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efe73b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->