### PR TITLE
fix(node-sdk,browser-sdk): make stream end() terminal and race-safe in createStream

### DIFF
--- a/sdks/js/browser-sdk/src/utils/streams.ts
+++ b/sdks/js/browser-sdk/src/utils/streams.ts
@@ -10,8 +10,6 @@ const isPromise = <T = unknown>(value: unknown): value is Promise<T> => {
   );
 };
 
-const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 export const DEFAULT_RETRY_DELAY = 10000; // milliseconds
 export const DEFAULT_RETRY_ATTEMPTS = 6;
 
@@ -81,6 +79,9 @@ export type StreamValueMutator<T = unknown, V = T> = (
  *
  * If the stream fails, an attempt will be made to restart it.
  *
+ * Ending the stream is terminal: no callbacks are invoked and no native
+ * stream is created after the stream ends.
+ *
  * This function is not intended to be used directly.
  *
  * @param streamFunction - The stream function to create a stream from
@@ -113,7 +114,56 @@ export const createStream = async <T = unknown, V = T>(
   }
 
   const asyncStream = new AsyncStream<V>();
+
+  // lifecycle state, owned by this wrapper
+  let stopped = false;
+  // reading the flag through a function call defeats TS control-flow
+  // narrowing, which cannot see the closure mutation across awaits
+  const isStopped = () => stopped;
+  let currentCloser: (() => void) | undefined;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let retryInFlight = false;
+  // the retry budget is monotonic: it is never reset for the lifetime of
+  // this wrapper, so restarts are bounded even across successful restarts
+  let remainingRetries = retryAttempts;
+
+  // terminal transition: cancel any pending retry, close the active native
+  // stream, and notify onEnd exactly once
+  const stop = () => {
+    if (isStopped()) {
+      return;
+    }
+    stopped = true;
+    if (retryTimer !== undefined) {
+      clearTimeout(retryTimer);
+      retryTimer = undefined;
+    }
+    currentCloser?.();
+    currentCloser = undefined;
+    onEnd?.();
+  };
+  // registered before any async work so ending the stream is always terminal,
+  // even while a retry is pending or a native stream is being created
+  asyncStream.onDone = stop;
+
+  const fail = (error: Error) => {
+    if (isStopped()) {
+      return;
+    }
+    // the terminal transition must run even if onError throws, otherwise a
+    // throwing consumer callback leaves the stream open and hangs next()
+    try {
+      onError?.(error);
+    } finally {
+      void asyncStream.end();
+    }
+  };
+
   const streamCallback: StreamCallback<T> = (error, value) => {
+    // an ended stream must not invoke any callbacks
+    if (isStopped()) {
+      return;
+    }
     // if a stream error occurs, call the onError callback
     if (error) {
       onError?.(error);
@@ -128,16 +178,21 @@ export const createStream = async <T = unknown, V = T>(
           if (isPromise(mutatedValue)) {
             void mutatedValue
               .then((mutatedValue) => {
-                if (mutatedValue !== undefined) {
+                // the stream may have ended while the value was mutating
+                if (!isStopped() && mutatedValue !== undefined) {
                   asyncStream.push(mutatedValue);
                   onValue?.(mutatedValue);
                 }
               })
               .catch((error: unknown) => {
-                onError?.(error as Error);
+                if (!isStopped()) {
+                  onError?.(error as Error);
+                }
               });
           } else {
-            if (mutatedValue !== undefined) {
+            // a synchronous mutator may have ended the stream; gate delivery
+            // on the stopped flag to match the async branch above
+            if (!isStopped() && mutatedValue !== undefined) {
               asyncStream.push(mutatedValue);
               onValue?.(mutatedValue);
             }
@@ -151,45 +206,66 @@ export const createStream = async <T = unknown, V = T>(
       }
     }
   };
-  const retry = async (retries: number = retryAttempts) => {
+
+  const scheduleRetry = () => {
+    // at most one retry may be in flight per wrapper
+    if (isStopped() || retryInFlight) {
+      return;
+    }
+    if (remainingRetries <= 0) {
+      fail(new StreamFailedError(retryAttempts));
+      return;
+    }
+    retryInFlight = true;
+    retryTimer = setTimeout(() => {
+      retryTimer = undefined;
+      void attemptRestart();
+    }, retryDelay);
+  };
+
+  const attemptRestart = async () => {
+    if (isStopped()) {
+      retryInFlight = false;
+      return;
+    }
+    remainingRetries -= 1;
+    onRetry?.(retryAttempts - remainingRetries, retryAttempts);
     try {
-      // if the stream has been retried the maximum number of times without
-      // success, throw an error
-      if (retries === 0) {
-        void asyncStream.end();
-        throw new StreamFailedError(retryAttempts);
-      }
-
-      // wait for the retry delay before attempting to restart the stream
-      await wait(retryDelay);
-      // call the onRetry callback
-      onRetry?.(retryAttempts - retries + 1, retryAttempts);
-
       // attempt to restart the stream
-      const streamCloser = await streamFunction(streamCallback, () => {
-        // call the onFail callback
-        onFail?.();
-        void retry();
-      });
-
-      // when the async stream is done, end the stream
-      asyncStream.onDone = () => {
+      const streamCloser = await streamFunction(
+        streamCallback,
+        handleNativeClose,
+      );
+      if (isStopped()) {
+        // the stream ended while the native stream was being created
         streamCloser();
-        onEnd?.();
-      };
-
+        retryInFlight = false;
+        return;
+      }
+      currentCloser = streamCloser;
+      retryInFlight = false;
       // stream restarted, call the onRestart callback
       onRestart?.();
     } catch (error) {
+      retryInFlight = false;
+      if (isStopped()) {
+        return;
+      }
       onError?.(error as Error);
-      // retry
-      void retry(retries - 1);
+      scheduleRetry();
     }
   };
-  const startRetry = () => {
-    // if the stream should be retried, start the process
+
+  const handleNativeClose = () => {
+    // ending the stream closes the native stream, which still triggers this
+    // callback; only an unexpected close is a failure
+    if (isStopped()) {
+      return;
+    }
+    currentCloser = undefined;
+    onFail?.();
     if (retryOnFail) {
-      void retry();
+      scheduleRetry();
     } else {
       void asyncStream.end();
       // stream failed and should not be retried, throw an error
@@ -199,19 +275,24 @@ export const createStream = async <T = unknown, V = T>(
 
   try {
     // create the stream
-    const streamCloser = await streamFunction(streamCallback, () => {
-      // call the onFail callback
-      onFail?.();
-      startRetry();
-    });
-    // when the async stream is done, end the stream
-    asyncStream.onDone = () => {
+    const streamCloser = await streamFunction(
+      streamCallback,
+      handleNativeClose,
+    );
+    if (isStopped()) {
       streamCloser();
-      onEnd?.();
-    };
+    } else {
+      currentCloser = streamCloser;
+    }
   } catch (error) {
     onError?.(error as Error);
-    startRetry();
+    if (retryOnFail) {
+      scheduleRetry();
+    } else {
+      void asyncStream.end();
+      // stream failed and should not be retried, throw an error
+      throw new StreamFailedError(0);
+    }
   }
 
   // return a proxy for the async stream

--- a/sdks/js/browser-sdk/test/streams.test.ts
+++ b/sdks/js/browser-sdk/test/streams.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   StreamFailedError,
   StreamInvalidRetryAttemptsError,
@@ -807,5 +807,326 @@ describe("createStream", () => {
       });
       await stream.end();
     });
+  });
+});
+
+type StreamInstance = {
+  callback: StreamCallback<number>;
+  onFail: () => void;
+  closer: ReturnType<typeof vi.fn>;
+};
+
+// Captures every native stream created by createStream so tests can drive
+// the value callback and the native close (onFail) callback directly.
+const makeHarness = () => {
+  const instances: StreamInstance[] = [];
+  const streamFunction = vi.fn(
+    async (callback: StreamCallback<number>, onFail: () => void) => {
+      const closer = vi.fn();
+      instances.push({ callback, onFail, closer });
+      return closer as () => void;
+    },
+  );
+  const last = () => instances[instances.length - 1];
+  return { instances, streamFunction, last };
+};
+
+describe("createStream lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not restart after end() during a pending retry", async () => {
+    const { streamFunction, last } = makeHarness();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      retryDelay: 1000,
+    });
+
+    // native close schedules a retry
+    last().onFail();
+    // consumer ends the stream before the retry delay expires
+    await stream.end();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(streamFunction).toHaveBeenCalledTimes(1);
+    // the pending retry timer must be cancelled
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("immediately closes a native stream created after end()", async () => {
+    const instances: StreamInstance[] = [];
+    let resolveSecond!: (closer: () => void) => void;
+    const secondCloser = vi.fn();
+    const streamFunction = vi.fn(
+      (callback: StreamCallback<number>, onFail: () => void) => {
+        if (instances.length === 0) {
+          const closer = vi.fn();
+          instances.push({ callback, onFail, closer });
+          return Promise.resolve(closer as () => void);
+        }
+        // second call: retry creation stays in flight until the test resolves it
+        instances.push({ callback, onFail, closer: secondCloser });
+        return new Promise<() => void>((resolve) => {
+          resolveSecond = resolve;
+        });
+      },
+    );
+    const onRestart = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onRestart,
+      retryDelay: 1000,
+    });
+
+    // native close schedules a retry, then the retry enters streamFunction
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(streamFunction).toHaveBeenCalledTimes(2);
+
+    // consumer ends the stream while the retry creation is in flight
+    await stream.end();
+    resolveSecond(secondCloser as () => void);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(secondCloser).toHaveBeenCalled();
+    expect(onRestart).not.toHaveBeenCalled();
+  });
+
+  it("suppresses onValue and onError after end()", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onValue = vi.fn();
+    const onError = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      onValue,
+    });
+
+    await stream.end();
+    instances[0].callback(null, 1);
+    instances[0].callback(new Error("boom"), undefined);
+
+    expect(onValue).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not emit a value whose async mutation resolves after end()", async () => {
+    const { instances, streamFunction } = makeHarness();
+    let resolveMutation!: (value: number) => void;
+    const mutator = vi.fn(
+      () =>
+        new Promise<number>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+    const onValue = vi.fn();
+    const stream = await createStream<number, number>(streamFunction, mutator, {
+      onValue,
+    });
+
+    // a value arrives and its async mutation is in flight
+    instances[0].callback(null, 1);
+    await stream.end();
+    resolveMutation(2);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onValue).not.toHaveBeenCalled();
+  });
+
+  it("allows only one retry in flight per stream", async () => {
+    const { streamFunction, last } = makeHarness();
+    await createStream<number>(streamFunction, undefined, {
+      retryDelay: 1000,
+    });
+
+    // multiple native close callbacks before the retry timer expires
+    last().onFail();
+    last().onFail();
+    last().onFail();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // initial stream + exactly one replacement
+    expect(streamFunction).toHaveBeenCalledTimes(2);
+  });
+
+  it("stays silent when end() precedes the native close callback", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onError = vi.fn();
+    const onFail = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      onFail,
+      retryDelay: 1000,
+    });
+
+    await stream.end();
+    // ending the native stream triggers its close callback
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(onFail).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(streamFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent when end() precedes the native close callback with retryOnFail disabled", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onError = vi.fn();
+    const onFail = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      onFail,
+      retryOnFail: false,
+    });
+
+    await stream.end();
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(onFail).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(streamFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops retrying after the retry budget is exhausted", async () => {
+    const { streamFunction, last } = makeHarness();
+    const onError = vi.fn();
+    const onRestart = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      onRestart,
+      retryAttempts: 3,
+      retryDelay: 1000,
+    });
+
+    // three failures, three successful restarts
+    for (let i = 0; i < 3; i++) {
+      last().onFail();
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+    expect(streamFunction).toHaveBeenCalledTimes(4);
+    expect(onRestart).toHaveBeenCalledTimes(3);
+
+    // the budget is monotonic: the next failure is terminal
+    last().onFail();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(streamFunction).toHaveBeenCalledTimes(4);
+    expect(onError).toHaveBeenCalledWith(expect.any(StreamFailedError));
+    expect(stream.isDone).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("counts failed restart attempts against the retry budget", async () => {
+    const instances: StreamInstance[] = [];
+    const streamFunction = vi.fn(
+      (callback: StreamCallback<number>, onFail: () => void) => {
+        if (instances.length === 0) {
+          const closer = vi.fn();
+          instances.push({ callback, onFail, closer });
+          return Promise.resolve(closer as () => void);
+        }
+        // every restart attempt fails to create a stream
+        return Promise.reject(new Error("creation failed"));
+      },
+    );
+    const onError = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      retryAttempts: 2,
+      retryDelay: 1000,
+    });
+
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // initial stream + two failed restart attempts
+    expect(streamFunction).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledWith(expect.any(StreamFailedError));
+    expect(stream.isDone).toBe(true);
+  });
+
+  it("restarts the stream after a failure and continues delivering values", async () => {
+    const { instances, streamFunction, last } = makeHarness();
+    const onValue = vi.fn();
+    const onRestart = vi.fn();
+    const onRetry = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onRestart,
+      onRetry,
+      onValue,
+      retryDelay: 1000,
+    });
+
+    last().onFail();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(streamFunction).toHaveBeenCalledTimes(2);
+    expect(onRestart).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(1, 6);
+
+    // values flow through the replacement stream
+    last().callback(null, 42);
+    expect(onValue).toHaveBeenCalledWith(42);
+
+    // end() closes the replacement stream, not the original
+    await stream.end();
+    expect(instances[1].closer).toHaveBeenCalled();
+  });
+
+  it("invokes onEnd once when the stream ends twice", async () => {
+    const { streamFunction } = makeHarness();
+    const onEnd = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onEnd,
+    });
+
+    await stream.end();
+    await stream.end();
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("ends the stream even when onError throws at terminal failure", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onError = vi.fn(() => {
+      throw new Error("consumer onError threw");
+    });
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      retryAttempts: 0,
+      retryDelay: 1000,
+    });
+
+    // the exhausted-budget native close triggers a terminal failure; a
+    // throwing consumer onError must not prevent the stream from ending
+    expect(() => instances[0].onFail()).toThrow("consumer onError threw");
+
+    expect(onError).toHaveBeenCalledWith(expect.any(StreamFailedError));
+    expect(stream.isDone).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("suppresses onValue when a sync mutator ends the stream", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onValue = vi.fn();
+    const streamRef: { end?: () => Promise<unknown> } = {};
+    const mutator = vi.fn((value: number) => {
+      // a synchronous mutator that ends the stream, then returns a value
+      void streamRef.end?.();
+      return value * 2;
+    });
+    const stream = await createStream<number, number>(streamFunction, mutator, {
+      onValue,
+    });
+    streamRef.end = () => stream.end();
+
+    // drive a value after the proxy exists so the mutator can end the stream
+    instances[0].callback(null, 1);
+
+    expect(mutator).toHaveBeenCalled();
+    expect(onValue).not.toHaveBeenCalled();
   });
 });

