### PR TITLE
feat(telemetry): add context and caller spans to the reference-ID parse warn

### DIFF
--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -890,6 +890,7 @@ where
 
     /// Look up and enrich a message by its ID, returning a [`DecodedMessage`]
     /// Returns an error if the message is not found or if it cannot be decoded/enriched
+    #[xmtp_common::mls_span]
     pub fn message_v2(&self, message_id: Vec<u8>) -> Result<DecodedMessage, ClientError> {
         let conn = self.context.db();
         let message = conn

--- a/crates/xmtp_mls/src/groups/message_list.rs
+++ b/crates/xmtp_mls/src/groups/message_list.rs
@@ -10,6 +10,7 @@ impl<Context> MlsGroup<Context>
 where
     Context: XmtpSharedContext,
 {
+    #[xmtp_common::mls_span]
     pub fn find_messages_v2(
         &self,
         query: &MsgQueryArgs,
@@ -18,6 +19,7 @@ where
         self.find_messages_v2_with_conn(query, conn)
     }
 
+    #[xmtp_common::mls_span]
     pub fn find_messages_v2_with_conn<C>(
         &self,
         query: &MsgQueryArgs,

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -1817,6 +1817,7 @@ where
     }
 
     /// Query for enriched messages (with reactions, replies, and deletion status)
+    #[xmtp_common::mls_span]
     pub fn find_enriched_messages(
         &self,
         args: &MsgQueryArgs,

--- a/crates/xmtp_mls/src/messages/enrichment.rs
+++ b/crates/xmtp_mls/src/messages/enrichment.rs
@@ -77,6 +77,7 @@ pub(crate) fn is_deletion_valid(
     is_sender || deletion.is_super_admin_deletion
 }
 
+#[xmtp_common::mls_span]
 pub fn enrich_messages(
     conn: impl DbQuery,
     group_id: &GroupId,
@@ -131,7 +132,18 @@ pub fn enrich_messages(
                 if let MessageBody::Reply(mut reply_body) = decoded.content {
                     let _ = hex::decode(&reply_body.reference_id)
                         .inspect_err(|err| {
-                            tracing::warn!("could not parse reference ID as hex: {:?}", err)
+                            // The reference is sender-controlled; truncate so a
+                            // malformed value can't flood the log line.
+                            let reference_id: String =
+                                reply_body.reference_id.chars().take(64).collect();
+                            tracing::warn!(
+                                group_id = %group_id,
+                                message_id = %hex::encode(&stored_message.id),
+                                sender_inbox_id = %stored_message.sender_inbox_id,
+                                reference_id = %reference_id,
+                                "could not parse reference ID as hex: {:?}",
+                                err
+                            )
                         })
                         .inspect(|id| {
                             let mut in_reply_to = relations


### PR DESCRIPTION

## Notes

- No behavior change; log/instrumentation only. The span form's invariants (`skip_all`, canonical `operation` field) are enforced by the `mls_span` macro at compile time, per its design — no runtime test added.
- The one-shot DM-updates migration (`cleanup_duplicate_updates`) also calls `enrich_messages` but is left uninstrumented: its warns still carry the `mls.enrich_messages` span, and the migration logs its own context.
- `just lint` (rust) green; `cargo check -p xmtp_mls` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MLS tracing spans and structured logging to reference-ID parse warnings in message enrichment
> - Adds `#[xmtp_common::mls_span]` instrumentation to `enrich_messages`, `find_enriched_messages`, `find_messages_v2`, `find_messages_v2_with_conn`, and `client.message_v2` for observability.
> - Expands the warning log in [`enrichment.rs`](https://github.com/xmtp/libxmtp/pull/3938/files#diff-ea8724206a28aee000055a5b6d488f8de21e315d8dc96067ced3205f0448a75e) when a reply `reference_id` fails hex decoding: now includes structured fields (`group_id`, `message_id`, `sender_inbox_id`) and truncates the sender-controlled `reference_id` to 64 characters instead of logging the raw value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f166658.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->