### PR TITLE
fix(xmtp_mls): silence unused_mut warning without breaking test-utils build

### DIFF
--- a/crates/xmtp_mls/src/identity.rs
+++ b/crates/xmtp_mls/src/identity.rs
@@ -839,6 +839,7 @@ impl XmtpKeyPackageBuilder {
             Extension::ApplicationId(ApplicationIdExtension::new(this.inbox_id.as_bytes()));
         let leaf_node_extensions = Extensions::<LeafNode>::single(application_id)?;
 
+        #[allow(unused_mut)]
         let mut capability_extensions = vec![
             ExtensionType::LastResort,
             ExtensionType::ApplicationId,


### PR DESCRIPTION
Small standalone fix, noticed while working on #3961 (unrelated -- flagged separately per reviewer feedback there rather than bundled in).

## Problem
`cargo check -p xmtp_mls` warns that `mut` on `capability_extensions` in `identity.rs` is unused.

## Why it's not as simple as removing `mut`
`capability_extensions` **is** mutated, but only inside `#[cfg(any(test, feature = \"test-utils\"))]`, via a `.retain()` call that opts a simulated old client out of the `AppDataDictionary` advertisement. In a plain build that block doesn't exist, so the compiler is technically correct that `mut` is unused there -- but removing it outright would break `cargo test` / `--features test-utils` builds, since `.retain()` needs `&mut self`.

## Fix
Used the `#[allow(unused_mut)]` idiom already established elsewhere in this codebase for the same conditionally-mutated-under-cfg pattern (see `get_keypackages_for_installation_ids` in `mls_sync.rs:4587`), rather than inventing a new approach.

## Testing
- `cargo check -p xmtp_mls` -- clean, warning gone
- `cargo check -p xmtp_mls --features test-utils` -- clean, still compiles (confirms the mutation path still works)
- `cargo clippy -p xmtp_mls --lib -- -D warnings` -- clean

## Note on process
Used AI assistance (Claude) to investigate and draft this, disclosed per your AI-contributions policy. Reviewed and understood the change before submitting.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress `unused_mut` warning in `XmtpKeyPackageBuilder.build`
> Adds `#[allow(unused_mut)]` to the `capability_extensions` binding in [identity.rs](https://github.com/xmtp/libxmtp/pull/3962/files#diff-7a53ab1775c572e550b2b08934d90d3f8433e012043b1ee641110036902663ed) to fix a compiler warning that surfaces when `test-utils` feature is not enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3c81e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->