### PR TITLE
fix(xmtp_api_d14n): track in-wave bidi replay progress per topic

### DIFF
--- a/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
+++ b/crates/xmtp_api_d14n/src/queries/bidi_transport.rs
@@ -793,8 +793,13 @@ where
     /// while part of their topic history was still replaying here. Released
     /// (re-checked) when this wave resolves or is removed.
     holds: Vec<LeaseId>,
-    progress_group: Option<B::Cursor>,
-    progress_welcome: Option<B::Cursor>,
+    /// Per-topic in-wave replay progress. A topic's replay cursor ascends for
+    /// the wave's lifetime under both the legacy single-scan server and the
+    /// batch-rotation server — but the rotation server orders frames only
+    /// within a batch, so cross-topic comparison is meaningless and is not
+    /// tracked. Telemetry-only: a per-topic regression is a real server
+    /// order fault.
+    progress: HashMap<Topic, B::Cursor>,
 }
 
 impl<B: TransportBinding> PendingWave<B>
@@ -808,16 +813,7 @@ where
             issued_at: std::time::Instant::now(),
             claims,
             holds: Vec::new(),
-            progress_group: None,
-            progress_welcome: None,
-        }
-    }
-
-    /// The wave's progress slot for `kind`'s cursor sequence.
-    fn progress_mut(&mut self, kind: DeliveryKind) -> &mut Option<B::Cursor> {
-        match kind {
-            DeliveryKind::Group => &mut self.progress_group,
-            DeliveryKind::Welcome => &mut self.progress_welcome,
+            progress: HashMap::new(),
         }
     }
 }
@@ -1910,7 +1906,7 @@ where
                     }
                 }
             }
-            // Advance the wire position and the wave's per-kind progress —
+            // Advance the wire position and the wave's per-topic progress —
             // both max-fold, so a deep-history replay below `last_seen`
             // moves neither the siblings' view nor the wire position.
             if let Some(seen) = self.last_seen.get_mut(&topic) {
@@ -1921,12 +1917,15 @@ where
             if let Some(wave) = wave
                 && let Some(pending) = self.pending_waves.get_mut(&wave)
             {
-                match pending.progress_mut(kind) {
+                match pending.progress.get_mut(&topic) {
                     Some(progress) => {
                         if B::covers(progress, &cursor) {
-                            // In-wave replay is total cursor order per kind
-                            // (XIP-83): a regression is a server order fault.
-                            // Telemetry only — max-fold keeps state sane.
+                            // A topic's in-wave replay ascends under both the
+                            // legacy single-scan server and the batch-rotation
+                            // server (which orders frames only within a batch,
+                            // so cross-topic order is deliberately not checked).
+                            // A per-topic regression is a real server order
+                            // fault. Telemetry only — max-fold keeps state sane.
                             tracing::warn!(
                                 %topic,
                                 wave = wave.0,
@@ -1936,7 +1935,9 @@ where
                         }
                         B::advance(progress, cursor)
                     }
-                    progress @ None => *progress = Some(cursor),
+                    None => {
+                        pending.progress.insert(topic.clone(), cursor);
+                    }
                 }
             }
         }
@@ -3514,6 +3515,54 @@ mod tests {
             ),
             _ => panic!("alpha expected only the new message"),
         }
+    }
+
+    /// The batch-rotation server replays a wave's topics in rotating batches:
+    /// ids ascend per topic and within each frame, but a later frame may open
+    /// below an earlier frame's ids. The transport must deliver such a replay
+    /// completely and in order per topic — cross-topic order within a wave is
+    /// not part of the contract.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn rotation_ordered_replay_delivers_every_topic() {
+        let (transport, servers) = transport();
+        let mut alpha = transport
+            .lease(vec![(group_topic(b"g1"), 0), (group_topic(b"g2"), 0)], 8)
+            .await?;
+        let mut server = take_server(&servers);
+        let first = server.next_mutate().await;
+
+        // Turn 1 replays g1's rows; turn 2 replays g2's, opening below g1's
+        // last id — the rotation shape a single-scan server never produced.
+        server.send(replay(
+            first.mutate_id,
+            vec![group_msg(5, b"g1"), group_msg(6, b"g1")],
+            vec![],
+        ));
+        server.send(replay(
+            first.mutate_id,
+            vec![group_msg(3, b"g2"), group_msg(4, b"g2")],
+            vec![],
+        ));
+        server.send(catchup_complete(first.mutate_id));
+
+        match recv(&mut alpha).await {
+            Some(LeaseEvent::GroupMessages(got)) => {
+                assert_eq!(got, vec![group_msg(5, b"g1"), group_msg(6, b"g1")])
+            }
+            _ => panic!("expected the first rotation turn"),
+        }
+        match recv(&mut alpha).await {
+            Some(LeaseEvent::GroupMessages(got)) => assert_eq!(
+                got,
+                vec![group_msg(3, b"g2"), group_msg(4, b"g2")],
+                "a later turn opening below an earlier turn's ids must still deliver"
+            ),
+            _ => panic!("expected the second rotation turn"),
+        }
+        assert!(matches!(
+            recv(&mut alpha).await,
+            Some(LeaseEvent::CatchUpComplete)
+        ));
     }
 
     /// Tag routing is unconditional for the owner and closed to everyone


