### PR TITLE
fix(scw): replace panic with error on empty API response in signature verification

### DIFF
--- a/crates/xmtp_api/src/scw_verifier.rs
+++ b/crates/xmtp_api/src/scw_verifier.rs
@@ -43,7 +43,10 @@ where
         Ok(responses
             .into_iter()
             .next()
-            .expect("Api given one request will return one response")
+            .ok_or(VerifierError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "API returned empty response for signature verification request",
+            )))?
             .into())
     }
 }

--- a/crates/xmtp_id/src/scw_verifier/remote_signature_verifier.rs
+++ b/crates/xmtp_id/src/scw_verifier/remote_signature_verifier.rs
@@ -50,7 +50,10 @@ where
         Ok(responses
             .into_iter()
             .next()
-            .expect("Api given one request will return one response")
+            .ok_or(VerifierError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "API returned empty response for signature verification request",
+            )))?
             .into())
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3926

Replaces `.expect()` with `.ok_or(VerifierError::Other(...))` in two `SmartContractSignatureVerifier::is_valid_signature()` implementations to prevent client panic when the API returns an empty response.

## Changes

- `crates/xmtp_api/src/scw_verifier.rs`: `.expect()` → `.ok_or(VerifierError::Other(...))?`
- `crates/xmtp_id/src/scw_verifier/remote_signature_verifier.rs`: same fix

## Testing

- Existing tests pass — no behavior change for non-empty responses
- Empty response now returns `VerifierError::Other` instead of panicking

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace panic with error return in `is_valid_signature` on empty API response
> Both `xmtp_api` and `xmtp_id` implementations of `is_valid_signature` previously called `expect` on the API response, causing a panic when the response was empty. They now use `ok_or` to return a `VerifierError::Io(InvalidData, ...)` error instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc1aee2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->