### PR TITLE
fix(nix): restore build-platform cc in cross nativeBuildInputs (crane#1059)

### DIFF
--- a/nix/lib/base.nix
+++ b/nix/lib/base.nix
@@ -47,7 +47,11 @@ let
       perl
       zlib
     ]
-    ++ lib.optionals stdenv.buildPlatform.isDarwin [ darwin.libiconv ];
+    ++ lib.optionals stdenv.buildPlatform.isDarwin [ darwin.libiconv ]
+    # crane#1059 stopped adding toolchain cc's to nativeBuildInputs; restore the
+    # build-platform cc so its setup hook feeds build-role NIX_LDFLAGS (-liconv
+    # for darwin build scripts) and keeps unprefixed `cc` on PATH (aws-lc-sys).
+    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ pkgsBuildHost.stdenv.cc ];
     # these inputs do get cross compiled
     buildInputs = [
       zstd


### PR DESCRIPTION
## Problem

Second failure class in the macOS "Cache all Nix Outputs" job since #3909 (alongside the codesign crash fixed in #3917): every cross-from-darwin derivation (linux-musl, android) fails compiling `ring`'s **build script** — a host-side aarch64-apple-darwin link:

```
error: linking with '/nix/store/wzp8w4j2vadz23gxic4xhb8mw3g46rv6-clang-wrapper-21.1.8/bin/cc' failed
= note: ld: library not found for -liconv
```

## Root cause

Not nixpkgs — **crane**, which #3909 also bumped. [crane#1059](https://github.com/ipetkov/crane/pull/1059) (merged 2026-07-20, in our pinned rev) switched `mkCrossToolchainEnv` to absolute store paths and **stopped adding the toolchain compilers to `nativeBuildInputs`**. Crane's changelog marks it breaking: *"To bring back the previous behavior add the necessary compilers to `nativeBuildInputs`."*

Consequences:
- nixpkgs deliberately strips `libiconv.tbd` from the apple SDK (`apple-sdk/metadata/disallowed-packages.json`) and instead propagates the Nix `libiconv` package, whose `-L` flag reaches the linker **only** via the cc-wrapper's setup hook.
- With the wrapper no longer an activated dependency, that hook never runs — so `-liconv` (which Rust std emits for every apple target) has no search path. `-lSystem` still resolves because the bintools wrapper bakes a `-L<libSystem-B>/lib` and falls back to `SDKROOT`; `libiconv.tbd` exists in neither.
- Same cause breaks `AWS_LC_SYS_TARGET_CC_<build> = "cc"` (base.nix) — the unprefixed `cc` is no longer on `PATH`.

Native darwin builds are unaffected (the stdenv's own cc is always activated); only the *build-role* compiler in cross sets went missing.

## Fix

Exactly what crane's changelog prescribes — one line in `commonArgs.nativeBuildInputs` (flows to android, ios, node, and validation-service cross derivations):

```nix
++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ pkgsBuildHost.stdenv.cc ]
```

This reproduces the exact pre-#3909 dependency shape (old crane injected `(stdenvSelector pkgsBuildHost).cc` itself).

## Verification

- `.#packages.aarch64-darwin.node-bindings-linux-arm64-musl` now lists `/nix/store/wzp8w4j2…-clang-wrapper-21.1.8` — the **exact store path from the error message** — in `nativeBuildInputs` (in both the napi drv and the failing `cargo-package-deps` drv).
- Native builds untouched: `.#packages.x86_64-linux.node-bindings-fast.drvPath` is byte-identical to main's (`k2ycj0h7…`), so no cache invalidation for non-cross builds.
- `just lint-config` clean. Real proof is CI's macOS cache job (cross darwin builds can't run on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore build-platform `cc` in cross-compile `nativeBuildInputs` in `base.nix`
> When cross-compiling (`buildPlatform != hostPlatform`), `pkgsBuildHost.stdenv.cc` is now added to `nativeBuildInputs` in [base.nix](https://github.com/xmtp/libxmtp/pull/3918/files#diff-78e27920e7e7f148052510551d065fae07e34ca9a88df0abd2450dedb25668bc). This restores the build-platform C compiler's setup hook, which provides build-role `NIX_LDFLAGS` and keeps an unprefixed `cc` on `PATH` during the build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1f82b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->