### PR TITLE
feat(xmtp_mls): populate per-inbox failed_installations on the AppData path

### DIFF
--- a/crates/xmtp_mls/src/groups/group_membership.rs
+++ b/crates/xmtp_mls/src/groups/group_membership.rs
@@ -119,6 +119,10 @@ pub struct MembershipDiffWithKeyPackages {
     pub new_key_packages: Vec<KeyPackage>,
     pub removed_installations: HashSet<Vec<u8>>,
     pub failed_installations: Vec<Vec<u8>>,
+    /// Maps `installation_id` to `inbox_id`. It comes from
+    /// [`crate::identity_updates::InstallationDiff`]. A caller uses it to
+    /// split `failed_installations` per inbox.
+    pub installation_owners: HashMap<Vec<u8>, String>,
 }
 
 impl MembershipDiffWithKeyPackages {
@@ -127,12 +131,14 @@ impl MembershipDiffWithKeyPackages {
         new_key_packages: Vec<KeyPackage>,
         removed_installations: HashSet<Vec<u8>>,
         failed_installations: Vec<Vec<u8>>,
+        installation_owners: HashMap<Vec<u8>, String>,
     ) -> MembershipDiffWithKeyPackages {
         MembershipDiffWithKeyPackages {
             new_installations,
             new_key_packages,
             removed_installations,
             failed_installations,
+            installation_owners,
         }
     }
 }

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -3380,6 +3380,9 @@ where
                 let extensions: Extensions<GroupContext> = openmls_group.extensions().clone();
                 let old_group_membership = extract_group_membership(&extensions)?;
                 let mut new_membership = old_group_membership.clone();
+                // The AppDataUpdate payload below uses this map to split
+                // `failed_installations`. Only the adds branch makes failures.
+                let mut installation_owners: HashMap<Vec<u8>, String> = HashMap::new();
 
                 // Handle adds
                 if !intent_data.add_inbox_ids.is_empty() {
@@ -3450,24 +3453,13 @@ where
                         new_membership.add(inbox_id.clone(), sequence_id as u64);
                     }
 
-                    // Carry forward the failed-installations set on
-                    // the local `new_membership`. On the legacy path
-                    // this drives the GCE proposal that
-                    // `CommitPendingProposals` emits against
-                    // GROUP_MEMBERSHIP_EXTENSION_ID, where
-                    // failed_installations is part of the wire form.
-                    // On the migrated path the AppDataUpdate payload
-                    // built by `build_group_membership_app_data_payload`
-                    // intentionally does NOT propagate
-                    // failed_installations (see that function's doc);
-                    // we still set it here so the equality check at
-                    // the AppDataUpdate emit site below
-                    // (`old_group_membership != new_membership`)
-                    // detects kp-failure-only deltas, and so the
-                    // unmigrated and migrated branches share one
-                    // `new_membership` value.
+                    // The legacy GCE proposal sends this list. The AppDataUpdate
+                    // payload below splits it per inbox. It also lets the
+                    // `old_group_membership != new_membership` check below see a
+                    // delta that holds only key package failures.
                     new_membership.failed_installations =
                         changes_with_kps.failed_installations.clone();
+                    installation_owners = changes_with_kps.installation_owners;
 
                     // Generate add proposals for each key package
                     for key_package in &changes_with_kps.new_key_packages {
@@ -3534,6 +3526,7 @@ where
                     let payload = build_group_membership_app_data_payload(
                         &old_group_membership,
                         &new_membership,
+                        &installation_owners,
                     )?;
                     let (proposal_msg, _) = openmls_group
                         .propose_app_data_update(
@@ -4555,6 +4548,7 @@ async fn calculate_membership_changes_with_keypackages<'a>(
         new_key_packages,
         installation_diff.removed_installations,
         failed_installations,
+        installation_diff.installation_owners,
     ))
 }
 

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -79,35 +79,25 @@ pub(crate) fn strip_unverified_new_adds(
     }
 }
 
