### PR TITLE
fix(archive): error instead of spinning when an archive is truncated

### DIFF
--- a/crates/xmtp_archive/src/importer.rs
+++ b/crates/xmtp_archive/src/importer.rs
@@ -75,8 +75,18 @@ impl Stream for ArchiveImporter {
                 return Poll::Ready(Some(element.map_err(ArchiveError::from)));
             }
 
-            if amount == 0 && this.decoded.is_empty() {
-                break;
+            if amount == 0 {
+                // Reader is exhausted. An empty buffer with no element in
+                // flight is a clean end of stream; anything left over is a
+                // partial element the archive promised but never delivered,
+                // and looping again would just re-read EOF forever.
+                if element_len == 0 && this.decoded.is_empty() {
+                    break;
+                }
+                return Poll::Ready(Some(Err(std::io::Error::from(
+                    std::io::ErrorKind::UnexpectedEof,
+                )
+                .into())));
             }
         }
 
@@ -117,5 +127,43 @@ impl ArchiveImporter {
 
     pub fn metadata(&self) -> &BackupMetadata {
         &self.metadata
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BACKUP_VERSION;
+    use async_compression::futures::write::ZstdEncoder;
+    use futures_util::AsyncWriteExt;
+
+    /// Header + a zstd payload whose length prefix promises far more bytes
+    /// than the stream actually carries -- i.e. an archive truncated
+    /// part-way through an element.
+    async fn truncated_archive() -> Vec<u8> {
+        let mut payload = 1024u32.to_le_bytes().to_vec();
+        payload.extend_from_slice(&[0u8; 8]);
+
+        let mut encoder = ZstdEncoder::new(Vec::new());
+        encoder.write_all(&payload).await.unwrap();
+        encoder.close().await.unwrap();
+
+        let mut archive = BACKUP_VERSION.to_le_bytes().to_vec();
+        archive.extend_from_slice(&[0u8; NONCE_SIZE]);
+        archive.extend_from_slice(&encoder.into_inner());
+        archive
+    }
+
+    /// A truncated archive must end the stream with an error. Before the
+    /// EOF check below, `poll_next` looped on `read() == 0` forever
+    /// without ever yielding, so this call never returned.
+    #[xmtp_common::test]
+    async fn truncated_archive_terminates_with_error() {
+        let reader: AsyncReader = Box::pin(futures::io::Cursor::new(truncated_archive().await));
+        let result = ArchiveImporter::load(reader, &[0u8; 32]).await;
+        assert!(
+            result.is_err(),
+            "a truncated archive must surface an error instead of spinning"
+        );
     }
 }


### PR DESCRIPTION
Closes #3973

## Problem

`ArchiveImporter`'s `poll_next` only left its read loop when the reader was exhausted **and**
nothing was buffered:

```rust
if amount == 0 && this.decoded.is_empty() {
    break;
}
```

When an archive ends part-way through an element, neither escape is reachable again:
`element_len != 0 && decoded.len() >= element_len` can't fire because the remaining bytes are
short of the promised length, and the `break` can't fire because `decoded` isn't empty. The
loop keeps calling `read()` on an exhausted reader.

It never returns `Pending`, so this isn't a stall the executor can observe or time out — it's
a tight busy loop that pins a core and never yields. The same happens when fewer than 4 bytes
remain, since `element_len` never gets set.

## Impact

A truncated or corrupt archive hangs the import instead of failing it. Reachable from every
binding's device-sync surface — `bindings/mobile/src/mls/device_sync/mod.rs`,
`bindings/node/src/device_sync.rs`, `bindings/wasm/src/device_sync.rs` — and from
`worker/device_sync/worker.rs:718`, which builds the importer over a `StreamReader` around the
sync payload's HTTP response body. A download cut short by a dropped connection produces
exactly this input, so a corrupt file on disk isn't required; an interrupted network read
wedges the device-sync worker. On WASM it's worse, since a loop that never yields blocks the
only thread.

## Fix

Treat exhaustion of the reader as terminal, separating a clean end of stream from a partial
element:

```rust
if amount == 0 {
    if element_len == 0 && this.decoded.is_empty() {
        break;
    }
    return Poll::Ready(Some(Err(std::io::Error::from(
        std::io::ErrorKind::UnexpectedEof,
    )
    .into())));
}
```

`ArchiveError` already carries `IO(#[from] std::io::Error)`, so this needs no new error
variant. Well-formed archives are unaffected — they always hit the
`decoded.len() >= element_len` branch and return before the reader runs dry, which the rest of
the suite covers.

## Testing

Added `truncated_archive_terminates_with_error`, which builds a header plus a zstd payload
whose length prefix promises 1024 bytes while the stream carries 8, and asserts the import
surfaces an error.

Because the old behavior is a non-yielding busy loop rather than a failed assertion, the
"before" evidence is a timeout rather than a test failure. Running the test on an unpatched
tree under `timeout 90`:

```
running 1 test
EXIT_CODE=124
RESULT: HUNG (timed out) - bug reproduced
```

With this change the same command completes immediately — `test result: ok. 6 passed; 0
failed; 0 ignored; finished in 0.00s` — and `cargo fmt -p xmtp_archive -- --check` and `cargo
clippy -p xmtp_archive --lib -- -D warnings` are both clean.

## One thing I left out

`element_len` is a local, so it resets on every `poll_next` call even though `this.decoded`
persists. If the reader returns `Pending` after the 4-byte length prefix has been drained, the
length is lost and the next poll reads 4 payload bytes as a fresh prefix. That looks wrong to
me too, but it's a separate failure mode and I haven't reproduced it end to end, so I left it
out rather than fold an unverified change into this one. Happy to follow up if you agree it's
worth fixing.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ArchiveImporter` to return an error instead of spinning on truncated archives
> Previously, if an archive was truncated mid-element, `ArchiveImporter::poll_next` would loop indefinitely on repeated EOF reads. Now it yields `UnexpectedEof` and terminates the stream when EOF is reached while a length prefix or partial element is in progress. A clean EOF with no element in flight still ends the stream normally. A new test in [importer.rs](https://github.com/xmtp/libxmtp/pull/3974/files#diff-f21fd15a4b7c9ec0cac9b64b696eb8a4ddc8f237fe16d6d9e8ec03e58ebd37f1) verifies this behavior using a synthetic truncated archive.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d98f51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->