### PR TITLE
deflake should stream prefs

### DIFF
--- a/sdks/js/node-sdk/test/Preferences.test.ts
+++ b/sdks/js/node-sdk/test/Preferences.test.ts
@@ -246,14 +246,25 @@ describe("Preferences", () => {
     await client2.conversations.syncAll();
     await sleep(1000);
 
-    setTimeout(() => {
-      void stream.end();
-    }, 100);
-
     const preferences: UserPreferenceUpdate[] = [];
+
+    // Safety net: end the stream if the expected updates never arrive, so the
+    // assertion below fails clearly instead of the test hanging until timeout.
+    // The HmacKeyUpdate events depend on network propagation, so we collect
+    // until we have all 4 expected updates rather than ending on a fixed timer.
+    const endTimeout = setTimeout(() => {
+      void stream.end();
+    }, 10000);
+
     for await (const update of stream) {
       preferences.push(...update);
+      if (preferences.length >= 4) {
+        break;
+      }
     }
+    clearTimeout(endTimeout);
+    await stream.end();
+
     expect(preferences.length).toBe(4);
     const consentUpdate1 = preferences[0] as Extract<
       UserPreferenceUpdate,


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3831

## Problem

The Node SDK integration test `Preferences > should stream preferences` is flaky (CI failure: `expected 3 to be 4`). It ends its preference stream on a **fixed 100 ms timer** — far shorter than the 2000 ms every other streaming test in this SDK uses:

```ts
setTimeout(() => {
  void stream.end();
}, 100);
```

The test expects 4 updates: 2 `ConsentUpdate` + 2 `HmacKeyUpdate`. The two `HmacKeyUpdate` events come from registering new installations and depend on **network propagation**, so the 4th event frequently arrives after the 100 ms window. `stream.end()` then flushes the iterator early and the loop exits with only 3 updates collected.

## Fix

Collect updates until all 4 expected preferences have arrived, then end the stream, rather than ending on an arbitrary fixed timer. A generous 10 s safety-net timeout (well under vitest's 120 s `testTimeout`) still ends the stream if fewer than 4 updates ever arrive, so a genuine regression fails with the same clear `expected N to be 4` assertion instead of hanging.

```ts
const preferences: UserPreferenceUpdate[] = [];
const endTimeout = setTimeout(() => {
  void stream.end();
}, 10000);
for await (const update of stream) {
  preferences.push(...update);
  if (preferences.length >= 4) {
    break;
  }
}
clearTimeout(endTimeout);
await stream.end();
expect(preferences.length).toBe(4);
```

- Normal case: loop breaks as soon as all 4 arrive — the test finishes fast and no longer races a wall-clock deadline.
- Slow case: waits up to the safety-net window instead of a 100 ms deadline, eliminating the flake.
- Real regression: the safety net ends the stream and the existing assertion fails clearly.

## Scope

Test-only change. No production/library code touched. All existing assertions on update ordering, types, and payloads are unchanged.

## Verification

- `eslint` passes on the modified file.
- The remaining `typecheck` errors in this environment stem from the unbuilt `@xmtp/node-bindings` native crate (they affect every test file equally) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky preferences stream test to stop after collecting 4 updates
> Replaces a fixed 100ms timeout in the `should get inbox states from inbox IDs` test with a data-driven termination condition that exits the `for-await` loop after 4 updates are received. A 10s safety-timeout serves as a fallback, and the stream is explicitly ended after the loop exits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc58b45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->