-/// Build the wire-level `TlsMapDelta<InboxId, VLBytes>` payload for an
-/// `AppDataUpdate(GROUP_MEMBERSHIP)` proposal from the diff between
-/// the old and new `GroupMembership` view. Shared between the commit-
-/// bundling `apply_update_group_membership_intent` flow and the
-/// propose-by-reference `IntentKind::ProposeMemberUpdate` flow so
-/// both emit byte-identical payloads for the same diff.
-///
-/// One mutation per affected inbox:
-/// - `Insert(inbox_id, encode(V1 { sequence_id, failed_installations: [] }))`
-///   for inboxes added.
-/// - `Update(inbox_id, encode(V1 { ... }))` for inboxes whose
-///   `sequence_id` changed.
-/// - `Delete(inbox_id)` for inboxes removed.
-///
-/// `failed_installations` is left empty here — per the proto comment
-/// it's a sender-authoritative retry-suppression hint and the
-/// per-inbox partitioning happens at bootstrap. Steady-state membership
-/// updates intentionally don't propagate failed_installations changes
-/// over the AppData path; the worst case is a slightly noisier retry
-/// loop. Future enhancement once a clearer attribution path exists.
+/// Build the `AppDataUpdate(GROUP_MEMBERSHIP)` payload for a membership diff.
+/// `failed_installations` is flat, but the wire form is per-inbox.
+/// `installation_owners` maps each id to its inbox. A failed installation has
+/// no key package, so it carries no credential. This code rewrites only the
+/// inboxes that get an Insert or an Update. Other inboxes keep their entry.
+/// If the map has no owner for an id, this code drops the id.
 pub(crate) fn build_group_membership_app_data_payload(
     old: &GroupMembership,
     new: &GroupMembership,
+    installation_owners: &HashMap<Vec<u8>, String>,
 ) -> Result<Vec<u8>, GroupError> {
     let mut delta = TlsMapDelta::<InboxId, VLBytes>::new();
+    let per_inbox_failed = partition_failed_installations(new, installation_owners);
+    let no_failures: Vec<Vec<u8>> = Vec::new();
 
     // Inserts and updates: walk new.members, classify against old.
     for (inbox_id_str, &sequence_id) in new.members.iter() {
-        let entry = encode_membership_entry(sequence_id)?;
+        let failed = per_inbox_failed.get(inbox_id_str).unwrap_or(&no_failures);
+        let entry = encode_membership_entry(sequence_id, failed)?;
         match old.members.get(inbox_id_str) {
             None => {
                 // New inbox: Insert.
@@ -143,14 +133,51 @@ pub(crate) fn build_group_membership_app_data_payload(
     })
 }
 
-/// Encode a per-inbox `GroupMembershipEntry::V1` value with the given
-/// `sequence_id` and an empty `failed_installations` list.
-fn encode_membership_entry(sequence_id: u64) -> Result<Vec<u8>, GroupError> {
+/// Put each failed installation into a bucket for its owner inbox. If an
+/// inbox is not in `members`, skip it. This code deletes that inbox's entry,
+/// so the id has no place to go.
+fn partition_failed_installations(
+    membership: &GroupMembership,
+    installation_owners: &HashMap<Vec<u8>, String>,
+) -> HashMap<String, Vec<Vec<u8>>> {
+    let mut per_inbox: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+    let mut unattributed = 0usize;
+    for installation_id in &membership.failed_installations {
+        match installation_owners.get(installation_id) {
+            Some(inbox_id) if membership.members.contains_key(inbox_id) => per_inbox
+                .entry(inbox_id.clone())
+                .or_default()
+                .push(installation_id.clone()),
+            _ => unattributed += 1,
+        }
+    }
+    if unattributed > 0 {
+        // This is normal. An inbox that this update does not change keeps its
+        // entry. The receiver still rebuilds the complete list.
+        tracing::debug!(
+            unattributed,
+            total = membership.failed_installations.len(),
+            "some failed_installations were not attributable to an inbox in this membership update"
+        );
+    }
+    // Sort the ids. The same set must always encode to the same bytes.
+    for failed in per_inbox.values_mut() {
+        failed.sort_unstable();
+    }
+    per_inbox
+}
+
+/// Encode one `GroupMembershipEntry::V1` value for an inbox. It holds the
+/// inbox's `sequence_id` and the inbox's share of `failed_installations`.
+fn encode_membership_entry(
+    sequence_id: u64,
+    failed_installations: &[Vec<u8>],
+) -> Result<Vec<u8>, GroupError> {
     let entry = GroupMembershipEntry {
         version: Some(group_membership_entry::Version::V1(
             group_membership_entry::V1 {
                 sequence_id,
-                failed_installations: vec![],
+                failed_installations: failed_installations.to_vec(),
             },
         )),
     };
@@ -285,6 +312,7 @@ pub(crate) async fn apply_update_group_membership_intent(
             Some(build_group_membership_app_data_payload(
                 &old_group_membership,
                 &new_group_membership,
+                &changes_with_kps.installation_owners,
             )?)
         } else {
             None
@@ -699,5 +727,83 @@ mod tests {
         strip_unverified_new_adds(&mut new, &old, &[]);
         assert_eq!(new.get("alice"), Some(&5));
         assert!(!new.members.contains_key("bob"));
+    }
+
+    /// Make a hex inbox id with the length that `InboxId::from_hex` needs.
+    fn inbox_hex(byte: u8) -> String {
+        hex::encode([byte; 32])
+    }
+
+    /// Decode a payload into `inbox_id_hex -> (is_insert, sequence_id,
+    /// failed_installations)`.
+    #[allow(clippy::type_complexity)]
+    fn decode_payload(payload: &[u8]) -> HashMap<String, (bool, u64, Vec<Vec<u8>>)> {
+        use tls_codec::Deserialize as _;
+        use xmtp_mls_common::tls_map::TlsMapMutation;
+
+        let delta = TlsMapDelta::<InboxId, VLBytes>::tls_deserialize_exact(payload).unwrap();
+        delta
+            .mutations
+            .into_iter()
+            .map(|mutation| {
+                let (key, value, is_insert) = match mutation {
+                    TlsMapMutation::Insert { key, value } => (key, value, true),
+                    TlsMapMutation::Update { key, value } => (key, value, false),
+                    TlsMapMutation::Delete { key } => {
+                        panic!("unexpected Delete for {}", key.to_hex())
+                    }
+                };
+                let entry = GroupMembershipEntry::decode(value.as_slice()).unwrap();
+                let Some(group_membership_entry::Version::V1(v1)) = entry.version else {
+                    panic!("expected a V1 entry");
+                };
+                (
+                    key.to_hex(),
+                    (is_insert, v1.sequence_id, v1.failed_installations),
+                )
+            })
+            .collect()
+    }
+
+    #[xmtp_common::test]
+    fn app_data_payload_partitions_failed_installations_per_inbox() {
+        let (alix, bo, caro) = (inbox_hex(0xAA), inbox_hex(0xBB), inbox_hex(0xCC));
+        let (bo_failed, caro_failed, orphan) = (vec![0x01; 32], vec![0x02; 32], vec![0x03; 32]);
+
+        let mut old = GroupMembership::new();
+        old.add(alix.clone(), 1);
+        old.add(bo.clone(), 1);
+
+        let mut new = old.clone();
+        // bo gains a failed installation. caro joins with one too.
+        new.add(bo.clone(), 2);
+        new.add(caro.clone(), 1);
+        new.failed_installations = vec![bo_failed.clone(), caro_failed.clone(), orphan];
+
+        let owners = HashMap::from([
+            (bo_failed.clone(), bo.clone()),
+            (caro_failed.clone(), caro.clone()),
+            // The map has no owner for `orphan`.
+        ]);
+
+        let decoded =
+            decode_payload(&build_group_membership_app_data_payload(&old, &new, &owners).unwrap());
+
+        assert_eq!(
+            decoded.get(&bo),
+            Some(&(false, 2, vec![bo_failed])),
+            "bo's bumped entry must carry only bo's failed installation"
+        );
+        assert_eq!(
+            decoded.get(&caro),
+            Some(&(true, 1, vec![caro_failed])),
+            "caro's new entry must carry only caro's failed installation"
+        );
+        assert!(
+            !decoded.contains_key(&alix),
+            "alix's sequence id is unchanged, so no mutation should be emitted"
+        );
+        // The code drops `orphan`. It does not guess an inbox.
+        assert_eq!(decoded.len(), 2);
     }
 }

--- a/crates/xmtp_mls/src/groups/tests/test_failed_installations.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_failed_installations.rs
@@ -1,6 +1,7 @@
 //! A key package can become unfetchable between intent-build and publish.
 //! `GroupMembership::failed_installations` must still record it.
 
+use crate::groups::EnableProposalsOptions;
 use crate::groups::GroupError;
 use crate::groups::intents::QueueIntent;
 use crate::groups::validated_commit::extract_group_membership;
@@ -111,6 +112,52 @@ async fn joiner_accepts_welcome_with_publish_time_failed_installation() {
         "caro's welcome must not be rejected as InvalidGroupMembership"
     );
     assert_eq!(caro.find_groups(GroupQueryArgs::default())?.len(), 1);
+
+    set_test_mode_upload_malformed_keypackage(false, None);
+}
+
+/// The same problem on a migrated group. Membership travels as an
+/// `AppDataUpdate(GROUP_MEMBERSHIP)` proposal. The failure reaches the wire
+/// only if the per-inbox `failed_installations` field holds it.
+#[xmtp_common::test(unwrap_try = true)]
+async fn migrated_group_carries_failed_installation_in_app_data() {
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+
+    let alix_group = alix
+        .create_group_with_members(&[bo.inbox_id()], None, None)
+        .await?;
+
+    // This drops the legacy extension. Membership moves into the AppData dict.
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+
+    tester!(bo2, from: bo);
+    let bo2_installation = bo2.context.installation_id().to_vec();
+
+    publish_update_with_publish_time_failure(&alix_group, &[caro.inbox_id()], &bo2_installation)
+        .await?;
+
+    // On a migrated group, this joins the per-inbox dict entries to rebuild
+    // the group-level list.
+    let membership = alix_group
+        .load_mls_group_with_lock_async(async |mls_group| {
+            Ok::<_, GroupError>(extract_group_membership(mls_group.extensions())?)
+        })
+        .await?;
+    assert!(
+        membership.failed_installations.contains(&bo2_installation),
+        "the failure must survive the round trip through the per-inbox AppData entries"
+    );
+
+    let caro_groups = caro.sync_welcomes().await?;
+    assert_eq!(
+        caro_groups.len(),
+        1,
+        "caro's welcome must not be rejected as InvalidGroupMembership"
+    );
 
     set_test_mode_upload_malformed_keypackage(false, None);
 }

--- a/crates/xmtp_mls/src/identity_updates.rs
+++ b/crates/xmtp_mls/src/identity_updates.rs
@@ -45,10 +45,16 @@ pub enum IdentityUpdateError {
     InvalidSignatureRequest(#[from] SignatureRequestError),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct InstallationDiff {
     pub added_installations: HashSet<Vec<u8>>,
     pub removed_installations: HashSet<Vec<u8>>,
+    /// Maps `installation_id` to `inbox_id`. An inbox `aa..` that owns
+    /// installations `0x01` and `0x02` gives `{0x01: "aa..", 0x02: "aa.."}`.
+    /// The map holds the full installation list for each added or updated
+    /// inbox at the end sequence id. It does not hold only the delta. An
+    /// earlier commit can therefore still name the owner of a failed id.
+    pub installation_owners: HashMap<Vec<u8>, String>,
 }
 
 #[derive(Debug, Error)]
@@ -235,15 +241,16 @@ where
         .await
     }
 
-    /// Calculate the changes between the `starting_sequence_id` and `ending_sequence_id` for the
-    /// provided `inbox_id`
+    /// Calculate the changes between `starting_sequence_id` and `ending_sequence_id`
+    /// for `inbox_id`. Also return the state at `ending_sequence_id`. This
+    /// function verifies the signatures, so a caller does not repeat that work.
     pub(crate) async fn get_association_state_diff(
         &self,
         conn: &impl DbQuery,
         inbox_id: InboxIdRef<'a>,
         starting_sequence_id: Option<i64>,
         ending_sequence_id: Option<i64>,
-    ) -> Result<AssociationStateDiff, ClientError> {
+    ) -> Result<(AssociationStateDiff, AssociationState), ClientError> {
         tracing::debug!(
             "Computing diff for {:?} from {:?} to {:?}",
             inbox_id,
@@ -252,10 +259,11 @@ where
         );
         // If no starting sequence ID, get all updates from the beginning of the inbox's history up to the ending sequence ID
         if starting_sequence_id.is_none() {
-            return Ok(self
+            let final_state = self
                 .get_association_state(conn, inbox_id, ending_sequence_id)
-                .await?
-                .as_diff());
+                .await?;
+            let diff = final_state.as_diff();
+            return Ok((diff, final_state));
         }
 
         // Get the initial state to compare against
@@ -302,7 +310,8 @@ where
             )?;
         }
 
-        Ok(initial_state.diff(&final_state))
+        let diff = initial_state.diff(&final_state);
+        Ok((diff, final_state))
     }
 
     /// Generate a `CreateInbox` signature request for the given wallet address.
@@ -518,6 +527,7 @@ where
 
         let mut added_installations: HashSet<Vec<u8>> = HashSet::new();
         let mut removed_installations: HashSet<Vec<u8>> = HashSet::new();
+        let mut installation_owners: HashMap<Vec<u8>, String> = HashMap::new();
 
         let mut futs = FuturesUnordered::new();
         for inbox_id in added_and_updated_members {
@@ -533,7 +543,7 @@ where
                 // `0` through. Every receiver then rejects the commit.
                 // `get_installation_diff_rejects_added_inbox_at_sequence_zero`
                 // guards this.
-                let state_diff = self
+                let (state_diff, ending_state) = self
                     .get_association_state_diff(
                         conn,
                         inbox_id.as_str(),
@@ -542,13 +552,18 @@ where
                     )
                     .await?;
 
-                Ok::<_, InstallationDiffError>(state_diff)
+                Ok::<_, InstallationDiffError>((state_diff, ending_state))
             });
         }
         while let Some(result) = futs.next().await {
-            let diff = result?;
+            let (diff, ending_state) = result?;
             added_installations.extend(diff.new_installations());
             removed_installations.extend(diff.removed_installations());
+            // Record every installation that this inbox owns at that sequence id.
+            let owner = ending_state.inbox_id().to_string();
+            for installation_id in ending_state.installation_ids() {
+                installation_owners.insert(installation_id, owner.clone());
+            }
         }
 
         for inbox_id in membership_diff.removed_inboxes.iter() {
@@ -584,6 +599,7 @@ where
         Ok(InstallationDiff {
             added_installations,
             removed_installations,
+            installation_owners,
         })
     }
 }


