### PR TITLE
chore: remove leftover x86_64-apple-darwin cargo linker export

### DIFF
--- a/nix/lib/ios-env.nix
+++ b/nix/lib/ios-env.nix
@@ -111,7 +111,6 @@ let
       export CC="$_XCODE_CLANG"
       export CXX="$_XCODE_CLANGXX"
       export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="$_XCODE_CLANG"
-      export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="$_XCODE_CLANG"
     ''
     + lib.optionalString (isIosTarget target) ''
       _IOS_SDKROOT="$_XCODE_DEV/${sdkSuffixForTarget target}"


### PR DESCRIPTION
## Summary

Follow-up to #3914, addressing the review feedback that was posted after auto-merge fired: `nix/lib/ios-env.nix` still exported `CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER`. The removal sweep grepped the hyphenated target spelling (`x86_64-apple-darwin`) and missed the underscored env-var form. Also swept for other `X86_64_APPLE_DARWIN`/`X86_64_DARWIN` spellings — this was the only one.

Harmless functionally (an unused env export for a target no longer built), but dead config.

## Test plan

- `nix eval .#packages.aarch64-darwin` evaluates clean; `nix fmt` no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER` export from iOS environment setup
> Removes a leftover `CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER` export from [ios-env.nix](https://github.com/xmtp/libxmtp/pull/3915/files#diff-42b6ece9dfbfd6a6c08cbf5a9e3a654c1bd5f4cbf45fdfbeef15754cdb6a14eb) that was forcing Cargo to use Xcode clang as the linker for x86_64-apple-darwin builds. Also adds a conditional export of `_IOS_SDKROOT` to an SDK-specific path when building iOS targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3c079f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->