### PR TITLE
fix(ci): don't retrigger release-notes drafting on notes-only pushes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,6 +3,10 @@ name: Release Notes
 on:
   push:
     branches: ["release/**"]
+    # Notes-only pushes (e.g. merging the drafter's own PR) must not
+    # retrigger drafting — that redrafts the redraft, forever (#3919/#3920).
+    paths-ignore:
+      - "docs/release-notes/**"
   workflow_dispatch:
     inputs:
       release-branch:


### PR DESCRIPTION
## Problem

The release-notes automation is a perpetual-motion machine: every push to `release/**` redispatches the AI drafter, and merging the drafter's *own* notes PR is itself such a push. Since the drafter always finds some wording to tweak, each merge spawns the next PR — #3919 → #3920 → (cancelled third run).

## Fix

`paths-ignore: docs/release-notes/**` on the push trigger. Drafting should re-run when release *content* changes, not when the notes themselves do. Mixed pushes (code + notes) still trigger.

Cherry-picked directly onto `release/1.11.0` with `[skip ci]` as well, since push events evaluate the workflow file at the pushed ref — the copy on main only protects future release branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent release-notes workflow from re-triggering on release note pushes
> Adds a `paths-ignore` block to the `push` trigger in [release-notes.yml](.github/workflows/release-notes.yml) to skip workflow runs when only files under `docs/release-notes/**` are changed. This avoids an infinite loop where the workflow pushing drafted release notes would retrigger itself.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ee9af6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->