### PR DESCRIPTION
> Stacked on #3949 — review that one first.

## Recap: the two-fetch divergence

Key packages are fetched twice for a membership update — once when the intent is
built, once at publish time — and only the publish-time fetch decides which
`Add` proposals go into the commit. If a key package goes fetchable →
unfetchable in between, the membership claims an installation with no MLS leaf
and no `failed_installations` entry, and a joiner's `check_initial_membership`
rejects the welcome with the non-retryable
`GroupError::InvalidGroupMembership`.

The PR below this one makes the publish-time fetch authoritative for the
group-level `failed_installations`.

## Why a second layer

That is enough for unmigrated groups, where membership rides the legacy
`GROUP_MEMBERSHIP_EXTENSION_ID` as a flat list. On **migrated** groups the
legacy extension is gone: membership travels as an
`AppDataUpdate(GROUP_MEMBERSHIP)` proposal whose value is a per-inbox
`GroupMembershipEntry::V1`. That entry *has* a `failed_installations` field, but
`encode_membership_entry` hardcoded it to `vec![]`:

> `failed_installations` is left empty here — per the proto comment it's a
> sender-authoritative retry-suppression hint and the per-inbox partitioning
> happens at bootstrap. […] Future enhancement once a clearer attribution path
> exists.

So layer 1 alone never reaches the wire for migrated groups. This PR populates
the field.

