### PR TITLE
chore(ci): consolidate nix sticky disks into closure families

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -6,11 +6,19 @@ inputs:
     required: true
   disk-key:
     description: >-
-      Per-workflow namespace for the /nix sticky disk; pass the workflow file
-      stem (e.g. test-workspace). Required on Linux. Keep the value a literal:
+      Closure-family namespace for the /nix sticky disk (rust, web, android,
+      fh-cache); workflows with near-identical Nix closures share a disk.
+      Required on Linux unless nix-disk is "false". Keep the value a literal:
       reset-sticky-disks.yml greps workflows for `disk-key:` to enumerate disks.
     required: false
     default: ""
+  nix-disk:
+    description: >-
+      Mount the persistent /nix sticky disk (Linux). Set "false" in rarely-run
+      workflows (releases): Cachix substitution costs minutes per run, cheaper
+      than a sticky disk storing the closure 24/7.
+    required: false
+    default: "true"
   cachix-auth-token:
     description: "Cachix auth token for xmtp cache"
     required: false
@@ -29,26 +37,26 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Persistent /nix sticky disk, one per (repo, workflow, OS, arch); must
-    # mount before Nix installs. Per-workflow keys stop concurrent workflows
-    # from overwriting each other's commits (last write wins per disk, so the
-    # slowest workflow used to decide what the shared disk kept). Concurrent
-    # jobs within a workflow still race, but they build near-identical
-    # closures and Cachix backfills anything a lost commit drops.
+    # Persistent /nix sticky disk, one per (repo, closure family, OS, arch);
+    # must mount before Nix installs. Workflows with near-identical closures
+    # share a family disk so storage doesn't hold N copies of the same
+    # toolchains. Commits are last-write-wins, so concurrent workflows in a
+    # family can drop each other's store paths; Cachix backfills anything a
+    # lost commit misses.
     - name: Require disk-key on Linux
-      if: ${{ runner.os == 'Linux' && inputs.disk-key == '' }}
+      if: ${{ runner.os == 'Linux' && inputs.nix-disk == 'true' && inputs.disk-key == '' }}
       run: |
-        echo "::error::setup-nix needs a disk-key input on Linux (the workflow file stem, e.g. test-workspace)"
+        echo "::error::setup-nix needs a disk-key input on Linux (a closure-family key, e.g. rust)"
         exit 1
       shell: bash
     - name: Prepare /nix mount point
-      if: ${{ runner.os == 'Linux' }}
+      if: ${{ runner.os == 'Linux' && inputs.nix-disk == 'true' }}
       run: |
         sudo mkdir -p /nix/store
         sudo chmod -R 777 /nix
       shell: bash
     - name: Mount /nix sticky disk
-      if: ${{ runner.os == 'Linux' }}
+      if: ${{ runner.os == 'Linux' && inputs.nix-disk == 'true' }}
       uses: useblacksmith/stickydisk@v1
       with:
         key: ${{ github.repository }}-nix-${{ inputs.disk-key }}-${{ runner.os }}-${{ runner.arch }}
@@ -76,7 +84,7 @@ runs:
     # action-post-run exec()s its `run` input as a bare executable (no
     # shell), so the script must live in a file.
     - name: Write /nix busy-process cleanup script
-      if: ${{ runner.os == 'Linux' }}
+      if: ${{ runner.os == 'Linux' && (inputs.nix-disk == 'true' || inputs.gradle-disk == 'true') }}
       run: |
         cat > "$RUNNER_TEMP/nix-unmount-cleanup.sh" << 'EOF'
         #!/usr/bin/env bash
@@ -93,7 +101,7 @@ runs:
         chmod +x "$RUNNER_TEMP/nix-unmount-cleanup.sh"
       shell: bash
     - name: Register /nix busy-process cleanup
-      if: ${{ runner.os == 'Linux' }}
+      if: ${{ runner.os == 'Linux' && (inputs.nix-disk == 'true' || inputs.gradle-disk == 'true') }}
       uses: webiny/action-post-run@3.1.0
       with:
         run: bash ${{ runner.temp }}/nix-unmount-cleanup.sh

--- a/.github/workflows/cross-test.yml
+++ b/.github/workflows/cross-test.yml
@@ -109,7 +109,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: cross-test
+          disk-key: rust
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"