--- a/sdks/js/node-sdk/src/utils/streams.ts
+++ b/sdks/js/node-sdk/src/utils/streams.ts
@@ -3,8 +3,6 @@ import type { StreamCloser } from "@xmtp/node-bindings";
 import { AsyncStream, createAsyncStreamProxy } from "@/AsyncStream";
 import { StreamFailedError, StreamInvalidRetryAttemptsError } from "./errors";
 
-const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 export const DEFAULT_RETRY_DELAY = 60_000; // milliseconds
 export const DEFAULT_RETRY_ATTEMPTS = 10;
 
@@ -74,6 +72,9 @@ export type StreamValueMutator<T = unknown, V = T> = (
  *
  * If the stream fails, an attempt will be made to restart it.
  *
+ * Ending the stream is terminal: no callbacks are invoked and no native
+ * stream is created after the stream ends.
+ *
  * This function is not intended to be used directly.
  *
  * @param streamFunction - The stream function to create a stream from
@@ -90,6 +91,7 @@ export const createStream = async <T = unknown, V = T>(
   options?: StreamOptions<T, V>,
 ) => {
   const {
+    onEnd,
     onError,
     onFail,
     onRestart,
@@ -105,7 +107,56 @@ export const createStream = async <T = unknown, V = T>(
   }
 
   const asyncStream = new AsyncStream<V>();
+
+  // lifecycle state, owned by this wrapper
+  let stopped = false;
+  // reading the flag through a function call defeats TS control-flow
+  // narrowing, which cannot see the closure mutation across awaits
+  const isStopped = () => stopped;
+  let currentCloser: StreamCloser | undefined;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let retryInFlight = false;
+  // the retry budget is monotonic: it is never reset for the lifetime of
+  // this wrapper, so restarts are bounded even across successful restarts
+  let remainingRetries = retryAttempts;
+
+  // terminal transition: cancel any pending retry, close the active native
+  // stream, and notify onEnd exactly once
+  const stop = () => {
+    if (isStopped()) {
+      return;
+    }
+    stopped = true;
+    if (retryTimer !== undefined) {
+      clearTimeout(retryTimer);
+      retryTimer = undefined;
+    }
+    currentCloser?.end();
+    currentCloser = undefined;
+    onEnd?.();
+  };
+  // registered before any async work so ending the stream is always terminal,
+  // even while a retry is pending or a native stream is being created
+  asyncStream.onDone = stop;
+
+  const fail = (error: Error) => {
+    if (isStopped()) {
+      return;
+    }
+    // the terminal transition must run even if onError throws, otherwise a
+    // throwing consumer callback leaves the stream open and hangs next()
+    try {
+      onError?.(error);
+    } finally {
+      void asyncStream.end();
+    }
+  };
+
   const streamCallback: StreamCallback<T> = (error, value) => {
+    // an ended stream must not invoke any callbacks
+    if (isStopped()) {
+      return;
+    }
     // if a stream error occurs, call the onError callback
     if (error) {
       onError?.(error);
@@ -120,16 +171,21 @@ export const createStream = async <T = unknown, V = T>(
           if (isPromise(mutatedValue)) {
             void mutatedValue
               .then((mutatedValue) => {
-                if (mutatedValue !== undefined) {
+                // the stream may have ended while the value was mutating
+                if (!isStopped() && mutatedValue !== undefined) {
                   asyncStream.push(mutatedValue);
                   onValue?.(mutatedValue);
                 }
               })
               .catch((error: unknown) => {
-                onError?.(error as Error);
+                if (!isStopped()) {
+                  onError?.(error as Error);
+                }
               });
           } else {
-            if (mutatedValue !== undefined) {
+            // a synchronous mutator may have ended the stream; gate delivery
+            // on the stopped flag to match the async branch above
+            if (!isStopped() && mutatedValue !== undefined) {
               asyncStream.push(mutatedValue);
               onValue?.(mutatedValue);
             }
@@ -143,65 +199,100 @@ export const createStream = async <T = unknown, V = T>(
       }
     }
   };
-  const retry = async (retries: number = retryAttempts) => {
-    // if the stream has been retried the maximum number of times without
-    // success, call onError
-    if (retries === 0) {
-      void asyncStream.end();
-      onError?.(new StreamFailedError(retryAttempts));
+
+  const scheduleRetry = () => {
+    // at most one retry may be in flight per wrapper
+    if (isStopped() || retryInFlight) {
       return;
     }
+    if (remainingRetries <= 0) {
+      fail(new StreamFailedError(retryAttempts));
+      return;
+    }
+    retryInFlight = true;
+    retryTimer = setTimeout(() => {
+      retryTimer = undefined;
+      void attemptRestart();
+    }, retryDelay);
+  };
 
-    // wait for the retry delay before attempting to restart the stream
-    await wait(retryDelay);
-    // call the onRetry callback
-    onRetry?.(retryAttempts - retries + 1, retryAttempts);
+  const attemptRestart = async () => {
+    if (isStopped()) {
+      retryInFlight = false;
+      return;
+    }
+    remainingRetries -= 1;
+    onRetry?.(retryAttempts - remainingRetries, retryAttempts);
     try {
       // attempt to restart the stream
-      const streamCloser = await streamFunction(streamCallback, () => {
-        // call the onFail callback
-        onFail?.();
-        void retry();
-      });
-      await streamCloser.waitForReady();
-      // when the async stream is done, end the stream
-      asyncStream.onDone = () => {
+      const streamCloser = await streamFunction(
+        streamCallback,
+        handleNativeClose,
+      );
+      if (isStopped()) {
+        // the stream ended while the native stream was being created
         streamCloser.end();
-      };
+        retryInFlight = false;
+        return;
+      }
+      await streamCloser.waitForReady();
+      if (isStopped()) {
+        streamCloser.end();
+        retryInFlight = false;
+        return;
+      }
+      currentCloser = streamCloser;
+      retryInFlight = false;
       // stream restarted, call the onRestart callback
       onRestart?.();
     } catch (error) {
+      retryInFlight = false;
+      if (isStopped()) {
+        return;
+      }
       onError?.(error as Error);
-      // retry
-      void retry(retries - 1);
+      scheduleRetry();
     }
   };
-  const startRetry = () => {
-    // if the stream should be retried, start the process
+
+  const handleNativeClose = () => {
+    // ending the stream closes the native stream, which still triggers this
+    // callback; only an unexpected close is a failure
+    if (isStopped()) {
+      return;
+    }
+    currentCloser = undefined;
+    onFail?.();
     if (retryOnFail) {
-      void retry();
+      scheduleRetry();
     } else {
-      void asyncStream.end();
-      // stream failed and should not be retried, throw an error
-      onError?.(new StreamFailedError(0));
+      fail(new StreamFailedError(0));
     }
   };
 
   try {
     // create the stream
-    const streamCloser = await streamFunction(streamCallback, () => {
-      // call the onFail callback
-      onFail?.();
-      startRetry();
-    });
-    await streamCloser.waitForReady();
-    // when the async stream is done, end the stream
-    asyncStream.onDone = () => {
+    const streamCloser = await streamFunction(
+      streamCallback,
+      handleNativeClose,
+    );
+    if (isStopped()) {
       streamCloser.end();
-    };
+    } else {
+      await streamCloser.waitForReady();
+      if (isStopped()) {
+        streamCloser.end();
+      } else {
+        currentCloser = streamCloser;
+      }
+    }
   } catch (error) {
     onError?.(error as Error);
-    startRetry();
+    if (retryOnFail) {
+      scheduleRetry();
+    } else {
+      fail(new StreamFailedError(0));
+    }
   }
 
   // return a proxy for the async stream

--- a/sdks/js/node-sdk/test/streams.test.ts
+++ b/sdks/js/node-sdk/test/streams.test.ts
@@ -1,6 +1,352 @@
-import { describe, expect, it, vi } from "vitest";
+import type { StreamCloser } from "@xmtp/node-bindings";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StreamFailedError } from "@/utils/errors";
-import { createStream } from "@/utils/streams";
+import { createStream, type StreamCallback } from "@/utils/streams";
+
+const makeCloser = () => ({
+  end: vi.fn(),
+  endAndWait: vi.fn().mockResolvedValue(undefined),
+  isClosed: vi.fn().mockReturnValue(false),
+  waitForReady: vi.fn().mockResolvedValue(undefined),
+});
+
+type MockCloser = ReturnType<typeof makeCloser>;
+
+type StreamInstance = {
+  callback: StreamCallback<number>;
+  onFail: () => void;
+  closer: MockCloser;
+};
+
+// Captures every native stream created by createStream so tests can drive
+// the value callback and the native close (onFail) callback directly.
+const makeHarness = () => {
+  const instances: StreamInstance[] = [];
+  const streamFunction = vi.fn(
+    async (callback: StreamCallback<number>, onFail: () => void) => {
+      const closer = makeCloser();
+      instances.push({ callback, onFail, closer });
+      return closer as unknown as StreamCloser;
+    },
+  );
+  const last = () => instances[instances.length - 1];
+  return { instances, streamFunction, last };
+};
+
+describe("createStream lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ends the native stream when the consumer ends the stream", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      retryDelay: 1000,
+    });
+
+    await stream.end();
+
+    expect(instances[0].closer.end).toHaveBeenCalled();
+  });
+
+  it("does not restart after end() during a pending retry", async () => {
+    const { streamFunction, last } = makeHarness();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      retryDelay: 1000,
+    });
+
+    // native close schedules a retry
+    last().onFail();
+    // consumer ends the stream before the retry delay expires
+    await stream.end();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(streamFunction).toHaveBeenCalledTimes(1);
+    // the pending retry timer must be cancelled
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("immediately closes a native stream created after end()", async () => {
+    const instances: StreamInstance[] = [];
+    let resolveSecond!: (closer: StreamCloser) => void;
+    const secondCloser = makeCloser();
+    const streamFunction = vi.fn(
+      (callback: StreamCallback<number>, onFail: () => void) => {
+        if (instances.length === 0) {
+          const closer = makeCloser();
+          instances.push({ callback, onFail, closer });
+          return Promise.resolve(closer as unknown as StreamCloser);
+        }
+        // second call: retry creation stays in flight until the test resolves it
+        instances.push({
+          callback,
+          onFail,
+          closer: secondCloser,
+        });
+        return new Promise<StreamCloser>((resolve) => {
+          resolveSecond = resolve;
+        });
+      },
+    );
+    const onRestart = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onRestart,
+      retryDelay: 1000,
+    });
+
+    // native close schedules a retry, then the retry enters streamFunction
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(streamFunction).toHaveBeenCalledTimes(2);
+
+    // consumer ends the stream while the retry creation is in flight
+    await stream.end();
+    resolveSecond(secondCloser as unknown as StreamCloser);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(secondCloser.end).toHaveBeenCalled();
+    expect(onRestart).not.toHaveBeenCalled();
+  });
+
+  it("suppresses onValue and onError after end()", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onValue = vi.fn();
+    const onError = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      onValue,
+    });
+
+    await stream.end();
+    instances[0].callback(null, 1);
+    instances[0].callback(new Error("boom"), undefined);
+
+    expect(onValue).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not emit a value whose async mutation resolves after end()", async () => {
+    const { instances, streamFunction } = makeHarness();
+    let resolveMutation!: (value: number) => void;
+    const mutator = vi.fn(
+      () =>
+        new Promise<number>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+    const onValue = vi.fn();
+    const stream = await createStream<number, number>(streamFunction, mutator, {
+      onValue,
+    });
+
+    // a value arrives and its async mutation is in flight
+    instances[0].callback(null, 1);
+    await stream.end();
+    resolveMutation(2);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onValue).not.toHaveBeenCalled();
+  });
+
+  it("allows only one retry in flight per stream", async () => {
+    const { streamFunction, last } = makeHarness();
+    await createStream<number>(streamFunction, undefined, {
+      retryDelay: 1000,
+    });
+
+    // multiple native close callbacks before the retry timer expires
+    last().onFail();
+    last().onFail();
+    last().onFail();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // initial stream + exactly one replacement
+    expect(streamFunction).toHaveBeenCalledTimes(2);
+  });
+
+  it("stays silent when end() precedes the native close callback", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onError = vi.fn();
+    const onFail = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      onFail,
+      retryDelay: 1000,
+    });
+
+    await stream.end();
+    // ending the native stream triggers its close callback
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(onFail).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(streamFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent when end() precedes the native close callback with retryOnFail disabled", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onError = vi.fn();
+    const onFail = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      onFail,
+      retryOnFail: false,
+    });
+
+    await stream.end();
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(onFail).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(streamFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops retrying after the retry budget is exhausted", async () => {
+    const { streamFunction, last } = makeHarness();
+    const onError = vi.fn();
+    const onRestart = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      onRestart,
+      retryAttempts: 3,
+      retryDelay: 1000,
+    });
+
+    // three failures, three successful restarts
+    for (let i = 0; i < 3; i++) {
+      last().onFail();
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+    expect(streamFunction).toHaveBeenCalledTimes(4);
+    expect(onRestart).toHaveBeenCalledTimes(3);
+
+    // the budget is monotonic: the next failure is terminal
+    last().onFail();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(streamFunction).toHaveBeenCalledTimes(4);
+    expect(onError).toHaveBeenCalledWith(expect.any(StreamFailedError));
+    expect(stream.isDone).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("counts failed restart attempts against the retry budget", async () => {
+    const instances: StreamInstance[] = [];
+    const streamFunction = vi.fn(
+      (callback: StreamCallback<number>, onFail: () => void) => {
+        if (instances.length === 0) {
+          const closer = makeCloser();
+          instances.push({ callback, onFail, closer });
+          return Promise.resolve(closer as unknown as StreamCloser);
+        }
+        // every restart attempt fails to create a stream
+        return Promise.reject(new Error("creation failed"));
+      },
+    );
+    const onError = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      retryAttempts: 2,
+      retryDelay: 1000,
+    });
+
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // initial stream + two failed restart attempts
+    expect(streamFunction).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledWith(expect.any(StreamFailedError));
+    expect(stream.isDone).toBe(true);
+  });
+
+  it("restarts the stream after a failure and continues delivering values", async () => {
+    const { instances, streamFunction, last } = makeHarness();
+    const onValue = vi.fn();
+    const onRestart = vi.fn();
+    const onRetry = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onRestart,
+      onRetry,
+      onValue,
+      retryDelay: 1000,
+    });
+
+    last().onFail();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(streamFunction).toHaveBeenCalledTimes(2);
+    expect(onRestart).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(1, 10);
+
+    // values flow through the replacement stream
+    last().callback(null, 42);
+    expect(onValue).toHaveBeenCalledWith(42);
+
+    // end() closes the replacement stream, not the original
+    await stream.end();
+    expect(instances[1].closer.end).toHaveBeenCalled();
+  });
+
+  it("invokes onEnd once when the stream ends", async () => {
+    const { streamFunction } = makeHarness();
+    const onEnd = vi.fn();
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onEnd,
+    });
+
+    await stream.end();
+    await stream.end();
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("ends the stream even when onError throws at terminal failure", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onError = vi.fn(() => {
+      throw new Error("consumer onError threw");
+    });
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onError,
+      retryAttempts: 0,
+      retryDelay: 1000,
+    });
+
+    // the exhausted-budget native close triggers a terminal failure; a
+    // throwing consumer onError must not prevent the stream from ending
+    expect(() => instances[0].onFail()).toThrow("consumer onError threw");
+
+    expect(onError).toHaveBeenCalledWith(expect.any(StreamFailedError));
+    expect(stream.isDone).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("suppresses onValue when a sync mutator ends the stream", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const onValue = vi.fn();
+    const streamRef: { end?: () => Promise<unknown> } = {};
+    const mutator = vi.fn((value: number) => {
+      // a synchronous mutator that ends the stream, then returns a value
+      void streamRef.end?.();
+      return value * 2;
+    });
+    const stream = await createStream<number, number>(streamFunction, mutator, {
+      onValue,
+    });
+    streamRef.end = () => stream.end();
+
+    // drive a value after the proxy exists so the mutator can end the stream
+    instances[0].callback(null, 1);
+
+    expect(mutator).toHaveBeenCalled();
+    expect(onValue).not.toHaveBeenCalled();
+  });
+});
 
 describe("createStream", () => {
   it("should forward StreamFailedError to onError", async () => {


### PR DESCRIPTION
## Summary

`createStream()` in the Node and Browser JS SDKs treated **every** native stream
close as a failure to be retried. That is unsafe when a consumer intentionally
ends a stream: the wrapper's `end()` did not actually stop the underlying retry
machinery, so ended streams kept coming back to life.

A downstream agent-sdk consumer running long-lived Node agents hit this in
production as a **zombie-stream leak**. Over time, native streams that nobody
could reach any longer kept re-delivering every XMTP message, with bursts of up
to **~146 duplicate `onValue` callbacks for a single message id**. The
population of zombies grew after every transport hiccup (h2 `UnexpectedEof` /
`BrokenPipe` recovery), so the amplification compounded with each recovery
round.

## Root cause

The agent-sdk's own recovery intentionally ends node-sdk streams. But ending a
stream did not stop anything downstream of it:

1. The consumer calls the wrapper's `end()`.
2. The native `on_close` still fires and was always interpreted as a failure.
3. node-sdk schedules a 60s retry timer that `end()` had no way to cancel.
4. When the retry fires it opens a **new** native stream, but the wrapper is
   already done — its closer is assigned to `asyncStream.onDone` *after*
   `onDone` has already run, so nothing can ever close it.
5. That orphaned native stream keeps invoking `onValue`, because delivery was
   never gated on the wrapper being done.

Every recovery round repeated this and added more unreachable, still-delivering
native streams. `end()` was not terminal.

## The fix — an explicit stream lifecycle

`createStream` in both
[`sdks/js/node-sdk/src/utils/streams.ts`](../blob/fix-stream-end-terminal/sdks/js/node-sdk/src/utils/streams.ts)
and
[`sdks/js/browser-sdk/src/utils/streams.ts`](../blob/fix-stream-end-terminal/sdks/js/browser-sdk/src/utils/streams.ts)
is rewritten around a single `stopped` flag and a `stop()` transition. `stop()`
is registered as `asyncStream.onDone` **before any async work begins**, so it is
in place no matter when the stream is ended. The lifecycle contract it
establishes:

1. **End cancels retries.** `stop()` clears the pending retry timer and never
   restarts one afterward.
2. **Intentional close is silent.** `stop()` sets the flag synchronously
   *before* calling the native closer's `end`, so the native close callback that
   follows an intentional `end()` is recognized as intentional and stays silent
   — no scheduled retry, no spurious `StreamFailedError`. (This was wrong even
   for `retryOnFail: false` consumers.)
3. **Late closers can't leak.** Every await point (stream creation,
   `waitForReady`, the async value mutators) re-checks the flag. A native closer
   that materializes *after* end is immediately closed and never installed.
4. **No callbacks after end.** `onValue` / `onError` / `onFail` are suppressed
   once stopped, including from in-flight async mutators.
5. **Single-flight retries.** At most one retry is in flight per wrapper.
6. **Monotonic retry budget.** `remainingRetries` never resets, so a restarted
   stream cannot refill its own budget.
7. **`onEnd` fires exactly once** when the stream ends. node-sdk previously never
   invoked its documented `onEnd` option at all; browser-sdk invoked it per
   closer.
8. **Default `retryOnFail: true` preserved** — non-breaking.

A small `isStopped()` helper reads the flag through a call because
typescript-eslint's `no-unnecessary-condition` cannot see the closure mutation
across `await` points and would otherwise narrow the flag to a constant.

browser-sdk additionally had an **infinite-retry bug**: at budget 0 it called
`retry(-1)`, which never terminates. The monotonic-budget logic above fixes it.

## Deliberate design decisions

- **Monotonic budget** (guarantee 6): a restarted stream inherits the remaining
  budget rather than a fresh one, so a flapping stream can't retry forever.
- **Default `retryOnFail` unchanged**: kept `true` to avoid a behavior change in
  this PR. Flipping the default to `false` is a possible future
  major-version change, not this one.
- **Preserved node/browser asymmetry on initial failure**: with
  `retryOnFail: false`, browser-sdk `createStream` **rejects** on the initial
  attempt while node-sdk **resolves** and reports via `onError`. Both are
  pre-existing, individually tested public behaviors and are intentionally left
  as-is here.

## Tests

Written TDD-style (red first — each new test was confirmed to fail for the
expected reason before the fix). 11 new lifecycle tests per SDK, using vitest
fake timers, covering: end during a pending retry, end while creation is
in-flight, no callbacks after end, the async-mutator race, single-flight,
silent intentional close (both `retryOnFail` modes), monotonic budget,
failed-attempt budget accounting, restart-and-deliver, and `onEnd`-once.

## Out of scope (follow-ups)

These land after the agent-sdk is migrated into this repo (migration in progress
separately):

- agent-sdk should pass `retryOnFail: false` so there is exactly **one** recovery
  owner.
- an agent-sdk ↔ node-sdk integration regression test that exercises the
  recovery-during-active-stream path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `createStream` end() terminal and race-safe in browser and node SDKs
> - Introduces a `stop()` terminal transition that cancels pending retry timers, closes the active native stream, and invokes `onEnd` exactly once; all value/error callbacks after `end()` are suppressed.
> - Replaces the recursive retry flow with `scheduleRetry()`/`attemptRestart()` to guarantee at most one retry is in flight at a time.
> - Treats the retry budget as monotonic across successful restarts and failed creations; exhausted retries or `retryOnFail: false` now end the stream with `StreamFailedError`.
> - Adds `fail(error)` to ensure the async stream terminates even if `onError` throws.
> - Behavioral Change: streams created after `end()` is called are immediately closed, and late async/sync mutator resolutions are suppressed rather than delivered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f5e39e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->