## The hard part: attribution

`GroupMembership.failed_installations` is a flat, group-level list; the wire
form is per-inbox. Partitioning it needs `installation_id -> inbox_id` — and a
*failed* installation is precisely one with no key package, so there is no
credential to read the inbox id from.

**Approach chosen:** build the map inside `get_installation_diff`.

It already resolves an `AssociationState` per added/updated inbox, and
`AssociationState::installation_ids()` enumerates exactly that inbox's
installations. The map is plumbed out as a new field on `InstallationDiff`, then
through `MembershipDiffWithKeyPackages`, then into
`build_group_membership_app_data_payload`.

Why this over the alternatives:

- **No extra identity work.** `get_association_state_diff` already computed the
  end state and threw it away; it now returns it alongside the diff. Resolving
  states separately would repeat signature verification (and can hit the SCW
  verifier).
- **Cannot disagree with the diff.** The attribution comes from the same
  association states the membership diff itself was derived from.
- **Matches existing precedent.** The bootstrap commit already partitions the
  legacy flat list this way in `build_partitioned_group_membership`.
- **Using `AssociationStateDiff::new_installations()` instead was rejected** —
  it only covers the delta, so failures carried forward from earlier commits
  would be unattributable and would get silently dropped when an inbox's entry
  is rewritten.

