### PR TITLE
fix: preserve ordered welcome cursor retries

### DIFF
--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -509,7 +509,6 @@ mod tests {
     use openmls::prelude::MlsMessageOut;
     use prost::Message;
     use rstest::*;
-    use std::sync::Mutex;
     use tls_codec::Serialize;
     use xmtp_common::Generate;
     use xmtp_configuration::Originators;
@@ -818,7 +817,7 @@ mod tests {
         );
 
         let (context, validator) = TestWelcomeSetup::builder()
-            .validator(NoopValidator)
+            .validator(SequenceValidator { fail: false })
             .context(context)
             .nested_transaction_calls(|db: &mut MockDbQuery| {
                 db.expect_find_group().returning(|_id| Ok(None));
@@ -921,7 +920,6 @@ mod tests {
             None,
         );
 
-        let welcome_cursor_updates = Arc::new(Mutex::new(Vec::new()));
         let (context, _) = TestWelcomeSetup::builder()
             .validator(NoopValidator)
             .context(context)
@@ -935,23 +933,11 @@ mod tests {
                     .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
             })
             .nested_transaction_calls({
-                let welcome_cursor_updates = welcome_cursor_updates.clone();
-                move |db: &mut MockDbQuery| {
+                |db: &mut MockDbQuery| {
                     db.expect_find_group().returning(|_id| Ok(None));
                     db.expect_get_last_cursor_for_originators()
                         .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
-                    db.expect_update_cursor().returning({
-                        let welcome_cursor_updates = welcome_cursor_updates.clone();
-                        move |_, entity, cursor| {
-                            if entity == EntityKind::Welcome {
-                                welcome_cursor_updates
-                                    .lock()
-                                    .expect("welcome cursor updates lock poisoned")
-                                    .push(cursor.sequence_id);
-                            }
-                            Ok(true)
-                        }
-                    });
+                    db.expect_update_cursor().never();
                     db.expect_update_responded_at_sequence_id()
                         .returning(|_, _, _| Ok(()));
                     db.expect_insert_or_replace_group().returning(Ok);
@@ -977,14 +963,6 @@ mod tests {
             .await;
 
         assert_eq!(groups.len(), 0);
-
-        assert!(
-            welcome_cursor_updates
-                .lock()
-                .expect("welcome cursor updates lock poisoned")
-                .is_empty(),
-            "later welcome advanced the durable cursor past a retryable failure"
-        );
     }
 
     // Helper functions for filter_groups_with_new_messages tests

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -9,12 +9,13 @@ use crate::mls_store::MlsStore;
 use futures::stream::{self, FuturesUnordered, StreamExt};
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::future::Future;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
 };
 use xmtp_common::Event;
-use xmtp_common::{Retry, retry_async};
+use xmtp_common::{Retry, RetryableError, retry_async};
 use xmtp_db::refresh_state::EntityKind;
 use xmtp_db::{consent_record::ConsentState, group::GroupQueryArgs, prelude::*};
 use xmtp_macro::log_event;
@@ -132,6 +133,51 @@ where
         }
     }
 
+    async fn process_welcomes_with<F, Fut>(
+        &self,
+        envelopes: Vec<xmtp_proto::types::WelcomeMessage>,
+        mut process: F,
+    ) -> Vec<MlsGroup<Context>>
+    where
+        F: FnMut(xmtp_proto::types::WelcomeMessage) -> Fut,
+        Fut: Future<Output = Result<Option<MlsGroup<Context>>, GroupError>>,
+    {
+        let mut groups = Vec::with_capacity(envelopes.len());
+
+        // Welcome commits advance the durable cursor. Stop after a retryable error
+        // so a later envelope cannot skip the failed welcome.
+        for welcome in envelopes {
+            let welcome_cursor = welcome.cursor;
+            let result = retry_async!(
+                Retry::default(),
+                ({
+                    let welcome = welcome.clone();
+                    process(welcome)
+                })
+            );
+
+            match result {
+                Ok(Some(group)) => groups.push(group),
+                Ok(None) => {}
+                Err(err) if err.is_retryable() => {
+                    tracing::warn!(
+                        welcome_cursor = %welcome_cursor,
+                        "stopping welcome sync after retryable failure: {err}"
+                    );
+                    break;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        welcome_cursor = %welcome_cursor,
+                        "skipping welcome after non-retryable failure: {err}"
+                    );
+                }
+            }
+        }
+
+        groups
+    }
+
     /// Download all unread welcome messages and converts to a group struct, ignoring malformed messages.
     /// Returns any new groups created in the operation
     #[tracing::instrument(level = "trace", skip_all)]
@@ -140,19 +186,11 @@ where
         let envelopes = store.query_welcome_messages().await?;
         let num_envelopes = envelopes.len();
 
-        // TODO: Update cursor correctly if some of the welcomes fail and some of the welcomes succeed
-        let groups: Vec<MlsGroup<Context>> = stream::iter(envelopes.into_iter())
-            .filter_map(|welcome| async move {
-                retry_async!(
-                    Retry::default(),
-                    (async {
-                        let validator = InitialMembershipValidator::new(&self.context);
-                        self.process_new_welcome(&welcome, true, validator).await
-                    })
-                )
-                .ok()?
+        let groups = self
+            .process_welcomes_with(envelopes, |welcome| async move {
+                let validator = InitialMembershipValidator::new(&self.context);
+                self.process_new_welcome(&welcome, true, validator).await
             })
-            .collect()
             .await;
 
         // Rotate the keys regardless of whether the welcomes failed or succeeded. It is better to over-rotate than
@@ -471,6 +509,7 @@ mod tests {
     use openmls::prelude::MlsMessageOut;
     use prost::Message;
     use rstest::*;
+    use std::sync::Mutex;
     use tls_codec::Serialize;
     use xmtp_common::Generate;
     use xmtp_configuration::Originators;
@@ -712,6 +751,23 @@ mod tests {
         }
     }
 
+    struct SequenceValidator {
+        fail: bool,
+    }
+
+    impl ValidateGroupMembership for SequenceValidator {
+        async fn check_initial_membership(
+            &self,
+            _welcome: &openmls::prelude::StagedWelcome,
+        ) -> Result<(), GroupError> {
+            if self.fail {
+                Err(GroupError::LockUnavailable)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
     #[rstest]
     #[xmtp_common::test]
     async fn increments_cursor_on_non_retryable_during_validation(context: NewMockContext) {
@@ -843,6 +899,92 @@ mod tests {
             .process_new_welcome(&network_welcome, cursor_increment, validator)
             .await;
         assert!(res.is_err(), "{}", res.unwrap_err());
+    }
+
+    #[rstest]
+    #[xmtp_common::test]
+    async fn later_welcome_must_not_advance_cursor_past_retryable_failure(context: NewMockContext) {
+        let mem = Arc::new(SqlKeyStore::new(MemoryStorage::default()));
+        let client = create_mls_client(mem.as_ref());
+        let (first_kp, first_mls_welcome) = client.join_group();
+        let first_welcome = generate_welcome(
+            50,
+            first_kp.hpke_init_key().as_slice().to_vec(),
+            first_mls_welcome,
+            None,
+        );
+        let (second_kp, second_mls_welcome) = client.join_group();
+        let second_welcome = generate_welcome(
+            51,
+            second_kp.hpke_init_key().as_slice().to_vec(),
+            second_mls_welcome,
+            None,
+        );
+
+        let welcome_cursor_updates = Arc::new(Mutex::new(Vec::new()));
+        let (context, _) = TestWelcomeSetup::builder()
+            .validator(NoopValidator)
+            .context(context)
+            .database_calls(|db: &mut MockDbQuery| {
+                db.expect_get_last_cursor_for_originators()
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
+                db.expect_find_group().returning(|_id| Ok(None));
+            })
+            .transaction_calls(|db: &mut MockDbQuery| {
+                db.expect_get_last_cursor_for_originators()
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
+            })
+            .nested_transaction_calls({
+                let welcome_cursor_updates = welcome_cursor_updates.clone();
+                move |db: &mut MockDbQuery| {
+                    db.expect_find_group().returning(|_id| Ok(None));
+                    db.expect_get_last_cursor_for_originators()
+                        .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
+                    db.expect_update_cursor().returning({
+                        let welcome_cursor_updates = welcome_cursor_updates.clone();
+                        move |_, entity, cursor| {
+                            if entity == EntityKind::Welcome {
+                                welcome_cursor_updates
+                                    .lock()
+                                    .expect("welcome cursor updates lock poisoned")
+                                    .push(cursor.sequence_id);
+                            }
+                            Ok(true)
+                        }
+                    });
+                    db.expect_update_responded_at_sequence_id()
+                        .returning(|_, _, _| Ok(()));
+                    db.expect_insert_or_replace_group().returning(Ok);
+                }
+            })
+            .mem(mem)
+            .build();
+
+        let service = WelcomeService::new(context);
+        let processing_service = service.clone();
+        let groups = service
+            .process_welcomes_with(vec![first_welcome, second_welcome], |welcome| {
+                let validator = SequenceValidator {
+                    fail: welcome.cursor.sequence_id == 50,
+                };
+                let processing_service = processing_service.clone();
+                async move {
+                    processing_service
+                        .process_new_welcome(&welcome, true, validator)
+                        .await
+                }
+            })
+            .await;
+
+        assert_eq!(groups.len(), 0);
+
+        assert!(
+            welcome_cursor_updates
+                .lock()
+                .expect("welcome cursor updates lock poisoned")
+                .is_empty(),
+            "later welcome advanced the durable cursor past a retryable failure"
+        );
     }
 
     // Helper functions for filter_groups_with_new_messages tests


### PR DESCRIPTION
Fixes #3396

When welcome messages are queried in cursor order, a retryable failure can be followed by another welcome. The later welcome was still processed and advanced the durable welcome cursor, which made the failed welcome disappear from the next sync.

I reproduced this locally with two real MLS welcomes. The first hit the retryable `LockUnavailable` path and the second was valid. The old implementation failed the regression with `later welcome advanced the durable cursor past a retryable failure`. The fix stops the batch at the first retryable error after the configured retries, so the failed cursor stays available for the next sync.

Non-retryable welcomes still get skipped so one malformed or permanently invalid welcome does not block the rest of the batch.

Checks run on macOS:

- `cargo fmt --all -- --check`
- `cargo clippy -p xmtp_mls --all-targets --all-features -- -D warnings`
- `cargo test -p xmtp_mls --lib groups::welcome_sync::tests`, 14 passed
- `RUST_LOG=off cargo test -p xmtp_mls --lib only_test_sync_welcomes -- --nocapture` against the local Docker backend, 1 passed
- `RUST_LOG=off cargo test -p xmtp_mls --lib -- --test-threads=1`, 705 passed, 6 unrelated timing or shared-backend failures, 4 ignored

The full suite failures were outside `welcome_sync.rs`. The changed welcome-sync tests and the service-backed welcome sync test pass.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix welcome cursor to stop processing on retryable failures in `WelcomeService`
> - Replaces the stream-based welcome processing in `sync_welcomes` with a new sequential `process_welcomes_with` helper in [welcome_sync.rs](https://github.com/xmtp/libxmtp/pull/3931/files#diff-5ad5d6ca4506c4960727c32b22b9168a128f14af4d61497cd168ba5c80fb43f5).
> - On a retryable error, processing halts immediately so later welcomes cannot advance the cursor past the failure point; non-retryable errors are skipped and processing continues.
> - Behavioral Change: `sync_welcomes` previously continued past all failures; it now stops on the first retryable failure, meaning welcomes after that point are excluded from the returned groups until the next sync.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7be9540.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->