### PR TITLE
test(browser-sdk): gate OPFS tests on feature support

### DIFF
--- a/sdks/js/browser-sdk/test/Opfs.test.ts
+++ b/sdks/js/browser-sdk/test/Opfs.test.ts
@@ -3,7 +3,13 @@ import { Opfs } from "@/Opfs";
 import { uuid } from "@/utils/uuid";
 import { createRegisteredClient, createSigner } from "./helpers";
 
-describe.skip("Opfs", () => {
+const hasOpfsSupport =
+  typeof globalThis.navigator !== "undefined" &&
+  typeof globalThis.navigator.storage?.getDirectory === "function";
+
+const describeOpfs = hasOpfsSupport ? describe : describe.skip;
+
+describeOpfs("Opfs", () => {
   describe.sequential("with no files", () => {
     let opfs: Opfs;
 


### PR DESCRIPTION
Closes #3970.

## What changed

- Replace the unconditional `describe.skip` around the OPFS test suite with a feature-detected suite selector.
- The tests now run when `navigator.storage.getDirectory` is available and remain skipped in environments without OPFS support.

## Why

The browser SDK exports `Opfs`, but the test suite was unreachable in every environment. This keeps unsupported Node-like environments quiet while allowing browser-capable runners to exercise OPFS behavior.

## Testing

- `git diff --check`
- `corepack yarn --cwd sdks/js/browser-sdk test Opfs` could not run in this environment because `@xmtp/browser-sdk` requires Node >=22 and this host has Node 21.6.1.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate OPFS tests on feature support via runtime detection
> Replaces the static `describe.skip` in [Opfs.test.ts](https://github.com/xmtp/libxmtp/pull/3972/files#diff-d66bae08ac82bd421f2c448291b666e6e44f22e7c53709c645d97d6f87ee8067) with a `describeOpfs` alias that checks for `navigator.storage.getDirectory` at runtime. The suite now runs when the environment supports OPFS and skips automatically when it does not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c648c7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->