Coverage properties that fall out of using the *full* end-state installation
list:

- An inbox that gets an `Insert`/`Update` in the delta has its entry rewritten,
  and the map covers all of its installations — so carried-forward failures
  survive the rewrite.
- An inbox with no mutation keeps its existing dict entry untouched, so its
  share of the list is preserved even though it isn't in the map.
- Failures whose owner can't be resolved are dropped, matching the hint-only
  contract the bootstrap partitioning already uses.

## Composition with #3946

Both layers are rebased onto `#3946` ("skip phantom members on partial key package
failure"), which lands in the same function. The two changes are complementary
rather than overlapping:

- **#3946** drops a net-new inbox that has *no* MLS leaf at all (every one of its
  installations failed key-package fetch).
- **These PRs** record an *installation* that has no leaf, for an inbox that does.

`#3946` also moved `membership_diff` to after the key-package fetch, which removed
the need for a borrow workaround in the layer below and made that PR 11 lines
smaller.

One consequence worth noting: when `strip_unverified_new_adds` removes a phantom
inbox, that inbox's failed installations still reach the group-level
`failed_installations` list, leaving ids attributed to a non-member. That is
harmless (`check_initial_membership` only walks `members`, and
`expected_diff_matches_commit` only subtracts from expected removals) and it
pre-dates both changes, since the intent-time list already carried them. This PR
incidentally cleans them up: `partition_failed_installations` drops any id whose
owner is not in `members`, so they never reach the dict on migrated groups.

