### PR TITLE
fix(xmtp_mls_common): correct migration policy defaults for absent metadata fields

### DIFF
--- a/crates/xmtp_mls_common/src/app_data/migration.rs
+++ b/crates/xmtp_mls_common/src/app_data/migration.rs
@@ -160,8 +160,10 @@ pub enum MigrationError {
 /// Mapping summary:
 ///
 /// - Mutable scalar components pull insert/update from
-///   `update_metadata_policy[field_name]` (default Allow); delete is
-///   hardcoded super-admin-only. Per-field `ComponentType` comes from
+///   `update_metadata_policy[field_name]`; a missing key defaults to
+///   admin-only (super-admin for the 0x800A protocol-version floor),
+///   mirroring the legacy enforcer. Delete is hardcoded super-admin-only.
+///   Per-field `ComponentType` comes from
 ///   [`metadata_field_registry_mapping`] — disappearing-message
 ///   timestamps are bytes (BE-u64), the rest are utf-8 strings.
 /// - `ADMIN_LIST` is constrained: insert/update from `add_admin_policy`,
@@ -234,16 +236,31 @@ fn build_registry(
     }
 
     // Mutable scalar components: insert/update from
-    // `update_metadata_policy[field]` (default Allow); delete is always
-    // super-admin-only. Per-field `ComponentType` comes from the
-    // mapping — strings for free-form text, bytes for the BE-u64
-    // disappearing-message timestamps.
+    // `update_metadata_policy[field]`; delete is always super-admin-only.
+    // Per-field `ComponentType` comes from the mapping — strings for
+    // free-form text, bytes for the BE-u64 disappearing-message
+    // timestamps.
+    //
+    // A field ABSENT from `update_metadata_policy` must default to what the
+    // legacy enforcer applied to a missing field — admin-only
+    // (`group_permissions.rs`: "default to admin only for fields with
+    // missing policies"), NOT `Allow`. The protocol-version floor defaults
+    // to super-admin instead, matching every preconfigured PolicySet
+    // (`default_map`/`default_policy`/`policy_admin_only`), so a group that
+    // predates the field can't be wedged by a non-super-admin raising the
+    // monotonic 0x800A floor. Present keys are carried verbatim, so a DM's
+    // stored `Allow` (from `dm_map`) is preserved rather than tightened.
     for (field, component_id, component_type) in metadata_field_registry_mapping() {
+        let default_base = if matches!(field, MetadataField::MinimumSupportedProtocolVersion) {
+            MetadataBasePolicy::AllowIfSuperAdmin
+        } else {
+            MetadataBasePolicy::AllowIfAdmin
+        };
         let policy = policy_set
             .update_metadata_policy
             .get(field.as_str())
             .cloned()
-            .unwrap_or_else(|| metadata_policy(MetadataBasePolicy::Allow));
+            .unwrap_or_else(|| metadata_policy(default_base));
 
         registry.set(
             *component_id,
@@ -964,6 +981,13 @@ mod tests {
             kind: Some(MetadataKind::Base(MetadataBasePolicy::AllowIfAdmin as i32)),
         }
     }
+    fn allow_if_super_admin_metadata() -> MetadataPolicyProto {
+        MetadataPolicyProto {
+            kind: Some(MetadataKind::Base(
+                MetadataBasePolicy::AllowIfSuperAdmin as i32,
+            )),
+        }
+    }
     fn admin_only_perms() -> PermissionsUpdatePolicyProto {
         PermissionsUpdatePolicyProto {
             kind: Some(PermissionsKind::Base(
@@ -1018,12 +1042,61 @@ mod tests {
     }
 
     #[test]
-    fn synthesis_defaults_to_allow_for_missing_metadata_fields() {
+    fn synthesis_defaults_to_admin_for_missing_metadata_fields() {
+        // A field absent from the legacy `update_metadata_policy` map must
+        // mirror the legacy enforcer's missing-field fallback (admin-only),
+        // NOT `Allow` — otherwise migrating a group that predates the field
+        // silently downgrades it to anyone-editable.
         let registry = synthesize_registry_from_policy_set(&minimal_default_policy_set()).unwrap();
         let meta = registry.get(&ComponentId::GROUP_NAME).unwrap().unwrap();
         let perms = meta.permissions.unwrap();
-        let ins = perms.insert_policy.unwrap();
-        assert_eq!(ins, allow_metadata());
+        assert_eq!(perms.insert_policy.unwrap(), allow_if_admin_metadata());
+        assert_eq!(perms.update_policy.unwrap(), allow_if_admin_metadata());
+    }
+
+    #[test]
+    fn synthesis_defaults_min_version_floor_to_super_admin_when_missing() {
+        // The monotonic 0x800A protocol-version floor is a group-wedge lever:
+        // a group whose stored PolicySet omits it (created before the field
+        // existed, or every DM created before it) must NOT let a non-super-
+        // admin raise it, or any member could pause the group permanently.
+        let registry = synthesize_registry_from_policy_set(&minimal_default_policy_set()).unwrap();
+        let meta = registry
+            .get(&ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION)
+            .unwrap()
+            .unwrap();
+        let perms = meta.permissions.unwrap();
+        assert_eq!(
+            perms.insert_policy.unwrap(),
+            allow_if_super_admin_metadata()
+        );
+        assert_eq!(
+            perms.update_policy.unwrap(),
+            allow_if_super_admin_metadata()
+        );
+    }
+
+    #[test]
+    fn synthesis_preserves_a_stored_min_version_policy() {
+        // The super-admin default only fills a MISSING key; a stored floor
+        // policy (e.g. a DM's `Allow` from `dm_map`) is carried verbatim so
+        // migration stays faithful rather than unfaithfully tightening it.
+        let mut ps = minimal_default_policy_set();
+        ps.update_metadata_policy.insert(
+            MetadataField::MinimumSupportedProtocolVersion
+                .as_str()
+                .to_string(),
+            allow_metadata(),
+        );
+        let registry = synthesize_registry_from_policy_set(&ps).unwrap();
+        let meta = registry
+            .get(&ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            meta.permissions.unwrap().insert_policy.unwrap(),
+            allow_metadata()
+        );
     }
 
     #[test]
@@ -1037,14 +1110,14 @@ mod tests {
             meta.permissions.clone().unwrap().insert_policy.unwrap(),
             allow_if_admin_metadata()
         );
-        // Description still defaults to Allow.
+        // Description, still absent from the map, defaults to admin-only.
         let desc = registry
             .get(&ComponentId::GROUP_DESCRIPTION)
             .unwrap()
             .unwrap();
         assert_eq!(
             desc.permissions.unwrap().insert_policy.unwrap(),
-            allow_metadata()
+            allow_if_admin_metadata()
         );
     }
 


### PR DESCRIPTION
## What

Corrects the app-data migration registry synthesis so a metadata field **absent** from the legacy `update_metadata_policy` map no longer defaults to `Allow`:

- absent key → `AllowIfAdmin` (mirrors the legacy enforcer's missing-field fallback in `group_permissions.rs`)
- absent `MIN_SUPPORTED_PROTOCOL_VERSION` (0x800A) → `AllowIfSuperAdmin` (matches every preconfigured `PolicySet`)
- **present keys are carried verbatim** — a DM's stored `Allow` (from `dm_map`) is preserved, so migration stays faithful and never tightens a policy the group actually had

Single file: `crates/xmtp_mls_common/src/app_data/migration.rs`.

## Why

Surfaced by the final pre-v1.11 re-review as a permanent-contract blocker. `build_registry` defaulted absent keys to `Allow`, but the legacy path enforced admin-only (super-admin for the floor). So migrating a group whose stored `PolicySet` omits a field — any group created before that field was added to `supported_fields()` — silently **downgraded** its authorization to anyone-editable.

- **Wedge (permanent group death):** `MIN_SUPPORTED_PROTOCOL_VERSION` rode the `Allow` default, so after migration **any member** could commit `AppDataUpdate(0x800A, "999.0.0")`. The floor is monotonic and version-gated (`validated_commit.rs`), so every receiver pauses forever with no way to lower it — unrecoverable. Pre-migration this required an admin.
- **Authorization downgrade:** name / description / image / disappearing-message settings became editable by non-admins on groups that had restricted them to admins.

This is release-blocking because migration synthesis is **deterministic and byte-compared across versions**: once v1.11.0 ships, the `Allow` default is a frozen cross-version contract and can't be changed in a later patch without forking every mixed-version migrating group. It has to be correct at the cut.

Present-key groups (all real preconfigured policy sets, and every existing test) are unaffected — the change only fills the missing-key gap, and fills it the way the legacy enforcer already did.

## Test plan

- `cargo nextest run -p xmtp_mls_common -E 'test(migration)'` → **34/34 pass**.
- Added 3 regression tests: the floor defaults to super-admin when the key is missing; other metadata fields default to admin-only when missing; a **stored** floor policy is preserved verbatim (DM `Allow` faithfulness).
- Corrected 2 tests that had pinned the old `Allow` default.
- Golden-vector and determinism tests **unchanged** — the change is policy synthesis only, not the byte-pinned canonical-subset value encoder, so no golden regeneration.
- `cargo clippy -p xmtp_mls_common --all-features --tests` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix default migration policy for absent metadata fields in `build_registry`
> - Mutable scalar metadata fields missing from `update_metadata_policy` now default to `AllowIfAdmin` instead of `Allow` when synthesizing the `ComponentRegistry`.
> - `MinimumSupportedProtocolVersion` gets a stricter default of `AllowIfSuperAdmin` when its policy key is absent.
> - Tests in [migration.rs](https://github.com/xmtp/libxmtp/pull/3910/files#diff-fb2c0e4b1c9d4141db1c1b094ed137f5ae4b462fb774ee95a8889b41e5c5ed73) are updated to assert the new defaults and cover the `MinimumSupportedProtocolVersion` edge case.
> - Behavioral Change: any absent metadata policy key that previously granted open (`Allow`) access now requires admin or super-admin permission.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a963153.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->