### PR TITLE
fix(ci): unblock release-notes drafting — git arg variants, turn budget, visibility

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -102,14 +102,21 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Agent mode denies tools not allow-listed here; the prompt needs
-          # git history reads, file edits, and the final commit. 50 turns
-          # covers six SDK note files.
+          # Agent mode denies tools not allow-listed here. Enumerated
+          # subcommands only — a blanket Bash(git:*) would allow
+          # arbitrary shell via `git -c alias.x='!cmd' x`, and this job
+          # holds write perms + API keys while reading untrusted commit
+          # history. The --no-pager variants are listed because prefix
+          # rules match literally. 100 turns: six SDK note files over a
+          # full release range didn't fit in 50.
           claude_args: >-
-            --max-turns 50
-            --allowed-tools "Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Read,Edit,Write,Glob,Grep"
+            --max-turns 100
+            --allowed-tools "Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(git add:*),Bash(git commit:*),Bash(git --no-pager diff:*),Bash(git --no-pager log:*),Bash(git --no-pager show:*),Read,Edit,Write,Glob,Grep"
           # The redispatch shim initiates runs as github-actions[bot]
           allowed_bots: "github-actions"
+          # Transcript in the job log — debugging denials/caps is blind
+          # without it. Nothing secret runs in this workflow.
+          show_full_output: true
           prompt: |
             You are drafting release notes for a software SDK. The audience is end users
             of this SDK, not contributors to this repo.
@@ -141,6 +148,11 @@ jobs:
 
             After editing all files, commit with message:
             docs: draft release notes for ${{ steps.version.outputs.version }} [skip ci]
+
+            Tool constraints: only plain git subcommands (diff, log, show,
+            status, add, commit) are allowed, optionally with --no-pager.
+            Do not use `git -c`, aliases, pipes, command substitution, or
+            heredocs — commit with a single `git commit -m "<message>"`.
 
       - name: Push draft release notes
         if: steps.classify.outputs.has_empty == 'true'
@@ -187,14 +199,21 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Agent mode denies tools not allow-listed here; the prompt needs
-          # git history reads, file edits, and the final commit. 50 turns
-          # covers six SDK note files.
+          # Agent mode denies tools not allow-listed here. Enumerated
+          # subcommands only — a blanket Bash(git:*) would allow
+          # arbitrary shell via `git -c alias.x='!cmd' x`, and this job
+          # holds write perms + API keys while reading untrusted commit
+          # history. The --no-pager variants are listed because prefix
+          # rules match literally. 100 turns: six SDK note files over a
+          # full release range didn't fit in 50.
           claude_args: >-
-            --max-turns 50
-            --allowed-tools "Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Read,Edit,Write,Glob,Grep"
+            --max-turns 100
+            --allowed-tools "Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(git add:*),Bash(git commit:*),Bash(git --no-pager diff:*),Bash(git --no-pager log:*),Bash(git --no-pager show:*),Read,Edit,Write,Glob,Grep"
           # The redispatch shim initiates runs as github-actions[bot]
           allowed_bots: "github-actions"
+          # Transcript in the job log — debugging denials/caps is blind
+          # without it. Nothing secret runs in this workflow.
+          show_full_output: true
           prompt: |
             You are reviewing release notes for a software SDK. The audience is end users
             of this SDK, not contributors to this repo.
@@ -230,6 +249,11 @@ jobs:
 
             If you make changes, commit with message:
             docs: suggest release notes updates for ${{ steps.version.outputs.version }}
+
+            Tool constraints: only plain git subcommands (diff, log, show,
+            status, add, commit) are allowed, optionally with --no-pager.
+            Do not use `git -c`, aliases, pipes, command substitution, or
+            heredocs — commit with a single `git commit -m "<message>"`.
 
       - name: Push suggestions and manage PR
         if: steps.classify.outputs.has_content == 'true'


### PR DESCRIPTION
## Summary

[Run 30380255573](https://github.com/xmtp/libxmtp/actions/runs/30380255573) — the first with an `--allowed-tools` list — confirmed the args parse correctly and did real drafting work, but still hit the cap: `num_turns: 51`, `permission_denials_count: 4`. Three adjustments:

1. **Cover the git variants prefix rules were missing — without widening the sandbox.** Initially this PR used `Bash(git:*)`; Macroscope correctly flagged that as arbitrary shell execution (`git -c alias.x='!cmd' x`) in a job holding write permissions and API keys while reading untrusted commit history. Now: the enumerated subcommand list stays, extended with the `Bash(git --no-pager diff/log/show:*)` variants that caused denials, and both prompts explicitly constrain Claude to plain subcommands with a single `-m` commit message (no `-c`, aliases, pipes, substitution, or heredocs — shapes the permission engine rejects anyway).
2. **`--max-turns 100`.** 51 turns with only 4 denials means the work itself doesn't fit in 50: six SDK note files, each drafted from a full v1.10.0..HEAD diff (~300 commits).
3. **`show_full_output: true`.** The per-turn transcript was hidden, making the last two failures blind guesses. Nothing secret runs in this workflow.

## Test plan

- YAML validated; both action steps carry the enumerated allow-list and prompt constraints.
- Real-world validation: merge main into `release/1.11.0` and let the push chain run drafting end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release-notes CI by adding git `--no-pager` arg variants, increasing turn budget, and enabling transcript output
> - Adds `Bash(git --no-pager diff:*)`, `Bash(git --no-pager log:*)`, and `Bash(git --no-pager show:*)` to `--allowed-tools` in both claude-code-action steps in [release-notes.yml](.github/workflows/release-notes.yml), alongside the existing plain `git` variants
> - Increases `--max-turns` from 50 to 100 to give the agent more headroom to complete drafting tasks
> - Adds `show_full_output: true` to emit full action transcripts to CI logs
> - Appends a "Tool constraints" block to each prompt clarifying only plain git subcommands (optionally with `--no-pager`) are allowed, forbidding pipes, aliases, and command substitution
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8309ba7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->