### PR TITLE
fix(deps): bump lru to 0.18.2 for RUSTSEC-2026-0253

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5714,9 +5714,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -5954,7 +5954,7 @@ dependencies = [
  "clap",
  "const-hex",
  "futures",
- "lru 0.18.1",
+ "lru 0.18.2",
  "openmls",
  "openmls_rust_crypto",
  "parking_lot",


### PR DESCRIPTION
## Urgency: low — this is hygiene, not an unblock

The `advisories` check is `continue-on-error` by design, and it is not a required context. `.github/workflows/cargo-deny-checker.yml`:

```yaml
# Prevent sudden announcement of a new advisory from failing CI
continue-on-error: ${{ matrix.checks == 'advisories' }}
```

So the red check was never blocking a merge. This PR removes a real advisory from the tree at no risk; it does not unblock anything.

## Problem

`cargo-deny` reports the `advisories` check red on `main`. Reproduced locally at `731a83ae` before any change:

```
error[unsound]: Potential use-after-free due to lack of panic safety in `LruCache::pop()`
    ┌─ Cargo.lock:430:1
430 │ lru 0.18.1 registry+https://github.com/rust-lang/crates.io-index
    ├ ID: RUSTSEC-2026-0253
    ├ Solution: Upgrade to >=0.18.2

advisories FAILED, bans ok, licenses ok, sources ok
```

`LruCache::pop()` is not panic-safe. If a stored key's `Drop` panics during `pop()`, `self.detach()` never runs, so the node is freed from the map but stays linked in the LRU list. A later insertion that triggers eviction traverses that dangling pointer and writes to freed memory.

- **CWE-416 (use-after-free)** on eviction
- **CWE-415 (double free)**

Both are reachable from safe Rust, but only with unwinding panics enabled and `catch_unwind` used with a key type whose `Drop` can panic.

## Fix

Upstream patched it in 0.18.2 ([lru-rs#238](https://github.com/jeromefroe/lru-rs/pull/238)) by detaching the node before freeing it. So this is a lockfile bump and needs **no `deny.toml` ignore entry**.

The dependency arrives through `mls_validation_service`. The other `lru` in the tree, 0.16.4, is outside the advisory's affected range and is untouched.

## Diff

One file. Three lines in `Cargo.lock`: version, checksum, and the single reference.

## Verification

| Check | Result |
|---|---|
| `cargo deny check` | `advisories ok, bans ok, licenses ok, sources ok` |
| `cargo hakari generate --diff` | exit 0, no regeneration needed |
| `cargo check -p mls_validation_service --locked` | exit 0 |

The failure reproduced on `main` before the change and is clean after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
