### PR TITLE
fix(ci): claude-code-action cannot run on push events — redispatch release-notes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,6 +3,12 @@ name: Release Notes
 on:
   push:
     branches: ["release/**"]
+  workflow_dispatch:
+    inputs:
+      release-branch:
+        description: "Release branch name (e.g. release/1.2.0)"
+        required: false
+        type: string
   workflow_call:
     inputs:
       release-branch:
@@ -15,7 +21,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # claude-code-action rejects push-triggered runs ("Unsupported event
+  # type: push"), so convert the push into a workflow_dispatch of this
+  # same workflow. GITHUB_TOKEN-created workflow_dispatch events are
+  # exempt from Actions' recursion prevention, and the dispatched run
+  # (a supported event type) does the real work below.
+  redispatch:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Redispatch as workflow_dispatch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          gh workflow run release-notes.yml \
+            --repo "${{ github.repository }}" \
+            --ref "$BRANCH" \
+            -f release-branch="$BRANCH"
+
   update-release-notes:
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Second blocker for the release-notes automation, surfaced after #3903 fixed OIDC: [run 30376445509](https://github.com/xmtp/libxmtp/actions/runs/30376445509) failed with

> Action failed with error: Unsupported event type: push

`anthropics/claude-code-action@v1` refuses to run in `push`-triggered workflows — supported contexts are `workflow_dispatch`, PR/issue events, etc. This is why the February run (invoked via `workflow_call` from the dispatch-triggered create-branch workflow, so `event_name == workflow_dispatch`) worked, while the documented on-push drafting path has never actually functioned.

Fix: convert the push into a supported event.

- New `redispatch` job (push only, `permissions: actions: write`): re-dispatches this same workflow via `gh workflow run --ref <release branch>`. `GITHUB_TOKEN`-created `workflow_dispatch` events are one of the two exemptions from Actions' recursion prevention, so the dispatched run fires; it can't loop because the dispatched run skips `redispatch`.
- New `workflow_dispatch` trigger with an optional `release-branch` input (falls back to `github.ref_name`); also enables manual re-runs of notes drafting for a branch.
- `update-release-notes` now gated `if: github.event_name != 'push'`. The `workflow_call` path is unaffected — a called workflow sees the caller's event (`workflow_dispatch`).

Note for existing release branches: a branch must contain this fix for its pushes to redispatch (workflows run from the file at the pushed ref), so merge main into open `release/*` branches after this lands.

## Test plan

- YAML validated; job/permission wiring mirrors the working `claude.yml` pattern.
- Real-world validation: merge main into `release/1.11.0`, whose push should chain push → redispatch → workflow_dispatch run that drafts `docs/release-notes/*/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `release-notes` workflow to redispatch on push events instead of running directly
> The `claude-code-action` used in the `update-release-notes` job does not support push events. The [release-notes.yml](.github/workflows/release-notes.yml) workflow is updated to work around this by splitting into two jobs: on push, a `redispatch` job triggers a new `workflow_dispatch` run of the same workflow against the current ref, passing the branch name as input. The `update-release-notes` job is then skipped on push events and runs only on `workflow_dispatch` or `workflow_call`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8b11fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->