### PR TITLE
fix(xmtp_api_d14n): surface extraction errors instead of silently dropping them

### DIFF
--- a/crates/xmtp_api_d14n/src/queries/stream/extractor.rs
+++ b/crates/xmtp_api_d14n/src/queries/stream/extractor.rs
@@ -13,10 +13,10 @@ use crate::protocol::{
 };
 
 #[pin_project]
-pub struct TryExtractorStream<S, E: TryExtractor> {
+pub struct TryExtractorStream<S: TryStream, E: TryExtractor> {
     #[pin]
     inner: S,
-    buffered: VecDeque<<E as TryExtractor>::Ok>,
+    buffered: VecDeque<Result<<E as TryExtractor>::Ok, S::Error>>,
     _marker: PhantomData<E>,
 }
 
@@ -25,6 +25,7 @@ pub struct TryExtractorStream<S, E: TryExtractor> {
 // specifying `Stream` type
 pub fn try_extractor<S, E>(s: S) -> TryExtractorStream<S, E>
 where
+    S: TryStream,
     E: TryExtractor,
 {
     TryExtractorStream::<S, E> {
@@ -52,18 +53,26 @@ where
     ) -> std::task::Poll<Option<Self::Item>> {
         let this = self.as_mut().project();
         if let Some(item) = this.buffered.pop_front() {
-            return Poll::Ready(Some(Ok(item)));
+            return Poll::Ready(Some(item));
         }
         let envelope = ready!(this.inner.try_poll_next(cx));
         match envelope {
             Some(item) => {
                 let item = item?;
-                let (success, _failure) = item.try_consume::<E>()?;
-                let mut consumed = success.into_iter();
-                let ready_item = consumed.next();
-                this.buffered.extend(consumed);
-                if let Some(item) = ready_item {
-                    return Poll::Ready(Some(Ok(item)));
+                let (success, failure) = item.try_consume::<E>()?;
+                // Previously `failure` was discarded here (bound to `_failure`),
+                // so an item whose extraction produced only errors yielded
+                // nothing at all instead of surfacing those errors. Buffer
+                // both: successes as `Ok`, extraction failures converted and
+                // surfaced as `Err`, so no result is silently dropped.
+                this.buffered.extend(success.into_iter().map(Ok));
+                this.buffered.extend(
+                    failure
+                        .into_iter()
+                        .map(|e| Err(S::Error::from(EnvelopeError::from(e)))),
+                );
+                if let Some(item) = this.buffered.pop_front() {
+                    return Poll::Ready(Some(item));
                 }
                 cx.waker().wake_by_ref();
                 Poll::Pending
@@ -156,8 +165,6 @@ mod test {
         assert!(results[1].is_err());
     }
 
-    //TODO ignored until https://github.com/xmtp/libxmtp/issues/2604
-    #[ignore]
     #[xmtp_common::test]
     async fn test_extraction_error_propagation() {
         let items: Vec<Result<Vec<u32>, EnvelopeError>> = vec![Ok(vec![1])];


### PR DESCRIPTION
Fixes #3960

## Problem
`TryExtractorStream::poll_next` discarded the `failure` half of `try_consume`'s `(success, failure)` result. When an item's extraction produced only errors, the stream returned `Pending` and then `None` on the next poll (inner stream exhausted) -- the error vanished silently instead of reaching the consumer.

## Fix
Buffer both success and failure as `Result<E::Ok, S::Error>`, converting extraction errors through the existing `EnvelopeError`/`S::Error` conversion bounds already present on the impl. Un-ignores `test_extraction_error_propagation`.

## Behavior change -- please review carefully
I checked all 6 existing call sites of `try_extractor`:

- `xmtp_mls/src/groups/subscriptions.rs` and `subscriptions/mod.rs` resolve a single-item stream via `try_collect().now_or_never().expect(...)`. Before this fix, a genuine extraction failure hit `Pending` on the first poll, `now_or_never()` returned `None`, and `.expect(...)` would panic. This fix incidentally resolves that latent panic risk -- the failure now resolves synchronously as `Err` and propagates via `?` instead.
- `xmtp_mls/src/subscriptions/stream_messages.rs` consumes a live, long-running message stream and already propagates `Err` via `?` in `next_message()`. **This is the one to scrutinize**: an extraction failure on a single message will now terminate that subscription stream with an error, where previously it was silently dropped and the stream continued to the next network item. I did not change this behavior -- whether extraction failures on a live stream should be fatal-and-surfaced vs. logged-and-skipped seemed like a product decision, not mine to make silently. Flagging for your judgment.

## Testing
- `cargo check -p xmtp_api_d14n` -- clean
- `cargo test -p xmtp_api_d14n --lib queries::stream::extractor` -- 9/9 pass, including the previously-ignored `test_extraction_error_propagation`
- `cargo clippy -p xmtp_api_d14n --lib -- -D warnings` -- clean
- `cargo check -p xmtp_mls` -- clean (confirms the call sites above still compile; only pre-existing unrelated warning in `identity.rs:842`)

## Note on process
I used AI assistance (Claude) to investigate the codebase and draft this fix, disclosed per your AI-contributions policy. I reviewed and understand the change, traced every call site of the affected function myself before submitting, and the behavior-change tradeoff above is something I'm flagging rather than deciding unilaterally.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `TryExtractorStream` to surface extraction errors instead of silently dropping them
> Previously, `TryExtractorStream` in [extractor.rs](https://github.com/xmtp/libxmtp/pull/3961/files#diff-bb01f510f2aa287d7ca6d33e07cafdc6a61ee8586dca38cb9a71f75fb75a290a) discarded extraction failures and only buffered successful results. The internal buffer type is changed from `VecDeque<E::Ok>` to `VecDeque<Result<E::Ok, S::Error>>`, and failures are now converted via `EnvelopeError` and enqueued as `Err` items. A previously ignored test (`test_extraction_error_propagation`) is re-enabled to verify this behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2c073b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->