### PR TITLE
feat(release): add node-sdk/browser-sdk bumps to create-release-branch

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -32,6 +32,26 @@ on:
           - "minor"
           - "major"
         default: "none"
+      node-sdk-bump:
+        description: "Node SDK version bump"
+        required: false
+        type: choice
+        options:
+          - "none"
+          - "patch"
+          - "minor"
+          - "major"
+        default: "none"
+      browser-sdk-bump:
+        description: "Browser SDK version bump"
+        required: false
+        type: choice
+        options:
+          - "none"
+          - "patch"
+          - "minor"
+          - "major"
+        default: "none"
       node:
         description: "Include Node bindings in release"
         required: false
@@ -61,12 +81,16 @@ jobs:
           BASE_REF: ${{ inputs.base-ref || github.ref_name }}
           IOS_BUMP: ${{ inputs.ios-bump }}
           ANDROID_BUMP: ${{ inputs.android-bump }}
+          NODE_SDK_BUMP: ${{ inputs.node-sdk-bump }}
+          BROWSER_SDK_BUMP: ${{ inputs.browser-sdk-bump }}
         run: |
           xmtp-release create-release-branch \
             --version "$RELEASE_VERSION" \
             --base "$BASE_REF" \
             --ios "$IOS_BUMP" \
             --android "$ANDROID_BUMP" \
+            --node-sdk "$NODE_SDK_BUMP" \
+            --browser-sdk "$BROWSER_SDK_BUMP" \
             ${{ inputs.node && '--node' || '' }} \
             ${{ inputs.wasm && '--wasm' || '' }}
 

--- a/dev/release-tools/README.md
+++ b/dev/release-tools/README.md
@@ -66,14 +66,16 @@ yarn cli update-spm-checksum --sdk ios \
 
 Orchestrate a full release branch — bumps versions, scaffolds release notes, and commits everything.
 
-| Flag        | Type                                     | Required | Description                                 |
-| ----------- | ---------------------------------------- | -------- | ------------------------------------------- |
-| `--version` | string                                   | yes      | Release version (used in branch name)       |
-| `--ios`     | `major` \| `minor` \| `patch` \| `none` | no       | iOS SDK version bump type (default: `none`) |
-| `--android` | `major` \| `minor` \| `patch` \| `none` | no       | Android SDK version bump type (default: `none`) |
-| `--node`    | boolean                                  | no       | Include Node bindings in release            |
-| `--wasm`    | boolean                                  | no       | Include WASM bindings in release            |
-| `--base`    | string                                   | no       | Base ref to branch from (default: `HEAD`)   |
+| Flag            | Type                                    | Required | Description                                     |
+| --------------- | --------------------------------------- | -------- | ----------------------------------------------- |
+| `--version`     | string                                  | yes      | Release version (used in branch name)           |
+| `--ios`         | `major` \| `minor` \| `patch` \| `none` | no       | iOS SDK version bump type (default: `none`)     |
+| `--android`     | `major` \| `minor` \| `patch` \| `none` | no       | Android SDK version bump type (default: `none`) |
+| `--node-sdk`    | `major` \| `minor` \| `patch` \| `none` | no       | Node SDK version bump type (default: `none`)    |
+| `--browser-sdk` | `major` \| `minor` \| `patch` \| `none` | no       | Browser SDK version bump type (default: `none`) |
+| `--node`        | boolean                                 | no       | Include Node bindings in release                |
+| `--wasm`        | boolean                                 | no       | Include WASM bindings in release                |
+| `--base`        | string                                  | no       | Base ref to branch from (default: `HEAD`)       |
 
 ```bash
 yarn cli create-release-branch \
@@ -81,13 +83,15 @@ yarn cli create-release-branch \
   --base main \
   --ios minor \
   --android patch \
+  --node-sdk minor \
+  --browser-sdk minor \
   --node \
   --wasm
 ```
 
 ## Supported SDKs
 
-All five SDKs are configured: `ios`, `android`, `node-bindings`, `wasm-bindings`, and `libxmtp`. SDK definitions live in `src/lib/sdk-config.ts`.
+All seven SDKs are configured: `ios`, `android`, `node-bindings`, `wasm-bindings`, `node-sdk`, `browser-sdk`, and `libxmtp`. SDK definitions live in `src/lib/sdk-config.ts`.
 
 ## Development
 

