### PR TITLE
fix(xmtp_mls): record publish-time key package failures in group membership

### DIFF
--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -4545,11 +4545,16 @@ async fn calculate_membership_changes_with_keypackages<'a>(
         .removed_installations
         .retain(|item| !common.contains(item));
 
+    // This field is a set, but `GroupMembership`'s `PartialEq` compares it as
+    // an ordered `Vec`. Sort it. An unchanged set must always compare equal.
+    let mut failed_installations: Vec<Vec<u8>> = failed_installations.into_iter().collect();
+    failed_installations.sort_unstable();
+
     Ok(MembershipDiffWithKeyPackages::new(
         new_installations,
         new_key_packages,
         installation_diff.removed_installations,
-        failed_installations.into_iter().collect(),
+        failed_installations,
     ))
 }
 

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -171,7 +171,7 @@ pub(crate) async fn apply_update_group_membership_intent(
     let mut new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
 
     let group_id = GroupId::try_from(openmls_group.group_id())?;
-    let changes_with_kps = calculate_membership_changes_with_keypackages(
+    let mut changes_with_kps = calculate_membership_changes_with_keypackages(
         context,
         &group_id,
         &new_group_membership,
@@ -194,6 +194,8 @@ pub(crate) async fn apply_update_group_membership_intent(
         return Ok(None);
     }
 
+    // Run this guard before the writeback below. A change that only moves
+    // `failed_installations` must not make an empty commit.
     if leaf_nodes_to_remove.is_empty()
         && changes_with_kps.new_key_packages.is_empty()
         && membership_diff.updated_inboxes.is_empty()
@@ -202,6 +204,23 @@ pub(crate) async fn apply_update_group_membership_intent(
     {
         return Ok(None);
     }
+
+    // The publish-time fetch decides which Add proposals exist. The intent's
+    // list is older, so it can be wrong. Union the two lists; do not assign.
+    // The fetch drops ids that this commit also removes.
+    // `expected_diff_matches_commit` needs those ids. They explain a removal
+    // that the commit could not make. Assign breaks
+    // `test_remove_inbox_with_bad_installation_from_group`.
+    let mut failed_installations: HashSet<Vec<u8>> =
+        std::mem::take(&mut new_group_membership.failed_installations)
+            .into_iter()
+            .collect();
+    failed_installations.extend(std::mem::take(&mut changes_with_kps.failed_installations));
+    let mut failed_installations: Vec<Vec<u8>> = failed_installations.into_iter().collect();
+    // `PartialEq` compares this field as an ordered `Vec`.
+    // `extensions_changed` uses that result to decide if it needs a GCE.
+    failed_installations.sort_unstable();
+    new_group_membership.failed_installations = failed_installations;
 
     // Detect whether this is a migrated group. On migrated groups the
     // legacy `GROUP_MEMBERSHIP_EXTENSION_ID` is gone and the

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -6,6 +6,8 @@ mod test_consent;
 mod test_delete_message;
 mod test_dm;
 mod test_extract_readded_installations;
+#[cfg(not(target_arch = "wasm32"))]
+mod test_failed_installations;
 mod test_group_updated;
 mod test_libxmtp_version;
 mod test_message_disappearing_settings;

--- a/crates/xmtp_mls/src/groups/tests/test_failed_installations.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_failed_installations.rs
@@ -1,0 +1,116 @@
+//! A key package can become unfetchable between intent-build and publish.
+//! `GroupMembership::failed_installations` must still record it.
+
+use crate::groups::GroupError;
+use crate::groups::intents::QueueIntent;
+use crate::groups::validated_commit::extract_group_membership;
+use crate::tester;
+use crate::utils::TestMlsGroup;
+use crate::utils::test_mocks_helpers::set_test_mode_upload_malformed_keypackage;
+use xmtp_db::group::GroupQueryArgs;
+
+/// `doomed_installation` must belong to an inbox that is already in the
+/// group and that just gained an installation. Publish then raises that
+/// inbox's sequence id. The membership therefore claims the installation.
+async fn publish_update_with_publish_time_failure(
+    alix_group: &TestMlsGroup,
+    inbox_ids_to_add: &[&str],
+    doomed_installation: &[u8],
+) -> Result<(), GroupError> {
+    // Build the intent while every key package still fetches and verifies.
+    let intent_data = alix_group
+        .get_membership_update_intent(inbox_ids_to_add, &[])
+        .await?;
+    assert!(
+        !intent_data.is_empty(),
+        "the new installation should produce a membership update"
+    );
+    assert!(
+        intent_data.failed_installations.is_empty(),
+        "every key package should still be fetchable when the intent is built"
+    );
+
+    // The key package now fails: rotation, expiry, or a bad verify.
+    set_test_mode_upload_malformed_keypackage(true, Some(vec![doomed_installation.to_vec()]));
+
+    let intent = QueueIntent::update_group_membership()
+        .data(intent_data)
+        .queue(alix_group)?;
+    alix_group.sync_until_intent_resolved(intent.id).await?;
+
+    Ok(())
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn publish_time_key_package_failure_lands_in_membership() {
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix
+        .create_group_with_members(&[bo.inbox_id()], None, None)
+        .await?;
+
+    // bo adds a second installation. This raises bo's identity sequence id.
+    tester!(bo2, from: bo);
+    let bo2_installation = bo2.context.installation_id().to_vec();
+
+    publish_update_with_publish_time_failure(&alix_group, &[], &bo2_installation).await?;
+
+    let membership = alix_group
+        .load_mls_group_with_lock_async(async |mls_group| {
+            Ok::<_, GroupError>(extract_group_membership(mls_group.extensions())?)
+        })
+        .await?;
+
+    assert!(
+        membership.failed_installations.contains(&bo2_installation),
+        "the publish-time key package failure must be recorded in the membership extension"
+    );
+
+    // The entry means something only if bo2 has no leaf.
+    let leaf_installations = alix_group
+        .load_mls_group_with_lock_async(async |mls_group| {
+            Ok::<_, GroupError>(
+                mls_group
+                    .members()
+                    .map(|member| member.signature_key)
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .await?;
+    assert!(
+        !leaf_installations.contains(&bo2_installation),
+        "bo2 should have no leaf in the ratchet tree"
+    );
+
+    set_test_mode_upload_malformed_keypackage(false, None);
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn joiner_accepts_welcome_with_publish_time_failed_installation() {
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+
+    let alix_group = alix
+        .create_group_with_members(&[bo.inbox_id()], None, None)
+        .await?;
+
+    tester!(bo2, from: bo);
+    let bo2_installation = bo2.context.installation_id().to_vec();
+
+    // The same commit adds caro and fails on bo2. caro's welcome claims bo
+    // at a sequence id that holds bo2. But bo2 has no leaf.
+    publish_update_with_publish_time_failure(&alix_group, &[caro.inbox_id()], &bo2_installation)
+        .await?;
+
+    let caro_groups = caro.sync_welcomes().await?;
+    assert_eq!(
+        caro_groups.len(),
+        1,
+        "caro's welcome must not be rejected as InvalidGroupMembership"
+    );
+    assert_eq!(caro.find_groups(GroupQueryArgs::default())?.len(), 1);
+
+    set_test_mode_upload_malformed_keypackage(false, None);
+}


### PR DESCRIPTION
## The two-fetch divergence

A membership update fetches key packages **twice**:

1. When the intent is built — `get_membership_update_intent` calls
   `calculate_membership_changes_with_keypackages` and stores the resulting
   `failed_installations` on the intent.
2. When the intent is published — `apply_update_group_membership_intent` calls
   `calculate_membership_changes_with_keypackages` *again*.

The second fetch is the one that decides which `Add` proposals actually go into
the commit. But only the first one reached the membership dict:

```rust
let mut new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
//   failed_installations = old ∪ INTENT-TIME failures

let changes_with_kps = calculate_membership_changes_with_keypackages(...).await?;
//   .failed_installations = old ∪ PUBLISH-TIME failures — never written back
```

When a key package goes fetchable → unfetchable between the two (rotation,
expiry, a transient verification failure), the membership ends up claiming an
installation that has **neither an MLS leaf nor a `failed_installations`
entry**. A joiner's `check_initial_membership` sees that leftover installation,
returns `GroupError::InvalidGroupMembership` — which is **non-retryable** — and
the conversation never materializes for them.

This is not theoretical: key package rotation is not firing reliably in
production, so the fetchable → unfetchable window is real.

## The fix

Union the publish-time failure set into the membership before the payload is
built.

**Union rather than assign.** `calculate_membership_changes_with_keypackages`
deliberately strips installations that are simultaneously being *removed* (its
`common` intersection) — it must not emit a `Remove` proposal for a leaf that
was never added. But the receiver still needs those ids listed:
`expected_diff_matches_commit` subtracts `failed_installations` from the
expected removals to excuse a removal the commit could not perform. Taking that
output verbatim drops them and fails commit validation (caught by
`test_remove_inbox_with_bad_installation_from_group`). Unioning is also strictly
additive over the previous behaviour, so it can only ever explain more of the
tree, never less.

Two details that were checked explicitly:

- **The early-return guard is unchanged.** It is still evaluated *before* the
  writeback, so a change that only moves `failed_installations` cannot
  manufacture an otherwise-empty commit. That is also safe for the divergence
  being fixed: when the guard fires we don't write the new membership either, so
  the dict never claims an installation the tree doesn't have.
- **`extensions_changed` newly firing is intentional.** `GroupMembership`
  derives `PartialEq`, which includes `failed_installations`, so a publish-time
  failure now correctly triggers the GCE proposal that carries it. To keep that
  equality meaningful, `failed_installations` is emitted in a canonical (sorted)
  order — draining a `HashSet` could otherwise make an unchanged set compare
  unequal and emit a no-op GCE.

`apply_readd_installations_intent` builds its own membership and is untouched.

## Why the fix is split in two layers

This PR is the **legacy path** only. On migrated groups the legacy
`GROUP_MEMBERSHIP_EXTENSION_ID` is gone and membership travels as an
`AppDataUpdate(GROUP_MEMBERSHIP)` proposal, whose per-inbox
`failed_installations` field is hardcoded to `vec![]`. So this change alone does
not reach the wire there. Populating it requires solving installation → inbox
attribution for installations that have no key package to read a credential
from, which is a meaningfully different problem and is handled in the PR stacked
on top of this one.

## Tests

`crates/xmtp_mls/src/groups/tests/test_failed_installations.rs` builds the
intent while the key package still fetches cleanly, then flips it to
unfetchable before publishing:

- `publish_time_key_package_failure_lands_in_membership` — the failure reaches
  the membership extension, and the installation genuinely has no leaf in the
  ratchet tree.
- `joiner_accepts_welcome_with_publish_time_failed_installation` — a member
  added by that same commit is not rejected with `InvalidGroupMembership`.

Both fail on `main` and pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record publish-time key package failures in group membership during intent application
> - In `apply_update_group_membership_intent`, the resulting `new_group_membership` now stores the union of publish-time and intent-time `failed_installations`, deduplicated and sorted for deterministic ordering.
> - In `calculate_membership_changes_with_keypackages`, `failed_installations` is now sorted before being placed into `MembershipDiffWithKeyPackages`, fixing equality checks that depend on ordering.
> - Adds tests in [`test_failed_installations.rs`](https://github.com/xmtp/libxmtp/pull/3949/files#diff-2570eef5444d39f4ef563711be85355fee3b158de8d3d6d0d1a065f76ea27b18) verifying that publish-time failures are recorded in membership and that joiners can still accept Welcome messages when a commit also contains a publish-time failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee70b71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->