### PR TITLE
feat(telemetry): export spans across send/sync/welcome/stream paths; log swallowed errors

### DIFF
--- a/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
+++ b/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
@@ -11,6 +11,7 @@ use xmtp_proto::prelude::{ApiBuilder, NetConnectConfig};
 use xmtp_proto::{ApiEndpoint, api::ApiClientError};
 
 /// Get the nodes from the gateway server and build the clients for each node.
+#[xmtp_common::rpc_span]
 pub(super) async fn get_nodes<C: Client>(
     gateway_client: &C,
     template: &ClientBuilder,
@@ -59,7 +60,12 @@ pub(super) async fn get_nodes<C: Client>(
                 clients.insert(node_id, client);
             }
             Err(err) => {
-                tracing::error!("failed to build client for node {}: {}", err.0, err.1);
+                tracing::error!(
+                    node_id = err.0,
+                    "failed to build client for node {}: {}",
+                    err.0,
+                    err.1
+                );
             }
         }
     }
@@ -75,6 +81,7 @@ pub(super) async fn get_nodes<C: Client>(
 }
 
 /// Get the fastest node from the list of endpoints.
+#[xmtp_common::rpc_span]
 pub async fn get_fastest_node(
     clients: HashMap<u32, GrpcClient>,
     timeout: Duration,
@@ -105,7 +112,12 @@ pub async fn get_fastest_node(
             xmtp_common::time::timeout(timeout, endpoint.query(&client))
                 .await
                 .map_err(|_| {
-                    tracing::error!("node {} timed out after {}ms", node_id, timeout.as_millis());
+                    tracing::error!(
+                        node_id,
+                        "node {} timed out after {}ms",
+                        node_id,
+                        timeout.as_millis()
+                    );
                     MultiNodeClientError::NodeTimedOut {
                         node_id,
                         latency: timeout.as_millis() as u64,
@@ -114,7 +126,7 @@ pub async fn get_fastest_node(
                 })
                 .and_then(|r| {
                     r.map_err(|e| {
-                        tracing::error!("node {} is unhealthy: {}", node_id, e);
+                        tracing::error!(node_id, "node {} is unhealthy: {}", node_id, e);
                         e.endpoint(ApiEndpoint::HealthCheck)
                     })
                 })
@@ -144,6 +156,7 @@ pub async fn get_fastest_node(
 
     let (node_id, client, latency) = fastest_client.ok_or_else(|| {
         tracing::error!(
+            failed_nodes = failed_nodes.len(),
             "no responsive nodes found, {} node(s) failed health checks",
             failed_nodes.len()
         );

--- a/crates/xmtp_api_d14n/src/queries/combined.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined.rs
@@ -70,6 +70,7 @@ where
     D14n: Client,
     S: CursorStore,
 {
+    #[xmtp_common::rpc_span]
     pub async fn choose_client(&self) -> Result<&XmtpApiClient, ApiClientError> {
         if self.store.has_migrated()? {
             return Ok(&self.xmtpd_client);
@@ -104,6 +105,7 @@ where
     }
 
     /// if the write fails because of a cutover, force a refresh and retry
+    #[xmtp_common::rpc_span]
     pub async fn write_with_refresh<F, R, Fut>(&self, f: F) -> Result<R, ApiClientError>
     where
         F: Fn() -> Fut,

--- a/crates/xmtp_api_grpc/src/grpc_client/client.rs
+++ b/crates/xmtp_api_grpc/src/grpc_client/client.rs
@@ -142,6 +142,9 @@ impl Client for GrpcClient {
         &self.host
     }
 
+    // Manual form: #[rpc_span] can't produce the rpc.grpc.* sub-namespace nor
+    // carry the bounded `path` field (it hard-codes skip_all + rpc.<fn_name>).
+    #[tracing::instrument(err, skip_all, fields(operation = "rpc.grpc.request", path = %path))]
     async fn request(
         &self,
         request: http::request::Builder,
@@ -162,6 +165,9 @@ impl Client for GrpcClient {
         Ok(response.to_http())
     }
 
+    // The span covers stream establishment only — the returned stream
+    // outlives it.
+    #[tracing::instrument(err, skip_all, fields(operation = "rpc.grpc.stream", path = %path))]
     async fn stream(
         &self,
         request: request::Builder,
@@ -192,6 +198,7 @@ impl Client for GrpcClient {
     // Full-duplex needs a real HTTP/2 transport; the gRPC-Web service used on
     // wasm cannot carry it, so the browser keeps the trait's default error.
     #[cfg(not(target_arch = "wasm32"))]
+    #[tracing::instrument(err, skip_all, fields(operation = "rpc.grpc.bidi_stream", path = %path))]
     async fn bidi_stream(
         &self,
         request: request::Builder,

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1010,6 +1010,7 @@ where
 
     /// Upload a Key Package to the network and publish the signed identity update
     /// from the provided SignatureRequest
+    #[xmtp_common::mls_span]
     pub async fn register_identity(
         &self,
         signature_request: SignatureRequest,
@@ -1151,7 +1152,7 @@ where
 
     /// Sync all unread welcome messages and then sync all groups.
     /// Returns the total number of active groups synced.
-    #[tracing::instrument(err, skip_all, fields(operation = "sync_all_welcomes_and_groups"))]
+    #[xmtp_common::mls_span]
     pub async fn sync_all_welcomes_and_groups(
         &self,
         consent_states: Option<Vec<ConsentState>>,

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -450,7 +450,7 @@ impl<Context> MlsGroup<Context>
 where
     Context: XmtpSharedContext,
 {
-    #[tracing::instrument(err, skip_all, fields(operation = "sync"))]
+    #[xmtp_common::mls_span]
     pub async fn sync(&self) -> Result<SyncSummary, GroupError> {
         let conn = self.context.db();
 
@@ -526,10 +526,7 @@ where
     /// must return a summary of all messages synced, whether they were
     /// successful or not.
     #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(err, fields(who = %self.context.inbox_id(), operation = "sync_with_conn")))]
-    #[cfg_attr(
-        not(any(test, feature = "test-utils")),
-        tracing::instrument(err, skip_all, fields(operation = "sync_with_conn"))
-    )]
+    #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub async fn sync_with_conn(&self) -> Result<SyncSummary, SyncSummary> {
         let _mutex = self.mutex.lock().await;
         let mut summary = SyncSummary::default();
@@ -586,10 +583,7 @@ where
     }
 
     #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip_all))]
-    #[cfg_attr(
-        not(any(test, feature = "test-utils")),
-        tracing::instrument(level = "trace", skip_all)
-    )]
+    #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub(crate) async fn sync_until_last_intent_resolved(&self) -> Result<SyncSummary, GroupError> {
         // Filter to kinds this build understands: after a downgrade,
         // rows written by a newer build would otherwise fail `FromSql`
@@ -615,10 +609,7 @@ where
      * This method will retry up to `xmtp_configuration::MAX_GROUP_SYNC_RETRIES` times.
      */
     #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(err, level = "info", fields(who = %self.context.inbox_id(), operation = "intent"), skip(self)))]
-    #[cfg_attr(
-        not(any(test, feature = "test-utils")),
-        tracing::instrument(err, level = "trace", skip(self), fields(operation = "intent"))
-    )]
+    #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub(crate) async fn sync_until_intent_resolved(
         &self,
         intent_id: ID,
@@ -730,7 +721,12 @@ where
                     );
                 }
                 Err(err) => {
-                    tracing::error!("database error fetching intent {err:?}");
+                    tracing::error!(
+                        group_id = %self.group_id,
+                        intent_id,
+                        attempt,
+                        "database error fetching intent {err:?}"
+                    );
                     summary.add_other(GroupError::Storage(err));
                 }
             };
@@ -977,6 +973,11 @@ where
             || intent.state == IntentState::Error
         {
             tracing::warn!(
+                group_id = %self.group_id,
+                intent_id = intent.id,
+                intent_kind = %intent.kind,
+                intent_state = ?intent.state,
+                cursor = envelope.cursor.sequence_id,
                 "Skipping already processed intent {} of kind {} because it is in state {:?}",
                 intent.id,
                 intent.kind,
@@ -2145,13 +2146,27 @@ where
     }
 
     fn get_message_expire_at_ns(mls_group: &OpenMlsGroup) -> Option<i64> {
+        // A parse failure here must not look identical to "disappearing
+        // messages disabled" — warn before treating it as None.
         let mutable_metadata =
             super::app_data::component_source::extract_group_mutable_metadata_capability_aware(
                 mls_group,
             )
+            .inspect_err(|err| {
+                tracing::warn!(
+                    group_id = hex::encode(mls_group.group_id().as_slice()),
+                    "failed to extract mutable metadata for message expiry: {err:?}"
+                )
+            })
             .ok()?;
         let group_disappearing_settings =
             Self::conversation_message_disappearing_settings_from_extensions(&mutable_metadata)
+                .inspect_err(|err| {
+                    tracing::warn!(
+                        group_id = hex::encode(mls_group.group_id().as_slice()),
+                        "failed to parse disappearing-message settings: {err:?}"
+                    )
+                })
                 .ok()?;
 
         if group_disappearing_settings.is_enabled() {
@@ -2172,10 +2187,7 @@ where
         any(test, feature = "test-utils"),
         tracing::instrument(level = "info", skip(self), fields(envelope = %envelope))
     )]
-    #[cfg_attr(
-        not(any(test, feature = "test-utils")),
-        tracing::instrument(level = "trace", skip_all)
-    )]
+    #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub(crate) async fn process_message(
         &self,
         envelope: &GroupMessage,
@@ -2385,7 +2397,7 @@ where
                                 return Err(err.processing_error);
                             }
                             if envelope.is_commit() && let Err(accounting_error) = mls_group.mark_failed_commit_logged(&provider, cursor.sequence_id, envelope.message.epoch(), &err.processing_error) {
-                                tracing::error!("Error inserting commit entry for failed self commit: {}", accounting_error);
+                                tracing::error!(group_id = %self.group_id, cursor = cursor.sequence_id, "Error inserting commit entry for failed self commit: {}", accounting_error);
                             }
                             if err.next_intent_state == IntentState::Error {
                                 error_cause = Some(err.processing_error);
@@ -2399,7 +2411,14 @@ where
                     if next_intent_state == intent.state {
                         // No state transition (e.g. a re-delivered message for an
                         // intent already in this state) — nothing new to report.
-                        tracing::warn!("Intent [{}] is already in state [{:?}]", intent_id, next_intent_state);
+                        tracing::warn!(
+                            group_id = %self.group_id,
+                            intent_id,
+                            intent_state = ?next_intent_state,
+                            "Intent [{}] is already in state [{:?}]",
+                            intent_id,
+                            next_intent_state
+                        );
                         return Ok(Continue(None));
                     }
                     let mut intent_error = None;
@@ -2570,7 +2589,7 @@ where
                     {
                         // We don't need to propagate the error if the cursor fails to update - the worst case is
                         // that the non-retriable error is processed again
-                        tracing::error!("Error updating cursor for non-retriable error: {update_cursor_error:?}");
+                        tracing::error!(group_id = %self.group_id, cursor = envelope.sequence_id(), "Error updating cursor for non-retriable error: {update_cursor_error:?}");
                     } else if envelope.is_commit()
                         && let Err(accounting_error) = mls_group.mark_failed_commit_logged(
                         &provider,
@@ -2579,6 +2598,8 @@ where
                         &e,
                     ) {
                         tracing::error!(
+                                group_id = %self.group_id,
+                                cursor = envelope.sequence_id(),
                                 "Error inserting commit entry for failed commit: {}",
                                 accounting_error
                         );
@@ -2587,7 +2608,7 @@ where
                 })
                 .map(TransactionOutcome::into_continued)
                 {
-                    tracing::error!("Error post-processing non-retryable error: {transaction_error:?}");
+                    tracing::error!(group_id = %self.group_id, cursor = envelope.sequence_id(), "Error post-processing non-retryable error: {transaction_error:?}");
                 };
 
                 if let Err(accounting_error) = self
@@ -2600,6 +2621,8 @@ where
                     .await
                 {
                     tracing::error!(
+                        group_id = %self.group_id,
+                        cursor = envelope.sequence_id(),
                         "Error trying to log fork detection errors: {}",
                         accounting_error
                     );
@@ -2614,9 +2637,11 @@ where
         any(test, feature = "test-utils"),
         tracing::instrument(level = "info", skip_all, fields(who = %self.context.inbox_id()))
     )]
+    // Returns a bare ProcessSummary, so the canonical `#[mls_span]` (which
+    // records `err`) cannot apply; keep the same span shape by hand.
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
-        tracing::instrument(level = "trace", skip_all)
+        tracing::instrument(skip_all, fields(operation = "mls.process_messages"))
     )]
     pub async fn process_messages(&self, messages: Vec<GroupMessage>) -> ProcessSummary {
         let mut summary = ProcessSummary::default();
@@ -2857,17 +2882,25 @@ where
                 original_error = error.to_string(),
                 fork_details
             );
-            let _ = self
+            if let Err(storage_error) = self
                 .context
                 .db()
-                .mark_group_as_maybe_forked(&self.group_id, fork_details);
+                .mark_group_as_maybe_forked(&self.group_id, fork_details)
+            {
+                // Losing this write silently loses the durable fork signal.
+                tracing::error!(
+                    group_id = %self.group_id,
+                    cursor = %message_cursor,
+                    "failed to persist maybe-forked flag: {storage_error:?}"
+                );
+            }
             return epoch_validation_result;
         }
 
         Ok(())
     }
 
