### PR TITLE
chore: bump manifests to next dev versions after 1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "async-trait",
  "bindings_node",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "alloy",
  "async-trait",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm_macros"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "error_glossary"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "clap",
  "syn 2.0.119",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "keepalive-probe"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5947,7 +5947,7 @@ dependencies = [
 
 [[package]]
 name = "mls_validation_service"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "alloy",
  "async-trait",
@@ -10453,7 +10453,7 @@ dependencies = [
 
 [[package]]
 name = "xdbg"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -10518,7 +10518,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp-db-tools"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -10650,7 +10650,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10676,7 +10676,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -10717,7 +10717,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "async-trait",
  "futures",
@@ -10750,7 +10750,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -10779,7 +10779,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -10814,7 +10814,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "openmls",
  "xmtp-workspace-hack",
@@ -10824,7 +10824,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "aes-gcm",
  "base64 0.23.0",
@@ -10845,7 +10845,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "alloy",
  "bincode",
@@ -10874,7 +10874,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "arc-swap",
  "ascii_table",
@@ -10923,7 +10923,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "alloy",
  "async-trait",
@@ -10959,7 +10959,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_logging"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "console_error_panic_hook",
  "opentelemetry",
@@ -10981,7 +10981,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -10994,7 +10994,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -11078,7 +11078,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "bon",
  "const-hex",
@@ -11105,7 +11105,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "async-trait",
  "bincode",
@@ -11150,7 +11150,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "alloy",
  "async-trait",
@@ -11189,7 +11189,7 @@ dependencies = [
 
 [[package]]
 name = "xnet-cli"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "clap",
  "color-eyre",
@@ -11201,7 +11201,7 @@ dependencies = [
 
 [[package]]
 name = "xnet-lib"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "alloy",
  "ascii_table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "3"
 
 [workspace.package]
 license = "MIT"
-version = "1.11.0"
+version = "1.12.0-dev"
 rust-version = "1.94.0"
 publish = false
 edition = "2024"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.11.0",
+  "version": "1.12.0-dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/xmtp/libxmtp.git",

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.11.0",
+  "version": "1.12.0-dev",
   "description": "WASM bindings for the libXMTP rust library",
   "keywords": [
     "xmtp",

--- a/sdks/android/gradle.properties
+++ b/sdks/android/gradle.properties
@@ -23,4 +23,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false
 # SDK version - managed by release-tools
-version=4.11.0
+version=4.12.0-dev

--- a/sdks/ios/XMTP.podspec
+++ b/sdks/ios/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.11.0"
+  spec.version      = "4.12.0-dev"
 
   spec.summary      = "XMTP SDK Cocoapod"
 

--- a/sdks/js/browser-sdk/package.json
+++ b/sdks/js/browser-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/browser-sdk",
-  "version": "7.1.0",
+  "version": "7.2.0-dev",
   "description": "XMTP client SDK for browsers written in TypeScript",
   "keywords": [
     "xmtp",

--- a/sdks/js/node-sdk/package.json
+++ b/sdks/js/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-sdk",
-  "version": "6.1.0",
+  "version": "6.2.0-dev",
   "description": "XMTP Node client SDK for interacting with XMTP networks",
   "keywords": [
     "xmtp",


### PR DESCRIPTION
Answers "do we need to PR the version bump" — yes. The 1.11.0 reconcile squash (#3922) left main's manifests at the *released* versions, but `compute-version` bases dev builds on the manifest: the next dev publish would emit `1.11.0-dev.<sha>`, which semver-sorts **below** the released 1.11.0 and would drag the npm `dev` dist-tag backwards.

Precedent: the 1.10.0 reconcile (#3327) included this bump (`1.10.0` → `1.11.0-dev`) in the same commit; the pipeline-generated reconcile doesn't do that — one more for the pipeline-gaps list (create-release-branch/merge flow should append the next-dev bump).

Applied with the release tooling (`xmtp-release set-manifest-version`), next-minor `-dev` per track:

| track | version |
|---|---|
| libxmtp / node-bindings / wasm-bindings | `1.12.0-dev` |
| node-sdk | `6.2.0-dev` |
| browser-sdk | `7.2.0-dev` |
| iOS / Android | `4.12.0-dev` |

Cargo.lock refreshed by the tool; verified with `cargo metadata --locked --offline`. (If the next release turns out patch-only, create-release-branch re-bakes the real versions at branch time — the manifest is the dev baseline, same as last cycle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump all package manifests to 1.12.0-dev after 1.11.0 release
> Advances version numbers across all SDK and binding manifests to the next development cycle. Updates cover [Cargo.toml](https://github.com/xmtp/libxmtp/pull/3923/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), [bindings/node/package.json](https://github.com/xmtp/libxmtp/pull/3923/files#diff-06bf05930f1d382293fb33e2ee9e53e49368846db93780261392231d64a0ea7f), [bindings/wasm/package.json](https://github.com/xmtp/libxmtp/pull/3923/files#diff-1f41234b939ba148924b9bbfedd557853ebcd22351a9c300e568ce7af0291bab), the Android, iOS, and JS SDKs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5071d0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->