### PR TITLE
fix(ci): accept release/vX.Y maintenance branches in release-notes validation

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -66,8 +66,10 @@ jobs:
         env:
           BRANCH: ${{ inputs.release-branch || github.ref_name }}
         run: |
-          if ! echo "$BRANCH" | grep -qE '^release/[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
-            echo "::error::Invalid branch name format: $BRANCH (expected release/X.Y.Z)"
+          # Two branch shapes exist: pipeline-created release/X.Y.Z and
+          # long-lived maintenance lines like release/v1.11 (patch optional).
+          if ! echo "$BRANCH" | grep -qE '^release/v?[0-9]+\.[0-9]+(\.[0-9]+)?(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Invalid branch name format: $BRANCH (expected release/X.Y.Z or release/vX.Y)"
             exit 1
           fi
 
@@ -76,7 +78,10 @@ jobs:
         env:
           BRANCH: ${{ inputs.release-branch || github.ref_name }}
         run: |
+          # Label-only downstream (commit messages, PR titles, suggestion
+          # branch name) — a partial version like "1.11" is fine.
           VERSION="${BRANCH#release/}"
+          VERSION="${VERSION#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "Detected release version: $VERSION from branch: $BRANCH"


### PR DESCRIPTION
Found by the adversarial review of the 1.11.0 postmortem: renaming the release branch to `release/v1.11` (matching the `release/v1.9`/`release/v1.10` maintenance convention) broke the release-notes workflow for it — the validate step required exactly `release/X.Y.Z`, so any future drafting run on this branch (e.g. for a 1.11.1 patch) would error out immediately.

Changes in `release-notes.yml`:
- Widen validation to accept both shapes: pipeline-created `release/X.Y.Z[-suffix]` and maintenance lines `release/vX.Y[.Z]`. Still rejects `main`, `release/foo`, `release/v1` (tested all shapes).
- Version extraction strips the optional `v`. The extracted value is label-only downstream (commit messages, PR titles, the `ai-release-notes/*` suggestion branch name), so a partial `1.11` is fine — noted in a comment.

Audit of other parsers: `release.yml` only checks the `release/` prefix (already fine — it's why the final release ran from the renamed branch), and `create-release-branch` constructs `release/${version}` without parsing. This regex was the only strict one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release-notes CI to accept `release/vX.Y` maintenance branches in branch validation
> - Updates the branch validation regex in [release-notes.yml](.github/workflows/release-notes.yml) to accept both `release/X.Y.Z` and `release/vX.Y` (with optional patch) formats.
> - Strips a leading `v` from the extracted version after removing the `release/` prefix, so the emitted `version` output is always numeric (e.g. `1.11` not `v1.11`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e4d82f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->