-    #[tracing::instrument]
+    #[xmtp_common::mls_span]
     pub(super) async fn publish_intents(&self) -> Result<(), GroupError> {
         let db = self.context.db();
         self.load_mls_group_with_lock_async(async |mut mls_group| {

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -105,7 +105,7 @@ fn encode_membership_entry(sequence_id: u64) -> Result<Vec<u8>, GroupError> {
 
 // Takes UpdateGroupMembershipIntentData and applies it to the openmls group
 // returning the commit and post_commit_action
-#[tracing::instrument(level = "trace", skip_all)]
+#[xmtp_common::mls_span]
 pub(crate) async fn apply_update_group_membership_intent(
     context: &impl XmtpSharedContext,
     openmls_group: &mut OpenMlsGroup,
@@ -361,7 +361,13 @@ async fn compute_publish_data_for_proposal_based_update(
             //    On migrated groups, also pre-compute the dict updates
             //    so the commit's confirmation tag agrees with what the
             //    receiver will compute via its own AppDataUpdate apply path.
-            let new_membership = extract_group_membership(&new_extensions_for_filter).ok();
+            let new_membership = extract_group_membership(&new_extensions_for_filter)
+                .inspect_err(|err| {
+                    // `None` downstream means "accept all GCE proposals" — a
+                    // parse failure taking that path deserves a trace.
+                    tracing::warn!("failed to extract legacy group membership: {err:?}")
+                })
+                .ok();
             let app_data_updates = if is_migrated_path {
                 Some(crate::groups::app_data::pending_app_data_updates(group)?)
             } else {
@@ -427,7 +433,7 @@ async fn compute_publish_data_for_proposal_based_update(
     })
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[xmtp_common::mls_span]
 pub(crate) async fn apply_readd_installations_intent(
     context: &impl XmtpSharedContext,
     openmls_group: &mut OpenMlsGroup,

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -1432,7 +1432,7 @@ where
     }
 
     /// Send a message on this users XMTP [`Client`](crate::client::Client).
-    #[tracing::instrument(level = "debug", err, skip_all, fields(who = self.context.inbox_id(), operation = "send_message"))]
+    #[xmtp_common::mls_span]
     pub async fn send_message(
         &self,
         message: &[u8],
@@ -1490,10 +1490,7 @@ where
     /// Publish all unpublished messages. This happens by calling `sync_until_last_intent_resolved`
     /// which publishes all pending intents and reads them back from the network.
     #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = self.context.inbox_id()), skip(self)))]
-    #[cfg_attr(
-        not(any(test, feature = "test-utils")),
-        tracing::instrument(level = "trace", skip(self))
-    )]
+    #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub async fn publish_messages(&self) -> Result<(), GroupError> {
         self.ensure_not_paused().await?;
         let update_interval_ns = Some(SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS);
@@ -1593,10 +1590,7 @@ where
     /// This is a no-op if the message is already published.
     ///
     /// Returns an error if the message is not found.
-    #[cfg_attr(
-        not(any(test, feature = "test-utils")),
-        tracing::instrument(level = "trace", skip(self))
-    )]
+    #[xmtp_common::mls_span]
     pub async fn publish_stored_message(&self, message_id: &[u8]) -> Result<(), GroupError> {
         if !self.is_active()? {
             return Err(GroupError::GroupInactive);

--- a/crates/xmtp_mls/src/groups/subscriptions.rs
+++ b/crates/xmtp_mls/src/groups/subscriptions.rs
@@ -97,6 +97,7 @@ where
             .await
     }
 
+    #[tracing::instrument(err, skip_all, fields(operation = "stream.stream_group_messages"))]
     pub async fn stream<'a>(
         &'a self,
     ) -> Result<impl Stream<Item = Result<StoredGroupMessage>> + use<'a, Context>>
@@ -107,6 +108,11 @@ where
     }
 
     /// create a stream that is not attached to any lifetime
+    #[tracing::instrument(
+        err,
+        skip_all,
+        fields(operation = "stream.stream_group_messages_owned")
+    )]
     pub async fn stream_owned(
         &self,
     ) -> Result<impl Stream<Item = Result<StoredGroupMessage>> + 'static>

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -19,7 +19,7 @@ use xmtp_common::{Retry, RetryableError, retry_async};
 use xmtp_db::refresh_state::EntityKind;
 use xmtp_db::{consent_record::ConsentState, group::GroupQueryArgs, prelude::*};
 use xmtp_macro::log_event;
