### PR TITLE
fix(common): prevent panic on backward system clock drift in duration_since_epoch

### DIFF
--- a/crates/xmtp_common/src/time.rs
+++ b/crates/xmtp_common/src/time.rs
@@ -42,7 +42,7 @@ impl crate::ErrorCode for Expired {
 fn duration_since_epoch() -> Duration {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
+        .unwrap_or_default()
 }
 
 pub fn now_ns() -> i64 {


### PR DESCRIPTION
Updated duration_since_epoch in crates/xmtp_common/src/time.rs to use .unwrap_or_default() instead of .expect("Time went backwards"). Previously, minor backward clock adjustments during NTP sync or VM drift caused unhandled thread panics across SDK clients.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix panic on backward system clock drift in `duration_since_epoch`
> Replaces `.expect("Time went backwards")` with `.unwrap_or_default()` in [`duration_since_epoch`](https://github.com/xmtp/libxmtp/pull/3968/files#diff-f3c9654f6a5c809c5331dcba4d28c14a678198b7c3513b5827137b4563122a89), returning a zero `Duration` instead of panicking when the system clock is before the Unix epoch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 110be09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->