### PR DESCRIPTION
## Why

Companion to xmtp/xmtp-node-go#565, which changes the XIP-83 wave replay from one globally id-ordered scan to rotating topic batches (ids ascend per topic and within each frame; cross-topic order holds only within a batch).

An audit of the client against that contract change confirmed everything load-bearing is already per-topic and unaffected: wave `claims` and `replayed` watermarks (admission, dedup, gap-guarding), the owed-history lane, and `reconnect_plan()`'s re-issues (explicitly drafted "each topic at the lease's own candidate — per topic"). The live lane's single wire cursor only polices live deliveries, whose total ordering the server change does not touch.

One thing did depend on the old shape: `PendingWave` kept a single replay-progress cursor per delivery kind and logged a **"server order fault"** warning whenever a frame regressed it. That invariant was true of the single-scan server; under batch rotation a later turn legally opens below an earlier turn's ids, so every multi-batch wave (>256 topics) with real backlog would spam the warning. State was never corrupted (max-fold, telemetry-only) — but a warn that cries server-fault on healthy behavior is an operational hazard.

## What

- `PendingWave.progress_group` / `progress_welcome` (per-kind scalars) become a single per-topic map. The regression check now fires only when **a topic's own** in-wave replay goes backwards — a real order fault under both the old and new server shapes, so this merges and deploys safely in either order relative to #565.
- New test `rotation_ordered_replay_delivers_every_topic` pins the rotation contract end-to-end: a wave whose second frame opens below the first frame's ids (the shape a single-scan server never produced) delivers every topic completely and in per-topic order.

## Verification

- `cargo nextest run -p xmtp_api_d14n -E 'test(bidi)'` — 66 tests, all pass (including the exactly-once ordering property suite)
- `cargo fmt` / `cargo clippy -p xmtp_api_d14n` — clean

## Companions

- xmtp/xmtp-node-go#565 — the server-side batch rotation
- xmtp/libxmtp#3933 — keepalive defaults (independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track in-wave bidi replay progress per topic in `PendingWave`
> Replaces two per-delivery-kind optional cursors (`progress_group`, `progress_welcome`) in `PendingWave` with a single `HashMap<Topic, B::Cursor>` that tracks progress independently per topic. Regression warnings and in-wave bookkeeping now operate per topic, reflecting that the batch-rotation server does not enforce cross-topic ordering. A new test (`rotation_ordered_replay_delivers_every_topic`) verifies that per-topic ordering is preserved and all messages are delivered across a two-topic batch-rotation replay.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9961be2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->