-use xmtp_proto::types::{GlobalCursor, GroupId, GroupMessageMetadata};
+use xmtp_proto::types::{Cursor, GlobalCursor, GroupId, GroupMessageMetadata};
 
 #[derive(Debug, Clone)]
 pub struct GroupSyncSummary {
@@ -34,6 +34,14 @@ impl GroupSyncSummary {
             num_synced,
         }
     }
+}
+
+// Outcome of span-instrumented welcome processing: the expected
+// already-processed duplicate is an `Ok` variant so it cannot mark the
+// `mls.process_new_welcome` span as status:error.
+enum WelcomeOutcome<Context> {
+    Processed(Option<MlsGroup<Context>>),
+    AlreadyProcessed(Cursor),
 }
 
 #[derive(Clone)]
@@ -54,12 +62,33 @@ where
     /// Internal API to process a unread welcome message and convert to a group.
     /// In a database transaction, increments the cursor for a given installation and
     /// applies the update after the welcome processed successfully.
+    // Callers still receive `Err(WelcomeAlreadyProcessed)` for the routine
+    // duplicate-delivery case, but the span lives on the inner fn where that
+    // expected outcome exits as `Ok` — so it never flags span status:error.
     pub(crate) async fn process_new_welcome(
         &self,
         welcome: &xmtp_proto::types::WelcomeMessage,
         cursor_increment: bool,
         validator: impl ValidateGroupMembership,
     ) -> Result<Option<MlsGroup<Context>>, GroupError> {
+        match self
+            .process_new_welcome_spanned(welcome, cursor_increment, validator)
+            .await?
+        {
+            WelcomeOutcome::Processed(group) => Ok(group),
+            WelcomeOutcome::AlreadyProcessed(cursor) => Err(GroupError::ProcessIntent(
+                ProcessIntentError::WelcomeAlreadyProcessed(cursor),
+            )),
+        }
+    }
+
+    #[tracing::instrument(err, skip_all, fields(operation = "mls.process_new_welcome"))]
+    async fn process_new_welcome_spanned(
+        &self,
+        welcome: &xmtp_proto::types::WelcomeMessage,
+        cursor_increment: bool,
+        validator: impl ValidateGroupMembership,
+    ) -> Result<WelcomeOutcome<Context>, GroupError> {
         let result = XmtpWelcome::builder()
             .context(self.context.clone())
             .welcome(welcome)
@@ -90,7 +119,7 @@ where
                     }
                 }
 
