### PR TITLE
chore: drop x86_64-darwin (Intel Mac) support

### DIFF
--- a/.claude/skills/working-with-nix/packages.md
+++ b/.claude/skills/working-with-nix/packages.md
@@ -15,7 +15,6 @@ All `nix build .#<package>` outputs defined in `flake.nix`.
 | `node-bindings-linux-x64-musl` | `nix build .#node-bindings-linux-x64-musl` | Per-target .node binary |
 | `node-bindings-linux-arm64-gnu` | `nix build .#node-bindings-linux-arm64-gnu` | Per-target .node binary |
 | `node-bindings-linux-arm64-musl` | `nix build .#node-bindings-linux-arm64-musl` | Per-target .node binary |
-| `node-bindings-darwin-x64` | `nix build .#node-bindings-darwin-x64` | Per-target .node binary |
 | `node-bindings-darwin-arm64` | `nix build .#node-bindings-darwin-arm64` | Per-target .node binary |
 | `node-bindings-fast` | `nix build .#node-bindings-fast` | Host-matching .node only |
 | `node-bindings-js` | `nix build .#node-bindings-js` | Generated index.js + index.d.ts |
@@ -47,7 +46,6 @@ Target mapping (Rust triple -> NAPI platform name):
 | `x86_64-unknown-linux-musl` | `linux-x64-musl` |
 | `aarch64-unknown-linux-gnu` | `linux-arm64-gnu` |
 | `aarch64-unknown-linux-musl` | `linux-arm64-musl` |
-| `x86_64-apple-darwin` | `darwin-x64` |
 | `aarch64-apple-darwin` | `darwin-arm64` |
 
 Windows targets are excluded from Nix (built separately in CI).

--- a/.claude/skills/working-with-nix/shells/default.md
+++ b/.claude/skills/working-with-nix/shells/default.md
@@ -43,7 +43,7 @@ Note: `SDKROOT` is explicitly **unset** so xcrun discovers the right SDK per tar
 - `wasm32-unknown-unknown`
 - `x86_64-unknown-linux-gnu`
 - `aarch64-linux-android`, `armv7-linux-androideabi`, `x86_64-linux-android`, `i686-linux-android`
-- Darwin only: `aarch64-apple-ios`, `aarch64-apple-ios-sim`, `x86_64-apple-darwin`, `aarch64-apple-darwin`
+- Darwin only: `aarch64-apple-ios`, `aarch64-apple-ios-sim`, `aarch64-apple-darwin`
 
 ## Rust Components
 

--- a/.claude/skills/working-with-nix/shells/ios.md
+++ b/.claude/skills/working-with-nix/shells/ios.md
@@ -31,8 +31,7 @@ Note: `SDKROOT` is explicitly **unset** so xcrun discovers the right SDK per tar
 
 ## Rust Targets
 
-- `x86_64-apple-darwin` — macOS Intel (universal binary)
-- `aarch64-apple-darwin` — macOS Apple Silicon (universal binary)
+- `aarch64-apple-darwin` — macOS Apple Silicon
 - `aarch64-apple-ios` — iOS device (arm64)
 - `aarch64-apple-ios-sim` — iOS simulator on Apple Silicon
 

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -108,7 +108,6 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - darwin-x64
           - darwin-arm64
     steps:
       - uses: actions/checkout@v6
@@ -236,38 +235,12 @@ jobs:
           path: bindings/node/bindings_node.${{ matrix.output_target }}.node
           retention-days: 1
 
-  build-macos-universal:
-    needs: [setup, build-macos]
-    runs-on: warp-macos-latest-arm64-6x
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: bindings_node_darwin-x64
-          path: artifacts/
-      - uses: actions/download-artifact@v8
-        with:
-          name: bindings_node_darwin-arm64
-          path: artifacts/
-      - name: Create universal binary
-        run: |
-          lipo -create \
-            artifacts/bindings_node.darwin-x64.node \
-            artifacts/bindings_node.darwin-arm64.node \
-            -output bindings_node.darwin-universal.node
-          lipo -info bindings_node.darwin-universal.node
-      - uses: actions/upload-artifact@v7
-        with:
-          name: bindings_node_darwin-universal
-          path: bindings_node.darwin-universal.node
-          retention-days: 1
-
   publish:
     needs:
       [
         setup,
         build-linux,
         build-macos,
-        build-macos-universal,
         build-js,
         build-windows,
       ]

--- a/.github/workflows/test-bindings-check.yml
+++ b/.github/workflows/test-bindings-check.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - x86_64-apple-darwin
           - aarch64-apple-darwin
     steps:
       - name: Checkout

--- a/nix/lib/ios-env.nix
+++ b/nix/lib/ios-env.nix
@@ -13,12 +13,12 @@
 { lib }:
 let
   # Cross-compilation targets for the iOS release:
