### PR TITLE
fix(nix): re-sign node bindings via signingUtils sign, not bare codesign

### DIFF
--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -81,11 +81,8 @@ rust.napiBuild (
     '';
   }
   // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    # sigtool provides `codesign` on PATH for the postFixup re-sign.
-    # See https://github.com/xmtp/libxmtp/issues/3513.
     nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
       darwin.autoSignDarwinBinariesHook
-      darwin.sigtool
     ];
     postFixup = ''
       NODE_LIB=$(echo $out/dist/bindings_node.*.node)
@@ -108,10 +105,11 @@ rust.napiBuild (
           install_name_tool -change "$old" "/usr/lib/$(basename "$old")" "$NODE_LIB"
         done
 
-      # install_name_tool invalidates the ad-hoc signature applied by
-      # darwin.autoSignDarwinBinariesHook; re-sign so the .node loads under
-      # Gatekeeper on end-user macOS hosts.
-      codesign --force --sign - "$NODE_LIB"
+      # install_name_tool invalidates the ad-hoc signature; re-sign with the
+      # `sign` function from signingUtils (sourced via autoSignDarwinBinariesHook),
+      # which sets CODESIGN_ALLOCATE — bare sigtool codesign aborts now that
+      # nixpkgs' darwin stdenv no longer puts cctools on PATH. See #3513.
+      sign "$NODE_LIB"
 
       # Assert no /nix/store references remain — guards against silent
       # no-ops in the rewrites above and catches the 1.10.0 regression.


### PR DESCRIPTION
## Problem

Since the nixpkgs bump in #3909, the darwin-arm64 node bindings build dies in `postFixup`:

```
libc++abi: terminating due to uncaught exception of type std::runtime_error: Failed to spawn codesign_allocate: No such file or directory
Abort trap: 6   codesign --force --sign - "$NODE_LIB"
```

This broke the node leg of the 1.11.0 RC (run 30406484418) and the macOS "Cache all Nix Outputs" job on main (run 30414469253), and will break tonight's nightly.

## Root cause

sigtool's `codesign` shells out to `codesign_allocate`, which it finds via `PATH` or the `CODESIGN_ALLOCATE` env var. The new nixpkgs darwin stdenv no longer puts cctools on `PATH`, and our bare `codesign --force --sign -` call sets neither. nixpkgs' own signing machinery (`pkgs/os-specific/darwin/signing-utils/utils.sh`) wires it explicitly:

```sh
CODESIGN_ALLOCATE=@codesignAllocate@ @sigtool@/bin/codesign -f -s - ...
# codesignAllocate = "${cctools}/bin/${cctools.targetPrefix}codesign_allocate"
```

## Fix

Use that machinery instead of reimplementing it: `darwin.autoSignDarwinBinariesHook` (already in our `nativeBuildInputs`) sources signingUtils into the build shell, providing a `sign` function with `CODESIGN_ALLOCATE` correctly set. Replace the bare `codesign` call with `sign "$NODE_LIB"`, and drop `darwin.sigtool` from `nativeBuildInputs` — its only purpose was providing `codesign` on `PATH` for the call being replaced.

`sign` also copies the binary aside before signing and moves it back, which sidesteps the in-place re-sign-after-install_name_tool corruption that signingUtils exists to work around.

Verified `nix eval .#packages.aarch64-darwin.node-bindings-darwin-arm64.drvPath` still evaluates. (The actual build is darwin-only; CI's macOS jobs are the real test.)

Note: this fixes one of two failure classes in the macOS cache job — the `ring` build-script `-liconv` cross-compile failures are separate and under investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix macOS re-signing of node bindings to use `signingUtils sign` instead of bare `codesign`
> In [node.nix](https://github.com/xmtp/libxmtp/pull/3917/files#diff-fa9b6ba547ea5ae35048580f634e5edb6375afb0138fd6fb6e77fef6ee8c357b), the `postFixup` hook now calls the `sign` function sourced from `autoSignDarwinBinariesHook` instead of invoking `codesign --force --sign -` directly. `darwin.sigtool` is also removed from `nativeBuildInputs` as it is no longer needed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14b47af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->