### PR TITLE
fix(nix): strip -mtls-dialect=gnu2 from the Android NDK cc wrapper

### DIFF
--- a/nix/lib/patches.nix
+++ b/nix/lib/patches.nix
@@ -96,5 +96,38 @@
       });
     }
   )
+  # nixpkgs 624af665's cc-wrapper enables TLSDESC for every Linux x86
+  # target when the compiler is clang >= 19.1 (tlsDialect in
+  # pkgs/build-support/cc-wrapper/default.nix) with no Android
+  # exclusion, so the NDK wrapper's clang hook injects
+  # -mtls-dialect=gnu2 into every compile. NDK clang hard-rejects it:
+  #   clang: error: unsupported argument 'gnu2' to option
+  #     '-mtls-dialect=' for target 'x86_64-unknown-linux-android'
+  # breaking all C/asm cross-compiles (first casualty: ring's
+  # pregenerated asm in the Android unit-test job).
+  #
+  # Strip the flag from the wrapper's add-local-cc-cflags-before.sh,
+  # where machineFlags are substituted for clang. Gated on isAndroid,
+  # and the android closure rebuilds on any nixpkgs bump anyway, so
+  # this invalidates no extra cache.
+  #
+  # Upstream fix would be `&& !targetPlatform.isAndroid` in the
+  # tlsDialect definition; drop this overlay once that lands.
+  (
+    final: prev:
+    prev.lib.optionalAttrs (prev.stdenv.hostPlatform.isAndroid or false) {
+      stdenv = prev.overrideCC prev.stdenv (
+        prev.stdenv.cc.overrideAttrs (old: {
+          postFixup = (old.postFixup or "") + ''
+            hook=$out/nix-support/add-local-cc-cflags-before.sh
+            if [ -f "$hook" ]; then
+              # escapeShellArgs single-quotes the substituted flag
+              sed -i -e "s/ '-mtls-dialect=gnu2'//g" -e 's/ -mtls-dialect=gnu2//g' "$hook"
+            fi
+          '';
+        })
+      );
+    }
+  )
 
 ]


### PR DESCRIPTION
## Summary

Fixes the Android unit-test failure on #3909 ([job 90383884388](https://github.com/xmtp/libxmtp/actions/runs/30391424768/job/90383884388)):

> `clang: error: unsupported argument 'gnu2' to option '-mtls-dialect=' for target 'x86_64-unknown-linux-android'`

The nixpkgs bump in #3909 (→ `624af665`) picks up a cc-wrapper change that enables TLSDESC (`-mtls-dialect=gnu2`) for **every Linux x86 target** when the compiler is clang ≥ 19.1 (`tlsDialect` in `pkgs/build-support/cc-wrapper/default.nix`) — with no Android exclusion. The flag is substituted into the NDK wrapper's `nix-support/add-local-cc-cflags-before.sh` and prepended to every compile, and NDK clang hard-rejects it, killing all C/asm cross-compiles for `x86_64-linux-android` (first casualty: `ring`'s pregenerated assembly).

This adds an overlay to `nix/lib/patches.nix` (following the existing atf/tcl precedents) that strips the flag from the wrapper's clang hook, gated on `isAndroid`. The android closure rebuilds on the nixpkgs bump anyway, so no extra cache invalidation.

Upstream fix would be `&& !targetPlatform.isAndroid` in the `tlsDialect` definition — this overlay carries a note to drop it once that lands.

## Test plan

Verified locally on this branch:
- `nix build` of the patched wrapper: the hook now reads `extraBefore+=(-target x86_64-unknown-linux-android)` — flag gone (was `… '-mtls-dialect=gnu2')`).
- A C compile through the patched wrapper (`x86_64-unknown-linux-android-cc -c`) succeeds and emits a valid x86-64 ELF object — the exact operation that failed in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip `-mtls-dialect=gnu2` from the Android NDK cc-wrapper hook
> The `-mtls-dialect=gnu2` flag is incompatible with clang on Android targets but gets injected via the cc-wrapper's `add-local-cc-cflags-before.sh` hook. A new `androidTlsDialectStrip` overlay in [patches.nix](https://github.com/xmtp/libxmtp/pull/3911/files#diff-a0c603b759efcc01ff44a1cc1d0f7aeb5b28903640bb2354bb0c6b41059a3609) wraps `stdenv.cc` with a `postFixup` step that uses `sed` to remove all occurrences of the flag (quoted and unquoted) from that hook script. The overlay only applies when `stdenv.hostPlatform.isAndroid` is true.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a67522.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->