### PR TITLE
fix(ci): grant id-token to the release-notes Claude action

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -99,6 +99,12 @@ jobs:
   release-notes:
     needs: create-branch
     uses: ./.github/workflows/release-notes.yml
+    # A called workflow's permissions are capped by the caller job's grant,
+    # and id-token defaults to none — it must be granted here too.
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     with:
       release-branch: release/${{ inputs.version }}
     secrets: inherit

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,6 +20,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # claude-code-action exchanges an OIDC token for its GitHub token
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

The `release-notes / update-release-notes` job failed in [run 30372377812](https://github.com/xmtp/libxmtp/actions/runs/30372377812/job/90322886396) with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

`anthropics/claude-code-action@v1` exchanges a GitHub OIDC token for its app token, which requires `id-token: write`. Two grants were missing:

- `release-notes.yml`: the job's `permissions` block only had `contents: write` + `pull-requests: write`. `id-token` defaults to `none`, so both the `push: release/**` path and the `workflow_call` path failed. (`claude.yml`, which works, already carries `id-token: write`.)
- `create-release-branch.yml`: a called workflow's permissions are capped by the caller job's grant, so the `release-notes` caller job needs an explicit `permissions` block including `id-token: write` as well.

## Test plan

- Permission model verified against the working `claude.yml` (has `id-token: write`) and GitHub's reusable-workflow permission-capping rules.
- Real-world validation: after merge, pushing a commit to `release/1.11.0` that includes this fix (the branch snapshot predates it) should let the notes job draft `docs/release-notes/*/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Grant `id-token: write` permission to the release-notes CI workflow
> The `release-notes` workflow's `update-release-notes` job and its invocation in [create-release-branch.yml](https://github.com/xmtp/libxmtp/pull/3903/files#diff-5fc90fff784d5ed4d963200e6dd124a507c9d12f0de1f5c06437f73b16f2633c) both lacked `id-token: write`, preventing `claude-code-action` from exchanging an OIDC token for its GitHub token. Both the job-level permissions in [release-notes.yml](https://github.com/xmtp/libxmtp/pull/3903/files#diff-42244398366244a59eb9bb95d4d4f8f8657297b9e8e5bf3a815f3e8cca374ce1) and the caller's explicit permissions block in `create-release-branch.yml` now include `id-token: write`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 945d814.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->