### PR TITLE
fix(db): return all non-reaction content types from get_group_messages_with_reactions

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/group_message.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message.rs
@@ -1040,26 +1040,13 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         // First get all the main messages
         let mut modified_args = args.clone();
         // filter out reactions from the main query so we don't get them twice
-        let content_types = match modified_args.content_types.clone() {
-            Some(content_types) => {
-                let mut content_types = content_types.clone();
-                content_types.retain(|content_type| *content_type != ContentType::Reaction);
-                Some(content_types)
-            }
-            None => Some(vec![
-                ContentType::Text,
-                ContentType::GroupMembershipChange,
-                ContentType::GroupUpdated,
-                ContentType::ReadReceipt,
-                ContentType::Reply,
-                ContentType::Attachment,
-                ContentType::RemoteAttachment,
-                ContentType::TransactionReference,
-                ContentType::Unknown,
-            ]),
-        };
+        let mut content_types = modified_args
+            .content_types
+            .clone()
+            .unwrap_or_else(ContentType::all);
+        content_types.retain(|content_type| *content_type != ContentType::Reaction);
 
-        modified_args.content_types = content_types;
+        modified_args.content_types = Some(content_types);
         let messages = self.get_group_messages(group_id, &modified_args)?;
 
         // Then get all reactions for these messages in a single query

--- a/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -2771,3 +2771,43 @@ fn test_min_expire_at_ns() {
         assert_eq!(conn.min_expire_at_ns()?, Some(3_000));
     })
 }
+
+#[xmtp_common::test]
+fn test_messages_with_reactions_returns_all_non_reaction_content_types() {
+    with_connection(|conn| {
+        let group = generate_group(None);
+        group.store(conn).unwrap();
+
+        // Store one message of every content type. Reactions are the only
+        // kind the caller expects to be folded into `reactions` instead of
+        // being returned as a top-level message.
+        let all_types = ContentType::all();
+        for (i, content_type) in all_types.iter().enumerate() {
+            generate_message(
+                None,
+                Some(&group.id),
+                Some(1_000 + i as i64),
+                Some(*content_type),
+                None,
+                None,
+            )
+            .store(conn)
+            .unwrap();
+        }
+
+        let returned = conn
+            .get_group_messages_with_reactions(&group.id, &MsgQueryArgs::default())
+            .unwrap();
+
+        let returned_types: Vec<ContentType> =
+            returned.iter().map(|m| m.message.content_type).collect();
+
+        for content_type in all_types.iter().filter(|t| **t != ContentType::Reaction) {
+            assert!(
+                returned_types.contains(content_type),
+                "{content_type:?} message was dropped from get_group_messages_with_reactions"
+            );
+        }
+        assert_eq!(returned.len(), all_types.len() - 1);
+    })
+}


### PR DESCRIPTION
Closes #3969

## Problem

`get_group_messages_with_reactions` strips reactions out of the main query so they
aren't returned twice — they come back folded into each message's `reactions` field.

The `Some(content_types)` branch did that correctly: take the caller's list, `retain`
everything that isn't `Reaction`. The `None` branch didn't — it substituted a hardcoded
allowlist of 9 `ContentType` variants. `ContentType` has 17, so the default query matched
9 of the 16 it should have.

Messages with these types were silently absent from the result — no error, no log line:

| variant | discriminant |
| --- | --- |
| `WalletSendCalls` | 10 |
| `LeaveRequest` | 11 |
| `Markdown` | 12 |
| `Actions` | 13 |
| `Intent` | 14 |
| `MultiRemoteAttachment` | 15 |
| `DeleteMessage` | 16 |

This is reachable from the public FFI surface —
`FfiConversation::find_messages_with_reactions` → `MlsGroup::find_messages_with_reactions`
→ here — and `FfiListMessagesOptions::content_types` is `Option<...>` defaulting to `None`,
so any iOS or Android caller that doesn't pass an explicit filter took the hardcoded branch.

The list looks like it was accurate when written and then went stale: every content type
added after it was introduced is missing from it.

## Fix

Both branches want the same rule — "whatever the caller asked for, minus `Reaction`" — so
this states it once and uses `ContentType::all()` (already defined in this file, and until
now unused) as the default:

```rust
let mut content_types = modified_args
    .content_types
    .clone()
    .unwrap_or_else(ContentType::all);
content_types.retain(|content_type| *content_type != ContentType::Reaction);
modified_args.content_types = Some(content_types);
```

New variants are picked up automatically, so it can't drift again. Concretely: #3523 adds
`ContentType::EditMessage = 17` to `ContentType::all()`, which under the current code would
land in the same hole on day one.

## Behavior

- **`content_types: None`** — was 9 types, now 16 (everything except `Reaction`). This is
  the fix.
- **`content_types: Some(list)`** — unchanged; same `retain` as before. The
  `Some(vec![Reaction])` edge case still resolves to an empty list and matches nothing.
- `get_group_messages` is untouched. It applies `eq_any` only when `content_types` is
  `Some`, so `find_messages` already returned all of these types normally — which is why
  this reads as a client rendering bug rather than a query bug.

## Testing

Added `test_messages_with_reactions_returns_all_non_reaction_content_types`: stores one
message of every `ContentType` and asserts the default query returns every non-reaction
type.

- On `main` it fails at the first missing type:
  `WalletSendCalls message was dropped from get_group_messages_with_reactions`
  (`test result: FAILED. 0 passed; 1 failed`)
- With this change: `cargo test -p xmtp_db --lib` → `217 passed; 0 failed; 8 ignored`
- `cargo fmt -p xmtp_db -- --check` and
  `cargo clippy -p xmtp_db --lib --all-features -- -D warnings` are both clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `get_group_messages_with_reactions` to return all non-reaction content types
> Previously, `get_group_messages_with_reactions` in [group_message.rs](https://github.com/xmtp/libxmtp/pull/3971/files#diff-c0d5a80dd8bc5f71fbd41e3be8e6a0209ecad08084303e910a8f81e6c8db2c2a) used a hardcoded list of content types when no filter was provided. It now derives the default set dynamically from `ContentType::all()` minus `ContentType::Reaction`, so newly added content types are included automatically. A new test verifies that all non-reaction types are present in the returned results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56de352.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->