## Receiver side: no change needed

`read_group_membership_from_dict` already concatenates the per-inbox
`failed_installations` lists back into the flat
`GroupMembership.failed_installations` that `extract_group_membership` returns —
which is what `check_initial_membership` and `expected_diff_matches_commit`
read. Migrated and unmigrated groups therefore stay interoperable, and the
steady-state `AppDataUpdate` validation path (`validate_one_app_data_update`)
checks *who* may write the component, not the entry contents, so a populated
field changes no permission outcome. The `allowed_failed_installations` bound in
`bootstrap_validator` applies only to the one-time bootstrap commit and is
untouched.

## Tests

- `app_data_payload_partitions_failed_installations_per_inbox` (unit) — decodes
  the emitted `TlsMapDelta` and asserts each inbox's entry carries only its own
  failed installations, that an inbox with an unchanged sequence id gets no
  mutation, and that an unattributable installation is dropped rather than
  guessed onto some inbox.
- `migrated_group_carries_failed_installation_in_app_data` (integration) —
  migrates a group via `enable_proposals`, induces a publish-time key package
  failure, and asserts it survives the round trip through the per-inbox AppData
  entries and that a joiner added by the same commit is accepted. Fails with the
  field hardcoded empty, passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Populate per-inbox `failed_installations` in the AppData payload for migrated groups
> - `InstallationDiff` now carries an `installation_owners` map (installation_id → inbox_id), built by `get_installation_diff` from the ending `AssociationState` of each added/updated inbox.
> - `build_group_membership_app_data_payload` accepts this map and uses a new `partition_failed_installations` helper to bucket failed installations per inbox, sorted for deterministic encoding.
> - Each `Insert`/`Update` entry in the `GROUP_MEMBERSHIP` AppDataUpdate payload now includes only the failed installations belonging to that inbox; failures with no attributable inbox are silently dropped.
> - A new integration test `migrated_group_carries_failed_installation_in_app_data` verifies end-to-end propagation through per-inbox AppData on migrated groups.
> - Behavioral Change: failed installations that cannot be attributed to an inbox present in the current mutation are excluded from the emitted payload.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cfda9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->