-                Ok(mls_group)
+                Ok(WelcomeOutcome::Processed(mls_group))
             }
             Err(err) => {
                 use crate::DuplicateItem::*;
@@ -102,13 +131,11 @@ where
                         "Welcome ID already stored: {}",
                         err
                     );
-                    return Err(GroupError::ProcessIntent(
-                        ProcessIntentError::WelcomeAlreadyProcessed(welcome.cursor),
-                    ));
-                } else if matches!(
-                    err,
-                    GroupError::ProcessIntent(ProcessIntentError::WelcomeAlreadyProcessed(_))
-                ) {
+                    return Ok(WelcomeOutcome::AlreadyProcessed(welcome.cursor));
+                } else if let GroupError::ProcessIntent(
+                    ProcessIntentError::WelcomeAlreadyProcessed(cursor),
+                ) = err
+                {
                     // Expected, non-retryable condition: the welcome was already
                     // processed (e.g. duplicate delivery for a group we are already
                     // in). It is handled gracefully upstream (cursor incremented,
@@ -119,6 +146,7 @@ where
                         "welcome already processed, skipping: {}",
                         err
                     );
+                    return Ok(WelcomeOutcome::AlreadyProcessed(cursor));
                 } else {
                     tracing::error!(
                         "failed to create group from welcome={} created at {}: {}",
@@ -180,7 +208,7 @@ where
 
     /// Download all unread welcome messages and converts to a group struct, ignoring malformed messages.
     /// Returns any new groups created in the operation
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[xmtp_common::mls_span]
     pub async fn sync_welcomes(&self) -> Result<Vec<MlsGroup<Context>>, GroupError> {
         let store = MlsStore::new(self.context.clone());
         let envelopes = store.query_welcome_messages().await?;

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -97,7 +97,10 @@ where
     C: XmtpSharedContext,
     V: ValidateGroupMembership,
 {
-    #[tracing::instrument(skip_all, level = "trace")]
+    // Named explicitly (derived `mls.process` is too generic) and without `err`:
+    // duplicate welcomes exit as Err(WelcomeAlreadyProcessed), an expected
+    // outcome; unexpected failures set status on mls.process_new_welcome above.
+    #[tracing::instrument(skip_all, fields(operation = "mls.process_welcome"))]
     pub async fn process(self) -> Result<Option<MlsGroup<C>>, GroupError> {
         let mut this = self.build()?;
         let db = this.context.db();

--- a/crates/xmtp_mls/src/identity_updates.rs
+++ b/crates/xmtp_mls/src/identity_updates.rs
@@ -494,8 +494,6 @@ where
         new_group_membership: &GroupMembership,
         membership_diff: &MembershipDiff<'_>,
     ) -> Result<InstallationDiff, InstallationDiffError> {
-        tracing::info!("Updating group membership...");
-
         let added_and_updated_members = membership_diff
             .added_inboxes
             .iter()

--- a/crates/xmtp_mls/src/subscriptions/catch_up.rs
+++ b/crates/xmtp_mls/src/subscriptions/catch_up.rs
@@ -240,6 +240,7 @@ where
     /// "everything else synced, one item pending replay" into a hard error
     /// on every wake. `Ok` therefore means "everything owed was received
     /// and attempted", not "zero processing errors".
+    #[xmtp_common::span(prefix = "stream")]
     pub async fn catch_up_to_live(
         &self,
         timeout: Option<Duration>,

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -446,7 +446,7 @@ where
         Ok(out)
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[xmtp_common::span(prefix = "stream")]
     pub async fn stream_conversations(
         &self,
         conversation_type: Option<ConversationType>,
@@ -465,7 +465,7 @@ where
     }
 
     /// Stream conversations but decouple the lifetime of 'self' from the stream.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[xmtp_common::span(prefix = "stream")]
     pub async fn stream_conversations_owned(
         &self,
         conversation_type: Option<ConversationType>,
@@ -520,7 +520,7 @@ where
         )
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[xmtp_common::span(prefix = "stream")]
     pub async fn stream_all_messages(
         &self,
         conversation_type: Option<ConversationType>,
@@ -536,7 +536,7 @@ where
         StreamAllMessages::new(&self.context, conversation_type, consent_state).await
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[xmtp_common::span(prefix = "stream")]
     pub async fn stream_all_messages_owned(
         &self,
         conversation_type: Option<ConversationType>,

--- a/crates/xmtp_mls/src/subscriptions/process_message.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message.rs
@@ -174,6 +174,7 @@ pub(crate) fn finish(processed: ProcessedMessage) -> Processed {
 /// The caller owns dedup and cursor advancement (see [`Processed`]). The live
 /// [`super::stream_messages`] stream shares the same [`prepare`]/[`finish`] steps from
 /// its poll state-machine (which cannot `.await` this directly).
+#[xmtp_common::span(prefix = "stream")]
 pub async fn process_one<'a>(
     factory: &impl ProcessFutureFactory<'a>,
     msg: xmtp_proto::types::GroupMessage,

--- a/crates/xmtp_mls/src/subscriptions/stream_router.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_router.rs
@@ -200,6 +200,7 @@ where
 
     /// Stream decoded messages for `group_ids`, resuming each group from its
     /// durable cursor (catch-up, then live, over the shared wire).
+    #[tracing::instrument(err, skip_all, fields(operation = "stream.router_stream_messages"))]
     pub async fn stream_messages(
         &self,
         group_ids: Vec<GroupId>,
@@ -220,6 +221,7 @@ where
     /// conversations: the subscribe-time set seeds the stream, and the
     /// welcome auto-subscribe reflex leases each later-joined group's topic
     /// as its welcome arrives — no re-subscribe needed.
+    #[tracing::instrument(err, skip_all, fields(operation = "stream.router_stream_all_messages"))]
     pub async fn stream_all_messages(
         &self,
         conversation_type: Option<ConversationType>,
@@ -250,6 +252,11 @@ where
 
     /// Stream new conversations from this client's welcome topic, resuming
     /// from the durable welcome cursor.
+    #[tracing::instrument(
+        err,
+        skip_all,
+        fields(operation = "stream.router_stream_conversations")
+    )]
     pub async fn stream_conversations(
         &self,
         conversation_type: Option<ConversationType>,
@@ -413,6 +420,9 @@ where
         }
     }
 
+    // Runs in the router task, detached from the caller's span — the entry
+    // spans above only observe the reply wait, this one the actual work.
+    #[tracing::instrument(skip_all, fields(operation = "stream.router_subscribe"))]
     async fn subscribe(&mut self, cmd: Cmd<Context>) {
         // A failed reply (the caller cancelled mid-subscribe) drops the
         // returned `RouterStream` right here, and its `Drop` routes back

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -296,22 +296,20 @@ pub trait Worker: MaybeSend + MaybeSync + 'static {
             let worker = format!("{:?}", kind);
             let run = async move {
                 loop {
-                    let outcome = async { self.run_tasks().await }
-                        .instrument(tracing::info_span!(
-                            "worker_run",
-                            operation = "worker_run",
-                            worker = %worker
-                        ))
-                        .await;
+                    // No span here: `run_tasks` runs until worker death, so a
+                    // wrapping span exports only on restart with an hours-long
+                    // duration. Per-tick visibility comes from `worker_turn`;
+                    // restarts from the structured logs below.
+                    let outcome = self.run_tasks().await;
                     if let Err(err) = outcome {
                         if err.needs_db_reconnect() {
                             // drop the worker
                             tracing::debug!("pool disconnected. task will restart on reconnect");
                             break;
                         } else {
-                            tracing::error!("{:?} worker error: {}", kind, err);
+                            tracing::error!(worker = %worker, "{:?} worker error: {}", kind, err);
                             xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
-                            tracing::info!("Restarting {:?} worker...", kind);
+                            tracing::info!(worker = %worker, "Restarting {:?} worker...", kind);
                         }
                     }
                 }

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -264,8 +264,10 @@ where
             return Ok(());
         }
         if task.next_attempt_at_ns > now {
-            // This will get called again
-            tracing::warn!(
+            // This will get called again — expected scheduler behavior, not a
+            // warning (it was ~3k warns/day in prod).
+            tracing::debug!(
+                task_id = task.id,
                 "Task {} called before next attempt at {}. Now: {now}",
                 task.id,
                 task.next_attempt_at_ns


### PR DESCRIPTION
## Summary

Follow-up to the observability sweep (and #3938): the customer-critical pipeline was instrumented at **debug/trace under an INFO+ OTLP export floor**, so `send_message`, intent publication, message/welcome processing, and the entire streaming subsystem produced **zero spans in production**. This PR promotes those paths to the canonical exported span forms, completes the operation-namespace migration the collector config already anticipates, and adds logs where errors were silently swallowed.

### Spans promoted / added

**`mls.*`** (via `#[mls_span]`, or the canonical manual form where the return type isn't `Result`): `send_message`, `publish_messages`, `publish_stored_message`, `publish_intents`, `sync`, `sync_with_conn`, `sync_until_intent_resolved`, `sync_until_last_intent_resolved`, `process_message`, `process_messages`, `process_new_welcome`, `sync_welcomes`, `process_welcome` (named explicitly — derived name would be `mls.process`), `apply_update_group_membership_intent`, `apply_readd_installations_intent`, `register_identity`. Test-only `cfg_attr` arms (with their `who` fields) are preserved; only production arms change.

**`stream.*`** (new namespace): `stream_conversations(_owned)`, `stream_all_messages(_owned)`, group message-stream entries, `StreamRouter` subscribe entries + the task-side `router_subscribe`, `catch_up_to_live`, `process_one`. ⚠️ Until the herald collector grows a `span_metrics/stream` + `filter/stream` pair, these fall into the `xmtp.mls.*` catch-all (counted, not lost) — the collector's exclusion filter only diverts `rpc|db|herald|bidi`. Convos-assistants follow-up: mirror the `bidi` connector blocks in `herald-lite/ops/telemetry/otel-collector.yaml`.

**`rpc.*`**: `choose_client` + `write_with_refresh` (d14n cutover routing, incl. the hidden post-cutover retry), `get_nodes` + `get_fastest_node` (multi-node), and low-level gRPC `request`/`stream`/`bidi_stream` establishment as `rpc.grpc.*` with a bounded `path` field. Note: `rpc.grpc.*` transport spans are counted in `xmtp.api.calls` alongside the wrapper spans — separable by the `operation` dimension; a dedicated `filter/grpc` family is optional follow-up.

Operation renames (`sync` → `mls.sync` etc.) are **non-breaking**: the collector config documents that dashboards/monitors group by `span.name`, not `operation`, and describes `mls.*` values as the post-migration state.

### Swallowed errors now logged
- ~~Welcome dropped after retry exhaustion in `sync_welcomes`~~ — superseded on rebase: #3931 landed on main and rewrote this path with `process_welcomes_with`, which already logs both skip/stop cases with `welcome_cursor` fields. This PR now only adds the `mls.sync_welcomes` / `mls.process_new_welcome` spans there.
- Failed `mark_group_as_maybe_forked` persistence (was `let _ =`) — losing the durable fork signal, relevant to #3008.
- Disappearing-message metadata parse failures (previously indistinguishable from "expiry disabled").
- Legacy membership-extraction failure that falls back to accept-all-GCEs.

### Structured context on hot warn/error sites
`mls_sync` intent-state warns (the only prod evidence of #3474) gain `group_id`/`intent_id`/`intent_state`/`cursor`; the failed-commit/fork-accounting error cluster gains `group_id`/`cursor` (#3747); `gateway_api` gains spans + `node_id` fields.

### Noise demotions
- `identity_updates.rs` "Updating group membership..." removed outright (**61% of herald-lite's total prod log volume**, context-free, and redundant next to the membership-apply spans).
- TaskRunner early-poll warn → debug (~3k/day; its own comment says the recall is expected).
- Removed the `worker_run` span: it wrapped one whole `run_tasks()` invocation — an infinite loop for most workers — so it exported only on worker death with an hours-long duration (p95 ≈ 11.7 h in prod): useless in a 30s-top-bucket histogram, and a trace root that holds children open (and defeats tail-sampling). Per-tick visibility stays on `worker_turn`; restart tracking moves to the now-structured, `worker`-tagged error/restart logs.

## Verification
- `cargo check` clean for `xmtp_mls` (both cfg arms), `xmtp_api_d14n`, `xmtp_api_grpc`, incl. `wasm32-unknown-unknown`.
- `just lint` (rust) green: clippy, fmt, hakari.
- Instrumentation/log-only — no behavior change except the new log lines; span invariants are compile-time-enforced by the macros.

Refs #3396, #3474, #3747, #3008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tracing spans across send, sync, welcome, and stream paths and log swallowed errors
> - Adds `#[xmtp_common::mls_span]`, `#[xmtp_common::rpc_span]`, and `#[tracing::instrument]` attributes across MLS sync, welcome processing, gRPC request/stream, and subscription stream methods to produce structured telemetry spans.
> - Refactors `WelcomeService.process_new_welcome` to use an internal `WelcomeOutcome` enum so duplicate-welcome cases don't mark spans as errors while preserving external behavior.
> - Surfaces previously swallowed errors: logs warnings on metadata parse failures, failed fork-flag persistence, and legacy membership extraction failures.
> - Reduces log noise by removing an unconditional info log in `get_installation_diff`, lowering an expected early-call warning in `run_and_reschedule_task` to debug, and removing per-loop worker spans.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b30eea3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
