### PR TITLE
fix(mls): reject admin/super-admin add for a non-member inbox_id

### DIFF
--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -3636,6 +3636,75 @@ async fn test_admin_list_add_via_app_data_path_after_migration() {
     }
 }
 
+/// A non-member inbox_id must not be promotable to admin/super-admin via
+/// `update_admin_list`. Before this fix, `validate_proposal`'s GCE branch
+/// only checked that the proposer had permission to grant admin rights —
+/// it never checked that the inbox_id being granted those rights was
+/// actually a group member. caro here is never added to the group at
+/// all, so the commit must be rejected the same way
+/// `test_inline_app_data_update_denied_by_registry_policy` pins a
+/// registry-policy denial: `Err(GroupError::Sync(summary))` carrying
+/// `CommitValidationError::InsufficientPermissions` in
+/// `summary.process.errored`, with the admin list left unchanged.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_admin_list_add_rejects_non_member_inbox_id() {
+    use crate::groups::{
+        GroupError, UpdateAdminListType, mls_sync::GroupMessageProcessingError,
+        validated_commit::CommitValidationError,
+    };
+
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+
+    // caro is intentionally NOT a member of this group.
+    let alix_group = alix
+        .create_group_with_members(&[bo.inbox_id()], None, None)
+        .await?;
+    let bo_groups = bo.sync_welcomes().await?;
+    let bo_group = bo_groups.first()?;
+    bo_group.sync().await?;
+
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+    bo_group.sync().await?;
+
+    let original_admin_list = alix_group.mutable_metadata()?.admin_list;
+
+    let result = alix_group
+        .update_admin_list(UpdateAdminListType::Add, caro.inbox_id().to_string())
+        .await;
+    let Err(GroupError::Sync(summary)) = result else {
+        panic!("expected Err(GroupError::Sync(_)), got {result:?}");
+    };
+    assert!(
+        summary.process.errored.iter().any(|(_, e)| matches!(
+            e,
+            GroupMessageProcessingError::CommitValidation(
+                CommitValidationError::InsufficientPermissions
+            )
+        )),
+        "summary should carry the CommitValidation cause, got: {summary}"
+    );
+
+    bo_group.sync().await?;
+    for (label, meta) in [
+        ("alix", alix_group.mutable_metadata()?),
+        ("bo", bo_group.mutable_metadata()?),
+    ] {
+        assert_eq!(
+            meta.admin_list, original_admin_list,
+            "{label} admin_list should be unchanged after the rejected add",
+        );
+        assert!(
+            !meta.admin_list.contains(&caro.inbox_id().to_string()),
+            "{label} should not see non-member caro as admin, admin_list={:?}",
+            meta.admin_list,
+        );
+    }
+}
+
 /// Round-trip: add then remove. With the real bootstrap commit the
 /// immutable seeds are in the dict, so the second `update_admin_list`
 /// call's `metadata()` read works on the migrated group.

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -2136,6 +2136,40 @@ pub fn validate_proposal(
                     );
                     return Err(CommitValidationError::InsufficientPermissions);
                 }
+
+                // The permission checks above only confirm the proposer is
+                // allowed to grant admin/super-admin rights — they say
+                // nothing about whether the inbox_id being promoted is
+                // actually part of the group. Without this, an admin add
+                // for a non-member inbox_id would pass validation and land
+                // in `admin_list`/`super_admin_list` with no member behind
+                // it. Mirror what `Remove` proposals already do via
+                // `openmls_group.member_at(...)` by requiring every
+                // newly-added admin/super-admin inbox_id to be a current
+                // member.
+                if !metadata_changes.admins_added.is_empty()
+                    || !metadata_changes.super_admins_added.is_empty()
+                {
+                    let current_member_inbox_ids = openmls_group
+                        .members()
+                        .map(|member| inbox_id_from_credential(&member.credential))
+                        .collect::<Result<HashSet<String>, _>>()?;
+
+                    for added in metadata_changes
+                        .admins_added
+                        .iter()
+                        .chain(metadata_changes.super_admins_added.iter())
+                    {
+                        if !current_member_inbox_ids.contains(&added.inbox_id) {
+                            tracing::warn!(
+                                proposer_inbox_id = %proposer.inbox_id,
+                                added_inbox_id = %added.inbox_id,
+                                "GCE proposal rejected: cannot grant admin rights to an inbox_id that is not a group member"
+                            );
+                            return Err(CommitValidationError::InsufficientPermissions);
+                        }
+                    }
+                }
             }
 
             // Check for permission changes (only super admin can


### PR DESCRIPTION
validate_proposal()'s GroupContextExtensions branch only checked that the proposer had permission to grant admin/super-admin rights (add_admin_policy / proposer.is_super_admin). It never checked that the inbox_id being promoted was actually a member of the group, so an admin-list update naming a non-member inbox_id would pass validation and land in admin_list/super_admin_list with no member behind it.

update_admin_list() on the MlsGroup side (groups/mod.rs) only guards against DM-type conversations before queuing the intent -- it doesn't validate membership either, so nothing on the send or receive side caught this.

Fix mirrors what Remove proposals already do via
openmls_group.member_at(...): after the existing permission checks, collect the group's current member inbox_ids from
openmls_group.members() and require every newly-added admin/ super-admin inbox_id to be in that set, rejecting the proposal with InsufficientPermissions otherwise.

Adds a regression test modeled on
test_admin_list_add_via_app_data_path_after_migration / test_inline_app_data_update_denied_by_registry_policy: alix attempts update_admin_list(Add, caro) where caro was never added to the group, and the update must fail with GroupError::Sync(summary) carrying CommitValidationError::InsufficientPermissions, with admin_list left unchanged on both peers.

Confirmed with maintainer insipx on #2581 that enforcing this at proposal-validation time (rather than looser pre-authorization) is the intended behavior.

Fixes #2581.

Note: this environment has no working Rust toolchain new enough to compile this crate (it uses let-chains; only rustc 1.75 was available via apt), so `members()`/`Member`'s signature was hand-verified against the exact pinned xmtp/openmls fork revision in Cargo.lock (3fabbf23d417ac80e787ca858a5134c6ca1d9ce6) rather than compiled locally. Please run the crate's normal check/test suite before merging.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject admin/super-admin additions for non-member inbox IDs in MLS groups
> - Adds a membership check in [`validate_proposal`](https://github.com/xmtp/libxmtp/pull/3977/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6): any inbox_id being added to `admins` or `super_admins` must already be a current group member, otherwise validation fails with `CommitValidationError::InsufficientPermissions`.
> - Adds a regression test covering the case where a non-member inbox_id is targeted, verifying the admin list remains unchanged after rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b3cfdb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->