### PR TITLE
fix consent prefs sync test

### DIFF
--- a/crates/xmtp_mls/src/worker/device_sync/tests.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/tests.rs
@@ -287,7 +287,19 @@ async fn test_hmac_and_consent_preference_sync() {
     alix1.sync_welcomes().await?;
     let alix1_group = alix1.group(&bo_group.group_id)?;
     assert_eq!(alix1_group.consent_state()?, ConsentState::Unknown);
+
+    // Wait for alix1 to publish the consent update to the sync group before
+    // alix2 syncs. `register_interest(ConsentReceived).wait()` only waits
+    // passively on the metric — it does not drive a re-sync — so alix2's
+    // one-shot `sync_all_welcomes_and_groups` below is the only chance to pull
+    // this consent.
+    alix1.worker().clear_metric(SyncMetric::ConsentSent);
     alix1_group.update_consent_state(ConsentState::Allowed)?;
+    alix1
+        .worker()
+        .register_interest(SyncMetric::ConsentSent, 1)
+        .wait()
+        .await?;
 
     alix2.sync_all_welcomes_and_groups(None).await?;
 


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3749

## Problem

`worker::device_sync::tests::test_hmac_and_consent_preference_sync` intermittently timed out waiting for the `ConsentReceived` metric to reach `2`, panicking with `Err(Expired)` (previously reported as FLAKY 2/4).

## Root cause (test-only race)

The second consent phase did:

```rust
alix1_group.update_consent_state(ConsentState::Allowed)?;   // async publish by alix1's worker
alix2.sync_all_welcomes_and_groups(None).await?;            // one-shot pull
alix2.worker().register_interest(SyncMetric::ConsentReceived, 2).wait().await?;
```

`update_consent_state` only queues work for alix1's device-sync worker, which publishes the consent update to the sync group asynchronously (incrementing `ConsentSent`). `register_interest(...).wait()` waits **passively** on the receiver metric — it does not itself drive any re-sync — so alix2's single `sync_all_welcomes_and_groups` call is the only opportunity to pull the second consent. That call filters out groups with no new server activity (`filter_groups_needing_sync`); if alix2 syncs before alix1's consent message lands on the server, the device-sync group is filtered out, alix2 never pulls the update, and `ConsentReceived` stays at `1` until the 10s timeout.

The **first** consent phase in the same test already guards against this by waiting for `ConsentSent` before the receiver syncs — the second phase simply omitted the same barrier.

## Fix

Add the same barrier (clear → update → wait for `ConsentSent`) before alix2's sync, mirroring the first-consent phase. `clear_metric` runs *before* `update_consent_state` so the wait targets the Allowed publish specifically. Production code is untouched.

## Verification

- `just test v3 test_hmac_and_consent_preference_sync` → **20/20 stress runs pass**.
- `just lint-rust` (clippy `-Dwarnings`, fmt, hakari) passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix race condition in `test_hmac_and_consent_preference_sync` test
> The test was non-deterministic because alix2 could run `sync_all_welcomes_and_groups` before alix1 had published its consent update. The fix clears the `ConsentSent` metric on alix1's worker before calling `update_consent_state(Allowed)`, then blocks until one `ConsentSent` event is emitted, ensuring correct ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad70f7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->