### PR TITLE
feat(telemetry): add bidi.* transport spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10703,6 +10703,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
  "wasm-bindgen-test",
  "xmtp-workspace-hack",

--- a/crates/xmtp_api_d14n/Cargo.toml
+++ b/crates/xmtp_api_d14n/Cargo.toml
@@ -51,6 +51,8 @@ hex.workspace = true
 mockall.workspace = true
 rstest.workspace = true
 tokio.workspace = true
+# Span-close capture for the bidi.wire_session lifetime test.
+tracing-subscriber = { workspace = true, features = ["registry", "std"] }
 # add self to auto enable test utils
 xmtp_api_d14n = { path = ".", features = ["test-utils"] }
 

--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -632,6 +632,7 @@ where
     /// deadlock discipline). A `resume()` right after may briefly overlap
     /// that dying drain with the fresh wire; the resume wave re-serves
     /// anything the drain discarded, so nothing is lost.
+    #[xmtp_common::span(prefix = "bidi")]
     pub async fn suspend(&self) -> Result<(), TransportError> {
         self.enqueue_suspend()?
             .await
@@ -666,6 +667,7 @@ where
     /// A process thawed *without* having suspended doesn't need this: the
     /// connection's own watchdog detects the stale wire and the transport
     /// reconnects transparently.
+    #[xmtp_common::span(prefix = "bidi")]
     pub async fn resume(&self) -> Result<(), TransportError> {
         self.enqueue_resume()?
             .await
@@ -1995,6 +1997,7 @@ async fn run_ledger<B: TransportBinding>(
         reconnect_delay: RECONNECT_INITIAL_DELAY,
         reconnect_at: tokio::time::Instant::now(),
         wire_opened_at: None,
+        wire_span: None,
         suspended: initially_suspended,
         wire_opens: 0,
         resume_notify: Vec::new(),
@@ -2037,6 +2040,12 @@ where
     /// having been up at least [`MIN_STABLE_UPTIME`] resets the backoff to the
     /// floor; a shorter-lived one is flapping and keeps it growing.
     wire_opened_at: Option<tokio::time::Instant>,
+    /// The current wire's `bidi.wire_session` span, or `None` between wires.
+    /// Opened alongside `wire_opened_at` and closed by [`Self::close_wire_span`]
+    /// on every path that releases the wire, so its duration is wire uptime.
+    /// Deliberately never entered: it must not parent the spans of the work that
+    /// happens while the wire is up.
+    wire_span: Option<tracing::Span>,
     /// `suspend()`ed: the wire stays down on purpose — no lazy open for new
     /// leases, no reconnect backoff — until `resume()` clears it.
     suspended: bool,
@@ -2122,10 +2131,43 @@ where
     /// Every handle and lease is gone — close up shop.
     fn shutdown(&mut self) -> Flow {
         self.outbox.clear();
+        // Defensive, and normally a no-op: the last lease's drop closes the
+        // command channel, and it retires the wire on the way out.
+        self.close_wire_span("shutdown");
         if let Some(wire) = self.conn.take() {
             close_gracefully(wire);
         }
         Flow::Shutdown
+    }
+
+    /// Start the wire clock and its `bidi.wire_session` span. Both wire-open
+    /// sites (the cold open in [`Self::lease`] and the reconnect in
+    /// [`Self::reopen`]) go through here, so a wire can never come up timed but
+    /// unspanned.
+    ///
+    /// `parent: None` roots the span: a wire outlives whatever command happened
+    /// to trigger the dial, so adopting that caller's trace would hang an
+    /// arbitrarily long span off it. It is never entered either, so it parents
+    /// none of the work that happens while the wire is up — it exists only to
+    /// carry a duration and its `reason` to the Collector.
+    fn open_wire_span(&mut self) {
+        self.wire_opened_at = Some(tokio::time::Instant::now());
+        self.wire_span = Some(tracing::info_span!(
+            parent: None,
+            "bidi_wire",
+            operation = "bidi.wire_session",
+            reason = tracing::field::Empty,
+        ));
+    }
+
+    /// End the current wire's `bidi.wire_session` span, tagging why it ended.
+    /// Every path that releases the wire goes through here so the span's
+    /// duration is always exactly wire uptime, and `reason` is never missing.
+    /// A no-op between wires.
+    fn close_wire_span(&mut self, reason: &'static str) {
+        if let Some(span) = self.wire_span.take() {
+            span.record("reason", reason);
+        }
     }
 
     /// `Cmd::Lease`: open the wire if this lease is the reason to have one,
@@ -2165,7 +2207,7 @@ where
                     self.conn = Some(wire);
                     // Backoff resets on stable death, not on open: a bare accept
                     // doesn't prove the wire works ([`Self::wire_died`]).
-                    self.wire_opened_at = Some(tokio::time::Instant::now());
+                    self.open_wire_span();
                     self.wire_opens += 1;
                     tracing::info!(
                         topics = topics.len(),
@@ -2280,6 +2322,10 @@ where
         );
         self.suspended = true;
         self.outbox.clear();
+        // Must close here too, not only in `wire_died`: suspend releases the
+        // wire without going through it, so the span would otherwise stay open
+        // across the whole background sojourn and report that as wire uptime.
+        self.close_wire_span("suspend");
         if let Some(wire) = self.conn.take() {
             // Detached on purpose: acknowledging must not await the wire's
             // bounded command channel (deadlock discipline above), and the
@@ -2377,6 +2423,9 @@ where
     fn wire_died(&mut self) -> Flow {
         self.outbox.clear();
         drop(self.conn.take());
+        // `Step::Wire(None)` carries no error detail, so a server close and a
+        // transport failure are indistinguishable here — both are `wire_end`.
+        self.close_wire_span("wire_end");
         // A wire that proved stable resets the backoff to the floor so the
         // reconnect is prompt; one that died inside `MIN_STABLE_UPTIME` is
         // flapping — grow the backoff so an accept-then-close server can't pin
@@ -2405,6 +2454,9 @@ where
 
     /// One reconnect attempt, absorbing every [`reopen`](Self::reopen)
     /// outcome: a dial-preempting suspend re-suspends, shutdown propagates.
+    // Not `#[span(prefix = "bidi")]`: that form always emits `err`, which only
+    // compiles on a `Result` return. Everything else matches it exactly.
+    #[tracing::instrument(skip_all, fields(operation = "bidi.reconnect"))]
     async fn reconnect(&mut self) -> Flow {
         match self.reopen().await {
             AfterReopen::Proceed => Flow::Continue,
@@ -2488,7 +2540,7 @@ where
             OpenOutcome::Opened(wire) => {
                 self.conn = Some(wire);
                 // Backoff resets on stable death, not on open ([`wire_died`]).
-                self.wire_opened_at = Some(tokio::time::Instant::now());
+                self.open_wire_span();
                 self.wire_opens += 1;
                 tracing::info!(
                     reconnects = self.wire_opens.saturating_sub(1),
@@ -2637,6 +2689,10 @@ where
         if self.ledger.leases.is_empty() {
             // Unsent waves are for a wire we're closing — nobody needs them.
             self.outbox.clear();
+            // The task outlives its last lease, so without this the span would
+            // keep accruing idle time and be overwritten reasonless by the next
+            // cold open.
+            self.close_wire_span("idle");
             if let Some(wire) = self.conn.take() {
                 close_gracefully(wire);
             }
@@ -2989,6 +3045,60 @@ mod tests {
 
     fn take_server(servers: &Servers) -> MockServer {
         servers.lock().unwrap().remove(0)
+    }
+
+    /// Collects the `reason` of every closing `bidi.wire_session` span, in close
+    /// order. `close_wire_span` is the only thing that records `reason`, and it
+    /// does so on the span it has just taken — so a recorded reason *is* a close,
+    /// and watching `on_record` needs no span bookkeeping.
+    #[derive(Clone, Default)]
+    struct WireCloseLog {
+        reasons: Arc<Mutex<Vec<String>>>,
+    }
+
+    struct ReasonVisitor<'a>(&'a Mutex<Vec<String>>);
+
+    impl tracing::field::Visit for ReasonVisitor<'_> {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "reason" {
+                self.0.lock().unwrap().push(value.to_owned());
+            }
+        }
+
+        fn record_debug(&mut self, _: &tracing::field::Field, _: &dyn std::fmt::Debug) {}
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for WireCloseLog {
+        fn on_record(
+            &self,
+            _: &tracing::Id,
+            values: &tracing::span::Record<'_>,
+            _: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            values.record(&mut ReasonVisitor(&self.reasons));
+        }
+    }
+
+    /// Wait until `n` wire spans have closed, then return their reasons.
+    async fn close_reasons(log: &WireCloseLog, n: usize) -> Vec<String> {
+        let poll = async {
+            loop {
+                {
+                    let reasons = log.reasons.lock().unwrap();
+                    if reasons.len() >= n {
+                        return reasons.clone();
+                    }
+                }
+                xmtp_common::time::sleep(Duration::from_millis(5)).await;
+            }
+        };
+        match tokio::time::timeout(WAIT, poll).await {
+            Ok(reasons) => reasons,
+            Err(_) => panic!(
+                "expected {n} closed wire spans, saw {:?}",
+                log.reasons.lock().unwrap()
+            ),
+        }
     }
 
     fn group_topic(id: &[u8]) -> Topic {
@@ -4013,6 +4123,58 @@ mod tests {
             }
             _ => panic!("the lease must survive suspend/resume invisibly"),
         }
+    }
+
+    /// Every reachable path that releases the wire ends its `bidi.wire_session`
+    /// span, and tags why. A missed path leaves the span open across the gap and
+    /// reports that as uptime — the metric reads as one long, healthy wire,
+    /// which is the opposite of the truth. That is not hypothetical: `retire`
+    /// was missed on the first pass, and its span survived to be misattributed
+    /// to whichever path closed next.
+    #[xmtp_common::test(flavor = "current_thread", unwrap_try = true)]
+    async fn wire_session_span_closes_with_a_reason_on_every_release_path() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let closes = WireCloseLog::default();
+        // Thread-local rather than global: the test harness already installs a
+        // global dispatcher. `current_thread` is what makes that sound — the
+        // ledger actor is spawned onto this same thread, so the guard, held
+        // across every await below, covers the spans it opens.
+        let _guard =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(closes.clone()));
+
+        // Deliberate suspend releases the wire without it ever dying.
+        let (suspended, servers_a) = transport();
+        let alpha = suspended.lease(vec![(group_topic(b"g1"), 0)], 8).await?;
+        let mut first = take_server(&servers_a);
+        first.next_mutate().await;
+        suspended.suspend().await?;
+        assert_eq!(close_reasons(&closes, 1).await[0], "suspend");
+        drop((alpha, first, suspended));
+
+        // The server's stream ends under a live lease.
+        let (dying, servers_b) = transport();
+        let beta = dying.lease(vec![(group_topic(b"g2"), 0)], 8).await?;
+        let mut second = take_server(&servers_b);
+        second.next_mutate().await;
+        drop(second);
+        assert_eq!(close_reasons(&closes, 2).await[1], "wire_end");
+        drop((beta, dying));
+
+        // The last lease is retired while the transport itself stays alive: the
+        // task outlives its leases, so this is a distinct path from shutdown.
+        let (retiring, servers_c) = transport();
+        let gamma = retiring.lease(vec![(group_topic(b"g3"), 0)], 8).await?;
+        let mut third = take_server(&servers_c);
+        third.next_mutate().await;
+        drop(gamma);
+        assert_eq!(close_reasons(&closes, 3).await[2], "idle");
+        drop((third, retiring));
+
+        // `shutdown` is not exercised: leases hold a strong command sender, so
+        // the channel only closes once the last one drops — and that drop
+        // retires the wire first, via the path above. Its `close_wire_span` is
+        // defensive, kept symmetric with the `conn.take()` beside it.
     }
 
     /// Two concurrent `resume()` callers join the same in-flight catch-up:


### PR DESCRIPTION
The bidi transport had no OTEL operation namespace, so reconnect latency, suspend/resume cost and wire uptime were invisible in Datadog — they existed only as `tracing::info!`/`warn!` lines. This adds the `bidi.` namespace feeding a new `xmtp.bidi.*` metric family, mirroring `rpc.*` → `xmtp.api.*`.

Three files, one of them `Cargo.lock`.

> [!IMPORTANT]
> The collector-config PR must land first, otherwise `bidi.*` spans fall through `filter/metrics` into the MLS catch-all and inflate `xmtp.mls.calls`.
> Companion PR: https://github.com/xmtplabs/convos-assistants/pull/3169

## No new macro

An earlier draft of this added a `#[bidi_span]` attribute. It isn't warranted for three call sites — `rpc_span` has ~13 uses in one file, `db_span` 16 — and `#[span(prefix = "...")]` already exists for exactly this case, documented as *"the escape hatch for a namespace without a dedicated attribute."*

| Site | Attribute | `operation` |
| --- | --- | --- |
| `BidiTransport::suspend` | `#[xmtp_common::span(prefix = "bidi")]` | `bidi.suspend` |
| `BidiTransport::resume` | `#[xmtp_common::span(prefix = "bidi")]` | `bidi.resume` |
| `LedgerTask::reconnect` | `#[tracing::instrument(skip_all, fields(operation = "bidi.reconnect"))]` | `bidi.reconnect` |

`reconnect` spells the attribute out because it returns `Flow`, and `#[tracing::instrument(err)]` only compiles on a `Result` — which `span(prefix = ...)` always emits. Everything else about the form is identical.

`reconnect` (not `reopen`) is the instrumented reconnect site: it already exists as the wrapper absorbing every `reopen` outcome, so the name is right without an override, and its duration is the `open_preemptibly` dial.

The public `suspend`/`resume` are instrumented rather than the same-named `LedgerTask` handlers — instrumenting both would collide on one series, and the public ones also cover the command-queue wait, so they measure what a caller experiences.

## What is *not* instrumented

The actor loops (`LedgerTask::run`, `MessageConsumer::run`, `WelcomeConsumer::run`) are deliberately left alone. A span there would:

- become the root parent of every span created inside for the process lifetime, including existing `mls_span`/`db_span` children — collapsing the process's bidi-adjacent traces into ~3 trace IDs, each open for hours;
- emit metrics only on span close, making `xmtp.bidi.calls` a crash counter and the duration a permanent bucket overflow;
- and still not measure the thing we want, since wire uptime is reconnect→death, not actor lifetime.

Also skipped: `deliver_batch` (high frequency, already manually timed, and MLS-layer work) and `wire_died` (it becomes the wire-session close, below).

## Scope: transport health, not throughput

`xmtp.bidi.*` will contain exactly four operations — `suspend`, `resume`, `reconnect`, `wire_session`. It measures whether the transport is healthy, not how much it carries.

Bidi message *delivery* stays unmeasured by this PR. The only span on that path is `debug_span!("process_envelope")` in `stream_router.rs`, and the OTLP layer exports INFO and above, so it emits nothing to Datadog today (verified: 0 `process_envelope` spans over 2 days). Measuring delivery is a separate change — promoting that span to info level would do it, but it carries `%topic, ?cursor`, which are per-message high-cardinality values that would need `skip_all`-equivalent treatment first.

For context, the transport is already live in production: `rpc.subscribe_bidi` recorded ~7k spans over 2 days, so `xmtp.bidi.*` will populate as soon as this ships. That span keeps its `rpc.` prefix and stays in `xmtp.api.*`.

## Wire-session span

Not an attribute — it spans a region between two functions. A `tracing::Span` held on `LedgerTask`, opened at **both** wire-open sites via `open_wire_span` (the cold open in `lease` and the reconnect in `reopen`) and closed by `close_wire_span` at every `self.conn.take()` site:

| Path | `reason` |
| --- | --- |
| `wire_died` | `wire_end` |
| `suspend` | `suspend` |
| `retire` | `idle` |
| `shutdown` | `shutdown` |

`retire` — the last lease dropping, so the wire is no longer needed — was **missed on the first pass** and caught in review by Macroscope. Worth recording how it hid: the test asserted `"shutdown"` for the drop-the-lease case and *passed because of the bug*. The span survived `retire`, and the later transport drop closed it as `"shutdown"` with a duration inflated by the idle gap. With the fix that case correctly reports `"idle"`, and the assertion had to change — which is the clearest evidence the reason was previously misattributed.

`shutdown` cannot actually close a live wire: `TopicLease` holds a *strong* `UnboundedSender` (`:478`), same as `BidiTransport` (`:448`), so the command channel only closes once the last lease drops — and that drop retires the wire on the way out. Its `close_wire_span` is kept as a defensive no-op, symmetric with the `conn.take()` beside it, and is not asserted in the test.

`parent: None` roots it, so it never adopts the trace of whatever command triggered the dial. It is never entered, so it parents none of the work that happens while the wire is up — it exists only to carry a duration and its `reason`.

Two subtleties worth review attention:

- **The `suspend` close is required, not optional.** `suspend` releases the wire without going through `wire_died`, so a span closed only there would stay open across the whole background sojourn and report that as wire uptime.
- **`close_wire_span` deliberately does not clear `wire_opened_at`.** `wire_died` reads it via `.take()` for the flapping-backoff decision; clearing it early would make every wire look unstable and grow the backoff.

`Step::Wire(None)` carries no error detail, so `wire_end` covers both server close and transport failure — finer granularity would need changes deeper in the wire.

## Testing

One behavioural test drives all three *reachable* release paths through the public API against the mock server, capturing span closes with a small `tracing_subscriber::Layer`. 57/57 `bidi_transport` tests pass.

Every close and open site is mutation-checked — removing any one makes the test fail:

- `close_wire_span("suspend")` → fails
- `close_wire_span("idle")` in `retire` → fails (`expected 3 closed wire spans, saw ["suspend", "wire_end"]`)
- the cold-open `open_wire_span()`, reverted to a bare `wire_opened_at = Some(..)` → fails

That last one was a gap I hit while writing this: the first draft instrumented only the reconnect path, leaving every cold-opened wire unspanned.

The four emitted operation strings were verified at runtime against a throwaway subscriber, which observed exactly `["bidi.wire_session", "bidi.suspend", "bidi.resume", "bidi.reconnect", "bidi.wire_session"]` across a suspend/resume/reconnect cycle. The probe was not kept — the strings are visible in the diff, and pinning `span(prefix = ...)`'s expansion would be testing a pre-existing macro.

`just lint` clean for Rust (clippy, fmt, hakari — the new `tracing-subscriber` dev-dep needed no hakari change).

Not fixed here, both confirmed identical on pristine `main`: 21 endpoint tests fail with `Connection refused` on `127.0.0.1:5556` (needs `dev/up`), and `just lint-markdown` fails on pre-existing `CHANGELOG.md`/`README.md`/`TEST_SCENARIOS.md`. This PR touches no markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aiZ6ZzJojtEZXiWzF64R8
