### PR TITLE
fix(xmtp_mls): treat membership sequence_id 0 as unset when resolving association state

### DIFF
--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -14,6 +14,7 @@ mod test_network;
 mod test_prepare_message_for_later_publish;
 mod test_proposals;
 mod test_send_message_opts;
+mod test_starting_membership_sequence_id;
 mod test_validate_app_data_update;
 mod test_welcome_pointers;
 mod test_welcomes;
@@ -2590,16 +2591,9 @@ async fn test_update_policies_empty_group() {
     let policy_set_2 = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
     let amal_group_2 = amal.create_group(policy_set_2, None).unwrap();
 
-    // Verify empty group fails to update metadata before syncing
-    amal_group_2
-        .update_group_name("New Group Name 2".to_string())
-        .await
-        .expect_err("Should fail to update group name before first sync");
-
-    // Sync the group
-    amal_group_2.sync().await.unwrap();
-
-    //Verify we can now update the group name
+    // A solo group still holds the `sequence_id: 0` placeholder. The
+    // placeholder must not block a metadata update. This assertion expected
+    // the failure before. See `test_starting_membership_sequence_id`.
     amal_group_2
         .update_group_name("New Group Name 2".to_string())
         .await

--- a/crates/xmtp_mls/src/groups/tests/test_starting_membership_sequence_id.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_starting_membership_sequence_id.rs
@@ -1,0 +1,28 @@
+//! Group creation writes `sequence_id: 0` for the creator. A commit before the
+//! first `UpdateGroupMembership` must still validate. For the opposite case, a
+//! commit that chooses `0`, see
+//! `identity_updates::tests::get_installation_diff_rejects_added_inbox_at_sequence_zero`.
+
+use crate::tester;
+
+/// The GCE proposal carries `{alix: 0}` directly.
+#[xmtp_common::test(unwrap_try = true)]
+async fn metadata_update_on_freshly_created_group_succeeds() {
+    tester!(alix);
+
+    let group = alix.create_group(None, None)?;
+    group.update_group_name("hello".to_string()).await?;
+
+    assert_eq!(group.group_name()?, "hello");
+}
+
+/// The commit has no GCE proposal. `get_latest_group_membership` then reads
+/// the staged commit group context. That context still holds `{alix: 0}`.
+#[xmtp_common::test(unwrap_try = true)]
+async fn key_update_on_freshly_created_group_succeeds() {
+    tester!(alix);
+
+    let group = alix.create_group(None, None)?;
+
+    group.key_update().await?;
+}

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -661,6 +661,7 @@ impl ValidatedCommit {
         .await?;
 
         let ExpectedDiff {
+            old_group_membership,
             new_group_membership,
             expected_installation_diff,
             added_inboxes,
@@ -698,12 +699,19 @@ impl ValidatedCommit {
         // 2. Anyone referenced in an update proposal
         // Satisfies Rule 4
         for participant in credentials_to_verify {
-            let to_sequence_id = new_group_membership
-                .get(&participant.inbox_id)
-                .ok_or(CommitValidationError::SubjectDoesNotExist)?;
+            // `0` is the placeholder written at group creation, not a real
+            // sequence id. Keep the `old == 0` guard. Without it, a commit can
+            // choose the 0. Each receiver then resolves the credential at its
+            // own identity tip. Two receivers can disagree and fork the group.
+            let inbox_id = &participant.inbox_id;
+            let to_sequence_id = match new_group_membership.get(inbox_id) {
+                None => return Err(CommitValidationError::SubjectDoesNotExist),
+                Some(0) if old_group_membership.get(inbox_id) == Some(&0) => None,
+                Some(sequence_id) => Some(*sequence_id as i64),
+            };
 
             let inbox_state = IdentityUpdates::new(&context)
-                .get_association_state(&conn, &participant.inbox_id, Some(*to_sequence_id as i64))
+                .get_association_state(&conn, &participant.inbox_id, to_sequence_id)
                 .await
                 .map_err(InstallationDiffError::from)?;
 
@@ -1007,6 +1015,8 @@ fn get_latest_group_membership(
 }
 
 struct ExpectedDiff {
+    /// The membership before this commit. The commit cannot change it.
+    old_group_membership: GroupMembership,
     new_group_membership: GroupMembership,
     expected_installation_diff: InstallationDiff,
     added_inboxes: Vec<Inbox>,
@@ -1170,6 +1180,7 @@ impl ExpectedDiff {
             .await?;
 
         Ok(ExpectedDiff {
+            old_group_membership,
             new_group_membership,
             expected_installation_diff,
             added_inboxes,

--- a/crates/xmtp_mls/src/identity_updates.rs
+++ b/crates/xmtp_mls/src/identity_updates.rs
@@ -527,6 +527,12 @@ where
                     Some(i) => Some(*i as i64),
                     None => None,
                 };
+                // This loop reads added and updated inboxes only. They never
+                // hold the creation placeholder. An attacker chooses any `0`
+                // here. Do not copy the `Some(0) => None` line above. Pass the
+                // `0` through. Every receiver then rejects the commit.
+                // `get_installation_diff_rejects_added_inbox_at_sequence_zero`
+                // guards this.
                 let state_diff = self
                     .get_association_state_diff(
                         conn,
@@ -1107,6 +1113,85 @@ pub(crate) mod tests {
             installation_diff
                 .removed_installations
                 .contains(&client_2_installation_key.to_vec())
+        );
+    }
+
+    /// The diff must reject an inbox that a commit adds at `sequence_id: 0`.
+    /// It must not read the receiver's latest identity state. If it does,
+    /// receivers with different identity history fork the group.
+    #[rstest::rstest]
+    #[xmtp_common::test]
+    async fn get_installation_diff_rejects_added_inbox_at_sequence_zero() {
+        let wallet = generate_local_wallet();
+        let client = ClientBuilder::new_test_client(&wallet).await;
+
+        let mut signature_request: SignatureRequest = client
+            .identity_updates()
+            .create_inbox(wallet.identifier(), None)
+            .await
+            .unwrap();
+        let inbox_id = signature_request.inbox_id().to_string();
+        add_wallet_signature(&mut signature_request, &wallet).await;
+        client
+            .identity_updates()
+            .apply_signature_request(signature_request)
+            .await
+            .unwrap();
+
+        // This client holds all the identity updates. A read of the latest
+        // state would succeed. So the `0` causes the rejection below.
+        let other_client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let other_conn = other_client.context.db();
+        load_identity_updates(
+            other_client.context.api(),
+            &other_conn,
+            &[inbox_id.as_str()],
+        )
+        .await
+        .expect("load should succeed");
+        let latest_sequence_id = *other_conn
+            .get_latest_sequence_id(&[inbox_id.as_str()])
+            .unwrap()
+            .get(&inbox_id)
+            .unwrap();
+
+        let old_membership = GroupMembership::new();
+
+        // The same add at the real sequence id succeeds.
+        let mut honest_membership = GroupMembership::new();
+        honest_membership.add(inbox_id.clone(), latest_sequence_id as u64);
+        other_client
+            .identity_updates()
+            .get_installation_diff(
+                &other_conn,
+                &GroupId::default(),
+                &old_membership,
+                &honest_membership,
+                &old_membership.diff(&honest_membership),
+            )
+            .await
+            .expect("an add at a real sequence id is valid");
+
+        // Now the attack. Same inbox, same receiver, but sequence id 0.
+        let mut crafted_membership = GroupMembership::new();
+        crafted_membership.add(inbox_id.clone(), 0);
+        let crafted_diff = old_membership.diff(&crafted_membership);
+        assert_eq!(crafted_diff.added_inboxes, vec![&inbox_id]);
+
+        let result = other_client
+            .identity_updates()
+            .get_installation_diff(
+                &other_conn,
+                &GroupId::default(),
+                &old_membership,
+                &crafted_membership,
+                &crafted_diff,
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "an inbox added at sequence_id 0 must be rejected, not resolved at latest"
         );
     }
 


### PR DESCRIPTION
## Problem

`create_group` seeds the membership extension with the creator at `sequence_id: 0` as a placeholder (`build_starting_group_membership_extension(creator_inbox_id, 0)`). Nothing replaces it with the creator's real sequence id until the first `UpdateGroupMembership` intent runs.

`0` is a sentinel meaning "unset", and `get_installation_diff` honors it on the **old** membership side:

```rust
let starting_sequence_id = match old_group_membership.get(inbox_id) {
    Some(0) => None,
    Some(i) => Some(*i as i64),
    None => None,
};
```

The actor credential check in `ValidatedCommit::from_staged_commit` did not. It resolved the committer's association state at the dict's literal value, and since no identity update can have `sequence_id <= 0`, `get_association_state_with_verifier` returns `MissingIdentityUpdate`. That error is explicitly non-retryable, so the intent is moved to `Error` and never recovers.

Any commit authored between group creation and the first membership update hits this. Apps that create a group and immediately write metadata hit it every time.

## Evidence

Seen in production logs from three independent clients. The failing commit's membership dict is the only one out of 824 logged that carries a `0`:

```
Group created. {group_id: "bdc50949"}
MetadataUpdate intent routing
Commit published successfully {group_id: "bdc50949", intent_id: 20148, MetadataUpdate}
Group context extensions proposal found:
  GroupMembership { members: {"d52b1ff1…": 0}, failed_installations: [] }
ERROR Error validating commit for own message. Intent ID [20148]:
  InstallationDiff(Client(Association(MissingIdentityUpdate)))
```

122ms from group creation to a permanently errored intent.

## Fix

In `groups/validated_commit.rs`, treat `0` as "unset" **only where it is provably the creation placeholder**: the inbox's membership entry must be *unchanged* by the commit under validation, i.e. the already-committed (already-validated) `old_group_membership` carries the same `0`.

```rust
let to_sequence_id = match new_group_membership.get(inbox_id) {
    None => return Err(CommitValidationError::SubjectDoesNotExist),
    Some(0) if old_group_membership.get(inbox_id) == Some(&0) => None,
    Some(sequence_id) => Some(*sequence_id as i64),
};
```

Fixing it at the read site (rather than resolving the real sequence id at creation time) also repairs groups already in the wild that carry a `0`.

### Why the fallback is gated on "unchanged"

A blanket `Some(0) => None` would be unsafe, and [Macroscope flagged this](https://github.com/xmtp/libxmtp/pull/3948#discussion_r3738976904) — correctly. Commit validation cannot assume honest input. If a commit could introduce a `0` for some inbox, every receiver would resolve that inbox's credential against *its own* identity-update tip, so two honest receivers straddling a revocation could reach opposite verdicts on the same commit. That is a non-retryable fork, and preventing exactly that is what commit validation is for.

Gating on "unchanged" closes it: the `0` must already be present in the pre-commit membership, which is state the commit under validation cannot influence. That is precisely the creation placeholder — `build_starting_group_membership_extension` is the only writer of `0`, and only for the creator. A `0` arriving *via* this commit's proposal keeps its literal value and fails closed on every receiver, exactly as before this PR.

### Chain of custody for `0`

Every way a `0` could reach a committed membership extension is closed, so the surviving fallback is deterministic:

1. **Creation** — `build_starting_group_membership_extension` is the only writer of `0`, and all three call sites (`create_group`, DM creation, the DM membership fallback) write it for the local inbox, which is the creator. The group has exactly one member at that point.
2. **First membership update erases it** — `get_membership_update_intent` bumps any member whose latest sequence id exceeds its recorded one, and for a real inbox `latest > 0` always. Adding a member requires a membership update, so the `0` is gone *before any welcome is ever sent*.
3. **Crafted add** — `get_installation_diff` resolves the ending sequence id literally and fails closed on `Some(0)` (unchanged by this PR).
4. **Crafted update** — `validate_membership_diff` rejects any decrease: `old > 0 → new = 0` is `SequenceIdDecreased`, and `old = 0 → new = 0` is not a change at all, so `updated_inboxes` can never carry a new value of `0`.
5. **Crafted welcome** — `InitialMembershipValidator::check_initial_membership` resolves *every* member at its literal sequence id, so a welcome carrying `{victim: 0}` fails with `MissingIdentityUpdate` and is rejected.

Consequence: a `0` implies a solo group, so the only client that ever evaluates the fallback is the creator validating their own message. No remote member resolves a credential against a `0`, and there is no receiver-dependent state to disagree about.

An earlier revision of this PR also applied `Some(0) => None` to `get_installation_diff`'s `ending_sequence_id`. That change has been dropped: it is not needed for the bug (in the failing scenario membership goes `{creator: 0} → {creator: 0}`, so the creator is in neither `added_inboxes` nor `updated_inboxes` and that loop never runs) and it would have opened the fork vector above at the site that drives `expected_installation_diff` — the actual membership-authorization check. `get_installation_diff` is left as-is, with a comment recording why the asymmetry with `starting_sequence_id` is deliberate.

## Tests

New `groups/tests/test_starting_membership_sequence_id.rs` covers both routes to the bad read:
- `metadata_update_on_freshly_created_group_succeeds` — GCE proposal carries `{creator: 0}`
- `key_update_on_freshly_created_group_succeeds` — no GCE proposal, so `get_latest_group_membership` falls back to the staged commit's group context, which still holds `{creator: 0}`

Both fail deterministically before the fix (reproducing the production error exactly) and pass after.

New `identity_updates::tests::get_installation_diff_rejects_added_inbox_at_sequence_zero` locks in the adversarial direction: an inbox *added* at `sequence_id: 0` must be rejected even when the receiver has fully synced that inbox's identity updates, so the rejection is attributable to the `0` and not to missing history. The test fails if the ending-sequence-id fallback is reintroduced.

`test_update_policies_empty_group` had codified the buggy behavior via `expect_err("Should fail to update group name before first sync")`. That assertion is flipped to expect success.

## Test plan

- [x] `just test crate xmtp_mls` — 713/713 passed
- [x] `just lint-rust` — clean (clippy, fmt, hakari)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix membership `sequence_id` 0 to be treated as unset when resolving association state
> - Freshly created groups carry a `{creator: sequence_id: 0}` placeholder that previously caused metadata and key update commits to fail validation before the first sync.
> - In [`validated_commit.rs`](https://github.com/xmtp/libxmtp/pull/3948/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6), when both old and new membership have `sequence_id: 0` for the same inbox, identity is now resolved at latest (passing `None`) rather than at sequence 0.
> - In [`identity_updates.rs`](https://github.com/xmtp/libxmtp/pull/3948/files#diff-93f82a1bc3c5238249de128f10cdaca01b706f8b455fde435ca1184739600fde), inboxes *added* at `sequence_id: 0` are validated strictly at 0 and rejected, preventing accidental resolution to latest state.
> - Behavioral Change: commits that add a new inbox with `sequence_id: 0` now fail validation, while commits by the creator on a freshly created group now succeed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e0f384.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->