### PR TITLE
fix(ci): raise release-notes drafting turn budget to 50

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -100,7 +100,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 15"
+          # Budget for six SDK note files: each needs a diff, a log, and a
+          # full draft, plus the final commit. 15 was exhausted mid-draft.
+          claude_args: "--max-turns 50"
           # The redispatch shim initiates runs as github-actions[bot]
           allowed_bots: "github-actions"
           prompt: |
@@ -180,7 +182,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 15"
+          # Budget for six SDK note files: each needs a diff, a log, and a
+          # full draft, plus the final commit. 15 was exhausted mid-draft.
+          claude_args: "--max-turns 50"
           # The redispatch shim initiates runs as github-actions[bot]
           allowed_bots: "github-actions"
           prompt: |


### PR DESCRIPTION
## Summary

Fourth blocker in the release-notes chain, and the first from a run that actually executed Claude: [run 30378640521](https://github.com/xmtp/libxmtp/actions/runs/30378640521) failed with

> Claude execution failed: Reached maximum number of turns (15)

`--max-turns 15` can't cover the drafting workload: six SDK note files, each needing a `git diff <prev-tag>..HEAD`, a `git log`, and a full multi-section draft, plus the final commit. Raised to 50 on both steps (draft + suggest-edits) — enough headroom for six SDKs without being unbounded.

With #3903 (OIDC), #3904 (push redispatch), #3905 (allowed_bots), and this, the full automated chain should finally work: push to `release/**` → shim redispatch → bot-initiated drafting run with an adequate budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise release-notes CI turn budget from 15 to 50 for drafting and editing steps
> Both the "Draft release notes" and "Suggest release notes edits" steps in [release-notes.yml](.github/workflows/release-notes.yml) now run `anthropics/claude-code-action` with `max_turns: 50` instead of 15, to accommodate workflows that process multiple SDK note files per run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cddef8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->