### PR TITLE
fix(xmtp_mls): detect unprocessed MLS commits in filter_groups_with_new_messages

### DIFF
--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -16,10 +16,10 @@ use std::sync::{
 };
 use xmtp_common::Event;
 use xmtp_common::{Retry, RetryableError, retry_async};
+use xmtp_configuration::Originators;
 use xmtp_db::refresh_state::EntityKind;
 use xmtp_db::{consent_record::ConsentState, group::GroupQueryArgs, prelude::*};
 use xmtp_macro::log_event;
-use xmtp_configuration::Originators;
 use xmtp_proto::types::{Cursor, GlobalCursor, GroupId, GroupMessageMetadata};
 
 #[derive(Debug, Clone)]

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -19,6 +19,7 @@ use xmtp_common::{Retry, RetryableError, retry_async};
 use xmtp_db::refresh_state::EntityKind;
 use xmtp_db::{consent_record::ConsentState, group::GroupQueryArgs, prelude::*};
 use xmtp_macro::log_event;
+use xmtp_configuration::Originators;
 use xmtp_proto::types::{Cursor, GlobalCursor, GroupId, GroupMessageMetadata};
 
 #[derive(Debug, Clone)]
@@ -510,11 +511,17 @@ fn filter_groups_with_new_messages(
     for (group_id, latest_message_metadata) in latest_messages {
         match last_synced_cursors.get(group_id.as_ref()) {
             Some(cursor) => {
-                // Get the database cursor for the originator ID
-                // or 0 if not found. Compare with the latest message.
-                if cursor.get(&latest_message_metadata.cursor.originator_id)
-                    < latest_message_metadata.cursor.sequence_id
-                {
+                // Check whether the latest message from the server has been seen.
+                let has_unseen_latest = cursor.get(&latest_message_metadata.cursor.originator_id)
+                    < latest_message_metadata.cursor.sequence_id;
+
+                // Every MLS group must have at least one commit (creation commit).
+                // An absent commit cursor while app-message processing is already
+                // underway signals missed commits — trigger a sync to recover them.
+                let has_unsynced_commits = cursor.get(&Originators::APPLICATION_MESSAGES) > 0
+                    && cursor.get(&Originators::MLS_COMMITS) == 0;
+
+                if has_unseen_latest || has_unsynced_commits {
                     groups_with_unread_messages.insert(group_id);
                 }
             }


### PR DESCRIPTION
Closes #3958 

## What changed

`filter_groups_with_new_messages` previously checked only the cursor for the
globally newest message's originator. If `APPLICATION_MESSAGES` (originator 10)
was current, the group was skipped even when `MLS_COMMITS` (originator 0) had
unprocessed messages.

### Fix

Added a second condition alongside the existing `has_unseen_latest` check:

```rust
let has_unsynced_commits = cursor.get(&Originators::APPLICATION_MESSAGES) > 0
    && cursor.get(&Originators::MLS_COMMITS) == 0;

if has_unseen_latest || has_unsynced_commits {
    groups_with_unread_messages.insert(group_id);
}
```

Also added `use xmtp_configuration::Originators;` import.

## Why this condition is correct

Every MLS group must have at least one commit (the creation commit).
`cursor[APPLICATION_MESSAGES] > 0` means app messages have been processed.
`cursor[MLS_COMMITS] == 0` means no commit was ever tracked.
Together they unambiguously indicate missed commit history → trigger a sync.

The condition is a no-op for fully synced groups (both cursors > 0) and
brand-new groups (both 0, caught by the `None` arm).

## Testing

New test `filter_groups_detects_missed_commits_when_app_messages_current`
fails on `main` and passes with this fix. All existing `filter_groups_*`
tests continue to pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `filter_groups_with_new_messages` to detect unprocessed MLS commits
> Groups with application messages but an MLS commits cursor of zero were previously not marked for syncing, causing unprocessed commits to be missed.
>
> - Adds `has_unsynced_commits` condition in [`welcome_sync.rs`](https://github.com/xmtp/libxmtp/pull/3959/files#diff-5ad5d6ca4506c4960727c32b22b9168a128f14af4d61497cd168ba5c80fb43f5): marks a group for sync when the application messages cursor is greater than 0 but the MLS commits cursor is still 0.
> - Preserves the existing `has_unseen_latest` condition, inserting a group if either condition is true.
> - Behavioral Change: groups that previously had no unread messages but had unprocessed MLS commits will now be included in the sync set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 180713a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->