### PR TITLE
fix(xmtp_mls): skip phantom members on partial key package failure (#3945)

### DIFF
--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -4194,15 +4194,8 @@ where
                 return Err(GroupError::FailedToVerifyInstallations);
             }
 
-            let mut membership_updates = changed_inbox_ids;
-            update_group_membership::filter_unverified_adds_from_membership_updates(
-                &mut membership_updates,
-                inbox_ids_to_add,
-                &changes_with_kps.new_key_packages,
-            );
-
             Ok(UpdateGroupMembershipIntentData::new(
-                membership_updates,
+                changed_inbox_ids,
                 inbox_ids_to_remove
                     .iter()
                     .map(|s| s.to_string())

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -3434,16 +3434,9 @@ where
                     // inbox_id whose installations all failed kp fetch has
                     // no MLS leaf in the commit, so claiming membership
                     // for it would diverge dict and tree state.
-                    let added_inbox_ids: HashSet<String> = changes_with_kps
-                        .new_key_packages
-                        .iter()
-                        .filter_map(|kp| {
-                            let credential =
-                                BasicCredential::try_from(kp.leaf_node().credential().clone())
-                                    .ok()?;
-                            parse_credential(credential.identity()).ok()
-                        })
-                        .collect();
+                    let added_inbox_ids = update_group_membership::inbox_ids_from_new_key_packages(
+                        &changes_with_kps.new_key_packages,
+                    );
                     for inbox_id in &intent_data.add_inbox_ids {
                         if !added_inbox_ids.contains(inbox_id) {
                             continue;
@@ -4201,8 +4194,15 @@ where
                 return Err(GroupError::FailedToVerifyInstallations);
             }
 
+            let mut membership_updates = changed_inbox_ids;
+            update_group_membership::filter_unverified_adds_from_membership_updates(
+                &mut membership_updates,
+                inbox_ids_to_add,
+                &changes_with_kps.new_key_packages,
+            );
+
             Ok(UpdateGroupMembershipIntentData::new(
-                changed_inbox_ids,
+                membership_updates,
                 inbox_ids_to_remove
                     .iter()
                     .map(|s| s.to_string())

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -193,15 +193,11 @@ pub(crate) async fn apply_update_group_membership_intent(
         return Ok(None);
     }
 
-    let failed_installations_changed =
-        new_group_membership.failed_installations != old_group_membership.failed_installations;
-
     if leaf_nodes_to_remove.is_empty()
         && changes_with_kps.new_key_packages.is_empty()
         && membership_diff.updated_inboxes.is_empty()
         && membership_diff.added_inboxes.is_empty()
         && membership_diff.removed_inboxes.is_empty()
-        && !failed_installations_changed
     {
         return Ok(None);
     }

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -35,8 +35,24 @@ pub(crate) fn inbox_ids_from_new_key_packages(
     new_key_packages
         .iter()
         .filter_map(|kp| {
-            let credential = BasicCredential::try_from(kp.leaf_node().credential().clone()).ok()?;
-            parse_credential(credential.identity()).ok()
+            let credential = match BasicCredential::try_from(kp.leaf_node().credential().clone()) {
+                Ok(credential) => credential,
+                Err(e) => {
+                    tracing::warn!(?e, "failed to decode key package leaf credential");
+                    return None;
+                }
+            };
+            match parse_credential(credential.identity()) {
+                Ok(inbox_id) => Some(inbox_id),
+                Err(e) => {
+                    tracing::warn!(
+                        ?e,
+                        "failed to parse inbox id from key package credential; \
+                         skipping inbox for phantom-member verification"
+                    );
+                    None
+                }
+            }
         })
         .collect()
 }

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -6,9 +6,12 @@ use crate::groups::{
     update_required_capabilities_for_proposals,
     validated_commit::extract_group_membership,
 };
+use crate::identity::parse_credential;
 use openmls::{
+    credentials::BasicCredential,
     extensions::Extensions,
     group::GroupContext,
+    key_packages::KeyPackage,
     messages::proposals::{AppDataUpdateOperation, Proposal},
     prelude::{LeafNodeIndex, MlsGroup as OpenMlsGroup, tls_codec::Serialize},
 };
@@ -24,6 +27,56 @@ use xmtp_mls_common::{
     tls_map::TlsMapDelta,
 };
 use xmtp_proto::xmtp::mls::message_contents::{GroupMembershipEntry, group_membership_entry};
+
+/// Inbox ids that received at least one Add proposal in this commit.
+pub(crate) fn inbox_ids_from_new_key_packages(
+    new_key_packages: &[KeyPackage],
+) -> std::collections::HashSet<String> {
+    new_key_packages
+        .iter()
+        .filter_map(|kp| {
+            let credential = BasicCredential::try_from(kp.leaf_node().credential().clone()).ok()?;
+            parse_credential(credential.identity()).ok()
+        })
+        .collect()
+}
+
+/// Drop net-new members whose installations all failed key-package fetch.
+/// An inbox without an MLS leaf must not appear in the membership dict/extension
+/// or dict and tree state diverge (see `ProposeMemberUpdate` path in `mls_sync.rs`).
+pub(crate) fn strip_unverified_new_adds(
+    new_membership: &mut GroupMembership,
+    old_membership: &GroupMembership,
+    new_key_packages: &[KeyPackage],
+) {
+    let verified_adds = inbox_ids_from_new_key_packages(new_key_packages);
+    let phantom_adds: Vec<String> = new_membership
+        .inbox_ids()
+        .into_iter()
+        .filter(|inbox_id| {
+            old_membership.get(inbox_id).is_none() && !verified_adds.contains(*inbox_id)
+        })
+        .map(str::to_string)
+        .collect();
+    for inbox_id in phantom_adds {
+        new_membership.remove(&inbox_id);
+    }
+}
+
+/// Remove requested net-new adds from `membership_updates` when no installation
+/// for that inbox produced a verified key package.
+pub(crate) fn filter_unverified_adds_from_membership_updates(
+    membership_updates: &mut std::collections::HashMap<String, u64>,
+    inbox_ids_to_add: &[impl AsRef<str>],
+    new_key_packages: &[KeyPackage],
+) {
+    let verified_adds = inbox_ids_from_new_key_packages(new_key_packages);
+    for inbox_id in inbox_ids_to_add {
+        if !verified_adds.contains(inbox_id.as_ref()) {
+            membership_updates.remove(inbox_id.as_ref());
+        }
+    }
+}
 
 /// Build the wire-level `TlsMapDelta<InboxId, VLBytes>` payload for an
 /// `AppDataUpdate(GROUP_MEMBERSHIP)` proposal from the diff between
@@ -114,8 +167,7 @@ pub(crate) async fn apply_update_group_membership_intent(
 ) -> Result<Option<PublishIntentData>, GroupError> {
     let extensions = openmls_group.extensions().clone();
     let old_group_membership = extract_group_membership(&extensions)?;
-    let new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
-    let membership_diff = old_group_membership.diff(&new_group_membership);
+    let mut new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
 
     let group_id = GroupId::try_from(openmls_group.group_id())?;
     let changes_with_kps = calculate_membership_changes_with_keypackages(
@@ -125,6 +177,14 @@ pub(crate) async fn apply_update_group_membership_intent(
         &old_group_membership,
     )
     .await?;
+
+    strip_unverified_new_adds(
+        &mut new_group_membership,
+        &old_group_membership,
+        &changes_with_kps.new_key_packages,
+    );
+    let membership_diff = old_group_membership.diff(&new_group_membership);
+
     let leaf_nodes_to_remove: Vec<LeafNodeIndex> =
         get_removed_leaf_nodes(openmls_group, &changes_with_kps.removed_installations);
 
@@ -133,9 +193,15 @@ pub(crate) async fn apply_update_group_membership_intent(
         return Ok(None);
     }
 
+    let failed_installations_changed =
+        new_group_membership.failed_installations != old_group_membership.failed_installations;
+
     if leaf_nodes_to_remove.is_empty()
         && changes_with_kps.new_key_packages.is_empty()
         && membership_diff.updated_inboxes.is_empty()
+        && membership_diff.added_inboxes.is_empty()
+        && membership_diff.removed_inboxes.is_empty()
+        && !failed_installations_changed
     {
         return Ok(None);
     }
@@ -596,5 +662,34 @@ mod tests {
         .await
         .unwrap();
         assert!(intent.is_none());
+    }
+
+    #[xmtp_common::test]
+    fn strip_unverified_new_adds_removes_phantom_members() {
+        let mut old = GroupMembership::new();
+        old.add("alice".to_string(), 1);
+
+        let mut new = old.clone();
+        new.add("bob".to_string(), 2);
+        new.add("carol".to_string(), 3);
+
+        // No key packages => both net-new adds are phantom.
+        strip_unverified_new_adds(&mut new, &old, &[]);
+        assert_eq!(new.members, old.members);
+
+        // Identity updates on existing members are preserved even without KPs.
+        new.add("bob".to_string(), 2);
+        new.add("alice".to_string(), 5);
+        strip_unverified_new_adds(&mut new, &old, &[]);
+        assert_eq!(new.get("alice"), Some(&5));
+        assert!(!new.members.contains_key("bob"));
+    }
+
+    #[xmtp_common::test]
+    fn filter_unverified_adds_from_membership_updates_drops_failed_adds() {
+        let mut updates = HashMap::from([("alice".to_string(), 5), ("bob".to_string(), 2)]);
+        filter_unverified_adds_from_membership_updates(&mut updates, &["bob"], &[]);
+        assert_eq!(updates.get("alice"), Some(&5));
+        assert!(!updates.contains_key("bob"));
     }
 }

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -63,21 +63,6 @@ pub(crate) fn strip_unverified_new_adds(
     }
 }
 
-/// Remove requested net-new adds from `membership_updates` when no installation
-/// for that inbox produced a verified key package.
-pub(crate) fn filter_unverified_adds_from_membership_updates(
-    membership_updates: &mut std::collections::HashMap<String, u64>,
-    inbox_ids_to_add: &[impl AsRef<str>],
-    new_key_packages: &[KeyPackage],
-) {
-    let verified_adds = inbox_ids_from_new_key_packages(new_key_packages);
-    for inbox_id in inbox_ids_to_add {
-        if !verified_adds.contains(inbox_id.as_ref()) {
-            membership_updates.remove(inbox_id.as_ref());
-        }
-    }
-}
-
 /// Build the wire-level `TlsMapDelta<InboxId, VLBytes>` payload for an
 /// `AppDataUpdate(GROUP_MEMBERSHIP)` proposal from the diff between
 /// the old and new `GroupMembership` view. Shared between the commit-
@@ -679,13 +664,5 @@ mod tests {
         strip_unverified_new_adds(&mut new, &old, &[]);
         assert_eq!(new.get("alice"), Some(&5));
         assert!(!new.members.contains_key("bob"));
-    }
-
-    #[xmtp_common::test]
-    fn filter_unverified_adds_from_membership_updates_drops_failed_adds() {
-        let mut updates = HashMap::from([("alice".to_string(), 5), ("bob".to_string(), 2)]);
-        filter_unverified_adds_from_membership_updates(&mut updates, &["bob"], &[]);
-        assert_eq!(updates.get("alice"), Some(&5));
-        assert!(!updates.contains_key("bob"));
     }
 }


### PR DESCRIPTION
Fixes #3945

## Summary

- Filter net-new inbox adds out of `UpdateGroupMembership` when no installation for that inbox received a verified key package.
- Apply the same filter in `get_membership_update_intent` so queued intents match what the commit will actually add.
- Reuse a shared `inbox_ids_from_new_key_packages` helper (also used by the existing `ProposeMemberUpdate` path).
- Add unit tests for the filter helpers.

## Problem

On partial `add_members` success (inbox A gets KPs, inbox B does not), the `UpdateGroupMembership` path could write B into the membership extension / AppData `GROUP_MEMBERSHIP` dict without an MLS `Add` proposal — dict and ratchet tree diverge.

## Test plan

- [x] `cargo test -p xmtp_mls strip_unverified filter_unverified --lib`
- [x] `cargo fmt --check` on changed files
- [ ] CI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip phantom members on partial key package failure in MLS group membership updates
> - Adds `strip_unverified_new_adds` in [update_group_membership.rs](https://github.com/xmtp/libxmtp/pull/3946/files#diff-56361bf0fcb1e9400991ea5996f3629427f28874ca78d913d3fd695be7c736f4) to remove net-new inboxes from `GroupMembership` when no corresponding key packages were provided, preventing divergence between the membership dict and the MLS tree state.
> - Adds `inbox_ids_from_new_key_packages` helper to centralize extraction of inbox IDs from key packages, emitting tracing warnings on credential decode or parse failures instead of silently skipping.
> - `apply_update_group_membership_intent` now calls `strip_unverified_new_adds` before computing the membership diff, and returns `None` (no commit/proposal) when the only remaining changes were unverified adds.
> - Behavioral Change: group sync may now produce no commit where it previously would have committed a membership update that included phantom members.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be67792.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->