--- a/.github/workflows/ignored-tests-tracker.yml
+++ b/.github/workflows/ignored-tests-tracker.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: ignored-tests-tracker
+          disk-key: rust
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/lint-android.yml
+++ b/.github/workflows/lint-android.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: lint-android
+          disk-key: android
           gradle-disk: "true"
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/lint-config.yml
+++ b/.github/workflows/lint-config.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: lint-config
+          disk-key: rust
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - name: Lint config files (TOML, Nix, shell)

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: lint-js
+          disk-key: web
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - name: Install dependencies

--- a/.github/workflows/lint-node.yml
+++ b/.github/workflows/lint-node.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: lint-node
+          disk-key: rust
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - name: Install dependencies

--- a/.github/workflows/lint-wasm.yml
+++ b/.github/workflows/lint-wasm.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: lint-wasm
+          disk-key: web
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/lint-workspace.yml
+++ b/.github/workflows/lint-workspace.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: lint-workspace
+          disk-key: rust
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "true"

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/actions/setup-release-tools
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: release-android
+          nix-disk: "false"
           gradle-disk: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/release-browser-sdk.yml
+++ b/.github/workflows/release-browser-sdk.yml
@@ -94,7 +94,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: release-browser-sdk
+          nix-disk: "false"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 

--- a/.github/workflows/release-kotlin-bindings-nix.yml
+++ b/.github/workflows/release-kotlin-bindings-nix.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: release-kotlin-bindings-nix
+          nix-disk: "false"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build jniLibs

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -94,7 +94,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: release-node-sdk
+          nix-disk: "false"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -84,7 +84,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: release-node
+          nix-disk: "false"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
@@ -115,7 +115,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: release-node
+          nix-disk: "false"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
@@ -140,7 +140,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: release-node
+          nix-disk: "false"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -81,7 +81,7 @@ jobs:
 
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: release-wasm
+          nix-disk: "false"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 

--- a/.github/workflows/reset-sticky-disks.yml
+++ b/.github/workflows/reset-sticky-disks.yml
@@ -3,12 +3,12 @@ name: Reset Sticky Disks
 # file deletion. Drop disks periodically; next run repopulates from Cachix.
 on:
   schedule:
-    # 1st of every other month (Jan, Mar, May, Jul, Sep, Nov) at 00:00 UTC
-    - cron: "0 0 1 */2 *"
+    # 1st of every month at 00:00 UTC
+    - cron: "0 0 1 * *"
   workflow_dispatch:
 jobs:
-  # Disks are keyed per workflow (see setup-nix). Enumerate the keys from
-  # the workflow files themselves so new workflows are reset automatically.
+  # Disks are keyed per closure family (see setup-nix). Enumerate the keys
+  # from the workflow files themselves so new families are reset automatically.
   enumerate:
     name: Enumerate disk keys
     runs-on: ubuntu-latest
@@ -19,7 +19,15 @@ jobs:
       - name: Collect disk-key values from workflows
         id: list
         run: |
-          keys=$(grep -rhoP 'disk-key:\s*\K[A-Za-z0-9_-]+' .github/workflows | sort -u | jq -Rnc '[inputs]')
+          # One-time: per-workflow keys from before the closure-family
+          # consolidation. Remove this list after one scheduled run.
+          legacy="cross-test ignored-tests-tracker lint-android lint-config
+            lint-js lint-node lint-wasm lint-workspace release-android
+            release-browser-sdk release-kotlin-bindings-nix release-node
+            release-node-sdk release-wasm test-android test-bindings-check
+            test-browser-sdk test-keepalive-probe test-node test-node-sdk
+            test-wasm test-workspace test-xdbg"
+          keys=$({ grep -rhoP 'disk-key:\s*\K[A-Za-z0-9_-]+' .github/workflows; printf '%s\n' $legacy; } | sort -u | jq -Rnc '[inputs]')
           echo "keys=$keys" >> "$GITHUB_OUTPUT"
           echo "Found nix disk keys: $keys"
   reset-nix-disks:

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-android
+          disk-key: android
           gradle-disk: "true"
           docker-builder: "true"
           github-token: ${{ github.token }}
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-android
+          disk-key: android
           gradle-disk: "true"
           docker-builder: "true"
           github-token: ${{ github.token }}

