### PR TITLE
fix(ci): allow tools for release-notes drafting + keep shim runs green

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -16,10 +16,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: release-notes-${{ inputs.release-branch || github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
   # claude-code-action rejects push-triggered runs ("Unsupported event
   # type: push"), so convert the push into a workflow_dispatch of this
@@ -45,6 +41,12 @@ jobs:
   update-release-notes:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
+    # Job-level (not workflow-level) so the push shim above never joins
+    # the group — its dispatched child was cancelling it, leaving a
+    # spurious cancelled run on every release-branch push.
+    concurrency:
+      group: release-notes-${{ inputs.release-branch || github.ref_name }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write
@@ -100,9 +102,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Budget for six SDK note files: each needs a diff, a log, and a
-          # full draft, plus the final commit. 15 was exhausted mid-draft.
-          claude_args: "--max-turns 50"
+          # Agent mode denies tools not allow-listed here; the prompt needs
+          # git history reads, file edits, and the final commit. 50 turns
+          # covers six SDK note files.
+          claude_args: >-
+            --max-turns 50
+            --allowed-tools "Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Read,Edit,Write,Glob,Grep"
           # The redispatch shim initiates runs as github-actions[bot]
           allowed_bots: "github-actions"
           prompt: |
@@ -182,9 +187,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Budget for six SDK note files: each needs a diff, a log, and a
-          # full draft, plus the final commit. 15 was exhausted mid-draft.
-          claude_args: "--max-turns 50"
+          # Agent mode denies tools not allow-listed here; the prompt needs
+          # git history reads, file edits, and the final commit. 50 turns
+          # covers six SDK note files.
+          claude_args: >-
+            --max-turns 50
+            --allowed-tools "Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Read,Edit,Write,Glob,Grep"
           # The redispatch shim initiates runs as github-actions[bot]
           allowed_bots: "github-actions"
           prompt: |


### PR DESCRIPTION
## Summary

Two fixes for the release-notes automation:

**1. The real reason runs were exhausting turns.** [Run 30379217109](https://github.com/xmtp/libxmtp/actions/runs/30379217109) hit the raised 50-turn cap with `"permission_denials_count": 6` in the execution log. `claude-code-action` agent mode denies any tool not allow-listed via `--allowed-tools`, and the drafting prompt requires exactly those tools (`git diff`/`git log` per SDK, file edits, `git commit`). Every run since #3906 was burning its budget on denials, so raising turns alone could never fix it. Both Claude steps now pass an explicit allow-list: git read/commit subcommands plus `Read`/`Edit`/`Write`/`Glob`/`Grep` — scoped, no blanket `Bash(*)`.

**2. Spurious cancelled run on every release-branch push.** The workflow-level concurrency group was shared by the push (shim) run and its dispatched child, so the child cancelled its parent — a red ✕ on every push. The group is now scoped to the `update-release-notes` job: shim runs finish green, and superseded drafting runs still cancel each other.

## Test plan

- YAML validated (job-level `concurrency` present, workflow-level removed, both steps carry `--allowed-tools`).
- Real-world validation: merge main into `release/1.11.0`; the push should produce a green shim run and a drafting run that finally commits `docs: draft release notes for 1.11.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release-notes CI by adding explicit tool allowlists and scoping concurrency to job level
> - Adds an explicit `--allowed-tools` whitelist (git read/write ops, file tools) to both Claude steps in [release-notes.yml](.github/workflows/release-notes.yml), replacing bare `--max-turns 50` args.
> - Moves the concurrency group from workflow level to the `update-release-notes` job level, so the redispatch shim job is no longer cancelled when a new run starts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63b60b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->