### PR TITLE
fix(xmtp_api_grpc): relax h2 keepalive defaults to stop bidi stream churn

### DIFF
--- a/apps/keepalive-probe/README.md
+++ b/apps/keepalive-probe/README.md
@@ -20,8 +20,8 @@ The defaults mirror libxmtp's real channel config in
 
 | flag | default | libxmtp source |
 |------|---------|----------------|
-| `--ka-interval` | `16s` | `http2_keep_alive_interval` |
-| `--ka-timeout` | `10s` | `keep_alive_timeout` ← the #70 knob |
+| `--ka-interval` | `45s` | `http2_keep_alive_interval` |
+| `--ka-timeout` | `20s` | `keep_alive_timeout` ← the #70 knob |
 | `--ka-while-idle` | `true` | `keep_alive_while_idle` |
 | `--connect-timeout` | `10s` | `connect_timeout` |
 | `--endpoint` | `https://grpc.dev.xmtp.network:443` | node-sdk `ApiUrls.dev` |

--- a/apps/keepalive-probe/src/main.rs
+++ b/apps/keepalive-probe/src/main.rs
@@ -40,13 +40,13 @@ struct Args {
     #[arg(long, default_value_t = 1)]
     count: usize,
 
-    /// HTTP/2 keepalive PING interval (libxmtp default: 16s).
-    #[arg(long, default_value = "16s", value_parser = humantime::parse_duration)]
+    /// HTTP/2 keepalive PING interval (libxmtp default: 45s).
+    #[arg(long, default_value = "45s", value_parser = humantime::parse_duration)]
     ka_interval: Duration,
 
-    /// Close the connection if no PONG arrives within this (libxmtp default: 10s).
+    /// Close the connection if no PONG arrives within this (libxmtp default: 20s).
     /// This is the #70 knob — raise it to give a slow path more slack.
-    #[arg(long, default_value = "10s", value_parser = humantime::parse_duration)]
+    #[arg(long, default_value = "20s", value_parser = humantime::parse_duration)]
     ka_timeout: Duration,
 
     /// Send keepalive PINGs even with no active streams (libxmtp default: true).

--- a/bindings/node/test/Conversations.test.ts
+++ b/bindings/node/test/Conversations.test.ts
@@ -21,6 +21,14 @@ import {
   PermissionUpdateType,
 } from '../dist'
 
+// The connection-death test below relies on the h2 transport keepalive to notice
+// a black-holed connection; pin it fast before any client exists (the Rust side
+// reads these once per process, and vitest gives each test file its own) so
+// detection lands well inside the test's wait windows regardless of the library
+// defaults.
+process.env.XMTP_GRPC_KEEPALIVE_INTERVAL_SECS = '10'
+process.env.XMTP_GRPC_KEEPALIVE_TIMEOUT_SECS = '10'
+
 describe('Conversations', () => {
   it('should not have initial conversations', async () => {
     const user = createUser()

--- a/crates/xmtp_api_grpc/src/grpc_client/native.rs
+++ b/crates/xmtp_api_grpc/src/grpc_client/native.rs
@@ -12,16 +12,23 @@ use std::task::{Context, Poll};
 
 /// HTTP/2 / TCP keep-alive parameters for the gRPC channel.
 ///
-/// Defaults favour *fast* detection of a dead connection (~26s = interval + timeout),
-/// which suits mobile clients and the default native path. A deployment on a high-latency
-/// link can relax any of them via environment variables, without affecting other
-/// consumers:
+/// The previous 16s/10s defaults optimized for fast dead-path detection (~26s worst
+/// case) but tore down otherwise-healthy long-lived connections whenever one PING ack
+/// straggled past the tight deadline — reconnect churn observed from server (herald-lite
+/// #70) and mobile clients alike, where every teardown forces a full stream re-subscribe
+/// against the backend (2026-08 production incident). The defaults now trade detection
+/// speed for stability: ~65s worst case (interval + timeout), with the 45s cadence
+/// chosen to stay inside common 60s middlebox idle timers. Where the XIP-83 Subscribe
+/// ping/pong or the stream watchdog is enabled, the application layer detects a dead
+/// stream on its own; for default consumers this transport keep-alive remains the only
+/// dead-path detector, just a slower and less trigger-happy one. A deployment can tune
+/// any of these via environment variables, without affecting other consumers:
 ///
 /// | env var                             | field                        | default |
 /// |-------------------------------------|------------------------------|---------|
-/// | `XMTP_GRPC_KEEPALIVE_INTERVAL_SECS` | `http2_keep_alive_interval`  | 16      |
-/// | `XMTP_GRPC_KEEPALIVE_TIMEOUT_SECS`  | `keep_alive_timeout`         | 10      |
-/// | `XMTP_GRPC_TCP_KEEPALIVE_SECS`      | `tcp_keepalive` (0 disables) | 16      |
+/// | `XMTP_GRPC_KEEPALIVE_INTERVAL_SECS` | `http2_keep_alive_interval`  | 45      |
+/// | `XMTP_GRPC_KEEPALIVE_TIMEOUT_SECS`  | `keep_alive_timeout`         | 20      |
+/// | `XMTP_GRPC_TCP_KEEPALIVE_SECS`      | `tcp_keepalive` (0 disables) | 45      |
 /// | `XMTP_GRPC_KEEPALIVE_WHILE_IDLE`    | `keep_alive_while_idle`      | true    |
 ///
 /// Read once per process (servers set these before start), so it is not part of the TLS
@@ -35,9 +42,9 @@ struct KeepaliveConfig {
 }
 
 impl KeepaliveConfig {
-    const DEFAULT_INTERVAL: Duration = Duration::from_secs(16);
-    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
-    const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(16);
+    const DEFAULT_INTERVAL: Duration = Duration::from_secs(45);
+    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
+    const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(45);
 
     fn from_env() -> Self {
         Self::from_lookup(|key| std::env::var(key).ok())
@@ -143,12 +150,11 @@ pub(crate) fn apply_channel_options(endpoint: Endpoint, limit: u64) -> Endpoint 
         // Functionality: If a ping response is not received within this duration, the connection is presumed to be lost and is closed.
         // Impact: This setting is crucial for quickly detecting unresponsive connections and freeing up resources associated with them. It ensures that the client has up-to-date information on the status of connections and can react accordingly.
         //
-        // Values are sourced from `KeepaliveConfig` (env-overridable). The defaults are
-        // intentionally aggressive (~26s detection = interval + timeout), which suits mobile
-        // and the default native path. A high-latency deployment such as herald — whose
-        // cross-cloud Fly->AWS round-trip can transiently starve a PONG past a tight deadline
-        // and trigger spurious `UNAVAILABLE` (status 14) disconnects (herald-lite #70) —
-        // relaxes them via environment variables without affecting other consumers.
+        // Values are sourced from `KeepaliveConfig` (env-overridable). See the config's
+        // doc comment for why the defaults are unaggressive: a missed PING ack here kills
+        // the whole connection — and with it every bidi stream, whose reconnects replay
+        // server-side catch-up waves — so this layer must tolerate transient stalls that
+        // the app-level heartbeat is already equipped to judge.
         .keep_alive_timeout(keepalive.timeout)
         .http2_keep_alive_interval(keepalive.interval)
         .rate_limit(limit, Duration::from_secs(60))
@@ -204,9 +210,9 @@ mod keepalive_tests {
     #[test]
     fn defaults_when_env_absent() {
         let cfg = KeepaliveConfig::from_lookup(|_| None);
-        assert_eq!(cfg.interval, Duration::from_secs(16));
-        assert_eq!(cfg.timeout, Duration::from_secs(10));
-        assert_eq!(cfg.tcp_keepalive, Some(Duration::from_secs(16)));
+        assert_eq!(cfg.interval, Duration::from_secs(45));
+        assert_eq!(cfg.timeout, Duration::from_secs(20));
+        assert_eq!(cfg.tcp_keepalive, Some(Duration::from_secs(45)));
         assert!(cfg.while_idle);
     }
 
@@ -236,7 +242,7 @@ mod keepalive_tests {
             ("XMTP_GRPC_KEEPALIVE_INTERVAL_SECS", "not-a-number"),
             ("XMTP_GRPC_KEEPALIVE_WHILE_IDLE", "maybe"),
         ]));
-        assert_eq!(cfg.interval, Duration::from_secs(16));
+        assert_eq!(cfg.interval, Duration::from_secs(45));
         assert!(cfg.while_idle);
     }
 }

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -2068,12 +2068,21 @@ pub(crate) mod tests {
         assert_eq!(item[0].state, ConsentState::Allowed);
     }
 
-    #[xmtp_common::timeout(Duration::from_secs(50))]
+    #[xmtp_common::timeout(Duration::from_secs(100))]
     #[rstest::rstest]
     #[xmtp_common::test(unwrap_try = true)]
-    // Set to 50 seconds to safely account for the 16 second keepalive interval and 10 second timeout
+    // Detection of the black-holed connection comes from the h2 transport keepalive.
+    // Pin it fast (5s ping / 5s ack) so the failure lands in seconds under nextest,
+    // whose process-per-test isolation guarantees the pin is read before the
+    // process-wide config latches. Under a plain `cargo test`, a sibling test may
+    // latch the library defaults (45s/20s) first and the pin becomes a no-op, so
+    // the timeout budget also covers their ~65s worst-case detection.
     #[cfg_attr(any(target_arch = "wasm32"), ignore)]
     async fn should_reconnect() {
+        unsafe {
+            std::env::set_var("XMTP_GRPC_KEEPALIVE_INTERVAL_SECS", "5");
+            std::env::set_var("XMTP_GRPC_KEEPALIVE_TIMEOUT_SECS", "5");
+        }
         toxiproxy_test(async || {
             let alix = Tester::builder().proxy().build().await;
             let bo = Tester::builder().build().await;


### PR DESCRIPTION
## Why

Production incident (P1 on the network `mls` DB, Jul 28–Aug 3): the ~6 bidi-enabled endpoints in production generated ~1,450 stream reconnects/hour, and every reconnect replayed a server-side catch-up wave against the database. The reconnect cadence matched libxmtp's h2 transport keepalive almost exactly: prod heralds cycled roughly once per keepalive interval, and the single bidi-enabled mobile device churned at ~10s intervals. Mechanism: with a 16s ping / 10s ack deadline, one straggling PING ack (cross-cloud RTT spike, radio wake latency) kills the entire HTTP/2 connection and every stream on it — the same failure previously root-caused as herald-lite #70. The env-var escape hatch added for #70 (#3715) was never wired into any deployment, so the aggressive defaults were live everywhere.

## What

Defaults move from **16s interval / 10s ack timeout / 16s TCP keepalive** to **45s / 20s / 45s** (still env-overridable per deployment via `XMTP_GRPC_KEEPALIVE_*`):

- ~65s worst-case dead-path detection (interval + timeout) instead of ~26s — deliberately traded for connections that survive transient stalls instead of tearing down healthy long-lived streams
- 45s cadence stays inside common 60s middlebox idle timers (a 60s cadence would race them)
- 20s ack window doubles tolerance for the stalls that actually killed connections
- `keep_alive_while_idle` unchanged (true) — idle bidi streams still get checked, just at the relaxed cadence

The doc comment states the honest contract: where the XIP-83 Subscribe ping/pong or the stream watchdog is enabled, the app layer detects dead streams itself; for default consumers (mobile FFI, node bindings with neither enabled) this transport keepalive remains the **only** dead-path detector — just a slower, less trigger-happy one. `apps/keepalive-probe` defaults and README move in lockstep so a bare probe run keeps mirroring a real client.

Historical release notes documenting the old defaults are intentionally untouched; the next release's notes must document the new values.

## Adversarial review

Reviewed adversarially before opening. Findings, all addressed: the original draft claimed app-level liveness owns detection (false for default consumers — both mechanisms are opt-in; comment rewritten and the detection regression shrunk from ~90s to ~65s worst-case), a 60s cadence sat exactly on common idle-timeout boundaries (now 45s), and the keepalive-probe tool still hardcoded the old defaults while claiming to mirror libxmtp (updated). The review could not refute: no code anywhere derives timing from the old 16/10/26 numbers (watchdog, bidi backoff, and request timeouts are independent; worst-case keepalive failure still lands under the 120s request timeout), the process-wide `LazyLock` config remains coherent with the TLS endpoint cache, and wasm has no transport keepalive to diverge.

## Verification

- `cargo test -p xmtp_api_grpc --lib` — 25 passed (keepalive default + override + parsing tests updated meaningfully)
- `cargo check -p keepalive-probe`, `cargo clippy -p xmtp_api_grpc` — clean

## Companions

- xmtp-node-go#565: catch-up wave scans rewritten (prune + rotation + LATERAL probes) so reconnects that do happen cost the DB almost nothing
- convos-assistants: herald env overrides set generously so the XIP-83 ping/pong owns liveness on the herald fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Relax HTTP/2 keepalive defaults in `xmtp_api_grpc` to reduce bidi stream churn
> - Increases `DEFAULT_INTERVAL` from 16s to 45s, `DEFAULT_TIMEOUT` from 10s to 20s, and `DEFAULT_TCP_KEEPALIVE` from 16s to 45s in [`native.rs`](https://github.com/xmtp/libxmtp/pull/3933/files#diff-d8ababd4174607b4463cfa01411d0034229c7d7bfccd1aecb5066b2386fb6d6a) to reduce unnecessary ping-pong on long-lived bidirectional streams.
> - Updates the `keepalive-probe` tool defaults and README to match the new libxmtp values (45s interval, 20s timeout).
> - Test files pin faster keepalive values via environment variables (`XMTP_GRPC_KEEPALIVE_INTERVAL_SECS`, `XMTP_GRPC_KEEPALIVE_TIMEOUT_SECS`) so existing reconnect and conversation tests remain fast and deterministic.
> - Behavioral Change: Any deployment relying on the old 16s/10s defaults will now use 45s/20s unless overridden by environment variables.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2139cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->