### PR TITLE
fix(db): base consent includes_all on distinct coverage, not length

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/conversation_list.rs
+++ b/crates/xmtp_db/src/encrypted_store/conversation_list.rs
@@ -188,7 +188,17 @@ impl<C: ConnectionExt> QueryConversationList for DbConnection<C> {
         };
 
         let includes_unknown = effective_consent_states.contains(&ConsentState::Unknown);
-        let includes_all = effective_consent_states.len() == 3;
+        // "All states requested" means the request covers every distinct
+        // ConsentState, not merely that it has three elements — a caller passing
+        // duplicates (e.g. `[Allowed, Allowed, Allowed]`) must not be treated as
+        // an unfiltered query and leak Denied/Unknown conversations.
+        let includes_all = [
+            ConsentState::Allowed,
+            ConsentState::Denied,
+            ConsentState::Unknown,
+        ]
+        .iter()
+        .all(|state| effective_consent_states.contains(state));
 
         let filtered_states: Vec<_> = effective_consent_states
             .iter()
@@ -480,6 +490,61 @@ pub(crate) mod tests {
                 })
                 .unwrap();
             assert_eq!(empty_array_results.len(), 3);
+        })
+    }
+
+    // A consent_states list with duplicates that does not cover all three
+    // distinct states must still filter. Previously `includes_all` was
+    // `len() == 3`, so `[Allowed, Allowed, Allowed]` was mistaken for "all
+    // states" and returned Denied/Unknown conversations the caller did not ask
+    // for.
+    #[xmtp_common::test]
+    fn test_find_conversations_consent_duplicates_do_not_disable_filter() {
+        with_connection(|conn| {
+            let allowed = generate_group(Some(GroupMembershipState::Allowed));
+            allowed.store(conn).unwrap();
+            let denied = generate_group(Some(GroupMembershipState::Allowed));
+            denied.store(conn).unwrap();
+            let unknown = generate_group(Some(GroupMembershipState::Allowed));
+            unknown.store(conn).unwrap();
+
+            generate_consent_record(
+                ConsentType::ConversationId,
+                ConsentState::Allowed,
+                hex::encode(allowed.id),
+            )
+            .store(conn)
+            .unwrap();
+            generate_consent_record(
+                ConsentType::ConversationId,
+                ConsentState::Denied,
+                hex::encode(denied.id),
+            )
+            .store(conn)
+            .unwrap();
+            // `unknown` intentionally has no consent record.
+
+            // Three elements, but only the Allowed state is covered.
+            let results = conn
+                .fetch_conversation_list(GroupQueryArgs {
+                    consent_states: Some(vec![
+                        ConsentState::Allowed,
+                        ConsentState::Allowed,
+                        ConsentState::Allowed,
+                    ]),
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let ids: Vec<_> = results.iter().map(|g| g.id.clone()).collect();
+            assert_eq!(
+                results.len(),
+                1,
+                "duplicate Allowed states must not disable consent filtering"
+            );
+            assert!(ids.contains(&allowed.id));
+            assert!(!ids.contains(&denied.id));
+            assert!(!ids.contains(&unknown.id));
         })
     }
 

--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -657,7 +657,17 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         };
 
         let includes_unknown = effective_consent_states.contains(&ConsentState::Unknown);
-        let includes_all = effective_consent_states.len() == 3;
+        // "All states requested" means the request covers every distinct
+        // ConsentState, not merely that it has three elements — a caller passing
+        // duplicates (e.g. `[Allowed, Allowed, Allowed]`) must not be treated as
+        // an unfiltered query and leak Denied/Unknown conversations.
+        let includes_all = [
+            ConsentState::Allowed,
+            ConsentState::Denied,
+            ConsentState::Unknown,
+        ]
+        .iter()
+        .all(|state| effective_consent_states.contains(state));
 
         if let Some(should_publish_commit_log) = should_publish_commit_log {
             query = query.filter(dsl::should_publish_commit_log.eq(should_publish_commit_log));
@@ -1720,6 +1730,60 @@ pub(crate) mod tests {
                 })
                 .unwrap();
             assert_eq!(empty_array_results.len(), 3);
+        })
+    }
+
+    // A consent_states list with duplicates that does not cover all three
+    // distinct states must still filter. Previously `includes_all` was
+    // `len() == 3`, so `[Allowed, Allowed, Allowed]` was mistaken for "all
+    // states" and returned Denied/Unknown groups the caller did not ask for.
+    #[xmtp_common::test]
+    fn test_find_groups_consent_duplicates_do_not_disable_filter() {
+        with_connection(|conn| {
+            let allowed = generate_group(Some(GroupMembershipState::Allowed));
+            allowed.store(conn).unwrap();
+            let denied = generate_group(Some(GroupMembershipState::Allowed));
+            denied.store(conn).unwrap();
+            let unknown = generate_group(Some(GroupMembershipState::Allowed));
+            unknown.store(conn).unwrap();
+
+            generate_consent_record(
+                ConsentType::ConversationId,
+                ConsentState::Allowed,
+                hex::encode(allowed.id),
+            )
+            .store(conn)
+            .unwrap();
+            generate_consent_record(
+                ConsentType::ConversationId,
+                ConsentState::Denied,
+                hex::encode(denied.id),
+            )
+            .store(conn)
+            .unwrap();
+            // `unknown` intentionally has no consent record.
+
+            // Three elements, but only the Allowed state is covered.
+            let results = conn
+                .find_groups(GroupQueryArgs {
+                    consent_states: Some(vec![
+                        ConsentState::Allowed,
+                        ConsentState::Allowed,
+                        ConsentState::Allowed,
+                    ]),
+                    ..Default::default()
+                })
+                .unwrap();
+
+            let ids: Vec<_> = results.iter().map(|g| g.id.clone()).collect();
+            assert_eq!(
+                results.len(),
+                1,
+                "duplicate Allowed states must not disable consent filtering"
+            );
+            assert!(ids.contains(&allowed.id));
+            assert!(!ids.contains(&denied.id));
+            assert!(!ids.contains(&unknown.id));
         })
     }
 


