### PR TITLE
fix(ci): allow the github-actions bot to initiate release-notes drafting

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -101,6 +101,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--max-turns 15"
+          # The redispatch shim initiates runs as github-actions[bot]
+          allowed_bots: "github-actions"
           prompt: |
             You are drafting release notes for a software SDK. The audience is end users
             of this SDK, not contributors to this repo.
@@ -179,6 +181,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--max-turns 15"
+          # The redispatch shim initiates runs as github-actions[bot]
+          allowed_bots: "github-actions"
           prompt: |
             You are reviewing release notes for a software SDK. The audience is end users
             of this SDK, not contributors to this repo.


### PR DESCRIPTION
## Summary

Third and hopefully final blocker in the release-notes chain: [run 30378438774](https://github.com/xmtp/libxmtp/actions/runs/30378438774) got past the event-type check (#3904) but failed with

> Workflow initiated by non-human actor: github-actions (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

The redispatch shim dispatches with `GITHUB_TOKEN`, so the dispatched run's actor is `github-actions[bot]`, which `claude-code-action` rejects by default. This adds `allowed_bots: "github-actions"` to both action steps (draft + suggest-edits). Scoped to that one bot rather than `*`.

Validation that the rest of the chain works: a manual human-actor dispatch of the same workflow file on `release/1.11.0` proceeds past this check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow the github-actions bot to trigger release notes drafting in CI
> Adds `allowed_bots: "github-actions"` to both `anthropics/claude-code-action@v1` steps in [release-notes.yml](.github/workflows/release-notes.yml) so the GitHub Actions bot can initiate the "Draft release notes" and "Suggest release notes edits" jobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb91a89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->