-  #   x86_64-apple-darwin    — macOS Intel (for universal macOS binary)
-  #   aarch64-apple-darwin   — macOS Apple Silicon (for universal macOS binary)
+  #   aarch64-apple-darwin   — macOS Apple Silicon
   #   aarch64-apple-ios      — iOS device (arm64)
   #   aarch64-apple-ios-sim  — iOS simulator on Apple Silicon
+  # (x86_64-apple-darwin was dropped with nixpkgs' x86_64-darwin support;
+  # the macOS slice is arm64-only now.)
   iosTargets = [
-    "x86_64-apple-darwin"
     "aarch64-apple-darwin"
     "aarch64-apple-ios"
     "aarch64-apple-ios-sim"
@@ -44,7 +44,6 @@ let
     {
       "aarch64-apple-ios" = "Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk";
       "aarch64-apple-ios-sim" = "Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk";
-      "x86_64-apple-darwin" = "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
       "aarch64-apple-darwin" = "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
     }
     .${target};

--- a/nix/lib/packages/swiftformat.nix
+++ b/nix/lib/packages/swiftformat.nix
@@ -25,11 +25,6 @@ let
       binary = "swiftformat_linux_aarch64";
       hash = "sha256-N0sZdQgpcKwXybMHY528ChSGVkNM1hLP8GlX4nkCDzQ=";
     };
-    x86_64-darwin = {
-      asset = "swiftformat.zip";
-      binary = "swiftformat";
-      hash = "sha256-fLHLH64EkyBHxwFUQcVDhI6OYOFXLYCNCA4KHxZhEUo=";
-    };
     aarch64-darwin = {
       asset = "swiftformat.zip";
       binary = "swiftformat";

--- a/nix/node-packages.nix
+++ b/nix/node-packages.nix
@@ -27,7 +27,6 @@
       ];
 
       darwinTargets = [
-        "x86_64-apple-darwin"
         "aarch64-apple-darwin"
       ];
 

--- a/sdks/ios/VALIDATION.md
+++ b/sdks/ios/VALIDATION.md
@@ -4,7 +4,7 @@
 
 ### Build (`./sdks/ios/dev/build`)
 
-- [x] Rust cross-compilation succeeds for all targets (aarch64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-darwin, aarch64-apple-darwin)
+- [x] Rust cross-compilation succeeds for all targets (aarch64-apple-ios, aarch64-apple-ios-sim, aarch64-apple-darwin)
 - [x] xcframework created at `sdks/ios/.build/LibXMTPSwiftFFI.xcframework`
 - [x] Swift package builds successfully (108 files compiled)
 


### PR DESCRIPTION
## Summary

Latest nixpkgs ended x86_64-darwin support, and no known consumers remain on Intel Macs. This removes the x86_64-darwin surface across the repo:

- **iOS/macOS xcframework** (`nix/lib/ios-env.nix`): `x86_64-apple-darwin` dropped from the target list — the macOS slice is arm64-only now. The lipo/assembly in `nix/package/ios.nix` is target-list-driven and adapts unchanged.
- **Node bindings** (`nix/node-packages.nix`, `release-node.yml`): `darwin-x64` build removed along with the now-pointless `build-macos-universal` lipo job; npm ships `darwin-arm64` only. The napi loader's fallback chain tolerates the missing universal/x64 binaries (try/catch per candidate), so ARM Macs load `darwin-arm64` and Intel Macs get a clean load error.
- **CI** (`test-bindings-check.yml`): `x86_64-apple-darwin` check matrix entry removed.
- **swiftformat prebuilt** (`nix/lib/packages/swiftformat.nix`): dead `x86_64-darwin` source entry removed — the flake never exposed x86_64-darwin as a host system.
- **Docs**: working-with-nix skill pages and `sdks/ios/VALIDATION.md` updated.

Deliberately untouched: `release/1.11.0` — the in-flight release keeps the Intel slice; this lands on main only and takes effect from the next release.

## Test plan

- `nix eval .#packages.aarch64-darwin` — set evaluates; `node-bindings-darwin-x64` gone, `darwin-arm64` intact.
- `nix fmt` clean; both workflow YAMLs validated (universal job gone, matrices correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop x86_64-darwin (Intel Mac) support from builds and CI
> - Removes `x86_64-apple-darwin` from all build targets: Node bindings, Swift bindings, iOS env, and Nix package definitions.
> - Deletes the `build-macos-universal` CI job that used `lipo` to merge Intel and ARM artifacts into a universal binary; only `darwin-arm64` is now built.
> - Updates CI workflows, Nix expressions, and documentation to reflect ARM-only macOS support.
> - Behavioral Change: universal macOS Node bindings are no longer produced or published.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a438a21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->