### PR DESCRIPTION
Closes #3975

## Problem

The consent-state filter decides whether to skip filtering entirely by counting the requested
states:

```rust
let includes_unknown = effective_consent_states.contains(&ConsentState::Unknown);
let includes_all = effective_consent_states.len() == 3;
```

`ConsentState` has exactly three variants (`Unknown`, `Allowed`, `Denied`), so `len() == 3` is
used as a proxy for "the caller requested every state → don't filter." That proxy breaks on
duplicates: any three-element list passes it, including one that doesn't cover all three states.

When it misfires, the query takes the "no filtering at all" branch and returns conversations of
every consent state:

- `[Allowed, Allowed, Allowed]` → treated as "all states" → returns **Denied and Unknown** too,
  when only Allowed was requested.
- `[Allowed, Denied, Denied]` → returns **Unknown** as well.

Reachable from the public FFI: `FfiListConversationsOptions.consent_states` is passed straight
through to `GroupQueryArgs` and `validate()` doesn't dedup, so `Conversations.list(...)` and the
group query both hit it. The same check lived in both `find_groups`
(`encrypted_store/group.rs`) and `fetch_conversation_list` (`encrypted_store/conversation_list.rs`).

## Fix

Base `includes_all` on distinct coverage instead of length, at both call sites:

```rust
let includes_all = [
    ConsentState::Allowed,
    ConsentState::Denied,
    ConsentState::Unknown,
]
.iter()
.all(|state| effective_consent_states.contains(state));
```

Correct regardless of duplicates or ordering; a genuine all-three-states request behaves exactly
as before. One- and two-element lists, and four-or-more-element lists, were already correct and
are unchanged.

## Testing

Added a regression test to each query path (`find_groups` and `fetch_conversation_list`): three
groups — one `Allowed`, one `Denied`, one `Unknown` (no consent record) — queried with
`consent_states: Some(vec![Allowed, Allowed, Allowed])`, asserting only the Allowed group comes
back.

- On `main` both fail — all three groups are returned (the Denied and Unknown ones leak in).
- With this change both pass, and the existing consent tests
  (`test_find_groups_by_consent_state`, `test_find_conversations_by_consent_state`) and the rest
  of the `xmtp_db` suite still pass. `cargo clippy -p xmtp_db --all-features -- -D warnings` and
  `cargo fmt` are clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix consent filtering to check distinct states instead of list length
> - In `fetch_conversation_list` and `find_groups`, `includes_all` was computed by checking `len() == 3`, which incorrectly treated lists like `[Allowed, Allowed, Allowed]` as covering all states and disabled filtering.
> - Both methods now check for the presence of all three distinct `ConsentState` variants (Allowed, Denied, Unknown) before disabling filtering.
> - New tests in [conversation_list.rs](https://github.com/xmtp/libxmtp/pull/3976/files#diff-12fb716ce95c9ce34d5af447a3f8952c5c1d8f7305e8055ec32e12dcc6f497f8) and [group.rs](https://github.com/xmtp/libxmtp/pull/3976/files#diff-24266c317af66ff8a8b94857a2d4fc62cda2bbc52c3e30cc05bd5c7f3feda9af) verify that duplicate-only consent state lists still apply filtering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 682617b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->