### PR TITLE
fix(xmtp_mls): stop one unresolvable member from jamming a group

### DIFF
--- a/crates/xmtp_mls/src/groups/error.rs
+++ b/crates/xmtp_mls/src/groups/error.rs
@@ -101,8 +101,10 @@ pub enum GroupError {
     UserLimitExceeded,
     /// Sequence ID not found.
     ///
-    /// No sequence ID for an inbox after an identity-update refresh —
-    /// its registration hasn't propagated yet. Retryable.
+    /// An inbox that the caller wants to add has no sequence id after an
+    /// identity-update refresh. Its registration is not visible yet. Retryable.
+    /// A member that the group already committed never raises this error. The
+    /// membership builders skip that member and keep its dictionary entry.
     #[error("SequenceId not found in local db")]
     MissingSequenceId,
     /// Addresses not found.
@@ -624,12 +626,10 @@ impl RetryableError for GroupError {
             Self::DeleteMessage(e) => e.is_retryable(),
             Self::DeviceSync(e) => e.is_retryable(),
             Self::MergePendingCommit(e) => e.is_retryable(),
-            // Only emitted when a fresh `load_identity_updates` network
-            // refresh still has no sequence id for an inbox — i.e. its
-            // registration hasn't propagated to reads yet. Retrying re-runs
-            // the fetch, so the miss is transient; classifying it
-            // non-retryable permanently failed sync-group membership adds
-            // that raced a new installation's identity propagation.
+            // Only an inbox that the caller wants to add raises this error. Its
+            // registration is not visible to reads yet, so a retry can succeed. An
+            // already committed member cannot reach here: the membership builders
+            // skip it. See `get_membership_update_intent`.
             Self::MissingSequenceId => true,
             Self::NotFound(_)
             | Self::UserLimitExceeded
@@ -682,10 +682,10 @@ mod tests {
 
     #[xmtp_common::test]
     fn missing_sequence_id_is_retryable() {
-        // Regression lock: while non-retryable, a membership add racing a
-        // new installation's identity propagation burned all publish
-        // attempts instantly and permanently failed the sync-group add
-        // (surfaced as the DeviceSync sendSyncRequest CI failures).
+        // Regression lock: while non-retryable, a membership add that raced a new
+        // installation's identity propagation burned all publish attempts at once.
+        // The add then failed for good. Only unregistered adds reach this error, so
+        // a retry is correct. See `get_membership_update_intent`.
         assert!(GroupError::MissingSequenceId.is_retryable());
     }
 

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -4128,47 +4128,62 @@ where
     ) -> Result<UpdateGroupMembershipIntentData, GroupError> {
         self.load_mls_group_with_lock_async(async |mls_group| {
             let existing_group_membership = extract_group_membership(mls_group.extensions())?;
-            // TODO:nm prevent querying for updates on members who are being removed
             let mut inbox_ids = existing_group_membership.inbox_ids();
             inbox_ids.extend_from_slice(inbox_ids_to_add);
             let conn = self.context.db();
-            // Load any missing updates from the network
+            // Members that leave keep their refresh. `get_installation_diff` must
+            // resolve them to know which leaves the commit removes.
             load_identity_updates(self.context.api(), &conn, &inbox_ids).await?;
 
             let latest_sequence_id_map = conn.get_latest_sequence_id(&inbox_ids as &[&str])?;
 
             // Get a list of all inbox IDs that have increased sequence_id for the group
-            let changed_inbox_ids =
-                inbox_ids
-                    .iter()
-                    .try_fold(HashMap::new(), |mut updates, inbox_id| {
-                        match (
-                            latest_sequence_id_map.get(inbox_id as &str),
-                            existing_group_membership.get(inbox_id),
-                        ) {
-                            // This is an update. We have a new sequence ID and an existing one
-                            (Some(latest_sequence_id), Some(current_sequence_id)) => {
-                                let latest_sequence_id_u64 = *latest_sequence_id as u64;
-                                if latest_sequence_id_u64.gt(current_sequence_id) {
-                                    updates.insert(inbox_id.to_string(), latest_sequence_id_u64);
-                                }
-                            }
-                            // This is for new additions to the group
-                            (Some(latest_sequence_id), None) => {
-                                // This is the case for net new members to the group
-                                updates.insert(inbox_id.to_string(), *latest_sequence_id as u64);
-                            }
-                            (_, _) => {
-                                tracing::warn!(
-                                    "Could not find existing sequence ID for inbox {}",
-                                    inbox_id
-                                );
-                                return Err(GroupError::MissingSequenceId);
+            let changed_inbox_ids = inbox_ids
+                .iter()
+                .filter(|inbox_id| !inbox_ids_to_remove.contains(*inbox_id))
+                .try_fold(HashMap::new(), |mut updates, inbox_id| {
+                    match (
+                        latest_sequence_id_map.get(inbox_id as &str),
+                        existing_group_membership.get(inbox_id),
+                    ) {
+                        // This is an update. We have a new sequence ID and an existing one
+                        (Some(latest_sequence_id), Some(current_sequence_id)) => {
+                            let latest_sequence_id_u64 = *latest_sequence_id as u64;
+                            if latest_sequence_id_u64.gt(current_sequence_id) {
+                                updates.insert(inbox_id.to_string(), latest_sequence_id_u64);
                             }
                         }
+                        // This is for new additions to the group
+                        (Some(latest_sequence_id), None) => {
+                            // This is the case for net new members to the group
+                            updates.insert(inbox_id.to_string(), *latest_sequence_id as u64);
+                        }
+                        // The group already committed this inbox. The network has no
+                        // identity updates for it. Skip the member. Keep its dictionary
+                        // entry. If we stop here, one member blocks every commit in the
+                        // group. If we drop the entry, the commit makes a membership
+                        // change that the other members reject.
+                        (None, Some(_)) => {
+                            tracing::warn!(
+                                group_id = %self.group_id,
+                                %inbox_id,
+                                "Group member has no identity updates. Skipped the member and kept its entry."
+                            );
+                        }
+                        // The caller wants to add an inbox that has no identity updates.
+                        // The registration may not be visible yet. This error retries.
+                        (None, None) => {
+                            tracing::warn!(
+                                group_id = %self.group_id,
+                                %inbox_id,
+                                "Cannot add an inbox that has no identity updates."
+                            );
+                            return Err(GroupError::MissingSequenceId);
+                        }
+                    }
 
-                        Ok(updates)
-                    })?;
+                    Ok(updates)
+                })?;
             let extensions = mls_group.extensions().clone();
             let old_group_membership = extract_group_membership(&extensions)?;
             let mut new_membership = old_group_membership.clone();

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -196,6 +196,8 @@ pub(crate) async fn apply_update_group_membership_intent(
 
     // Run this guard before the writeback below. A change that only moves
     // `failed_installations` must not make an empty commit.
+    // A dictionary entry can exist with no leaf in the tree. Adding or removing
+    // such an entry moves no leaf. The commit must still carry the change.
     if leaf_nodes_to_remove.is_empty()
         && changes_with_kps.new_key_packages.is_empty()
         && membership_diff.updated_inboxes.is_empty()

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -17,6 +17,7 @@ mod test_prepare_message_for_later_publish;
 mod test_proposals;
 mod test_send_message_opts;
 mod test_starting_membership_sequence_id;
+mod test_unresolvable_member;
 mod test_validate_app_data_update;
 mod test_welcome_pointers;
 mod test_welcomes;

--- a/crates/xmtp_mls/src/groups/tests/test_unresolvable_member.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_unresolvable_member.rs
@@ -1,0 +1,152 @@
+//! An inbox in the group membership dictionary can have no identity updates on
+//! this network. The group must stay usable, and the member must be removable.
+//! See xmtp/libxmtp#3952.
+//!
+//! A new installation still cannot join such a group. `check_initial_membership`
+//! resolves every inbox in the dictionary before it accepts a welcome. Remove the
+//! entry first. `test_unresolvable_member_can_be_removed` proves that order.
+
+use crate::context::XmtpSharedContext;
+use crate::groups::group_membership::GroupMembership;
+use crate::groups::send_message_opts::SendMessageOpts;
+use crate::groups::validated_commit::extract_group_membership;
+use crate::groups::{GroupError, build_group_membership_extension};
+use crate::identity_updates::load_identity_updates;
+use crate::tester;
+use crate::utils::TestMlsGroup;
+use crate::utils::test::FullXmtpClient;
+use xmtp_common::RetryableError;
+use xmtp_db::prelude::*;
+
+/// Add an inbox to the group membership dictionary with no leaf in the tree.
+/// The commit stays local, so no other member has to accept it. This copies a
+/// group that a different client already jammed.
+fn add_dict_entry(client: &FullXmtpClient, group: &TestMlsGroup, inbox_id: &str, sequence_id: u64) {
+    let provider = client.context.mls_provider();
+
+    group
+        .load_mls_group_with_lock(client.context.mls_storage(), |mut mls_group| {
+            let mut extensions = mls_group.extensions().clone();
+            let mut membership = extract_group_membership(&extensions)?;
+            membership.add(inbox_id.to_string(), sequence_id);
+            extensions.add_or_replace(build_group_membership_extension(&membership))?;
+
+            mls_group
+                .update_group_context_extensions(
+                    &provider,
+                    extensions,
+                    &client.identity().installation_keys,
+                )
+                .unwrap();
+            mls_group.merge_pending_commit(&provider).unwrap();
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// Add an inbox that has no identity updates on this network.
+fn jam_group(client: &FullXmtpClient, group: &TestMlsGroup) -> String {
+    let unresolvable = hex::encode(xmtp_common::rand_array::<32>());
+    add_dict_entry(client, group, &unresolvable, 1);
+    unresolvable
+}
+
+fn membership(client: &FullXmtpClient, group: &TestMlsGroup) -> GroupMembership {
+    group
+        .load_mls_group_with_lock(client.context.mls_storage(), |mls_group| {
+            Ok(extract_group_membership(mls_group.extensions())?)
+        })
+        .unwrap()
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_unresolvable_member_does_not_block_messages() {
+    tester!(alix);
+    let group = alix.create_group(None, None)?;
+    let unresolvable = jam_group(&alix, &group);
+
+    // This refresh reads every member of the dictionary. The jam stops it.
+    group.update_installations().await?;
+    group
+        .send_message(b"hello", SendMessageOpts::default())
+        .await?;
+
+    // The skip keeps the entry. A drop is itself a membership change.
+    assert!(membership(&alix, &group).get(&unresolvable).is_some());
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_unresolvable_member_does_not_block_other_members() {
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+    let group = alix.create_group(None, None)?;
+    let unresolvable = jam_group(&alix, &group);
+
+    group.add_members(&[bo.inbox_id()]).await?;
+    group.add_members(&[caro.inbox_id()]).await?;
+    group.remove_members(&[bo.inbox_id()]).await?;
+
+    let members = membership(&alix, &group);
+    assert!(members.get(bo.inbox_id()).is_none());
+    assert!(members.get(caro.inbox_id()).is_some());
+    assert!(members.get(&unresolvable).is_some());
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_unresolvable_member_can_be_removed() {
+    tester!(alix);
+    tester!(bo);
+    let group = alix.create_group(None, None)?;
+    // Bring every sequence id up to date first. A stale id hides the defect,
+    // because the refresh of that member also carries the removal.
+    group.update_installations().await?;
+    let unresolvable = jam_group(&alix, &group);
+
+    group.remove_members(&[unresolvable.as_str()]).await?;
+    assert!(membership(&alix, &group).get(&unresolvable).is_none());
+
+    // The group works again. A new member joins and reads it.
+    group.add_members(&[bo.inbox_id()]).await?;
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&group.group_id)?;
+    group.test_can_talk_with(&bo_group).await?;
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_dict_entry_without_leaf_can_be_removed() {
+    tester!(alix);
+    tester!(mallory);
+    let group = alix.create_group(None, None)?;
+    group.update_installations().await?;
+
+    // Alix resolves this inbox, but it has no leaf in the tree. The removal
+    // commit drops no leaf, so the expectation must drop it too.
+    let db = alix.context.db();
+    load_identity_updates(alix.context.api(), &db, &[mallory.inbox_id()]).await?;
+    let sequence_id = db.get_latest_sequence_id(&[mallory.inbox_id()])?[mallory.inbox_id()];
+    add_dict_entry(&alix, &group, mallory.inbox_id(), sequence_id as u64);
+
+    group.remove_members(&[mallory.inbox_id()]).await?;
+    assert!(membership(&alix, &group).get(mallory.inbox_id()).is_none());
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_missing_sequence_id_is_only_for_unregistered_adds() {
+    tester!(alix);
+    let group = alix.create_group(None, None)?;
+
+    // An add of an unregistered inbox still fails. The registration may arrive
+    // later, so the error retries.
+    let unregistered = hex::encode(xmtp_common::rand_array::<32>());
+    let err = group
+        .add_members(&[unregistered.as_str()])
+        .await
+        .unwrap_err();
+    assert!(matches!(err, GroupError::MissingSequenceId));
+    assert!(err.is_retryable());
+
+    // A member that the group already committed raises no error at all.
+    jam_group(&alix, &group);
+    group.update_installations().await?;
+}

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -1250,10 +1250,14 @@ fn expected_diff_matches_commit(
         ));
     }
 
+    // A commit can only remove a leaf that is in the tree. Drop the rest of the
+    // expectation. Without this, a member that still resolves a dictionary entry
+    // with no leaf rejects the commit that removes the entry. The group forks.
     let filtered_expected: HashSet<_> = expected_diff
         .removed_installations
         .iter()
         .filter(|id| !failed_installation_ids.contains(*id))
+        .filter(|id| existing_installation_ids.contains(*id))
         .cloned()
         .collect();
 

--- a/crates/xmtp_mls/src/identity_updates.rs
+++ b/crates/xmtp_mls/src/identity_updates.rs
@@ -499,6 +499,8 @@ where
             .iter()
             .chain(membership_diff.updated_inboxes.iter());
 
+        // Inboxes that leave are part of this refresh. The skip below needs a
+        // current local log.
         let filters = added_and_updated_members
             .clone()
             .map(|i| {
@@ -507,6 +509,12 @@ where
                     new_group_membership.get(i).map(|i| *i as i64).unwrap_or(0),
                 )
             })
+            .chain(membership_diff.removed_inboxes.iter().map(|i| {
+                (
+                    i.as_str(),
+                    old_group_membership.get(i).map(|i| *i as i64).unwrap_or(0),
+                )
+            }))
             .collect::<Vec<(&str, i64)>>();
 
         load_identity_updates(
@@ -551,7 +559,27 @@ where
             removed_installations.extend(diff.removed_installations());
         }
 
+        let removed_inbox_ids = membership_diff
+            .removed_inboxes
+            .iter()
+            .map(|i| i.as_str())
+            .collect::<Vec<&str>>();
+        let removed_sequence_ids = conn.get_latest_sequence_id(&removed_inbox_ids)?;
+
         for inbox_id in membership_diff.removed_inboxes.iter() {
+            // An inbox with no identity updates has no leaf in the tree. It removes
+            // no installations. If we fail here, the entry stays in the dictionary
+            // forever. An empty log after the refresh above means the inbox has no
+            // identity here. A short log means stale local data, so it still fails:
+            // `get_association_state` needs the exact sequence id.
+            if !removed_sequence_ids.contains_key(inbox_id.as_str()) {
+                tracing::warn!(
+                    %inbox_id,
+                    "Removed inbox has no identity updates. It removes no installations."
+                );
+                continue;
+            }
+
             let state_diff = self
                 .get_association_state(
                     conn,


### PR DESCRIPTION
Fixes #3952.

## The problem

A group's `GroupMembership` dictionary can end up holding an inbox id that has
zero identity updates on the network the client is connected to. Once that
happens the group is permanently unusable, and the entry cannot be removed.

`MlsGroup::get_membership_update_intent` builds its work list from **every**
inbox in the dictionary and then runs a `try_fold`. `get_latest_sequence_id`
omits inboxes with no rows, so the unresolvable inbox lands in the catch-all
arm, which returns `GroupError::MissingSequenceId` and aborts the whole
computation. One member kills the intent for the entire group.

### Blast radius

Everything membership-related funnels through that one function, so the group
cannot send messages either:

| Caller | Path |
| --- | --- |
| `add_members` | `groups/mod.rs` |
| `remove_members` | `groups/mod.rs` |
| `add_missing_installations` | `groups/mls_sync.rs` |
| `send_message` | via `maybe_update_installations` |
| `publish_messages` | via `maybe_update_installations` |
| `update_installations` | via `maybe_update_installations` |
| `MlsGroup::sync` | via `maybe_update_installations` |
| durable `AddMissingInstallations` task | `worker/tasks.rs` |

`MissingSequenceId` is classified retryable, so the intent retries the same
failing read forever.

### No recovery path

`remove_members` calls `get_membership_update_intent(&[], inbox_ids)` and the
fold walked the existing membership **without** excluding the inboxes being
removed — there was a `TODO:nm` acknowledging exactly this. Even past that,
`get_installation_diff` resolved an association state for every removed inbox
and failed the same way. The bad member was unremovable by construction.

## The fix

The user-facing goal is recovery: a group already in this state must become
usable again, and the bad entry must be removable.

**1. `get_membership_update_intent` — skip instead of abort.**
The old catch-all arm covered two different situations and logged the same
message for both. It is now split:

- `(None, Some(_))` — the group already committed this inbox and the network
  has no identity updates for it. Warn, skip the member, and **leave its
  dictionary entry untouched**. Dropping the entry would itself be a membership
  change that other members do not expect, so the entry stays and the rest of
  the membership still updates. This alone restores `send_message` and every
  other caller in the table above.
- `(None, None)` — a net-new add of an inbox with no identity log. Still an
  error. Registration may genuinely not be visible to reads yet.

Members named in `inbox_ids_to_remove` are now excluded from the fold (the
`TODO:nm`). They stay in the `load_identity_updates` refresh on purpose:
`get_installation_diff` still has to resolve them to know which leaves the
commit drops, and dropping the refresh would make a stale local log look
identical to an absent one.

**2. `get_installation_diff` — a removed inbox with no identity log removes no
installations.**
Such an inbox has no leaf in the tree, so "nothing to remove" is the correct
answer, not an error. The check is deliberately narrow: it only skips when the
local log is **empty** after a refresh. A short-but-present log still fails,
because `get_association_state` needs the exact sequence id and a partial log
means "stale", not "absent". Removed inboxes were added to the refresh filter
so the emptiness test is authoritative.

**3. `expected_diff_matches_commit` — expected removals are restricted to
installations that are in the tree.**
A commit can only remove a leaf that exists. Without this, a member that *can*
resolve the entry (the one plausible way it got written in the first place)
computes a non-empty expected removal set, sees a commit that removed no
leaves, and rejects it — trading the jam for a fork. This tightens the
comparison onto the domain the commit can actually act on; it does not let a
commit skip removing a leaf that is present.

A fourth change was needed on the original base: the "nothing to do" early
return in `apply_update_group_membership_intent` ignored `removed_inboxes`, so
a dictionary-only removal produced no commit at all. #3946 landed the same
condition (plus `added_inboxes`) while this branch was open, so after the
rebase only a comment remains there.

### Composition with #3949

#3949 unions the publish-time key-package failures into
`new_group_membership.failed_installations`, which `expected_diff_matches_commit`
reads as `failed_installation_ids`. That predicate and the new
`existing_installation_ids` predicate are ANDed, so both only ever shrink
`filtered_expected` and the result is order-independent.

The two are in fact disjoint by construction. A `failed_installations` entry is
an installation id, and you can only derive an installation id for an inbox
whose association state resolves — so an inbox with **no** identity log, the
case change 2 skips, can never contribute one. `test_remove_inbox_with_bad_installation_from_group`
(the test #3949's comment calls out as sensitive to this field) and both of
#3949's new tests pass alongside the five added here.

## Retryability

Defect 3 in the issue — `MissingSequenceId` retried forever for a permanent
condition — is resolved by change 1 rather than by a new error variant. After
the split, the permanent case produces no error at all, and `MissingSequenceId`
is reachable **only** from a net-new add of an unregistered inbox. That case is
plausibly transient, so retryable stays correct and the existing regression
lock in `groups/error.rs` stays valid. The two other emitters of
`MissingSequenceId` (`CommitPendingProposals`, `ProposeMemberUpdate`) are both
add-only paths, so the narrowed contract holds crate-wide. Adding a
non-retryable variant would have left it dead. The variant docs, the
`is_retryable` comment and the regression test comment were updated to state
the narrowed contract, and the two warnings now name which case fired and the
group id — the ambiguity the issue called out.

## Commit validation

The skip is chosen so that the unresolvable entry never appears in the
membership diff: it is not added, not updated, and not removed. It therefore
never reaches `get_installation_diff`, and `validate_membership_diff` (which
only inspects `updated_inboxes`) is unaffected. Every member computes the same
diff from the same dictionary, so the commit is accepted by all of them.

## Tests

New module `crates/xmtp_mls/src/groups/tests/test_unresolvable_member.rs`. Each
test builds the jammed state by writing a dictionary entry with no leaf via a
local-only group-context-extensions commit — the commit never reaches the
network, so it reproduces a group that some other client already jammed.

- a group with one unresolvable member can still send a message, and the entry
  is still there afterwards
- a group with one unresolvable member can still add and remove other members
- the unresolvable member can be removed, and the group is fully usable
  afterwards: a new member joins and exchanges a message
- a dictionary entry with no leaf whose inbox **is** resolvable can also be
  removed (covers change 3)
- `MissingSequenceId` is still raised, and still retryable, for a net-new add
  of an unregistered inbox — and is not raised for an already-committed member

All five fail on `main` and pass with this change, re-verified after every
rebase (#3946, #3948, #3949). Each change was also reverted individually
against the new tests to confirm every one of them is load-bearing.

### Known boundary

A group still in this state cannot onboard a **new** installation, because
`InitialMembershipValidator::check_initial_membership` resolves every inbox in
the dictionary before accepting a welcome. That is deliberately left alone
here: relaxing welcome validation has its own security surface, and it is not
needed for recovery, since removing the bad entry restores joining as well.
The third test above proves that ordering end to end.

## Verification

- `just test crate xmtp_mls` — 722 passed, 0 failed (1 flaky)
- `just test d14n` (`--features d14n --profile ci-d14n`) — 803 passed, 0 failed
  (27 flaky; high flake count comes from a shared local backend)
- `just lint-rust` — clean, re-run after every rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unresolvable group members blocking MLS group commits
> - In `get_membership_update_intent`, members already in the group but lacking identity updates are now skipped (with a warning) instead of returning `MissingSequenceId`, which previously jammed the entire group.
> - `MissingSequenceId` is now only raised for attempted additions of inboxes with no identity updates, where it remains retryable.
> - Commit validation in `expected_diff_matches_commit` no longer rejects commits that attempt to remove installations without a leaf in the current tree.
> - Installation diff calculation tolerates removed inboxes with no identity updates by skipping their installation removals rather than erroring.
> - A new test suite in [test_unresolvable_member.rs](https://github.com/xmtp/libxmtp/pull/3955/files#diff-1c0e61a8ce5b992846428be96b3ddcef992bf0c9505026bd509f486635d0f012) verifies that unresolvable members do not block sends, adds, removes, or other group operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f771d35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->