### PR TITLE
fix(xmtp_mls): treat membership sequence_id 0 as unset when resolving association state

### DIFF
--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -14,6 +14,7 @@ mod test_network;
 mod test_prepare_message_for_later_publish;
 mod test_proposals;
 mod test_send_message_opts;
+mod test_starting_membership_sequence_id;
 mod test_validate_app_data_update;
 mod test_welcome_pointers;
 mod test_welcomes;
@@ -2590,16 +2591,10 @@ async fn test_update_policies_empty_group() {
     let policy_set_2 = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
     let amal_group_2 = amal.create_group(policy_set_2, None).unwrap();
 
-    // Verify empty group fails to update metadata before syncing
-    amal_group_2
-        .update_group_name("New Group Name 2".to_string())
-        .await
-        .expect_err("Should fail to update group name before first sync");
-
-    // Sync the group
-    amal_group_2.sync().await.unwrap();
-
-    //Verify we can now update the group name
+    // A solo group still carries the creation-time `sequence_id: 0` placeholder
+    // in its membership extension until something bumps it, and that must not
+    // block a metadata update. This previously failed with a non-retryable
+    // `MissingIdentityUpdate` — see `test_starting_membership_sequence_id`.
     amal_group_2
         .update_group_name("New Group Name 2".to_string())
         .await

--- a/crates/xmtp_mls/src/groups/tests/test_starting_membership_sequence_id.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_starting_membership_sequence_id.rs
@@ -1,0 +1,45 @@
+//! Regression coverage for the `sequence_id: 0` placeholder that
+//! `build_starting_group_membership_extension` writes at group creation.
+//!
+//! `create_group` is purely local and seeds the membership extension with the
+//! creator at sequence_id `0`. Nothing replaces it with the creator's real
+//! sequence id until an `UpdateGroupMembership` intent runs, and neither the
+//! metadata-update nor the key-update path triggers one.
+//!
+//! `0` is a sentinel meaning "unset" — `get_installation_diff` honors it on the
+//! *old* membership side (`Some(0) => None`), but the reads on the *new* side
+//! treat it as a literal sequence id. The actor credential check in
+//! `ValidatedCommit::from_staged_commit` then resolves the committer's
+//! association state at sequence id `0`, and since no identity update can have
+//! `sequence_id <= 0`, it fails with `MissingIdentityUpdate` — which is not
+//! retryable, so the intent lands in `Error` permanently.
+
+use crate::tester;
+
+/// A metadata update issued before anything has bumped the creator's
+/// placeholder sequence id must still commit successfully.
+#[xmtp_common::test(unwrap_try = true)]
+async fn metadata_update_on_freshly_created_group_succeeds() {
+    tester!(alix);
+
+    // Membership is `{alix: 0}` at this point — creation does no network I/O
+    // and queues no membership-update intent.
+    let group = alix.create_group(None, None)?;
+
+    // This commit's GroupContextExtensions proposal carries `{alix: 0}`.
+    group.update_group_name("hello".to_string()).await?;
+
+    assert_eq!(group.group_name()?, "hello");
+}
+
+/// Same placeholder, reached through a commit with no GCE proposal at all —
+/// `get_latest_group_membership` falls back to the staged commit's group
+/// context, which still holds `{alix: 0}`.
+#[xmtp_common::test(unwrap_try = true)]
+async fn key_update_on_freshly_created_group_succeeds() {
+    tester!(alix);
+
+    let group = alix.create_group(None, None)?;
+
+    group.key_update().await?;
+}

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -698,12 +698,22 @@ impl ValidatedCommit {
         // 2. Anyone referenced in an update proposal
         // Satisfies Rule 4
         for participant in credentials_to_verify {
-            let to_sequence_id = new_group_membership
-                .get(&participant.inbox_id)
-                .ok_or(CommitValidationError::SubjectDoesNotExist)?;
+            // `0` is the placeholder `build_starting_group_membership_extension`
+            // writes at group creation, not a real sequence id. No identity
+            // update can have `sequence_id <= 0`, so resolving the association
+            // state *at* 0 fails with `MissingIdentityUpdate` — which is not
+            // retryable, permanently erroring any commit authored before the
+            // first `UpdateGroupMembership` replaces the placeholder. Treat it
+            // as "unset" and use the latest known state, matching how
+            // `get_installation_diff` already reads the old membership side.
+            let to_sequence_id = match new_group_membership.get(&participant.inbox_id) {
+                None => return Err(CommitValidationError::SubjectDoesNotExist),
+                Some(0) => None,
+                Some(sequence_id) => Some(*sequence_id as i64),
+            };
 
             let inbox_state = IdentityUpdates::new(&context)
-                .get_association_state(&conn, &participant.inbox_id, Some(*to_sequence_id as i64))
+                .get_association_state(&conn, &participant.inbox_id, to_sequence_id)
                 .await
                 .map_err(InstallationDiffError::from)?;
 

--- a/crates/xmtp_mls/src/identity_updates.rs
+++ b/crates/xmtp_mls/src/identity_updates.rs
@@ -527,12 +527,18 @@ where
                     Some(i) => Some(*i as i64),
                     None => None,
                 };
+                // `Some(0)` is the group-creation placeholder rather than a real
+                // sequence id, same as `starting_sequence_id` above treats it.
+                let ending_sequence_id = match new_group_membership.get(inbox_id) {
+                    Some(0) | None => None,
+                    Some(sequence_id) => Some(*sequence_id as i64),
+                };
                 let state_diff = self
                     .get_association_state_diff(
                         conn,
                         inbox_id.as_str(),
                         starting_sequence_id,
-                        new_group_membership.get(inbox_id).map(|i| *i as i64),
+                        ending_sequence_id,
                     )
                     .await?;
 


### PR DESCRIPTION
## Problem

`create_group` seeds the membership extension with the creator at `sequence_id: 0` as a placeholder (`build_starting_group_membership_extension(creator_inbox_id, 0)`). Nothing replaces it with the creator's real sequence id until the first `UpdateGroupMembership` intent runs.

`0` is a sentinel meaning "unset", and `get_installation_diff` honors it on the **old** membership side:

```rust
let starting_sequence_id = match old_group_membership.get(inbox_id) {
    Some(0) => None,
    Some(i) => Some(*i as i64),
    None => None,
};
```

The reads on the **new** membership side did not. The actor credential check in `ValidatedCommit::from_staged_commit` resolved the committer's association state at the dict's literal value, and since no identity update can have `sequence_id <= 0`, `get_association_state_with_verifier` returns `MissingIdentityUpdate`. That error is explicitly non-retryable, so the intent is moved to `Error` and never recovers.

Any commit authored between group creation and the first membership update hits this. Apps that create a group and immediately write metadata hit it every time.

## Evidence

Seen in production logs from three independent clients. The failing commit's membership dict is the only one out of 824 logged that carries a `0`:

```
Group created. {group_id: "bdc50949"}
MetadataUpdate intent routing
Commit published successfully {group_id: "bdc50949", intent_id: 20148, MetadataUpdate}
Group context extensions proposal found:
  GroupMembership { members: {"d52b1ff1…": 0}, failed_installations: [] }
ERROR Error validating commit for own message. Intent ID [20148]:
  InstallationDiff(Client(Association(MissingIdentityUpdate)))
```

122ms from group creation to a permanently errored intent.

## Fix

Apply the same `Some(0) => None` guard at the two new-membership read sites:

- `groups/validated_commit.rs` — the actor/proposer credential check
- `identity_updates.rs` — `ending_sequence_id` in `get_installation_diff`

Fixing it at the read sites (rather than resolving the real sequence id at creation time) also repairs groups already in the wild that carry a `0`.

### Note on the loosened check

Treating `Some(0)` as "use latest" means the actor check resolves against the newest known state instead of pinning to an agreed sequence id. The exposure is nil in practice: `0` only ever exists on a group whose sole member is its creator — it is replaced the moment any `UpdateGroupMembership` runs, and adding members necessarily bumps it — so no remote member ever validates a commit against a `0` dict.

## Tests

New `groups/tests/test_starting_membership_sequence_id.rs` covers both routes to the bad read:
- `metadata_update_on_freshly_created_group_succeeds` — GCE proposal carries `{creator: 0}`
- `key_update_on_freshly_created_group_succeeds` — no GCE proposal, so `get_latest_group_membership` falls back to the staged commit's group context, which still holds `{creator: 0}`

Both fail deterministically before the fix (reproducing the production error exactly) and pass after.

`test_update_policies_empty_group` had codified the buggy behavior via `expect_err("Should fail to update group name before first sync")`. That assertion is flipped to expect success.

## Test plan

- [x] `just test crate xmtp_mls` — 712/712 passed
- [x] `cargo fmt -p xmtp_mls --check` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix membership `sequence_id` 0 treated as unset when resolving association state
> - A freshly created group has `sequence_id: 0` in its membership, which was previously interpreted as a real sequence ID, causing non-retryable `MissingIdentityUpdate` failures on commits made before the first membership sync.
> - In [`validated_commit.rs`](https://github.com/xmtp/libxmtp/pull/3947/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6), credential verification now maps `sequence_id: 0` to `None`, falling back to the latest known association state instead of resolving at sequence 0.
> - In [`identity_updates.rs`](https://github.com/xmtp/libxmtp/pull/3947/files#diff-93f82a1bc3c5238249de128f10cdaca01b706f8b455fde435ca1184739600fde), `get_installation_diff` applies the same `Some(0) | None => None` mapping for the ending sequence ID.
> - Two regression tests in [`test_starting_membership_sequence_id.rs`](https://github.com/xmtp/libxmtp/pull/3947/files#diff-76a0f94c30fa6a91f00976e7331bbaac4bfc2e501a7e6b729aa1fd0478da80a9) confirm that metadata updates and key updates succeed on a freshly created, unsynced group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7aa50c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->