--- a/dev/release-tools/src/commands/create-release-branch.ts
+++ b/dev/release-tools/src/commands/create-release-branch.ts
@@ -46,6 +46,18 @@ export function builder(yargs: Argv<GlobalArgs>) {
       choices: BUMP_OPTIONS,
       describe: "Android SDK version bump type",
     })
+    .option("node-sdk", {
+      type: "string",
+      default: "none",
+      choices: BUMP_OPTIONS,
+      describe: "Node SDK version bump type",
+    })
+    .option("browser-sdk", {
+      type: "string",
+      default: "none",
+      choices: BUMP_OPTIONS,
+      describe: "Browser SDK version bump type",
+    })
     .option("node", {
       type: "boolean",
       default: false,
@@ -63,6 +75,8 @@ interface CreateReleaseBranchArgs extends GlobalArgs {
   base: string;
   ios: string;
   android: string;
+  nodeSdk?: string;
+  browserSdk?: string;
   node: boolean;
   wasm: boolean;
 }
@@ -80,6 +94,12 @@ export function handler(argv: ArgumentsCamelCase<CreateReleaseBranchArgs>) {
   if (argv.android !== "none") {
     sdkBumps.push({ sdk: Sdk.Android, bump: argv.android as BumpType });
   }
+  if (argv.nodeSdk && argv.nodeSdk !== "none") {
+    sdkBumps.push({ sdk: Sdk.NodeSdk, bump: argv.nodeSdk as BumpType });
+  }
+  if (argv.browserSdk && argv.browserSdk !== "none") {
+    sdkBumps.push({ sdk: Sdk.BrowserSdk, bump: argv.browserSdk as BumpType });
+  }
 
   // Collect SDK includes (node/wasm just set the version directly)
   const sdkIncludes: Sdk[] = [];
@@ -93,7 +113,7 @@ export function handler(argv: ArgumentsCamelCase<CreateReleaseBranchArgs>) {
   // Validate at least one SDK is being released
   if (sdkBumps.length === 0 && sdkIncludes.length === 0) {
     throw new Error(
-      "At least one SDK must be bumped (use --ios or --android with a bump type, or --node/--wasm)",
+      "At least one SDK must be bumped (use --ios/--android/--node-sdk/--browser-sdk with a bump type, or --node/--wasm)",
     );
   }
 

--- a/dev/release-tools/tests/commands/create-release-branch.test.ts
+++ b/dev/release-tools/tests/commands/create-release-branch.test.ts
@@ -53,6 +53,18 @@ describe("create-release-branch", () => {
       `{\n  "name": "@xmtp/wasm-bindings",\n  "version": "0.0.0"\n}\n`,
     );
 
+    // Create JS SDK structures
+    fs.mkdirSync(path.join(tmpDir, "sdks/js/node-sdk"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "sdks/js/node-sdk/package.json"),
+      `{\n  "name": "@xmtp/node-sdk",\n  "version": "6.0.0"\n}\n`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "sdks/js/browser-sdk"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "sdks/js/browser-sdk/package.json"),
+      `{\n  "name": "@xmtp/browser-sdk",\n  "version": "7.0.0"\n}\n`,
+    );
+
     // Create release notes directory
     fs.mkdirSync(path.join(tmpDir, "docs/release-notes"), { recursive: true });
 
@@ -236,6 +248,72 @@ describe("create-release-branch", () => {
     );
   });
 
+  it("creates branch with node-sdk and browser-sdk bumps", async () => {
+    const { handler } =
+      await import("../../src/commands/create-release-branch");
+
+    handler({
+      repoRoot: tmpDir,
+      version: "1.1.0",
+      base: "HEAD",
+      ios: "none",
+      android: "none",
+      nodeSdk: "minor",
+      browserSdk: "patch",
+      node: false,
+      wasm: false,
+      _: [],
+      $0: "",
+    });
+
+    // Check branch was created
+    const branch = execSync("git branch --show-current", { cwd: tmpDir })
+      .toString()
+      .trim();
+    expect(branch).toBe("release/1.1.0");
+
+    // Check JS SDK versions were bumped off their own bases
+    const nodeSdkPackageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, "sdks/js/node-sdk/package.json"),
+        "utf-8",
+      ),
+    );
+    expect(nodeSdkPackageJson.version).toBe("6.1.0");
+
+    const browserSdkPackageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, "sdks/js/browser-sdk/package.json"),
+        "utf-8",
+      ),
+    );
+    expect(browserSdkPackageJson.version).toBe("7.0.1");
+
+    // Check the bindings manifests were NOT touched
+    const nodeBindingsPackageJson = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "bindings/node/package.json"), "utf-8"),
+    );
+    expect(nodeBindingsPackageJson.version).toBe("0.0.0");
+
+    // Check release notes were created for both JS SDKs
+    expect(
+      fs.existsSync(path.join(tmpDir, "docs/release-notes/node-sdk/6.1.0.md")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(tmpDir, "docs/release-notes/browser-sdk/7.0.1.md"),
+      ),
+    ).toBe(true);
+
+    // Check commit message
+    const commitMsg = execSync("git log -1 --pretty=%B", { cwd: tmpDir })
+      .toString()
+      .trim();
+    expect(commitMsg).toBe(
+      "chore: create release 1.1.0 (node-sdk 6.1.0, browser-sdk 7.0.1)",
+    );
+  });
+
   it("creates branch with --node flag", async () => {
     const { handler } =
       await import("../../src/commands/create-release-branch");
@@ -260,10 +338,7 @@ describe("create-release-branch", () => {
 
     // Check Node version was set to release version
     const packageJson = JSON.parse(
-      fs.readFileSync(
-        path.join(tmpDir, "bindings/node/package.json"),
-        "utf-8",
-      ),
+      fs.readFileSync(path.join(tmpDir, "bindings/node/package.json"), "utf-8"),
     );
     expect(packageJson.version).toBe("1.1.0");
 
@@ -305,10 +380,7 @@ describe("create-release-branch", () => {
 
     // Check WASM version was set to release version
     const packageJson = JSON.parse(
-      fs.readFileSync(
-        path.join(tmpDir, "bindings/wasm/package.json"),
-        "utf-8",
-      ),
+      fs.readFileSync(path.join(tmpDir, "bindings/wasm/package.json"), "utf-8"),
     );
     expect(packageJson.version).toBe("1.1.0");
 
@@ -336,6 +408,8 @@ describe("create-release-branch", () => {
       base: "HEAD",
       ios: "major",
       android: "minor",
+      nodeSdk: "major",
+      browserSdk: "minor",
       node: true,
       wasm: true,
       _: [],
@@ -362,20 +436,30 @@ describe("create-release-branch", () => {
     expect(gradle).toContain("version=1.1.0");
 
     const nodePackageJson = JSON.parse(
-      fs.readFileSync(
-        path.join(tmpDir, "bindings/node/package.json"),
-        "utf-8",
-      ),
+      fs.readFileSync(path.join(tmpDir, "bindings/node/package.json"), "utf-8"),
     );
     expect(nodePackageJson.version).toBe("2.0.0");
 
     const wasmPackageJson = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "bindings/wasm/package.json"), "utf-8"),
+    );
+    expect(wasmPackageJson.version).toBe("2.0.0");
+
+    const nodeSdkPackageJson = JSON.parse(
       fs.readFileSync(
-        path.join(tmpDir, "bindings/wasm/package.json"),
+        path.join(tmpDir, "sdks/js/node-sdk/package.json"),
         "utf-8",
       ),
     );
-    expect(wasmPackageJson.version).toBe("2.0.0");
+    expect(nodeSdkPackageJson.version).toBe("7.0.0");
+
+    const browserSdkPackageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, "sdks/js/browser-sdk/package.json"),
+        "utf-8",
+      ),
+    );
+    expect(browserSdkPackageJson.version).toBe("7.1.0");
 
     // Check release notes were created for all
     expect(
@@ -383,6 +467,14 @@ describe("create-release-branch", () => {
     ).toBe(true);
     expect(
       fs.existsSync(path.join(tmpDir, "docs/release-notes/android/1.1.0.md")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(tmpDir, "docs/release-notes/node-sdk/7.0.0.md")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(tmpDir, "docs/release-notes/browser-sdk/7.1.0.md"),
+      ),
     ).toBe(true);
     expect(
       fs.existsSync(
@@ -400,7 +492,7 @@ describe("create-release-branch", () => {
       .toString()
       .trim();
     expect(commitMsg).toBe(
-      "chore: create release 2.0.0 (ios 2.0.0, android 1.1.0, node-bindings 2.0.0, wasm-bindings 2.0.0)",
+      "chore: create release 2.0.0 (ios 2.0.0, android 1.1.0, node-sdk 7.0.0, browser-sdk 7.1.0, node-bindings 2.0.0, wasm-bindings 2.0.0)",
     );
   });
 

--- a/docs/create-a-release.md
+++ b/docs/create-a-release.md
@@ -48,6 +48,8 @@ Final releases go through three phases: **create branch → publish RC → publi
    | `version` | Release version number, e.g. `1.8.0` |
    | `ios-bump` | Version bump for iOS SDK: `none`, `patch`, `minor`, or `major` |
    | `android-bump` | Version bump for Android SDK: `none`, `patch`, `minor`, or `major` |
+   | `node-sdk-bump` | Version bump for Node SDK: `none`, `patch`, `minor`, or `major` |
+   | `browser-sdk-bump` | Version bump for Browser SDK: `none`, `patch`, `minor`, or `major` |
    | `node` | Include Node bindings in release |
    | `wasm` | Include WASM bindings in release |
 


### PR DESCRIPTION
## Summary

The **Create Release Branch** workflow predates the js-sdk migration (#3720) and only knows how to bump iOS/Android and set the node/wasm **binding** versions. The independent-track `node-sdk` and `browser-sdk` manifests were never touched, so a final release cut from such a branch would resolve to the JS SDK versions already published as `latest` on npm (`6.0.0` / `7.0.0`) and fail (or worse, attempt a republish).

This adds the two missing SDKs, following the exact pattern used for iOS/Android (they're `independent`-track, so they take a bump *kind*, not a set-to-version boolean like the bindings):

- `create-release-branch.yml`: new `node-sdk-bump` and `browser-sdk-bump` choice inputs (`none`/`patch`/`minor`/`major`, default `none`), passed through to the CLI.
- `xmtp-release create-release-branch`: new `--node-sdk` / `--browser-sdk` options; bumps the manifest off its own base and scaffolds release notes under `docs/release-notes/{node-sdk,browser-sdk}/`, same as iOS/Android.
- Docs: option tables in `dev/release-tools/README.md` and `docs/create-a-release.md`.

## Test plan

- Extended `tests/commands/create-release-branch.test.ts`: new dedicated test for the JS SDK bumps (bases bumped independently, bindings untouched, notes scaffolded, commit message) and the all-SDKs test now covers all six.
- `yarn test` in `dev/release-tools`: 173 passed (21 files).
- `yarn typecheck`, `yarn format:check` clean on touched files; `yarn cli create-release-branch --help` shows the new options wired with choices/defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--node-sdk` and `--browser-sdk` bump options to the create-release-branch workflow
> - Adds `node-sdk-bump` and `browser-sdk-bump` inputs to the [create-release-branch workflow](.github/workflows/create-release-branch.yml), forwarding them as `--node-sdk` and `--browser-sdk` flags to the `xmtp-release` CLI.
> - Extends the CLI in [create-release-branch.ts](https://github.com/xmtp/libxmtp/pull/3900/files#diff-2583718370e3aecca14a154f14c2383e9ad308900bcf15a4776b2f734d3e9962) with matching options (defaulting to `none`, constrained to `none|patch|minor|major`) and processes them alongside existing SDK bumps.
> - Updates [README.md](https://github.com/xmtp/libxmtp/pull/3900/files#diff-c23a5f65215ba4aa1813f664f9989f90e22f237367cca4a1598e73b90d4184b6) and [create-a-release.md](https://github.com/xmtp/libxmtp/pull/3900/files#diff-2585916296ef7c055cf349c0533c2612c90c1f4c1c5d9eb2e080f57dcf96b78d) to document the new flags and list `node-sdk` and `browser-sdk` as supported SDKs.
> - Adds test coverage for independent and combined node/browser SDK bumps in [create-release-branch.test.ts](https://github.com/xmtp/libxmtp/pull/3900/files#diff-0272ff271c97aac15bb7ccdd80d220fa9b6c5ca683ccf2fd3caf2b24bbb78daa).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d61f41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->