--- a/.github/workflows/test-bindings-check.yml
+++ b/.github/workflows/test-bindings-check.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-bindings-check
+          disk-key: android
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "true"
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-bindings-check
+          disk-key: android
           gradle-disk: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/test-browser-sdk.yml
+++ b/.github/workflows/test-browser-sdk.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-browser-sdk
+          disk-key: web
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/test-keepalive-probe.yml
+++ b/.github/workflows/test-keepalive-probe.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-keepalive-probe
+          disk-key: rust
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"

--- a/.github/workflows/test-node-sdk.yml
+++ b/.github/workflows/test-node-sdk.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-node-sdk
+          disk-key: web
           docker-builder: "true"
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-node
+          disk-key: rust
           docker-builder: "true"
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/test-wasm.yml
+++ b/.github/workflows/test-wasm.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-wasm
+          disk-key: web
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-workspace
+          disk-key: rust
           docker-builder: "true"
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
         with:
-          disk-key: test-xdbg
+          disk-key: rust
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"


### PR DESCRIPTION
Sticky disk usage reached ~2TB: 24 per-workflow `/nix` disks each held a near-identical copy of the same toolchain closures, at roughly 75GB per disk.

## Changes

**Consolidate 24 disks into 3 closure-family disks** (plus `fh-cache`, unchanged). Grouping follows the devshell each workflow actually enters — `node.just` and `android.just` run in the `default` shell, so the families are:

- `rust` (default devshell): test-workspace, lint-workspace, test-xdbg, test-keepalive-probe, lint-config, test-node, lint-node, cross-test, ignored-tests-tracker
- `web` (wasm + js devshells, overlapping via the bindings builds): test-wasm, lint-wasm, lint-js, test-node-sdk, test-browser-sdk
- `android` (default shell + kotlin-bindings cross toolchain): test-android, lint-android, test-bindings-check

Family disks share last-write-wins commits; racing workflows build near-identical closures and Cachix backfills whatever a lost commit drops — the same trade-off `setup-nix` already documented for concurrent jobs within a workflow.

**Drop disks from release workflows.** New `nix-disk: "false"` opt-out on `setup-nix`; all six `release-*` workflows use it. They run a handful of times a month, and `fh-cache` pins every tag's closure to Cachix, so substitution costs minutes per release instead of paying for storage 24/7. `release-android` keeps the shared repo-wide gradle disk (it exists regardless), and the busy-process unmount cleanup still runs whenever either disk is mounted.

**Reset monthly instead of bimonthly.** CoW snapshots never shrink, so reset cadence bounds accumulation — disks grow with every trusted push's new store paths, not just flake.lock bumps. With the consolidation doing the heavy lifting, monthly bounds that well enough; we'll monitor actual growth and tighten the cadence only if needed.

**Delete the orphaned disks.** The reset workflow enumerates disks by grepping live `disk-key:` values, so the 23 retired per-workflow disks — the bulk of the 2TB — would otherwise be stranded forever. A one-time `legacy` list in the enumerate step covers them; remove it after one scheduled run. Dispatching the reset workflow right after merge reclaims the space immediately.

Expected steady state: 4 X64 disks + ARM fh-cache + gradle + the 10GB-capped buildx caches, a few hundred GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate Nix sticky disk keys into closure-family namespaces across CI workflows
> - Replaces per-workflow `disk-key` values (e.g. `test-workspace`, `lint-js`) with shared closure-family keys (`rust`, `android`, `web`) across all CI workflows, so workflows with similar Nix closures share a single persistent disk.
> - Adds a `nix-disk` input (default `"true"`) to the [setup-nix action](.github/actions/setup-nix/action.yml) so callers can opt out of mounting the `/nix` sticky disk entirely; several release workflows set `nix-disk: "false"` to skip it.
> - Updates the [reset-sticky-disks workflow](.github/workflows/reset-sticky-disks.yml) to run monthly (was every two months) and includes legacy per-workflow keys in its next deletion pass.
> - Behavioral Change: workflows previously sharing no disk state will now share the same sticky disk; workflows setting `nix-disk: "false"` lose Nix store persistence across runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1856728.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->