### PR TITLE
feat(agent-sdk): migrate @xmtp/agent-sdk from xmtp-js

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -52,6 +52,16 @@ on:
           - "minor"
           - "major"
         default: "none"
+      agent-sdk-bump:
+        description: "Agent SDK version bump"
+        required: false
+        type: choice
+        options:
+          - "none"
+          - "patch"
+          - "minor"
+          - "major"
+        default: "none"
       node:
         description: "Include Node bindings in release"
         required: false
@@ -83,6 +93,7 @@ jobs:
           ANDROID_BUMP: ${{ inputs.android-bump }}
           NODE_SDK_BUMP: ${{ inputs.node-sdk-bump }}
           BROWSER_SDK_BUMP: ${{ inputs.browser-sdk-bump }}
+          AGENT_SDK_BUMP: ${{ inputs.agent-sdk-bump }}
         run: |
           xmtp-release create-release-branch \
             --version "$RELEASE_VERSION" \
@@ -91,6 +102,7 @@ jobs:
             --android "$ANDROID_BUMP" \
             --node-sdk "$NODE_SDK_BUMP" \
             --browser-sdk "$BROWSER_SDK_BUMP" \
+            --agent-sdk "$AGENT_SDK_BUMP" \
             ${{ inputs.node && '--node' || '' }} \
             ${{ inputs.wasm && '--wasm' || '' }}
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,11 @@ name: NPM Publish
 on:
   workflow_call:
     inputs:
+      ref:
+        description: 'Git ref to check out, package, and tag. Defaults to the workflow run ref; callers building a different ref MUST pass it or the version stamp and tag land on the wrong commit.'
+        required: false
+        type: string
+        default: ''
       package-dir:
         description: 'Path to the npm package directory'
         required: true
@@ -69,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Download build artifacts
         if: ${{ inputs.artifact-pattern != '' }}

--- a/.github/workflows/release-agent-sdk.yml
+++ b/.github/workflows/release-agent-sdk.yml
@@ -1,0 +1,177 @@
+name: Release Agent SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        required: true
+        type: choice
+        description: "dev, rc, or final"
+        options:
+          - dev
+          - rc
+          - final
+      rc-number:
+        required: false
+        type: string
+        description: "RC number (required for rc releases)"
+      node-sdk-version:
+        required: false
+        type: string
+        description: "Published @xmtp/node-sdk version to pin (defaults to npm latest)"
+      dry-run:
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      release-type:
+        required: true
+        type: string
+        description: "dev, rc, or final"
+      rc-number:
+        required: false
+        type: string
+        description: "RC number (required for rc releases)"
+      ref:
+        required: false
+        type: string
+        description: "Git ref to build from"
+      node-sdk-version:
+        required: false
+        type: string
+        description: "Published @xmtp/node-sdk version to pin (defaults to npm latest)"
+      pending-version:
+        required: false
+        type: string
+      pending-kind:
+        required: false
+        type: string
+      dry-run:
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      version:
+        description: "The published version string"
+        value: ${{ jobs.publish.outputs.version }}
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      node-sdk-version: ${{ steps.node-sdk-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: ./.github/actions/setup-release-tools
+
+      # Inputs are passed through env, never interpolated into shell source:
+      # this job holds contents/id-token write and dispatch inputs are free text.
+      - name: Compute version
+        id: version
+        env:
+          RELEASE_TYPE: ${{ inputs.release-type }}
+          RC_NUMBER: ${{ inputs.rc-number }}
+          PENDING_VERSION: ${{ inputs.pending-version }}
+          PENDING_KIND: ${{ inputs.pending-kind }}
+        run: |
+          if [ "$RELEASE_TYPE" = "rc" ]; then
+            VERSION=$(xmtp-release compute-version --sdk agent-sdk --release-type rc --rc-number "$RC_NUMBER")
+          elif [ "$RELEASE_TYPE" = "dev" ]; then
+            VERSION=$(xmtp-release compute-version --sdk agent-sdk --release-type dev)
+          elif [ "$RELEASE_TYPE" = "nightly" ]; then
+            if [ -z "$PENDING_VERSION" ] || [ -z "$PENDING_KIND" ]; then
+              echo "::error::nightly resolve called with empty pending version/kind"
+              exit 1
+            fi
+            VERSION=$(xmtp-release resolve-sdk-version \
+              --sdk agent-sdk --release-type nightly \
+              --pending-version "$PENDING_VERSION" \
+              --pending-kind "$PENDING_KIND")
+          else
+            VERSION=$(xmtp-release compute-version --sdk agent-sdk --release-type final)
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Computed version: $VERSION"
+
+      # The published package must depend on a published node-sdk, not the
+      # in-repo workspace copy it builds against.
+      - name: Resolve node-sdk version to pin
+        id: node-sdk-version
+        env:
+          NODE_SDK_VERSION: ${{ inputs.node-sdk-version }}
+        run: |
+          if [ -n "$NODE_SDK_VERSION" ]; then
+            VERSION="$NODE_SDK_VERSION"
+          else
+            VERSION=$(npm view @xmtp/node-sdk version)
+          fi
+          # The value flows into package.json via set-dependency-version;
+          # reject anything that is not a plain semver version.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::invalid @xmtp/node-sdk version: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Pinning @xmtp/node-sdk to: $VERSION"
+
+  build:
+    needs: setup
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    env:
+      NIX_DEVSHELL: js
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/setup-nix
+        with:
+          nix-disk: "false"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - uses: taiki-e/install-action@just
+
+      - name: Stage node bindings
+        run: just js bindings
+
+      - name: Install + build agent-sdk
+        run: |
+          nix develop .#js --command bash -euc '
+            cd sdks/js && yarn install --immutable
+            yarn workspace @xmtp/node-sdk run build
+            yarn workspace @xmtp/agent-sdk run build'
+
+      - name: Upload build output
+        uses: actions/upload-artifact@v7
+        with:
+          name: agent_sdk_build
+          path: sdks/js/agent-sdk/dist
+          retention-days: 1
+
+  publish:
+    needs: [setup, build]
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      package-dir: sdks/js/agent-sdk
+      install-dir: sdks/js
+      lockfile-path: sdks/js/yarn.lock
+      sdk: agent-sdk
+      version: ${{ needs.setup.outputs.version }}
+      artifact-pattern: agent_sdk_build
+      artifact-path: sdks/js/agent-sdk/dist
+      ignore-scripts: true
+      dep-name: "@xmtp/node-sdk"
+      dep-version: ${{ needs.setup.outputs.node-sdk-version }}
+      dry-run: ${{ inputs.dry-run }}
+    secrets: inherit

--- a/.github/workflows/release-browser-sdk.yml
+++ b/.github/workflows/release-browser-sdk.yml
@@ -120,6 +120,7 @@ jobs:
     needs: [setup, build, bindings]
     uses: ./.github/workflows/npm-publish.yml
     with:
+      ref: ${{ inputs.ref }}
       package-dir: sdks/js/browser-sdk
       install-dir: sdks/js
       lockfile-path: sdks/js/yarn.lock

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -120,6 +120,7 @@ jobs:
     needs: [setup, build, bindings]
     uses: ./.github/workflows/npm-publish.yml
     with:
+      ref: ${{ inputs.ref }}
       package-dir: sdks/js/node-sdk
       install-dir: sdks/js
       lockfile-path: sdks/js/yarn.lock

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -246,6 +246,7 @@ jobs:
       ]
     uses: ./.github/workflows/npm-publish.yml
     with:
+      ref: ${{ inputs.ref }}
       package-dir: bindings/node
       sdk: node-bindings
       version: ${{ needs.setup.outputs.version }}

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -102,6 +102,7 @@ jobs:
     needs: [setup, build]
     uses: ./.github/workflows/npm-publish.yml
     with:
+      ref: ${{ inputs.ref }}
       package-dir: bindings/wasm
       sdk: wasm-bindings
       version: ${{ needs.setup.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ on:
         required: false
         type: boolean
         default: false
+      agent-sdk:
+        description: "Release Agent SDK"
+        required: false
+        type: boolean
+        default: false
       no-merge:
         description: "Skip merging the release PR to main (only applies to final releases)"
         required: false
@@ -63,6 +68,7 @@ jobs:
       android: ${{ steps.resolve.outputs.android }}
       node-sdk: ${{ steps.resolve.outputs.node-sdk }}
       browser-sdk: ${{ steps.resolve.outputs.browser-sdk }}
+      agent-sdk: ${{ steps.resolve.outputs.agent-sdk }}
       dry-run: ${{ steps.resolve.outputs.dry-run }}
       skip: ${{ steps.skip-check.outputs.skip }}
     steps:
@@ -77,6 +83,7 @@ jobs:
           INPUT_ANDROID: ${{ inputs.android }}
           INPUT_NODE_SDK: ${{ inputs.node-sdk }}
           INPUT_BROWSER_SDK: ${{ inputs.browser-sdk }}
+          INPUT_AGENT_SDK: ${{ inputs.agent-sdk }}
           INPUT_DRY_RUN: ${{ inputs.dry-run }}
         run: |
           if [ "$EVENT_NAME" = "schedule" ]; then
@@ -86,6 +93,7 @@ jobs:
             echo "android=true" >> "$GITHUB_OUTPUT"
             echo "node-sdk=true" >> "$GITHUB_OUTPUT"
             echo "browser-sdk=true" >> "$GITHUB_OUTPUT"
+            echo "agent-sdk=true" >> "$GITHUB_OUTPUT"
             echo "dry-run=false" >> "$GITHUB_OUTPUT"
           else
             echo "release-type=$INPUT_RELEASE_TYPE" >> "$GITHUB_OUTPUT"
@@ -94,6 +102,7 @@ jobs:
             echo "android=$INPUT_ANDROID" >> "$GITHUB_OUTPUT"
             echo "node-sdk=$INPUT_NODE_SDK" >> "$GITHUB_OUTPUT"
             echo "browser-sdk=$INPUT_BROWSER_SDK" >> "$GITHUB_OUTPUT"
+            echo "agent-sdk=$INPUT_AGENT_SDK" >> "$GITHUB_OUTPUT"
             echo "dry-run=${INPUT_DRY_RUN:-false}" >> "$GITHUB_OUTPUT"
           fi
       - name: Validate dev release
@@ -229,12 +238,33 @@ jobs:
       dry-run: ${{ needs.validate.outputs.dry-run == 'true' }}
     secrets: inherit
 
+  # Depends on release-node-sdk so the published agent-sdk pins the node-sdk
+  # version shipped by this same run; when node-sdk is deselected (skipped),
+  # the empty version input falls back to npm latest inside the workflow.
+  release-agent-sdk:
+    needs: [validate, plan, release-node-sdk]
+    if: >-
+      !cancelled() && !contains(needs.*.result, 'failure')
+      && needs.validate.outputs.agent-sdk == 'true' && needs.validate.outputs.skip != 'true'
+      && (needs.validate.outputs.release-type != 'nightly'
+          || (needs.plan.outputs.gate-skip != 'true' && needs.plan.outputs.nothing-pending != 'true'))
+    uses: ./.github/workflows/release-agent-sdk.yml
+    with:
+      release-type: ${{ needs.validate.outputs.release-type }}
+      rc-number: ${{ inputs.rc-number }}
+      ref: ${{ needs.validate.outputs.ref }}
+      node-sdk-version: ${{ needs.release-node-sdk.outputs.version }}
+      pending-version: ${{ needs.plan.outputs.version }}
+      pending-kind: ${{ needs.plan.outputs.kind }}
+      dry-run: ${{ needs.validate.outputs.dry-run == 'true' }}
+    secrets: inherit
+
   merge-pr:
     # dry-run must not mutate the repo: a final + dry-run would otherwise merge
     # and delete the release branch even though the release-* jobs were skipped
     # (skipped ≠ failure, so the !contains(failure) check alone lets it through).
     if: needs.validate.outputs.release-type == 'final' && !inputs.no-merge && !cancelled() && !contains(needs.*.result, 'failure') && needs.validate.outputs.dry-run != 'true'
-    needs: [validate, release-ios, release-android, release-node-sdk, release-browser-sdk]
+    needs: [validate, release-ios, release-android, release-node-sdk, release-browser-sdk, release-agent-sdk]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -273,7 +303,7 @@ jobs:
   # Do NOT drop any of the three; they jointly make non-nightly run and nightly
   # block-on-not-green / block-on-error.
   hub:
-    needs: [validate, plan, release-ios, release-android, release-node-sdk, release-browser-sdk]
+    needs: [validate, plan, release-ios, release-android, release-node-sdk, release-browser-sdk, release-agent-sdk]
     if: >-
       needs.validate.outputs.release-type == 'nightly'
       && needs.plan.outputs.gate-skip != 'true'
@@ -367,6 +397,7 @@ jobs:
           ANDROID_VERSION: ${{ needs.release-android.outputs.version }}
           NODE_VERSION: ${{ needs.release-node-sdk.outputs.binding-version }}
           WASM_VERSION: ${{ needs.release-browser-sdk.outputs.binding-version }}
+          AGENT_VERSION: ${{ needs.release-agent-sdk.outputs.version }}
         run: |
           set -euo pipefail
           BODY=$(cat <<EOF
@@ -380,6 +411,7 @@ jobs:
           | Android | ${ANDROID_VERSION:-—} |
           | Node | ${NODE_VERSION:-—} |
           | WASM | ${WASM_VERSION:-—} |
+          | Agent | ${AGENT_VERSION:-—} |
 
           See per-SDK release notes under \`docs/release-notes/\`.
           EOF
@@ -406,7 +438,7 @@ jobs:
           fi
 
   notify:
-    needs: [validate, plan, hub, release-ios, release-android, release-node-sdk, release-browser-sdk, merge-pr]
+    needs: [validate, plan, hub, release-ios, release-android, release-node-sdk, release-browser-sdk, release-agent-sdk, merge-pr]
     if: always() && needs.validate.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
@@ -421,6 +453,8 @@ jobs:
           NODE_VERSION: ${{ needs.release-node-sdk.outputs.binding-version }}
           WASM_RESULT: ${{ needs.release-browser-sdk.result }}
           WASM_VERSION: ${{ needs.release-browser-sdk.outputs.binding-version }}
+          AGENT_RESULT: ${{ needs.release-agent-sdk.result }}
+          AGENT_VERSION: ${{ needs.release-agent-sdk.outputs.version }}
           RELEASE_TYPE: ${{ needs.validate.outputs.release-type }}
         run: |
           MSG="${RELEASE_TYPE^} Release:"
@@ -435,6 +469,9 @@ jobs:
           fi
           if [ -n "$WASM_VERSION" ] || [ "$WASM_RESULT" != "skipped" ]; then
             MSG="$MSG WASM ${WASM_VERSION:-failed} (${WASM_RESULT})"
+          fi
+          if [ -n "$AGENT_VERSION" ] || [ "$AGENT_RESULT" != "skipped" ]; then
+            MSG="$MSG Agent ${AGENT_VERSION:-failed} (${AGENT_RESULT})"
           fi
           echo "message=$MSG" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/slack-notify

--- a/.github/workflows/test-agent-sdk.yml
+++ b/.github/workflows/test-agent-sdk.yml
@@ -1,0 +1,25 @@
+name: Test Agent SDK
+on:
+  workflow_call:
+env:
+  NIX_DEVSHELL: js
+jobs:
+  test:
+    name: Test (agent-sdk)
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-nix
+        with:
+          disk-key: web
+          docker-builder: "true"
+          github-token: ${{ github.token }}
+      - uses: taiki-e/install-action@just
+      - name: Install dependencies
+        run: just js install-ci
+      - name: Start backend
+        run: just backend up
+      - name: Run agent-sdk tests
+        run: just js test-agent-sdk-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       wasm: ${{ steps.filter.outputs.wasm }}
       node_sdk: ${{ steps.filter.outputs.node_sdk }}
       browser_sdk: ${{ steps.filter.outputs.browser_sdk }}
+      agent_sdk: ${{ steps.filter.outputs.agent_sdk }}
       ios: ${{ steps.filter.outputs.ios }}
       android: ${{ steps.filter.outputs.android }}
       bindings-check: ${{ steps.filter.outputs.bindings-check }}
@@ -95,6 +96,22 @@ jobs:
               - 'flake.lock'
               - 'dev/docker/**'
               - '.github/workflows/test-browser-sdk*'
+            agent_sdk:
+              - 'sdks/js/agent-sdk/**'
+              - 'sdks/js/node-sdk/**'
+              - 'sdks/js/package.json'
+              - 'sdks/js/yarn.lock'
+              - 'sdks/js/.yarnrc.yml'
+              - 'sdks/js/tsconfig.json'
+              - 'sdks/js/eslint.config.js'
+              - 'sdks/js/js.just'
+              - 'sdks/js/dev/**'
+              - 'bindings/node/**'
+              - 'crates/**'
+              - 'nix/**'
+              - 'flake.lock'
+              - 'dev/docker/**'
+              - '.github/workflows/test-agent-sdk*'
             ios:
               - 'sdks/ios/**'
               - 'bindings/mobile/**'
@@ -200,6 +217,16 @@ jobs:
     uses: ./.github/workflows/test-browser-sdk.yml
     secrets: inherit
 
+  # Gated on test-node like node-sdk: agent-sdk runs against the local
+  # node-sdk (workspace dependency), whose bindings must be a nix cache hit.
+  test-agent-sdk:
+    needs: [detect-changes, test-node]
+    if: >-
+      !cancelled() && needs.test-node.result != 'failure'
+      && needs.detect-changes.outputs.agent_sdk == 'true'
+    uses: ./.github/workflows/test-agent-sdk.yml
+    secrets: inherit
+
   test-ios:
     needs: detect-changes
     if: |
@@ -250,6 +277,7 @@ jobs:
       - test-wasm
       - test-node-sdk
       - test-browser-sdk
+      - test-agent-sdk
       # - test-ios TODO:(nm) Temporarily making optional until we are confident the new workflows are fast/reliable enough to block CI
       # - test-android TODO:(nm) Temporarily making optional until we are confident the new workflows are fast/reliable enough to block CI
       - test-bindings-check

--- a/dev/release-tools/src/commands/create-release-branch.ts
+++ b/dev/release-tools/src/commands/create-release-branch.ts
@@ -58,6 +58,12 @@ export function builder(yargs: Argv<GlobalArgs>) {
       choices: BUMP_OPTIONS,
       describe: "Browser SDK version bump type",
     })
+    .option("agent-sdk", {
+      type: "string",
+      default: "none",
+      choices: BUMP_OPTIONS,
+      describe: "Agent SDK version bump type",
+    })
     .option("node", {
       type: "boolean",
       default: false,
@@ -77,6 +83,7 @@ interface CreateReleaseBranchArgs extends GlobalArgs {
   android: string;
   nodeSdk?: string;
   browserSdk?: string;
+  agentSdk?: string;
   node: boolean;
   wasm: boolean;
 }
@@ -100,6 +107,9 @@ export function handler(argv: ArgumentsCamelCase<CreateReleaseBranchArgs>) {
   if (argv.browserSdk && argv.browserSdk !== "none") {
     sdkBumps.push({ sdk: Sdk.BrowserSdk, bump: argv.browserSdk as BumpType });
   }
+  if (argv.agentSdk && argv.agentSdk !== "none") {
+    sdkBumps.push({ sdk: Sdk.AgentSdk, bump: argv.agentSdk as BumpType });
+  }
 
   // Collect SDK includes (node/wasm just set the version directly)
   const sdkIncludes: Sdk[] = [];
@@ -113,7 +123,7 @@ export function handler(argv: ArgumentsCamelCase<CreateReleaseBranchArgs>) {
   // Validate at least one SDK is being released
   if (sdkBumps.length === 0 && sdkIncludes.length === 0) {
     throw new Error(
-      "At least one SDK must be bumped (use --ios/--android/--node-sdk/--browser-sdk with a bump type, or --node/--wasm)",
+      "At least one SDK must be bumped (use --ios/--android/--node-sdk/--browser-sdk/--agent-sdk with a bump type, or --node/--wasm)",
     );
   }
 

--- a/dev/release-tools/src/lib/sdk-config.ts
+++ b/dev/release-tools/src/lib/sdk-config.ts
@@ -86,6 +86,23 @@ export const SDK_CONFIGS: Record<Sdk, SdkConfig> = {
     releaseWorkflow: "release-node-sdk.yml",
     channels: ["nightly", "rc", "final"],
   },
+  [Sdk.AgentSdk]: {
+    name: "Agent SDK",
+    manifestPath: "sdks/js/agent-sdk/package.json",
+    tagPrefix: "agent-sdk-",
+    artifactTagSuffix: "",
+    manifest: createPackageJsonManifestProvider("sdks/js/agent-sdk/package.json"),
+    versionTrack: "independent",
+    notesIncludeGlobs: ["sdks/js/agent-sdk/**"],
+    notesExcludeGlobs: [
+      "crates/**",
+      "bindings/**",
+      "sdks/js/node-sdk/**",
+      "sdks/js/browser-sdk/**",
+    ],
+    releaseWorkflow: "release-agent-sdk.yml",
+    channels: ["nightly", "rc", "final"],
+  },
   [Sdk.Libxmtp]: {
     name: "Libxmtp",
     manifestPath: "Cargo.toml",

--- a/dev/release-tools/src/types.ts
+++ b/dev/release-tools/src/types.ts
@@ -5,6 +5,7 @@ export enum Sdk {
   WasmBindings = "wasm-bindings",
   BrowserSdk = "browser-sdk",
   NodeSdk = "node-sdk",
+  AgentSdk = "agent-sdk",
   Libxmtp = "libxmtp",
 }
 

--- a/dev/release-tools/tests/commands/list-sdks.test.ts
+++ b/dev/release-tools/tests/commands/list-sdks.test.ts
@@ -5,7 +5,7 @@ describe("listSdksForChannel", () => {
   it("returns fan-out targets for nightly, excluding the hub", () => {
     const rows = listSdksForChannel("nightly");
     const names = rows.map((r) => r.sdk).sort();
-    expect(names).toEqual(["android", "browser-sdk", "ios", "node-bindings", "node-sdk", "wasm-bindings"]);
+    expect(names).toEqual(["agent-sdk", "android", "browser-sdk", "ios", "node-bindings", "node-sdk", "wasm-bindings"]);
     // hub (libxmtp, empty releaseWorkflow) is excluded
     expect(rows.every((r) => r.releaseWorkflow !== "")).toBe(true);
   });

--- a/dev/release-tools/tests/sdk-config.test.ts
+++ b/dev/release-tools/tests/sdk-config.test.ts
@@ -31,6 +31,10 @@ describe("SDK configs", () => {
     expect(nodeSdk.name).toBe("Node SDK");
     expect(nodeSdk.tagPrefix).toBe("node-sdk-");
 
+    const agentSdk = getSdkConfig("agent-sdk");
+    expect(agentSdk.name).toBe("Agent SDK");
+    expect(agentSdk.tagPrefix).toBe("agent-sdk-");
+
     const libxmtp = getSdkConfig("libxmtp");
     expect(libxmtp.name).toBe("Libxmtp");
     expect(libxmtp.tagPrefix).toBe("v");
@@ -38,7 +42,7 @@ describe("SDK configs", () => {
 
   it("throws for unknown SDK with available options", () => {
     expect(() => getSdkConfig("unknown")).toThrow(
-      "Unknown SDK: unknown. Available: ios, android, node-bindings, wasm-bindings, browser-sdk, node-sdk, libxmtp",
+      "Unknown SDK: unknown. Available: ios, android, node-bindings, wasm-bindings, browser-sdk, node-sdk, agent-sdk, libxmtp",
     );
   });
 

--- a/sdks/js/agent-sdk/CHANGELOG.md
+++ b/sdks/js/agent-sdk/CHANGELOG.md
@@ -1,0 +1,464 @@
+# @xmtp/agent-sdk
+
+## 2.3.0
+
+### Minor Changes
+
+- 3557ccb: Added restart on error for streams in Agent SDK
+
+## 2.2.1
+
+### Patch Changes
+
+- 4f801a9: Added Wizard middleware for multi-step setup flows
+
+## 2.2.0
+
+### Minor Changes
+
+- da8658f: Added transaction utility functions
+
+## 2.1.0
+
+### Minor Changes
+
+- 126833a: Added PerformanceMonitor middleware
+
+## 2.0.2
+
+### Patch Changes
+
+- a87b56b: Added help command configuration to CommandRouter middleware
+
+## 2.0.1
+
+### Patch Changes
+
+- e100655: Added native events from Node SDK
+
+## 2.0.0
+
+This release includes major improvements and breaking changes to align with Node SDK 5.x. The SDK is now simpler to use with unified exports and cleaner APIs.
+
+### Breaking Changes
+
+The Agent SDK now depends on `@xmtp/node-sdk` v5.2.0, which includes significant API changes.
+
+#### Removed `sendText` and `sendMarkdown` from `ConversationContext`
+
+Use `conversation.sendText()` and `conversation.sendMarkdown()` directly instead:
+
+```ts
+// Before
+await ctx.sendText("Hello");
+await ctx.sendMarkdown("**Hello**");
+
+// After
+await ctx.conversation.sendText("Hello");
+await ctx.conversation.sendMarkdown("**Hello**");
+```
+
+#### Built-in content types
+
+The Node SDK now includes built-in support for all standard content types. These content types can be sent using dedicated methods on `conversation`:
+
+```ts
+await ctx.conversation.sendText("Hello!");
+await ctx.conversation.sendMarkdown("**Bold** and _italic_");
+await ctx.conversation.sendReaction(reaction);
+await ctx.conversation.sendReply(reply);
+await ctx.conversation.sendReadReceipt();
+await ctx.conversation.sendAttachment(attachment);
+await ctx.conversation.sendRemoteAttachment(remoteAttachment);
+await ctx.conversation.sendMultiRemoteAttachment(attachments);
+await ctx.conversation.sendTransactionReference(txRef);
+await ctx.conversation.sendWalletSendCalls(walletCalls);
+```
+
+#### Content type filters moved to Node SDK
+
+The following filters have been removed from `filter.*` and are now exported directly from the SDK:
+
+- `isGroupUpdated` (renamed from `isGroupUpdate`)
+- `isMarkdown`
+- `isReaction`
+- `isReadReceipt`
+- `isRemoteAttachment`
+- `isReply`
+- `isText`
+- `isTextReply`
+- `isTransactionReference`
+- `isWalletSendCalls`
+
+```ts
+// Before
+import { filter } from "@xmtp/agent-sdk";
+if (filter.isText(message)) { ... }
+
+// After
+import { isText } from "@xmtp/agent-sdk";
+if (isText(message)) { ... }
+```
+
+#### `downloadRemoteAttachment` API simplified
+
+The function no longer requires an agent parameter:
+
+```ts
+// Before
+const attachment = await downloadRemoteAttachment(remoteAttachment, agent);
+
+// After
+const attachment = await downloadRemoteAttachment(remoteAttachment);
+```
+
+#### Attachment `data` property renamed to `content`
+
+The `Attachment` type now uses `content` instead of `data` for the payload.
+
+#### `consentState` is now a method
+
+```ts
+// Before
+const state = conversation.consentState;
+
+// After
+const state = conversation.consentState();
+```
+
+#### Debug environment variable changes
+
+`XMTP_FORCE_DEBUG` has been removed. Use `XMTP_FORCE_DEBUG_LEVEL` to enable debug logging:
+
+```bash
+XMTP_FORCE_DEBUG_LEVEL=Debug
+```
+
+### New Features
+
+#### Gateway host configuration
+
+Added support for `XMTP_GATEWAY_HOST` environment variable to configure the gateway host.
+
+#### Unified exports
+
+All utilities are now exported from the main entry point. Subpackage imports are no longer needed:
+
+```ts
+// Before
+import { Agent } from "@xmtp/agent-sdk";
+import { CommandRouter } from "@xmtp/agent-sdk/middleware";
+import { createUser, createSigner } from "@xmtp/agent-sdk/user";
+import { getTestUrl, logDetails } from "@xmtp/agent-sdk/debug";
+
+// After
+import {
+  Agent,
+  CommandRouter,
+  createUser,
+  createSigner,
+  getTestUrl,
+  logDetails,
+} from "@xmtp/agent-sdk";
+```
+
+#### Improved default app version
+
+The SDK now uses the agent SDK version as the default `appVersion` instead of `"agent-sdk/alpha"`.
+
+## 1.2.4
+
+### Patch Changes
+
+- 1f7e6ed: Exposed command list in CommandRouter middleware
+
+## 1.2.3
+
+### Patch Changes
+
+- d655457: Added support for encrypted file attachments
+
+## 1.2.2
+
+Upgraded Node SDK to `4.6.0`
+
+## 1.2.1
+
+### Patch Changes
+
+- 1f737c5: Fixed LibXMTP version reporting
+
+## 1.2.0
+
+This release includes a new property, performance optimizations and bug fixes. If you've been building on a previous release, this one should be a **drop-in replacement**. Update as soon as possible to take advantage of these optimizations and fixes.
+
+### New `libxmtpVersion` property
+
+The `libxmtpVersion` property can be useful for debugging or ensuring compatibility with the underlying XMTP APIs.
+
+For more information on these updates, see these [release notes](https://github.com/xmtp/xmtp-js/releases/tag/%40xmtp%2Fnode-sdk%404.5.0) for the Node SDK.
+
+## 1.1.16
+
+### Patch Changes
+
+- f3017b3: Disabled device sync by default
+
+## 1.1.15
+
+### Patch Changes
+
+- cddbb41: Made streaming options configurable
+
+## 1.1.14
+
+### Patch Changes
+
+- 8e6c633: Strip the command token in the message context of `CommandRouter`
+- 1fe5810: Pinned Node.js SDK version
+
+## 1.1.13
+
+### Patch Changes
+
+- 24c866e: Exported `usesCodec` in `filter`
+
+## 1.1.12
+
+### Patch Changes
+
+- 13a14ba:
+  - Update xmtp.chat URLs
+  - Updated dependencies
+    - @xmtp/node-sdk@4.2.6
+
+## 1.1.11
+
+### Patch Changes
+
+- e01f21b: Add AgentStreamingError
+
+## 1.1.10
+
+### Patch Changes
+
+- 594dd71: Re-export `isHexString` and discriminating content types in `CommandRouter` handlers
+
+## 1.1.9
+
+### Patch Changes
+
+- bde0bfb: Expose `XMTP_DB_DIRECTORY` for `Agent.createFromEnv`
+
+## 1.1.8
+
+### Patch Changes
+
+- 9003bb9: Enable hex strings as database encryption keys
+- Updated dependencies [9003bb9]
+  - @xmtp/node-sdk@4.2.4
+
+## 1.1.7
+
+### Patch Changes
+
+- 8279497: Added warning about installation limit
+
+## 1.1.6
+
+### Patch Changes
+
+- 932f01d: - Fixed an issue where duplicate welcome errors were fired erroneously
+  - Fixed a bug where building a client did a network request when not needed
+
+## 1.1.5
+
+### Patch Changes
+
+- d0798bc: Updated `@xmtp/node-sdk` dependency to `^4.2.2`
+
+## 1.1.4
+
+### Patch Changes
+
+- 45160dc: Added `MessageContext.useCodec` to identify custom content types
+
+## 1.1.3
+
+### Patch Changes
+
+- 3c28612: Added XMTP_FORCE_DEBUG_LEVEL env variable
+
+## 1.1.2
+
+### Patch Changes
+
+- 9538002: Added ENS name resolution
+
+## 1.1.1
+
+### Patch Changes
+
+- a0b5d11: Updated Node SDK in Agent SDK
+
+## 1.1.0
+
+### Minor Changes
+
+- 70d1a21: Added listening to conversation events
+
+## 1.0.1
+
+### Patch Changes
+
+- 54577da: Added "group-update" events
+
+## 1.0.0
+
+### Major Changes
+
+- 5b0c9f8: Removed Beta label
+
+## 0.0.17
+
+### Patch Changes
+
+- e0b035c: - Added conversation creation
+
+## 0.0.16
+
+### Patch Changes
+
+- 07ea5c3: - Exposed `debug`, `middleware`, and `user` packages
+  - Passed `ClientContext` to `start` and `stop` event listeners
+
+## 0.0.15
+
+### Patch Changes
+
+- 07fa1c3: Implemented message streaming with callbacks
+
+## 0.0.14
+
+### Patch Changes
+
+- 4da121f: Remove listening to `'dm'` and `'group'` events
+
+## 0.0.13
+
+### Patch Changes
+
+- b4f86cc: - Simplified filter usage with parameter-based API
+  - Removed `withFilter`
+  - Changed all interface definitions to type definitions
+  - Updated `ConversationContext` to use new filter methods
+  - Introduced unified context types in `AgentContext`
+
+## 0.0.12
+
+### Patch Changes
+
+- 2bcf5ee: - Renamed `ctx.getOwnAddress()` to `ctx.getClientAddress()`
+  - Added `AgentError` class with `cause` attribute (keeping the originating error)
+  - Introduced error `code` values for programmatic handling of `AgentError` instances
+  - Added Context hierarchy: `ClientContext` → client, `ConversationContext` → client, conversation, `MessageContext` → client, conversation, message
+  - Added `AgentContext` union type for all contexts
+  - Error middleware now receives `AgentErrorContext` (holds client, conversation, message if available)
+
+## 0.0.11
+
+### Patch Changes
+
+- 7e0c321: - Removed "crypto" and "message" utils
+  - Removed `filter.notFromSelf` in favor of `!filter.fromSelf`
+  - Added `filter.hasDefinedContent`
+  - Added `filter.isDM`
+  - Added `filter.isGroup`
+  - Added `filter.isReaction`
+  - Added `filter.isRemoteAttachment`
+  - Added `filter.isReply`
+  - Added `filter.isTextReply`
+  - Allowed async filters
+  - Added tests to verify typed message content in event callbacks
+
+## 0.0.10
+
+### Patch Changes
+
+- 20d64c3: Skipped messages from agent itself in middleware
+
+## 0.0.9
+
+### Patch Changes
+
+- 854a9d1: - Renamed `filter.textOnly` to `filter.isText`
+  - Renamed `AgentContext` to `MessageContext`
+  - Renamed event `on("message")` to `on("unhandledMessage")`
+  - Added `on("dm")` for direct messages
+  - Added `on("attachment")` for remote attachments
+  - Added `on("group")` for group messages
+  - Added `on("reaction")` for reactions
+  - Added `on("reply")` for replies
+  - Introduced `ConversationContext` for handling new conversations
+
+## 0.0.8
+
+### Patch Changes
+
+- 0857103: - Forced middleware to call `next` to execute the next middleware or `return` to break the middleware chain
+  - Made `use` accept an array of middlewares
+  - Forwarded options to `streamAllMessages`
+  - Replaced `generatePrivateKey` with implementation from `viem/accounts`
+  - Removed `@noble/curves` package
+  - Renamed `AgentEventHandler` to `AgentMessageHandler`
+  - Introduced error-handling middleware chain (`agent.errors.on`)
+
+## 0.0.7
+
+### Patch Changes
+
+- b296a2a: - Exposed default middleware
+  - Exposed debug utils
+  - Added default Reaction schema
+
+## 0.0.6
+
+### Patch Changes
+
+- 8277202: Locked dependency versions
+
+## 0.0.5
+
+### Patch Changes
+
+- 071aed4: - Made `signer` optional in `Agent.create` to allow Agent configuration via env variables
+  - Introduced `crypto` utils
+  - Exposed `filter` with `f` alias
+  - Introduced `XMTP_FORCE_REVOKE_INSTALLATIONS` and `XMTP_FORCE_DEBUG`
+  - Removed `Agent.build`
+  - Added `gen:keys` command for agent contributors
+  - Added `CommandRouter` middleware
+  - Added `startsWith` filter
+  - Added codecs for `Reaction` and `RemoteAttachment`
+  - Added `sendReaction` functionality through `AgentContext`
+  - Added `getOwnAddress()` in `AgentContext`
+  - Added `debug` util with `logDetails()` functionality
+  - Added `message` utils with type guards for different content types
+
+## 0.0.4
+
+### Patch Changes
+
+- 880f8f2: Added path alias resolution
+
+## 0.0.3
+
+### Patch Changes
+
+- f83dcf9: Fixed module resolution for ESM
+
+## 0.0.2
+
+### Patch Changes
+
+- 5a2bd1e: Fixed dist reference in Agent SDK

--- a/sdks/js/agent-sdk/LICENSE
+++ b/sdks/js/agent-sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 XMTP (xmtp.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdks/js/agent-sdk/README.md
+++ b/sdks/js/agent-sdk/README.md
@@ -1,0 +1,480 @@
+# XMTP Agent SDK
+
+Build event‑driven, middleware‑powered messaging agents on the XMTP network. 🚀
+
+## Documentation
+
+Full agent building guide: **[Build an XMTP Agent](https://docs.xmtp.org/agents/get-started/build-an-agent)**
+
+This SDK is based on familiar Node.js patterns: you register event listeners, compose middleware, and extend behavior just like you would in frameworks such as [Express](https://expressjs.com/). This makes it easy to bring existing JavaScript and TypeScript skills into building conversational agents.
+
+## Installation
+
+Choose your package manager:
+
+```bash
+npm install @xmtp/agent-sdk
+# or
+pnpm add @xmtp/agent-sdk
+# or
+yarn add @xmtp/agent-sdk
+```
+
+## Quick Start
+
+```ts
+import { Agent, createUser, createSigner, getTestUrl } from "@xmtp/agent-sdk";
+
+// 1. Create a local user + signer (you can plug in your own wallet signer)
+const user = createUser();
+const signer = createSigner(user);
+
+// 2. Spin up the agent
+const agent = await Agent.create(signer, {
+  env: "dev", // or 'production'
+  dbPath: null, // in-memory store; provide a path to persist
+});
+
+// 3. Respond to text messages
+agent.on("text", async (ctx) => {
+  await ctx.sendText("Hello from my XMTP Agent! 👋");
+});
+
+// 4. Log when we're ready
+agent.on("start", (ctx) => {
+  console.log(`We are online: ${getTestUrl(ctx.client)}`);
+});
+
+await agent.start();
+```
+
+## Environment Variables
+
+The XMTP Agent SDK supports configuration through environment variables (`process.env`), making it easy to configure your agent without code changes. Set the following variables and call `Agent.createFromEnv()` to automatically load them:
+
+**Available Variables:**
+
+| Variable                 | Purpose                                                                                                         | Example                                 |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `XMTP_DB_DIRECTORY`      | [Database directory](https://docs.xmtp.org/agents/build-agents/local-database#understand-local-database-files)  | `XMTP_DB_DIRECTORY=my/database/dir`     |
+| `XMTP_DB_ENCRYPTION_KEY` | [Database encryption key](https://docs.xmtp.org/agents/concepts/identity#keep-the-database-encryption-key-safe) | `XMTP_DB_ENCRYPTION_KEY=0xabcd...1234`  |
+| `XMTP_ENV`               | [Network environment](https://docs.xmtp.org/chat-apps/core-messaging/create-a-client#xmtp-network-environments) | `XMTP_ENV=dev` or `XMTP_ENV=production` |
+| `XMTP_WALLET_KEY`        | [Private key for Ethereum wallet](https://docs.xmtp.org/chat-apps/core-messaging/create-a-signer)               | `XMTP_WALLET_KEY=0x1234...abcd`         |
+
+Using the environment variables, you can setup your agent in just a few lines of code:
+
+```ts
+// Load variables from .env file
+process.loadEnvFile(".env");
+
+// Create agent using environment variables
+const agent = await Agent.createFromEnv();
+```
+
+Agents can also recognize the following environment variables:
+
+| Variable                 | Purpose                                                                                            | Example                        |
+| ------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `XMTP_FORCE_DEBUG_LEVEL` | [Activate debugging logs](https://docs.xmtp.org/agents/deploy/debug-agents) at the specified level | `XMTP_FORCE_DEBUG_LEVEL=Debug` |
+
+## Core Concepts
+
+### 1. Event‑Driven Architecture
+
+Subscribe only to what you need using Node’s `EventEmitter` interface. Events you can listen for:
+
+**Message Events**
+
+- `actions` – an incoming [actions message](https://docs.xmtp.org/agents/content-types/actions) (interactive buttons/choices)
+- `attachment` – an incoming [remote attachment message](https://docs.xmtp.org/agents/content-types/attachments#how-remote-attachments-work)
+- `group-update` – an incoming [group update](https://docs.xmtp.org/agents/content-types/group-updates#listen-for-group-updates) (like name change, member update, etc.)
+- `inline-attachment` – an incoming inline attachment (small files sent directly in the message)
+- `intent` – an incoming [intent message](https://docs.xmtp.org/agents/content-types/intents) (user's response to an actions message)
+- `leave-request` – an incoming leave request from a member wanting to leave a group
+- `markdown` – an incoming [markdown-formatted](https://docs.xmtp.org/agents/content-types/markdown) text message
+- `message` – all messages that are not having a [custom content type](https://docs.xmtp.org/agents/content-types/content-types#custom-content-types)
+- `multi-attachment` – an incoming message with multiple [remote attachments](https://docs.xmtp.org/agents/content-types/attachments#how-remote-attachments-work)
+- `reaction` – an incoming [reaction message](https://docs.xmtp.org/agents/content-types/reactions)
+- `read-receipt` – an incoming [read receipt](https://docs.xmtp.org/chat-apps/content-types/read-receipts) notification
+- `reply` – an incoming [reply message](https://docs.xmtp.org/agents/content-types/replies)
+- `text` – an incoming [text message](https://docs.xmtp.org/agents/content-types/content-types#text-content-type)
+- `transaction-reference` – an incoming onchain [transaction reference](https://docs.xmtp.org/agents/content-types/transaction-refs#receive-a-transaction-reference)
+- `wallet-send-calls` – an incoming wallet [transaction request](https://docs.xmtp.org/agents/content-types/transactions#create-a-transaction-request) (batch calls)
+- `unknownMessage` – a message event that does not correspond to any of the pre-implemented event types
+
+**Conversation Events**
+
+- `conversation` – a new group or DM conversation
+- `dm` – a new DM conversation
+- `group` – a new group conversation
+
+**Lifecycle Events**
+
+- `start` / `stop` – agent lifecycle events
+- `unhandledError` – unhandled errors
+
+**Example**
+
+```ts
+// Listen to specific message types
+agent.on("text", async (ctx) => {
+  console.log(`Text message: ${ctx.message.content}`);
+});
+
+agent.on("reaction", async (ctx) => {
+  console.log(`Reaction: ${ctx.message.content}`);
+});
+
+agent.on("reply", async (ctx) => {
+  console.log(`Reply to: ${ctx.message.content.reference}`);
+});
+
+// Listen to new conversations
+agent.on("dm", async (ctx) => {
+  await ctx.conversation.send("Welcome to our DM!");
+});
+
+agent.on("group", async (ctx) => {
+  await ctx.conversation.send("Hello group!");
+});
+
+// Listen to unhandled events
+agent.on("unhandledError", (error) => {
+  console.error("Agent error", error);
+});
+
+agent.on("unknownMessage", (ctx) => {
+  console.error("Message type is unknown", ctx);
+});
+```
+
+> **⚠️ Important:** The `"message"` event fires for **every** incoming message, regardless of type. When using the `"message"` event, always filter message types to prevent infinite loops. Without proper filtering, your agent might respond to its own messages or react to system messages like read receipts.
+
+**Best Practice Example**
+
+```ts
+import { filter } from "@xmtp/agent-sdk";
+
+agent.on("message", async (ctx) => {
+  // Filter for specific message types
+  if (filter.isText(ctx.message)) {
+    await ctx.conversation.send(`Echo: ${ctx.message.content}`);
+  }
+});
+```
+
+### 2. Middleware Support
+
+Extend your agent with custom business logic using middlewares. Compose cross-cutting behavior like routing, telemetry, rate limiting, analytics, and feature flags, or plug in your own.
+
+#### Standard Middleware
+
+Middlewares can be registered with `agent.use` either one at a time or as an array. They are executed in the order they were added.
+
+Middleware functions receive a `ctx` (context) object and a `next` function. Normally, a middleware calls `next()` to hand off control to the next one in the chain. However, a middleware can also alter the flow in the following ways:
+
+1. Use `next()` to continue the chain and pass control to the next middleware
+2. Use `return` to stop the chain and prevent events from firing
+3. Use `throw` to trigger the error-handling middleware chain
+
+**Example**
+
+```ts
+import { Agent, AgentMiddleware, filter } from "@xmtp/agent-sdk";
+
+const onlyText: AgentMiddleware = async (ctx, next) => {
+  if (filter.isText(ctx.message)) {
+    // Continue to next middleware
+    await next();
+  }
+  // Break middleware chain
+  return;
+};
+
+const agent = await Agent.createFromEnv();
+agent.use(onlyText);
+```
+
+#### Error-Handling Middleware
+
+Error middleware can be registered with `agent.errors.use` either one at a time or as an array. They are executed in the order they were added.
+
+Error middleware receives the `error`, `ctx`, and a `next` function. Just like regular middleware, the flow in error middleware depends on how to use `next`:
+
+1. Use `next()` to mark the error as handled and continue with the main middleware chain
+2. Use `next(error)` to forward the original (or transformed) error to the next error handler
+3. Use `return` to end error handling and stop the middleware chain
+4. Use `throw` to raise a new error to be caught by the error chain
+
+**Example**
+
+```ts
+import { Agent, AgentErrorMiddleware } from "@xmtp/agent-sdk";
+
+const errorHandler: AgentErrorMiddleware = async (error, ctx, next) => {
+  if (error instanceof Error) {
+    // Transform the error and pass it along
+    await next(`Validation failed: ${error.message}`);
+  } else {
+    // Let other error handlers deal with it
+    await next(error);
+  }
+};
+
+const agent = await Agent.createFromEnv();
+agent.errors.use(errorHandler);
+```
+
+#### Default Error Handler
+
+Any error not handled by custom error middleware is caught by the default error handler and published to the `unhandledError` topic, where it can be observed.
+
+**Example**
+
+```ts
+agent.on("unhandledError", (error) => {
+  console.log("Caught error", error);
+});
+```
+
+#### Provided Middleware
+
+Built‑in, officially supported middleware is provided by the Agent SDK.
+
+| Middleware           | Description                                                                    |
+| -------------------- | ------------------------------------------------------------------------------ |
+| `CommandRouter`      | Slash-command routing with optional help generation and a default handler      |
+| `PerformanceMonitor` | Measures message processing time and logs periodic CPU / memory health reports |
+
+**Example: CommandRouter**
+
+The `CommandRouter` makes it easy to handle slash commands out of the box.
+
+```ts
+import { Agent, CommandRouter } from "@xmtp/agent-sdk";
+
+const agent = await Agent.createFromEnv();
+const router = new CommandRouter()
+  .command("/hello", async (ctx) => {
+    await ctx.conversation.send("Hi there! 👋");
+  })
+  .default(async (ctx) => {
+    await ctx.conversation.send(`Unknown command: ${ctx.message.content}`);
+  });
+
+agent.use(router.middleware());
+```
+
+### 3. Built‑in Filters
+
+Instead of manually checking every incoming message, you can use the provided filters.
+
+**Example**
+
+```ts
+import { filter } from "@xmtp/agent-sdk";
+
+// Using filter in message handler
+agent.on("text", async (ctx) => {
+  if (filter.isText(ctx.message)) {
+    await ctx.conversation.send("You sent a text message!");
+  }
+});
+
+// Combine multiple conditions
+agent.on("text", async (ctx) => {
+  if (
+    filter.hasDefinedContent(ctx.message) &&
+    !filter.fromSelf(ctx.message, ctx.client) &&
+    filter.isText(ctx.message)
+  ) {
+    await ctx.conversation.send("Valid text message received ✅");
+  }
+});
+```
+
+For convenience, the `filter` object can also be imported as `f`:
+
+```ts
+// You can import either name:
+import { filter, f } from "@xmtp/agent-sdk";
+
+// Both work the same way:
+if (f.isText(ctx.message)) {
+  // Handle message...
+}
+```
+
+**Available Filters:**
+
+You can find all available prebuilt filters [here](https://github.com/xmtp/xmtp-js/blob/main/sdks/agent-sdk/src/core/filter.ts).
+
+### 4. Rich Context
+
+Every message event handler receives a `MessageContext` (`ctx`) with:
+
+- `message` – the decoded message object
+- `conversation` – the active conversation object
+- `client` – underlying XMTP client
+- Helpers like `sendTextReply`, `sendMarkdown`, `sendReaction`, `getSenderAddress`, and more
+
+**Example**
+
+```ts
+agent.on("text", async (ctx) => {
+  await ctx.sendTextReply("Reply using helper ✨");
+});
+```
+
+The Agent class also exposes a function to get the `ConversationContext`, so you can directly interact with a conversation.
+
+**Example**
+
+```ts
+const ctx = await agent.getConversationContext("conversationId");
+await ctx?.sendMarkdown("**Hello, World!**");
+```
+
+### 5. Starting Conversations
+
+These functionalities let you start a conversation:
+
+```ts
+// Direct Message
+const dm = await agent.createDmWithAddress("0x123");
+await dm.send("Hello!");
+
+// Group Conversation
+const group = await agent.createGroupWithAddresses(["0x123", "0x456"]);
+await group.addMembers(["0x789"]);
+await group.send("Hello group!");
+```
+
+### 6. Utilities
+
+The Agent SDK includes various utilities. You can for example get a testing URL or details of your Agent:
+
+```ts
+import { getTestUrl, logDetails } from "@xmtp/agent-sdk";
+
+// Get a test URL for your agent
+const testUrl = getTestUrl(agent.client);
+console.log(`Test your agent at: ${testUrl}`);
+
+// Log comprehensive details about your agent
+await logDetails(agent.client);
+```
+
+There are also utilities to simplify user management, such as signer creation or name resolutions:
+
+```ts
+import { createUser, createSigner, createNameResolver } from "@xmtp/agent-sdk";
+
+// Create a new user with a random private key
+const user = createUser();
+
+// Create a signer from the user
+const signer = createSigner(user);
+
+// Resolve ENS names or other web3 identities using web3.bio
+const resolver = createNameResolver("your-web3bio-api-key");
+const address = await resolver("vitalik.eth");
+console.log(`Resolved address: ${address}`);
+```
+
+### 7. Sending Attachments
+
+The Agent SDK supports sending encrypted remote attachments. Files are encrypted locally, uploaded to your storage provider of choice, and then sent as a remote attachment message containing the URL and decryption keys.
+
+**Example**
+
+```ts
+import { type AttachmentUploadCallback } from "@xmtp/agent-sdk";
+
+agent.on("text", async (ctx) => {
+  if (ctx.message.content === "/send-file") {
+    // Create a File object (in Node.js, you can use the File class from buffer or file-system)
+    const file = new File(["Hello, World!"], "hello.txt", {
+      type: "text/plain",
+    });
+
+    // Upload callback - implement your own storage solution
+    const uploadCallback: AttachmentUploadCallback = async (attachment) => {
+      // Upload "attachment.content.payload" to your storage
+      const pinata = new PinataSDK({
+        pinataJwt: process.env.PINATA_JWT,
+        pinataGateway: process.env.PINATA_GATEWAY,
+      });
+
+      const mimeType = "application/octet-stream";
+      const encryptedBlob = new Blob(
+        [Buffer.from(attachment.content.payload)],
+        {
+          type: mimeType,
+        },
+      );
+      const encryptedFile = new File([encryptedBlob], attachment.filename, {
+        type: mimeType,
+      });
+      const upload = await pinata.upload.public.file(encryptedFile);
+
+      // Return the public URL where the file can be downloaded
+      return pinata.gateways.public.convert(`${upload.cid}`);
+    };
+
+    // Send the encrypted remote attachment
+    await ctx.sendRemoteAttachment(file, uploadCallback);
+  }
+});
+```
+
+Other agents can then download and decrypt the attachment using the `"attachment"` topic:
+
+```ts
+import { downloadRemoteAttachment } from "@xmtp/agent-sdk";
+
+agent.on("attachment", async (ctx) => {
+  const receivedAttachment = await downloadRemoteAttachment(
+    ctx.message.content,
+    agent,
+  );
+  console.log(`Received attachment: ${receivedAttachment.filename}`);
+});
+```
+
+## Adding Custom Content Types
+
+Pass `codecs` when creating your agent to extend supported content:
+
+```ts
+const agent = await Agent.create(signer, {
+  env: "dev",
+  dbPath: null,
+  codecs: [new MyContentType()],
+});
+```
+
+## LibXMTP Version
+
+[LibXMTP](https://github.com/xmtp/libxmtp/) is a shared library encapsulating the core functionality of the XMTP messaging protocol, such as cryptography, networking, and language bindings.
+
+The LibXMTP version used in the Agent SDK can be accessed with the `libxmtpVersion` property of an agent instance.
+
+```ts
+console.log(agent.libxmtpVersion);
+```
+
+## Debugging
+
+- [Debug an agent](https://docs.xmtp.org/agents/debug-agents)
+- [Further debugging info](https://docs.xmtp.org/inboxes/debug-your-app#debug-your-inbox-app)
+
+## Contributing / Feedback
+
+We’d love your feedback: [open an issue](https://github.com/xmtp/xmtp-js/issues) or discussion. PRs welcome for docs, examples, and core improvements.
+
+---
+
+Build something delightful. Then tell us what you wish was easier.
+
+Happy hacking 💫

--- a/sdks/js/agent-sdk/package.json
+++ b/sdks/js/agent-sdk/package.json
@@ -1,0 +1,96 @@
+{
+  "name": "@xmtp/agent-sdk",
+  "version": "2.3.0",
+  "description": "XMTP Agent SDK for interacting with XMTP networks",
+  "keywords": [
+    "agents",
+    "javascript",
+    "js",
+    "messaging",
+    "node",
+    "nodejs",
+    "typescript",
+    "web3",
+    "xmtp"
+  ],
+  "homepage": "https://docs.xmtp.org/agents/get-started/build-an-agent",
+  "bugs": {
+    "url": "https://github.com/xmtp/libxmtp/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://git@github.com/xmtp/libxmtp.git",
+    "directory": "sdks/js/agent-sdk"
+  },
+  "license": "MIT",
+  "author": "XMTP Labs <eng@xmtp.com>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./debug": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./middleware": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./user": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./util": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "yarn clean:dist && rollup -c",
+    "clean": "rm -rf .turbo && rm -rf node_modules && yarn clean:dist",
+    "clean:dist": "rm -rf dist",
+    "demo:actions": "tsx watch src/demo/actions.ts",
+    "demo:main": "tsx watch src/demo/main.ts",
+    "demo:reconnect": "XMTP_FORCE_DEBUG_LEVEL=Error tsx src/demo/reconnect.ts",
+    "demo:transactions": "tsx watch src/demo/transactions.ts",
+    "gen:keys": "tsx src/bin/generateKeys.ts",
+    "start": "yarn dev",
+    "test": "yarn typecheck && vitest run --typecheck",
+    "test:cov": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@xmtp/content-type-primitives": "3.0.1",
+    "@xmtp/node-sdk": "workspace:^",
+    "ts-retry-promise": "^0.8.1",
+    "viem": "^2.37.6"
+  },
+  "devDependencies": {
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-typescript": "^12.3.0",
+    "@types/node": "^24.10.9",
+    "@vitest/coverage-v8": "^4.0.18",
+    "rollup": "^4.59.0",
+    "rollup-plugin-dts": "^6.3.0",
+    "rollup-plugin-tsconfig-paths": "^1.5.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vite-tsconfig-paths": "^6.0.4",
+    "vitest": "^4.0.18"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/sdks/js/agent-sdk/rollup.config.js
+++ b/sdks/js/agent-sdk/rollup.config.js
@@ -1,0 +1,51 @@
+import json from "@rollup/plugin-json";
+import typescript from "@rollup/plugin-typescript";
+import { defineConfig } from "rollup";
+import { dts } from "rollup-plugin-dts";
+import tsConfigPaths from "rollup-plugin-tsconfig-paths";
+
+const external = [
+  "@xmtp/content-type-primitives",
+  "@xmtp/node-sdk",
+  "node:events",
+  "node:fs",
+  "node:path",
+  "node:querystring",
+  "viem",
+  "viem/accounts",
+  "viem/chains",
+];
+
+const plugins = [
+  json({
+    preferConst: true,
+  }),
+  tsConfigPaths(),
+  typescript({
+    declaration: false,
+    declarationMap: false,
+    exclude: ["**/*.test.ts", "**/demo/**"],
+  }),
+];
+
+export default defineConfig([
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/index.js",
+      format: "es",
+      sourcemap: true,
+    },
+    plugins,
+    external,
+  },
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/index.d.ts",
+      format: "es",
+    },
+    plugins: [tsConfigPaths(), dts()],
+    external: ["node:events"],
+  },
+]);

--- a/sdks/js/agent-sdk/src/bin/generateKeys.ts
+++ b/sdks/js/agent-sdk/src/bin/generateKeys.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { getRandomValues } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { generatePrivateKey } from "viem/accounts";
+
+const generateClientKeys = () => {
+  const randomValues = getRandomValues(new Uint8Array(32));
+  const dbEncryptionKey = Buffer.from(randomValues).toString("hex");
+  return {
+    XMTP_DB_ENCRYPTION_KEY: dbEncryptionKey,
+    XMTP_WALLET_KEY: generatePrivateKey(),
+  };
+};
+
+/**
+ * Generates client keys and saves them to a .env file in the project root.
+ * This script creates the necessary environment variables for XMTP agent initialization.
+ */
+function main() {
+  try {
+    // Generate the client keys
+    const keys = generateClientKeys();
+
+    // Create the .env file content
+    const envContent =
+      Object.entries(keys)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("\n") + "\n";
+
+    if (!process.env.INIT_CWD) {
+      throw new Error(
+        `Cannot invoke script because "process.env.INIT_CWD" wasn't found.`,
+      );
+    }
+    const envFilePath = join(process.env.INIT_CWD, ".env");
+
+    writeFileSync(envFilePath, envContent, "utf8");
+
+    console.log("✅ Successfully generated client keys and saved to .env file");
+    console.log(`📁 File location: ${envFilePath}`);
+    console.log("🔑 Generated keys:");
+    Object.keys(keys).forEach((key) => {
+      console.log(`   - ${key}`);
+    });
+  } catch (error) {
+    console.error("❌ Error generating client keys:", error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/sdks/js/agent-sdk/src/core/Agent.reconnect.test.ts
+++ b/sdks/js/agent-sdk/src/core/Agent.reconnect.test.ts
@@ -1,0 +1,84 @@
+import { once } from "node:events";
+import { setTimeout } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import { Agent } from "@/core/Agent";
+import { createSigner, createUser } from "@/user/User";
+
+const PROXY_NAME = "node-go";
+// libxmtp's dev backend maps the toxiproxy API to host port 8474
+const TOXIPROXY_API = "http://localhost:8474";
+const TOXIPROXY_PORT = "6010";
+
+export async function enableBackend(enabled: boolean) {
+  const res = await fetch(`${TOXIPROXY_API}/proxies/${PROXY_NAME}`, {
+    method: "POST",
+    body: JSON.stringify({
+      name: PROXY_NAME,
+      listen: `[::]:${TOXIPROXY_PORT}`,
+      upstream: "node:5556",
+      enabled,
+    }),
+  });
+  if (!res.ok) throw new Error(`Failed to toggle proxy: ${await res.text()}`);
+}
+
+export async function createToxicAgent() {
+  await enableBackend(true);
+  return Agent.create(createSigner(createUser()), {
+    env: "local",
+    apiUrl: `http://localhost:${TOXIPROXY_PORT}`,
+    dbPath: null,
+    disableDeviceSync: true,
+  });
+}
+
+describe("Agent reconnect", () => {
+  it("should reconnect after a mid-stream disconnect", async () => {
+    const agent = await createToxicAgent();
+    await agent.start();
+
+    const reconnected = once(agent, "start", {
+      signal: AbortSignal.timeout(10000),
+    });
+
+    await enableBackend(false);
+    await setTimeout(5000);
+    await enableBackend(true);
+
+    await reconnected;
+    await agent.stop();
+  });
+
+  it("should reconnect when start() fails initially", async () => {
+    const agent = await createToxicAgent();
+
+    await enableBackend(false);
+
+    const started = once(agent, "start", {
+      signal: AbortSignal.timeout(10000),
+    });
+    void agent.start();
+
+    await setTimeout(5000);
+    await enableBackend(true);
+
+    await started;
+    await agent.stop();
+  });
+
+  it("should emit unhandledError on stream disconnect", async () => {
+    const agent = await createToxicAgent();
+    await agent.start();
+
+    const errored = once(agent, "unhandledError", {
+      signal: AbortSignal.timeout(10000),
+    });
+
+    await enableBackend(false);
+
+    const [error] = (await errored) as [unknown];
+    expect(error).toBeInstanceOf(Error);
+
+    await agent.stop();
+  });
+});

--- a/sdks/js/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/js/agent-sdk/src/core/Agent.test.ts
@@ -1,0 +1,802 @@
+import {
+  encodeText,
+  isReply,
+  ReactionAction,
+  ReactionSchema,
+  type BuiltInContentTypes,
+  type Client,
+  type Dm,
+  type EnrichedReply,
+  type Group,
+  type GroupUpdated,
+  type Reaction,
+  type RemoteAttachment,
+  type Reply,
+} from "@xmtp/node-sdk";
+import { version as appVersion } from "~/package.json";
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import {
+  Agent,
+  type AgentErrorMiddleware,
+  type AgentMiddleware,
+} from "@/core/Agent";
+import type { ClientContext } from "@/core/ClientContext";
+import { ConversationContext } from "@/core/ConversationContext";
+import { MessageContext } from "@/core/MessageContext";
+import { createSigner, createUser } from "@/user/User";
+import { createClient } from "@/util/test";
+
+describe("Agent", () => {
+  let agent: Agent<BuiltInContentTypes>;
+  let client: Client;
+
+  beforeEach(async () => {
+    client = await createClient();
+    agent = new Agent({
+      client,
+    });
+  });
+
+  describe("types", () => {
+    it("infers additional content types from given codecs", () => {
+      expectTypeOf(agent).toEqualTypeOf<Agent<BuiltInContentTypes>>();
+    });
+
+    it("types the content in message event listener", () => {
+      agent.on("unknownMessage", (ctx) => {
+        expectTypeOf(ctx).toEqualTypeOf<
+          MessageContext<unknown, BuiltInContentTypes>
+        >();
+      });
+    });
+
+    it("types content for 'attachment' events", () => {
+      agent.on("attachment", (ctx) => {
+        expectTypeOf(ctx.message.content).toEqualTypeOf<RemoteAttachment>();
+      });
+    });
+
+    it("types content for 'text' events", () => {
+      agent.on("text", (ctx) => {
+        expectTypeOf(ctx.message.content).toEqualTypeOf<string>();
+      });
+    });
+
+    it("types content for 'reaction' events", () => {
+      agent.on("reaction", (ctx) => {
+        expectTypeOf(ctx.message.content).toEqualTypeOf<Reaction>();
+      });
+    });
+
+    it("types content for 'reply' events", () => {
+      agent.on("reply", (ctx) => {
+        expectTypeOf(ctx.message.content).toEqualTypeOf<EnrichedReply>();
+      });
+    });
+
+    it("types content for 'group-update' events", () => {
+      agent.on("group-update", (ctx) => {
+        expectTypeOf(ctx.message.content).toEqualTypeOf<GroupUpdated>();
+      });
+    });
+
+    it("should have proper types when using type predicates in 'unknownMessage' event", () => {
+      agent.on("unknownMessage", (ctx) => {
+        if (ctx.isText()) {
+          expectTypeOf(ctx.message.content).toEqualTypeOf<string>();
+        }
+
+        if (ctx.isReply()) {
+          expectTypeOf(ctx.message.content).toEqualTypeOf<Reply>();
+        }
+
+        if (ctx.isReaction()) {
+          expectTypeOf(ctx.message.content).toEqualTypeOf<Reaction>();
+        }
+
+        if (ctx.isRemoteAttachment()) {
+          expectTypeOf(ctx.message.content).toEqualTypeOf<RemoteAttachment>();
+        }
+      });
+    });
+
+    it("should have proper types when using type predicates in 'conversation' event", () => {
+      agent.on("conversation", (ctx) => {
+        if (ctx.isDm()) {
+          expectTypeOf(ctx.conversation).toEqualTypeOf<
+            Dm<BuiltInContentTypes>
+          >();
+        }
+
+        if (ctx.isGroup()) {
+          expectTypeOf(ctx.conversation).toEqualTypeOf<
+            Group<BuiltInContentTypes>
+          >();
+        }
+      });
+    });
+
+    it("types content for 'start' events", () => {
+      agent.on("start", (ctx) => {
+        expectTypeOf(ctx).toEqualTypeOf<ClientContext<BuiltInContentTypes>>();
+      });
+    });
+
+    it("types content for 'stop' events", () => {
+      agent.on("stop", (ctx) => {
+        expectTypeOf(ctx).toEqualTypeOf<ClientContext<BuiltInContentTypes>>();
+      });
+    });
+  });
+
+  describe("start", () => {
+    it("should sync conversations and start listening", async () => {
+      const startSpy = vi.fn();
+      agent.on("start", startSpy);
+      await agent.start();
+      expect(startSpy).toHaveBeenCalled();
+    });
+
+    it("should not start twice if already listening", async () => {
+      const startSpy = vi.fn();
+      agent.on("start", startSpy);
+      await agent.start();
+      await agent.start(); // second call should return early
+      expect(startSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should auto-restart after a startup failure", async () => {
+      const startupError = new Error("Stream setup failed");
+      const originalStream = client.conversations.stream.bind(
+        client.conversations,
+      );
+      let callCount = 0;
+      const streamSpy = vi
+        .spyOn(client.conversations, "stream")
+        .mockImplementation(async (...args) => {
+          callCount++;
+          if (callCount === 1) {
+            throw startupError;
+          }
+          return originalStream(...args);
+        });
+
+      const startSpy = vi.fn();
+      agent.on("start", startSpy);
+
+      void agent.start();
+
+      await vi.waitFor(() => {
+        expect(startSpy).toHaveBeenCalledTimes(1);
+      });
+
+      streamSpy.mockRestore();
+      await agent.stop();
+    });
+
+    it("should filter messages from the agent itself (same senderInboxId)", async () => {
+      const textEventSpy = vi.fn();
+      const unknownMessageSpy = vi.fn();
+      agent.on("text", textEventSpy);
+      agent.on("unknownMessage", unknownMessageSpy);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("Hello world");
+      const messages = await dm.messages();
+      const message = messages[1]!;
+
+      await vi.waitFor(() => {
+        expect(
+          textEventSpy,
+          "Should not emit events for message from self, but should for message from other",
+        ).toHaveBeenCalledTimes(1);
+      });
+      expect(
+        unknownMessageSpy,
+        "Filtered text messages don't go to unknownMessage",
+      ).toHaveBeenCalledTimes(0);
+
+      expect(textEventSpy).toHaveBeenCalledWith(
+        new MessageContext({
+          message,
+          conversation: dm,
+          client: otherClient,
+        }),
+      );
+    });
+
+    it("should filter reaction messages from the agent itself", async () => {
+      const reactionEventSpy = vi.fn();
+      const unknownMessageSpy = vi.fn();
+      agent.on("reaction", reactionEventSpy);
+      agent.on("unknownMessage", unknownMessageSpy);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+
+      await agent.client.conversations.sync();
+      const agentDm = (await agent.client.conversations.getConversationById(
+        dm.id,
+      )) as Dm<BuiltInContentTypes>;
+      const messageId = await agentDm.sendText("gm");
+
+      await agentDm.sendReaction({
+        action: ReactionAction.Added,
+        schema: ReactionSchema.Unicode,
+        content: "👍",
+        reference: messageId,
+        referenceInboxId: client.inboxId,
+      });
+
+      const reactionId = await dm.sendReaction({
+        action: ReactionAction.Added,
+        schema: ReactionSchema.Unicode,
+        content: "👍",
+        reference: messageId,
+        referenceInboxId: client.inboxId,
+      });
+      const reaction = agent.client.conversations.getMessageById(reactionId)!;
+
+      await vi.waitFor(() => {
+        expect(
+          reactionEventSpy,
+          "Should only emit reaction event for message from other sender",
+        ).toHaveBeenCalledTimes(1);
+      });
+      expect(
+        unknownMessageSpy,
+        "Filtered text messages don't go to unknownMessage",
+      ).toHaveBeenCalledTimes(0);
+
+      expect(reactionEventSpy).toHaveBeenCalledWith(
+        new MessageContext({
+          message: reaction,
+          conversation: dm,
+          client: otherClient,
+        }),
+      );
+    });
+
+    it("should emit 'group-update' events for group update messages", async () => {
+      const groupUpdateEventSpy = vi.fn();
+      agent.on("group-update", groupUpdateEventSpy);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const group = await otherClient.conversations.createGroup([
+        client.inboxId,
+      ]);
+      await group.addAdmin(client.inboxId);
+      const messages = await group.messages();
+      const message = messages[1]!;
+
+      await vi.waitFor(() => {
+        expect(groupUpdateEventSpy).toHaveBeenCalledTimes(1);
+      });
+      expect(groupUpdateEventSpy).toHaveBeenCalledWith(
+        new MessageContext({
+          message,
+          conversation: group,
+          client: otherClient,
+        }),
+      );
+    });
+
+    it("should emit generic 'message' event for all message types", async () => {
+      const messageEventSpy = vi.fn();
+      const textEventSpy = vi.fn();
+      const reactionEventSpy = vi.fn();
+      const replyEventSpy = vi.fn();
+      const groupUpdateEventSpy = vi.fn();
+
+      agent.on("message", messageEventSpy);
+      agent.on("text", textEventSpy);
+      agent.on("reaction", reactionEventSpy);
+      agent.on("reply", replyEventSpy);
+      agent.on("group-update", groupUpdateEventSpy);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const group = await otherClient.conversations.createGroup([
+        client.inboxId,
+      ]);
+      await group.addAdmin(client.inboxId);
+      const messageId = await group.sendText("gm");
+      await group.sendReaction({
+        action: ReactionAction.Added,
+        schema: ReactionSchema.Unicode,
+        content: "👍",
+        reference: messageId,
+        referenceInboxId: client.inboxId,
+      });
+      await group.sendReply({
+        content: encodeText("gm"),
+        reference: messageId,
+        referenceInboxId: client.inboxId,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          messageEventSpy,
+          "Generic 'message' event should fire for all message types",
+        ).toHaveBeenCalledTimes(4);
+      });
+      expect(textEventSpy).toHaveBeenCalledTimes(1);
+      expect(reactionEventSpy).toHaveBeenCalledTimes(1);
+      expect(replyEventSpy).toHaveBeenCalledTimes(1);
+      expect(groupUpdateEventSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("conversation events", () => {
+    it("should emit 'conversation' events for new conversations", async () => {
+      const conversationEventSpy = vi.fn();
+      agent.on("conversation", conversationEventSpy);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      const group = await otherClient.conversations.createGroup([
+        client.inboxId,
+      ]);
+
+      await vi.waitFor(() => {
+        expect(conversationEventSpy).toHaveBeenCalledTimes(2);
+      });
+      expect(conversationEventSpy).toHaveBeenNthCalledWith(
+        1,
+        new ConversationContext({
+          conversation: dm,
+          client: otherClient,
+        }),
+      );
+      expect(conversationEventSpy).toHaveBeenNthCalledWith(
+        2,
+        new ConversationContext({
+          conversation: group,
+          client: otherClient,
+        }),
+      );
+    });
+
+    it("should emit specific 'dm' events for direct messages", async () => {
+      const dmEventSpy = vi.fn();
+      const conversationEventSpy = vi.fn();
+      agent.on("dm", dmEventSpy);
+      agent.on("conversation", conversationEventSpy);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+
+      await vi.waitFor(() => {
+        expect(dmEventSpy).toHaveBeenCalledTimes(1);
+        expect(conversationEventSpy).toHaveBeenCalledTimes(1);
+      });
+
+      expect(dmEventSpy).toHaveBeenCalledWith(
+        new ConversationContext({
+          conversation: dm,
+          client: otherClient,
+        }),
+      );
+    });
+
+    it("should emit specific 'group' events for Group conversations", async () => {
+      const groupEventSpy = vi.fn();
+      const conversationEventSpy = vi.fn();
+      agent.on("group", groupEventSpy);
+      agent.on("conversation", conversationEventSpy);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const group = await otherClient.conversations.createGroup([
+        client.inboxId,
+      ]);
+
+      await vi.waitFor(() => {
+        expect(groupEventSpy).toHaveBeenCalledTimes(1);
+        expect(conversationEventSpy).toHaveBeenCalledTimes(1);
+      });
+
+      expect(groupEventSpy).toHaveBeenCalledWith(
+        new ConversationContext({
+          conversation: group,
+          client: otherClient,
+        }),
+      );
+    });
+  });
+
+  describe("use", () => {
+    it("should add middleware and return the agent instance", () => {
+      const middleware = vi.fn();
+      const result = agent.use(middleware);
+      expect(result).toBe(agent);
+    });
+
+    it("should execute middleware when processing messages", async () => {
+      const middleware = vi.fn<AgentMiddleware>(async (_, next) => {
+        await next();
+      });
+      agent.use(middleware);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("Hello world");
+      const messages = await dm.messages();
+      const message = messages[1]!;
+
+      await vi.waitFor(() => {
+        expect(middleware).toHaveBeenCalledTimes(1);
+      });
+      expect(middleware).toHaveBeenCalledWith(
+        new MessageContext({
+          message,
+          conversation: dm,
+          client: otherClient,
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it("should filter self messages before they reach middleware", async () => {
+      const middlewareCallsSpy = vi.fn<AgentMiddleware>(async (_, next) => {
+        await next();
+      });
+      agent.use(middlewareCallsSpy);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("Hello world");
+      const messages = await dm.messages();
+      const message = messages[1]!;
+
+      await vi.waitFor(() => {
+        // Middleware should only be called once (for the message from other user)
+        expect(
+          middlewareCallsSpy,
+          "Middleware should only process messages from other users, not self",
+        ).toHaveBeenCalledTimes(1);
+      });
+
+      // Verify middleware was called with the message from the other user
+      expect(middlewareCallsSpy).toHaveBeenCalledWith(
+        new MessageContext({
+          message,
+          conversation: dm,
+          client: otherClient,
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it("should continue to next middleware when next() is called", async () => {
+      const middlewareCalls: string[] = [];
+
+      const mw1 = vi.fn<AgentMiddleware>(async (ctx, next) => {
+        middlewareCalls.push("mw1-" + ctx.message.id);
+        await next();
+      });
+
+      const mw2 = vi.fn<AgentMiddleware>(async (ctx, next) => {
+        middlewareCalls.push("mw2-" + ctx.message.id);
+        await next();
+      });
+
+      const mw3 = vi.fn<AgentMiddleware>(async (ctx, next) => {
+        middlewareCalls.push("mw3-" + ctx.message.id);
+        await next();
+      });
+
+      agent.use([mw1, mw2, mw3]);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      const messageId1 = await dm.sendText("Hello world");
+      const messageId2 = await dm.sendText("Hello world");
+
+      await vi.waitFor(() => {
+        expect(middlewareCalls).toEqual([
+          `mw1-${messageId1}`,
+          `mw2-${messageId1}`,
+          `mw3-${messageId1}`,
+          `mw1-${messageId2}`,
+          `mw2-${messageId2}`,
+          `mw3-${messageId2}`,
+        ]);
+      });
+    });
+
+    it("should stop the processing chain when the middleware returns", async () => {
+      const middlewareCalls: string[] = [];
+
+      const mw1 = vi.fn<AgentMiddleware>(async (ctx, next) => {
+        middlewareCalls.push("mw1-" + ctx.message.id);
+        await next();
+      });
+
+      const filterReply = vi.fn<AgentMiddleware>(async ({ message }, next) => {
+        middlewareCalls.push("filterReply-" + message.id);
+        if (isReply(message)) {
+          return;
+        }
+        await next();
+      });
+
+      const mw3 = vi.fn<AgentMiddleware>(async (ctx, next) => {
+        middlewareCalls.push("mw3-" + ctx.message.id);
+        await next();
+      });
+
+      agent.use([mw1, filterReply, mw3]);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      const messageId1 = await dm.sendText("Hello world");
+      const messageId2 = await dm.sendReply({
+        content: encodeText("Hello world"),
+        reference: messageId1,
+        referenceInboxId: client.inboxId,
+      });
+
+      await vi.waitFor(() => {
+        expect(middlewareCalls).toEqual([
+          `mw1-${messageId1}`,
+          `filterReply-${messageId1}`,
+          `mw3-${messageId1}`,
+          `mw1-${messageId2}`,
+          `filterReply-${messageId2}`,
+        ]);
+      });
+    });
+  });
+
+  describe("emit", () => {
+    it("should emit 'text' and allow sending a reply via context", async () => {
+      const handler = vi.fn(async (ctx: MessageContext) => {
+        await ctx.conversation.sendText("gm");
+      });
+
+      agent.on("text", handler);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("Hello world");
+
+      await vi.waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(1);
+      });
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        const message = messages[2]!;
+        expect(message.senderInboxId).toBe(client.inboxId);
+        expect(message.content).toBe("gm");
+      });
+    });
+  });
+
+  describe("stop", () => {
+    it("should stop listening and emit stop event", async () => {
+      const stopSpy = vi.fn();
+      agent.on("stop", stopSpy);
+
+      await agent.start();
+      await agent.stop();
+
+      expect(stopSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("create", () => {
+    it("should set appVersion to include package version by default", async () => {
+      const signer = createSigner(createUser());
+      const agent = await Agent.create(signer);
+      expect(agent.client.appVersion).toBe(`agent-sdk/${appVersion}`);
+    });
+
+    it("should allow custom appVersion to override default", async () => {
+      const signer = createSigner(createUser());
+      const customVersion = "custom-app/1.0.0";
+      const agent = await Agent.create(signer, {
+        appVersion: customVersion,
+      });
+      expect(agent.client.appVersion).toBe(customVersion);
+    });
+  });
+
+  describe("errors.use", () => {
+    it("propagates error, transforms, recovers, and resumes remaining middleware", async () => {
+      const callOrder: string[] = [];
+      const onError = vi.fn();
+      agent.on("unhandledError", onError);
+
+      const mw1: AgentMiddleware = async (ctx, next) => {
+        expect(ctx).toBeInstanceOf(MessageContext);
+        callOrder.push("1");
+        await next();
+      };
+
+      const mw2: AgentMiddleware = (ctx) => {
+        expect(ctx).toBeInstanceOf(MessageContext);
+        callOrder.push("2");
+        throw new Error("Initial error");
+      };
+
+      const mw3: AgentMiddleware = async (ctx, next) => {
+        expect(ctx).toBeInstanceOf(MessageContext);
+        callOrder.push("3");
+        await next();
+      };
+
+      const mw4: AgentMiddleware = async (ctx, next) => {
+        expect(ctx).toBeInstanceOf(MessageContext);
+        callOrder.push("4");
+        await next();
+      };
+
+      const e1: AgentErrorMiddleware = async (err, ctx, next) => {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toBe("Initial error");
+        expect(ctx).toBeInstanceOf(MessageContext);
+        callOrder.push("E1");
+        // Transform the initial error
+        await next(new Error("Transformed error"));
+      };
+
+      const e2: AgentErrorMiddleware = async (err, ctx, next) => {
+        expect((err as Error).message).toBe("Transformed error");
+        expect(ctx).toBeInstanceOf(MessageContext);
+        callOrder.push("E2");
+        // Resume middleware chain
+        await next();
+      };
+
+      agent.use([mw1, mw2], [mw3], mw4);
+      agent.errors.use(e1, e2);
+
+      agent.on("text", () => {
+        callOrder.push("EMIT");
+      });
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("Hello world");
+
+      await vi.waitFor(() => {
+        expect(callOrder).toEqual(["1", "2", "E1", "E2", "3", "4", "EMIT"]);
+      });
+      expect(
+        onError,
+        "error chain recovered, no final error is emitted",
+      ).toHaveBeenCalledTimes(0);
+    });
+
+    it("doesn't emit when a middleware returns early", async () => {
+      const callOrder: string[] = [];
+
+      const mw1: AgentMiddleware = async (_, next) => {
+        callOrder.push("1");
+        await next();
+      };
+
+      const mw2: AgentMiddleware = async (_, next) => {
+        callOrder.push("2");
+        await next();
+      };
+
+      const returnsEarly: AgentMiddleware = () => {
+        return Promise.resolve();
+      };
+
+      const notBeingExecuted: AgentMiddleware = async (_, next) => {
+        callOrder.push("4");
+        await next();
+      };
+
+      agent.use(mw1, mw2, returnsEarly, notBeingExecuted);
+
+      agent.on("unknownMessage", () => {
+        callOrder.push("never happening");
+      });
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("Hello world");
+
+      await vi.waitFor(() => {
+        expect(callOrder).toEqual(["1", "2"]);
+      });
+    });
+
+    it("can end an error queue when returning", async () => {
+      const callOrder: string[] = [];
+
+      const mw1: AgentMiddleware = () => {
+        callOrder.push("mw1");
+        throw new Error();
+      };
+
+      const mw2: AgentMiddleware = async (_, next) => {
+        callOrder.push("mw2 won't be called");
+        await next();
+      };
+
+      const e1: AgentErrorMiddleware = () => {
+        callOrder.push("e1");
+        return;
+      };
+
+      const e2: AgentErrorMiddleware = async (_error, _ctx, next) => {
+        callOrder.push("e2 won't be called");
+        await next();
+      };
+
+      agent.use(mw1, mw2);
+
+      agent.errors.use(e1, e2);
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("Hello world");
+
+      await vi.waitFor(() => {
+        expect(callOrder).toEqual(["mw1", "e1"]);
+      });
+    });
+
+    it("emits an error if no custom error middleware is registered", async () => {
+      const callOrder: string[] = [];
+
+      const errorMessage = "Middleware failed";
+
+      const failingMiddleware: AgentMiddleware = () => {
+        throw new Error(errorMessage);
+      };
+
+      agent.use(failingMiddleware);
+
+      agent.on("unhandledError", (error) => {
+        callOrder.push(error.message);
+      });
+
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("Hello world");
+
+      await vi.waitFor(() => {
+        expect(callOrder).toEqual([errorMessage]);
+      });
+    });
+  });
+});

--- a/sdks/js/agent-sdk/src/core/Agent.ts
+++ b/sdks/js/agent-sdk/src/core/Agent.ts
@@ -1,0 +1,726 @@
+import EventEmitter from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import type { ContentCodec } from "@xmtp/content-type-primitives";
+import {
+  Client,
+  Dm,
+  Group,
+  IdentifierKind,
+  isActions,
+  isAttachment,
+  isGroupUpdated,
+  isHexString,
+  isIntent,
+  isLeaveRequest,
+  isMarkdown,
+  isMultiRemoteAttachment,
+  isReaction,
+  isReadReceipt,
+  isRemoteAttachment,
+  isReply,
+  isText,
+  isTransactionReference,
+  isWalletSendCalls,
+  LogLevel,
+  type Actions,
+  type Attachment,
+  type ClientOptions,
+  type Conversation,
+  type CreateDmOptions,
+  type CreateGroupOptions,
+  type DecodedMessage,
+  type EnrichedReply,
+  type GroupUpdated,
+  type HexString,
+  type Intent,
+  type LeaveRequest,
+  type MultiRemoteAttachment,
+  type NetworkOptions,
+  type Reaction,
+  type ReadReceipt,
+  type RemoteAttachment,
+  type StreamOptions,
+  type TransactionReference,
+  type WalletSendCalls,
+  type XmtpEnv,
+} from "@xmtp/node-sdk";
+import { version as appVersion } from "~/package.json";
+import { retry } from "ts-retry-promise";
+import { filter } from "@/core/filter";
+import { getInstallationInfo } from "@/debug";
+import { getValidLogLevels, parseLogLevel } from "@/debug/log";
+import { createSigner, createUser } from "@/user/User";
+import { AgentError, AgentStreamingError } from "./AgentError";
+import { ClientContext } from "./ClientContext";
+import { ConversationContext } from "./ConversationContext";
+import { MessageContext } from "./MessageContext";
+
+type ConversationStream<ContentTypes> = Awaited<
+  ReturnType<Client<ContentTypes>["conversations"]["stream"]>
+>;
+
+type MessageStream<ContentTypes> = Awaited<
+  ReturnType<Client<ContentTypes>["conversations"]["streamAllMessages"]>
+>;
+
+type EventHandlerMap<ContentTypes> = {
+  actions: [ctx: MessageContext<Actions, ContentTypes>];
+  attachment: [ctx: MessageContext<RemoteAttachment, ContentTypes>];
+  conversation: [ctx: ConversationContext<ContentTypes>];
+  "group-update": [ctx: MessageContext<GroupUpdated, ContentTypes>];
+  dm: [ctx: ConversationContext<ContentTypes, Dm<ContentTypes>>];
+  group: [ctx: ConversationContext<ContentTypes, Group<ContentTypes>>];
+  "inline-attachment": [ctx: MessageContext<Attachment, ContentTypes>];
+  intent: [ctx: MessageContext<Intent, ContentTypes>];
+  "leave-request": [ctx: MessageContext<LeaveRequest, ContentTypes>];
+  markdown: [ctx: MessageContext<string, ContentTypes>];
+  message: [ctx: MessageContext<unknown, ContentTypes>];
+  "multi-attachment": [
+    ctx: MessageContext<MultiRemoteAttachment, ContentTypes>,
+  ];
+  reaction: [ctx: MessageContext<Reaction, ContentTypes>];
+  "read-receipt": [ctx: MessageContext<ReadReceipt, ContentTypes>];
+  reply: [ctx: MessageContext<EnrichedReply, ContentTypes>];
+  start: [ctx: ClientContext<ContentTypes>];
+  stop: [ctx: ClientContext<ContentTypes>];
+  text: [ctx: MessageContext<string, ContentTypes>];
+  "transaction-reference": [
+    ctx: MessageContext<TransactionReference, ContentTypes>,
+  ];
+  unhandledError: [error: Error];
+  unknownMessage: [ctx: MessageContext<unknown, ContentTypes>];
+  "wallet-send-calls": [ctx: MessageContext<WalletSendCalls, ContentTypes>];
+};
+
+type EventName<ContentTypes> = keyof EventHandlerMap<ContentTypes>;
+
+type EthAddress = HexString;
+
+export type AgentBaseContext<ContentTypes = unknown> = {
+  client: Client<ContentTypes>;
+  conversation: Conversation;
+  message: DecodedMessage;
+};
+
+export type AgentErrorContext<ContentTypes = unknown> = Partial<
+  AgentBaseContext<ContentTypes>
+> & {
+  client: Client<ContentTypes>;
+};
+
+export type AgentOptions<ContentTypes> = {
+  client: Client<ContentTypes>;
+};
+
+export type AgentMessageHandler<ContentTypes = unknown> = (
+  ctx: MessageContext<ContentTypes>,
+) => Promise<void> | void;
+
+export type AgentMiddleware<ContentTypes = unknown> = (
+  ctx: MessageContext<unknown, ContentTypes>,
+  next: () => Promise<void> | void,
+) => Promise<void>;
+
+export type AgentErrorMiddleware<ContentTypes = unknown> = (
+  error: unknown,
+  ctx: AgentErrorContext<ContentTypes>,
+  next: (err?: unknown) => Promise<void> | void,
+) => Promise<void> | void;
+
+export type AgentCreateOptions<ContentCodecs extends ContentCodec[] = []> =
+  Omit<ClientOptions & NetworkOptions, "codecs"> & { codecs?: ContentCodecs };
+
+export type AgentStreamingOptions = Omit<StreamOptions, "onValue" | "onError">;
+
+export type StreamAllMessagesOptions<ContentTypes> = Parameters<
+  Client<ContentTypes>["conversations"]["streamAllMessages"]
+>[0];
+
+export type AgentErrorRegistrar<ContentTypes> = {
+  use(
+    ...errorMiddleware: Array<
+      AgentErrorMiddleware<ContentTypes> | AgentErrorMiddleware<ContentTypes>[]
+    >
+  ): AgentErrorRegistrar<ContentTypes>;
+};
+
+type ErrorFlow =
+  | { kind: "handled" } // next()
+  | { kind: "continue"; error: unknown } // next(err) or handler throws
+  | { kind: "stopped" }; // handler returns without next()
+
+export class Agent<ContentTypes = unknown> extends EventEmitter<
+  EventHandlerMap<ContentTypes>
+> {
+  #client: Client<ContentTypes>;
+  #conversationsStream?: ConversationStream<ContentTypes>;
+  #messageStream?: MessageStream<ContentTypes>;
+  #middleware: AgentMiddleware<ContentTypes>[] = [];
+  #errorMiddleware: AgentErrorMiddleware<ContentTypes>[] = [];
+  #errors: AgentErrorRegistrar<ContentTypes> = Object.freeze({
+    use: (...errorMiddleware: AgentErrorMiddleware<ContentTypes>[]) => {
+      for (const emw of errorMiddleware) {
+        if (Array.isArray(emw)) {
+          this.#errorMiddleware.push(...emw);
+        } else if (typeof emw === "function") {
+          this.#errorMiddleware.push(emw);
+        }
+      }
+      return this.#errors;
+    },
+  });
+  #defaultErrorHandler: AgentErrorMiddleware<ContentTypes> = (
+    currentError,
+    _ctx,
+    next,
+  ) => {
+    const emittedError =
+      currentError instanceof Error
+        ? currentError
+        : new AgentError(
+            9999,
+            `Unhandled error caught by default error middleware.`,
+            currentError,
+          );
+    this.emit("unhandledError", emittedError);
+    if (currentError instanceof AgentStreamingError) {
+      void next();
+    }
+  };
+  #isLocked: boolean = false;
+  #isRestarting: boolean = false;
+  #stopped: boolean = false;
+  #streamOptions?: AgentStreamingOptions;
+
+  constructor({ client }: AgentOptions<ContentTypes>) {
+    super();
+    this.#client = client;
+  }
+
+  static async create<ContentCodecs extends ContentCodec[] = []>(
+    signer: Parameters<typeof Client.create>[0],
+    // Note: we need to omit this so that "Client.create" can correctly infer the codecs.
+    options?: AgentCreateOptions<ContentCodecs>,
+  ) {
+    const initializedOptions = { ...(options ?? {}) };
+    initializedOptions.appVersion ??= `agent-sdk/${appVersion}`;
+    initializedOptions.disableDeviceSync ??= true;
+
+    if (process.env.XMTP_FORCE_DEBUG_LEVEL) {
+      const rawLevel = process.env.XMTP_FORCE_DEBUG_LEVEL;
+      const logLevel = parseLogLevel(rawLevel);
+
+      if (logLevel) {
+        initializedOptions.loggingLevel = logLevel;
+      } else {
+        console.warn(
+          `[WARNING] Invalid XMTP_FORCE_DEBUG_LEVEL "${rawLevel}". Defaulting to "${LogLevel.Warn}". Valid values are: ${getValidLogLevels().join(", ")}`,
+        );
+        initializedOptions.loggingLevel = LogLevel.Warn;
+      }
+      initializedOptions.structuredLogging = true;
+    }
+
+    const client = await Client.create(signer, {
+      ...initializedOptions,
+      codecs: initializedOptions.codecs,
+    });
+
+    const info = await getInstallationInfo(client);
+    if (info.totalInstallations > 1 && info.isMostRecent) {
+      console.warn(
+        `[WARNING] You have "${info.totalInstallations}" installations. Installation ID "${info.installationId}" is the most recent. Make sure to persist and reload your installation data. If you exceed the installation limit, your Agent will stop working. Read more: https://docs.xmtp.org/agents/build-agents/local-database#installation-limits-and-revocation-rules`,
+      );
+    }
+
+    return new Agent({ client });
+  }
+
+  static async createFromEnv<ContentCodecs extends ContentCodec[] = []>(
+    // Note: we need to omit this so that "Client.create" can correctly infer the codecs.
+    options?: AgentCreateOptions<ContentCodecs>,
+  ) {
+    const {
+      XMTP_DB_DIRECTORY,
+      XMTP_DB_ENCRYPTION_KEY,
+      XMTP_ENV,
+      XMTP_WALLET_KEY,
+      XMTP_GATEWAY_HOST,
+    } = process.env;
+
+    if (!isHexString(XMTP_WALLET_KEY)) {
+      throw new AgentError(
+        1000,
+        `XMTP_WALLET_KEY env is not in hex (0x) format.`,
+      );
+    }
+
+    const signer = createSigner(createUser(XMTP_WALLET_KEY));
+
+    const initializedOptions = { ...(options ?? {}) };
+
+    initializedOptions.dbEncryptionKey =
+      typeof XMTP_DB_ENCRYPTION_KEY === "string"
+        ? isHexString(XMTP_DB_ENCRYPTION_KEY)
+          ? XMTP_DB_ENCRYPTION_KEY
+          : `0x${XMTP_DB_ENCRYPTION_KEY}`
+        : undefined;
+
+    const validEnvs = [
+      "local",
+      "dev",
+      "production",
+      "testnet-staging",
+      "testnet-dev",
+      "testnet",
+      "mainnet",
+    ] as const;
+    if (XMTP_ENV && validEnvs.includes(XMTP_ENV as XmtpEnv)) {
+      initializedOptions.env = XMTP_ENV as XmtpEnv;
+    }
+
+    if (typeof XMTP_GATEWAY_HOST === "string") {
+      initializedOptions.gatewayHost = XMTP_GATEWAY_HOST;
+    }
+
+    if (typeof XMTP_DB_DIRECTORY === "string") {
+      fs.mkdirSync(XMTP_DB_DIRECTORY, { recursive: true, mode: 0o700 });
+      initializedOptions.dbPath = (inboxId: string) => {
+        const dbPath = path.join(XMTP_DB_DIRECTORY, `xmtp-${inboxId}.db3`);
+        console.info(`Saving local database to "${dbPath}"`);
+        return dbPath;
+      };
+    }
+
+    return this.create(signer, initializedOptions);
+  }
+
+  get libxmtpVersion() {
+    return this.#client.libxmtpVersion;
+  }
+
+  use(
+    ...middleware: Array<
+      AgentMiddleware<ContentTypes> | AgentMiddleware<ContentTypes>[]
+    >
+  ): this {
+    for (const mw of middleware) {
+      if (Array.isArray(mw)) {
+        this.#middleware.push(...mw);
+      } else if (typeof mw === "function") {
+        this.#middleware.push(mw);
+      }
+    }
+    return this;
+  }
+
+  async #stopStreams() {
+    try {
+      await this.#conversationsStream?.end();
+    } finally {
+      this.#conversationsStream = undefined;
+    }
+
+    try {
+      await this.#messageStream?.end();
+    } finally {
+      this.#messageStream = undefined;
+    }
+  }
+
+  /**
+   * Closes all existing streams and restarts with exponential backoff.
+   */
+  async #handleStreamError(error: unknown) {
+    if (this.#isRestarting) return;
+    this.#isRestarting = true;
+
+    await this.#stopStreams();
+
+    const recovered = await this.#runErrorChain(error, {
+      client: this.#client,
+    });
+
+    if (recovered && !this.#stopped) {
+      await this.#retryStreams();
+      this.emit("start", new ClientContext({ client: this.#client }));
+      this.#isLocked = false;
+    } else {
+      this.#isLocked = false;
+    }
+
+    this.#isRestarting = false;
+  }
+
+  async #retryStreams() {
+    return retry(
+      async () => {
+        await this.#stopStreams();
+        await this.#setupStreams(this.#streamOptions);
+      },
+      {
+        retries: 10,
+        delay: 1000,
+        backoff: "EXPONENTIAL",
+        maxBackOff: 30_000,
+        timeout: "INFINITELY",
+        retryIf: () => !this.#stopped,
+      },
+    );
+  }
+
+  async #setupStreams(options?: AgentStreamingOptions) {
+    this.#conversationsStream = await this.#client.conversations.stream({
+      ...options,
+      onValue: async (conversation) => {
+        try {
+          if (!conversation) {
+            return;
+          }
+          this.emit(
+            "conversation",
+            new ConversationContext<ContentTypes, Conversation<ContentTypes>>({
+              conversation,
+              client: this.#client,
+            }),
+          );
+          if (conversation instanceof Group) {
+            this.emit(
+              "group",
+              new ConversationContext<ContentTypes, Group<ContentTypes>>({
+                conversation,
+                client: this.#client,
+              }),
+            );
+          } else if (conversation instanceof Dm) {
+            this.emit(
+              "dm",
+              new ConversationContext<ContentTypes, Dm<ContentTypes>>({
+                conversation,
+                client: this.#client,
+              }),
+            );
+          }
+        } catch (error) {
+          const recovered = await this.#runErrorChain(
+            new AgentError(
+              1001,
+              "Emitted value from conversation stream caused an error.",
+              error,
+            ),
+            new ClientContext({ client: this.#client }),
+          );
+          if (!recovered) await this.stop();
+        }
+      },
+      onError: async (error) => {
+        await this.#handleStreamError(
+          new AgentStreamingError(
+            1002,
+            "Error occurred during conversation streaming.",
+            error,
+          ),
+        );
+      },
+    });
+
+    this.#messageStream = await this.#client.conversations.streamAllMessages({
+      ...options,
+      onValue: async (message) => {
+        try {
+          switch (true) {
+            case isActions(message):
+              await this.#processMessage(message, "actions");
+              break;
+            case isAttachment(message):
+              await this.#processMessage(message, "inline-attachment");
+              break;
+            case isIntent(message):
+              await this.#processMessage(message, "intent");
+              break;
+            case isGroupUpdated(message):
+              await this.#processMessage(message, "group-update");
+              break;
+            case isLeaveRequest(message):
+              await this.#processMessage(message, "leave-request");
+              break;
+            case isMultiRemoteAttachment(message):
+              await this.#processMessage(message, "multi-attachment");
+              break;
+            case isRemoteAttachment(message):
+              await this.#processMessage(message, "attachment");
+              break;
+            case isReaction(message):
+              await this.#processMessage(message, "reaction");
+              break;
+            case isReadReceipt(message):
+              await this.#processMessage(message, "read-receipt");
+              break;
+            case isReply(message):
+              await this.#processMessage(message, "reply");
+              break;
+            case isTransactionReference(message):
+              await this.#processMessage(message, "transaction-reference");
+              break;
+            case isWalletSendCalls(message):
+              await this.#processMessage(message, "wallet-send-calls");
+              break;
+            case isMarkdown(message):
+              await this.#processMessage(message, "markdown");
+              break;
+            case isText(message):
+              await this.#processMessage(message, "text");
+              break;
+            default:
+              await this.#processMessage(message);
+              break;
+          }
+        } catch (error) {
+          const recovered = await this.#runErrorChain(error, {
+            client: this.#client,
+          });
+          if (!recovered) {
+            await this.stop();
+          }
+          this.#isLocked = false;
+        }
+      },
+      onError: async (error) => {
+        await this.#handleStreamError(
+          new AgentStreamingError(
+            1004,
+            "Error occurred during message streaming.",
+            error,
+          ),
+        );
+      },
+    });
+  }
+
+  async start(options?: AgentStreamingOptions) {
+    if (this.#isLocked || this.#conversationsStream || this.#messageStream)
+      return;
+
+    this.#stopped = false;
+    this.#streamOptions = options;
+    this.#isLocked = true;
+
+    try {
+      await this.#setupStreams(options);
+      this.emit("start", new ClientContext({ client: this.#client }));
+      this.#isLocked = false;
+    } catch (error) {
+      await this.#handleStreamError(
+        new AgentStreamingError(
+          1005,
+          "Error occurred during stream setup.",
+          error,
+        ),
+      );
+    }
+  }
+
+  async #processMessage(
+    message: DecodedMessage<ContentTypes>,
+    topic: EventName<ContentTypes> = "unknownMessage",
+  ) {
+    // Skip messages with undefined content (failed to decode)
+    if (!filter.hasContent(message)) {
+      return;
+    }
+
+    // Skip messages from agent itself
+    if (filter.fromSelf(message, this.#client)) {
+      return;
+    }
+
+    const conversation = await this.#client.conversations.getConversationById(
+      message.conversationId,
+    );
+
+    if (!conversation) {
+      throw new AgentError(
+        1003,
+        `Failed to process message ID "${message.id}" for conversation ID "${message.conversationId}" because the conversation could not be found.`,
+      );
+    }
+
+    const context = new MessageContext({
+      message,
+      conversation,
+      client: this.#client,
+    });
+    await this.#runMiddlewareChain(context, topic);
+  }
+
+  async #runMiddlewareChain(
+    context: MessageContext<unknown, ContentTypes>,
+    topic: EventName<ContentTypes> = "unknownMessage",
+  ) {
+    const finalEmit = async () => {
+      try {
+        this.emit(topic, context);
+        this.emit("message", context);
+      } catch (error) {
+        await this.#runErrorChain(error, context);
+      }
+    };
+
+    const chain = this.#middleware.reduceRight<Parameters<AgentMiddleware>[1]>(
+      (next, mw) => {
+        return async () => {
+          try {
+            await mw(context, next);
+          } catch (error) {
+            const resume = await this.#runErrorChain(error, context);
+            if (resume) {
+              await next();
+            }
+            // Chain is not resuming, error is being swallowed
+          }
+        };
+      },
+      finalEmit,
+    );
+
+    await chain();
+  }
+
+  async #runErrorHandler(
+    handler: AgentErrorMiddleware<ContentTypes>,
+    context: AgentErrorContext<ContentTypes>,
+    error: unknown,
+  ): Promise<ErrorFlow> {
+    let settled = false as boolean;
+    let flow: ErrorFlow = { kind: "stopped" };
+
+    const next = (nextErr?: unknown) => {
+      if (settled) return;
+      settled = true;
+      flow =
+        nextErr === undefined
+          ? { kind: "handled" }
+          : { kind: "continue", error: nextErr };
+    };
+
+    try {
+      await handler(error, context, next);
+      return flow;
+    } catch (thrown) {
+      if (settled) {
+        return flow;
+      }
+      return { kind: "continue", error: thrown };
+    }
+  }
+
+  async #runErrorChain(
+    error: unknown,
+    context: AgentErrorContext<ContentTypes>,
+  ): Promise<boolean> {
+    const chain = [...this.#errorMiddleware, this.#defaultErrorHandler];
+
+    let currentError: unknown = error;
+
+    for (let i = 0; i < chain.length; i++) {
+      const handler = chain[i];
+      if (!handler) continue;
+      const outcome = await this.#runErrorHandler(
+        handler,
+        context,
+        currentError,
+      );
+
+      switch (outcome.kind) {
+        case "handled":
+          // Error was handled. Main middleware can continue.
+          return true;
+        case "stopped":
+          // Error cannot be handled. Main middleware won't continue.
+          return false;
+        case "continue":
+          // Error is passed to the next handler
+          currentError = outcome.error;
+      }
+    }
+
+    // Reached end of chain without recovery
+    return false;
+  }
+
+  get client() {
+    return this.#client;
+  }
+
+  get errors() {
+    return this.#errors;
+  }
+
+  async stop() {
+    this.#stopped = true;
+    this.#isLocked = true;
+
+    await this.#stopStreams();
+
+    this.emit("stop", new ClientContext({ client: this.#client }));
+
+    this.#isLocked = false;
+  }
+
+  createDmWithAddress(address: EthAddress, options?: CreateDmOptions) {
+    return this.#client.conversations.createDmWithIdentifier(
+      {
+        identifier: address,
+        identifierKind: IdentifierKind.Ethereum,
+      },
+      options,
+    );
+  }
+
+  createGroupWithAddresses(
+    addresses: EthAddress[],
+    options?: CreateGroupOptions,
+  ) {
+    const identifiers = addresses.map((address) => {
+      return {
+        identifier: address,
+        identifierKind: IdentifierKind.Ethereum,
+      };
+    });
+    return this.#client.conversations.createGroupWithIdentifiers(
+      identifiers,
+      options,
+    );
+  }
+
+  addMembersWithAddresses<ContentTypes>(
+    group: Group<ContentTypes>,
+    addresses: EthAddress[],
+  ) {
+    const identifiers = addresses.map((address) => {
+      return {
+        identifier: address,
+        identifierKind: IdentifierKind.Ethereum,
+      };
+    });
+
+    return group.addMembersByIdentifiers(identifiers);
+  }
+
+  async getConversationContext(conversationId: string) {
+    const conversation =
+      await this.client.conversations.getConversationById(conversationId);
+    if (conversation) {
+      const context = new ConversationContext({
+        conversation,
+        client: this.#client,
+      });
+      return context;
+    }
+  }
+
+  get address() {
+    return this.#client.accountIdentifier?.identifier;
+  }
+}

--- a/sdks/js/agent-sdk/src/core/AgentError.ts
+++ b/sdks/js/agent-sdk/src/core/AgentError.ts
@@ -1,0 +1,14 @@
+export class AgentError extends Error {
+  #code: number;
+
+  constructor(code: number, message: string, cause?: unknown) {
+    super(message, { cause });
+    this.#code = code;
+  }
+
+  get code() {
+    return this.#code;
+  }
+}
+
+export class AgentStreamingError extends AgentError {}

--- a/sdks/js/agent-sdk/src/core/ClientContext.ts
+++ b/sdks/js/agent-sdk/src/core/ClientContext.ts
@@ -1,0 +1,17 @@
+import type { Client } from "@xmtp/node-sdk";
+
+export class ClientContext<ContentTypes = unknown> {
+  #client: Client<ContentTypes>;
+
+  constructor({ client }: { client: Client<ContentTypes> }) {
+    this.#client = client;
+  }
+
+  getClientAddress() {
+    return this.#client.accountIdentifier?.identifier;
+  }
+
+  get client() {
+    return this.#client;
+  }
+}

--- a/sdks/js/agent-sdk/src/core/ConversationContext.ts
+++ b/sdks/js/agent-sdk/src/core/ConversationContext.ts
@@ -1,0 +1,66 @@
+import {
+  ConsentState,
+  type Client,
+  type Conversation,
+  type Dm,
+  type Group,
+} from "@xmtp/node-sdk";
+import { filter } from "@/core/filter";
+import {
+  createRemoteAttachmentFromFile,
+  type AttachmentUploadCallback,
+} from "@/util/AttachmentUtil";
+import { ClientContext } from "./ClientContext";
+
+export class ConversationContext<
+  ContentTypes = unknown,
+  ConversationType extends Conversation = Conversation,
+> extends ClientContext<ContentTypes> {
+  #conversation: ConversationType;
+
+  constructor({
+    conversation,
+    client,
+  }: {
+    conversation: ConversationType;
+    client: Client<ContentTypes>;
+  }) {
+    super({ client });
+    this.#conversation = conversation;
+  }
+
+  isDm(): this is ConversationContext<ContentTypes, Dm<ContentTypes>> {
+    return filter.isDM(this.#conversation);
+  }
+
+  isGroup(): this is ConversationContext<ContentTypes, Group<ContentTypes>> {
+    return filter.isGroup(this.#conversation);
+  }
+
+  async sendRemoteAttachment(
+    unencryptedFile: File,
+    uploadCallback: AttachmentUploadCallback,
+  ): Promise<void> {
+    const remoteAttachment = await createRemoteAttachmentFromFile(
+      unencryptedFile,
+      uploadCallback,
+    );
+    await this.#conversation.sendRemoteAttachment(remoteAttachment);
+  }
+
+  get conversation() {
+    return this.#conversation;
+  }
+
+  get isAllowed() {
+    return this.#conversation.consentState() === ConsentState.Allowed;
+  }
+
+  get isDenied() {
+    return this.#conversation.consentState() === ConsentState.Denied;
+  }
+
+  get isUnknown() {
+    return this.#conversation.consentState() === ConsentState.Unknown;
+  }
+}

--- a/sdks/js/agent-sdk/src/core/MessageContext.test.ts
+++ b/sdks/js/agent-sdk/src/core/MessageContext.test.ts
@@ -1,0 +1,37 @@
+import {
+  encodeText,
+  type DecodedMessage,
+  type EnrichedReply,
+} from "@xmtp/node-sdk";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { MessageContext } from "@/core/MessageContext";
+import { createClient } from "@/util/test";
+
+describe("MessageContext", () => {
+  it("should properly type the content when using reply as input", async () => {
+    const client = await createClient();
+    const group = await client.conversations.createGroup([]);
+    const messageId = await group.sendReply({
+      reference: "message-id",
+      referenceInboxId: "sender-inbox-id",
+      content: encodeText("This is a reply"),
+    });
+    const replyMessage = client.conversations.getMessageById(
+      messageId,
+    )! as DecodedMessage<EnrichedReply<string>>;
+    const messageContext = new MessageContext({
+      message: replyMessage,
+      conversation: group,
+      client,
+    });
+
+    const typedContext = messageContext as MessageContext<
+      EnrichedReply<string>
+    >;
+    expectTypeOf(typedContext.message.content).toEqualTypeOf<
+      EnrichedReply<string>
+    >();
+    const { content } = typedContext.message;
+    expect(content.content).toBe(replyMessage.content?.content);
+  });
+});

--- a/sdks/js/agent-sdk/src/core/MessageContext.ts
+++ b/sdks/js/agent-sdk/src/core/MessageContext.ts
@@ -1,0 +1,129 @@
+import type {
+  ContentCodec,
+  EncodedContent,
+} from "@xmtp/content-type-primitives";
+import {
+  encodeMarkdown,
+  encodeText,
+  isMarkdown,
+  isReaction,
+  isReadReceipt,
+  isRemoteAttachment,
+  isReply,
+  isText,
+  isTransactionReference,
+  isWalletSendCalls,
+  ReactionAction,
+  ReactionSchema,
+  type Reaction,
+  type ReadReceipt,
+  type RemoteAttachment,
+  type Reply,
+  type TransactionReference,
+  type WalletSendCalls,
+} from "@xmtp/node-sdk";
+import { filter, type DecodedMessageWithContent } from "@/core/filter";
+import type { AgentBaseContext } from "./Agent";
+import { ConversationContext } from "./ConversationContext";
+
+export type MessageContextParams<
+  MessageContentType = unknown,
+  ContentTypes = unknown,
+> = Omit<AgentBaseContext<ContentTypes>, "message"> & {
+  message: DecodedMessageWithContent<MessageContentType>;
+};
+
+export class MessageContext<
+  MessageContentType = unknown,
+  ContentTypes = unknown,
+> extends ConversationContext<ContentTypes> {
+  #message: DecodedMessageWithContent<MessageContentType>;
+
+  constructor({
+    message,
+    conversation,
+    client,
+  }: MessageContextParams<MessageContentType, ContentTypes>) {
+    super({ conversation, client });
+    this.#message = message;
+  }
+
+  usesCodec<T extends ContentCodec>(
+    codecClass: new () => T,
+  ): this is MessageContext<ReturnType<T["decode"]>> {
+    return filter.usesCodec(this.#message, codecClass);
+  }
+
+  isMarkdown(): this is MessageContext<string> {
+    return isMarkdown(this.#message);
+  }
+
+  isText(): this is MessageContext<string> {
+    return isText(this.#message);
+  }
+
+  isReply(): this is MessageContext<Reply> {
+    return isReply(this.#message);
+  }
+
+  isReaction(): this is MessageContext<Reaction> {
+    return isReaction(this.#message);
+  }
+
+  isReadReceipt(): this is MessageContext<ReadReceipt> {
+    return isReadReceipt(this.#message);
+  }
+
+  isRemoteAttachment(): this is MessageContext<RemoteAttachment> {
+    return isRemoteAttachment(this.#message);
+  }
+
+  isTransactionReference(): this is MessageContext<TransactionReference> {
+    return isTransactionReference(this.#message);
+  }
+
+  isWalletSendCalls(): this is MessageContext<WalletSendCalls> {
+    return isWalletSendCalls(this.#message);
+  }
+
+  async sendReaction(
+    content: string,
+    schema: Reaction["schema"] = ReactionSchema.Unicode,
+  ) {
+    const reaction: Reaction = {
+      action: ReactionAction.Added,
+      reference: this.#message.id,
+      referenceInboxId: this.#message.senderInboxId,
+      schema,
+      content,
+    };
+    await this.conversation.sendReaction(reaction);
+  }
+
+  async #sendReply(content: EncodedContent) {
+    await this.conversation.sendReply({
+      content,
+      reference: this.#message.id,
+      referenceInboxId: this.#message.senderInboxId,
+    });
+  }
+
+  async sendMarkdownReply(markdown: string) {
+    await this.#sendReply(encodeMarkdown(markdown));
+  }
+
+  async sendTextReply(text: string) {
+    await this.#sendReply(encodeText(text));
+  }
+
+  async getSenderAddress() {
+    const inboxState = await this.client.preferences.getInboxStates([
+      this.#message.senderInboxId,
+    ]);
+    return inboxState[0]?.identifiers[0]?.identifier;
+  }
+
+  get message() {
+    return this.#message;
+  }
+}

--- a/sdks/js/agent-sdk/src/core/filter.test.ts
+++ b/sdks/js/agent-sdk/src/core/filter.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { filter } from "@/core/filter";
+import { createClient, TestCodec } from "@/util/test";
+
+describe("Filters", () => {
+  describe("fromSelf", () => {
+    it("should return false for messages not from self", async () => {
+      const client = await createClient();
+      const otherClient = await createClient();
+      const group = await client.conversations.createGroup([
+        otherClient.inboxId,
+      ]);
+      await group.sendText("Hello world");
+      const messages = await group.messages();
+      const message = messages[0]!;
+      const result = filter.fromSelf(message, otherClient);
+      expect(result).toBe(false);
+    });
+
+    it("should return true for messages from self", async () => {
+      const client = await createClient();
+      const group = await client.conversations.createGroup([]);
+      await group.sendText("Hello world");
+      const messages = await group.messages();
+      const message = messages[0]!;
+      const result = filter.fromSelf(message, client);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("hasContent", () => {
+    it("should return true for messages with defined content", async () => {
+      const client = await createClient();
+      const group = await client.conversations.createGroup([]);
+      await group.sendText("Hello world");
+      const messages = await group.messages();
+      const message = messages[0]!;
+      const result = filter.hasContent(message);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for messages with no content", async () => {
+      const client = await createClient();
+      const group = await client.conversations.createGroup([]);
+      const testCodec = new TestCodec();
+      await group.send(testCodec.encode({ test: "test" }));
+      const messages = await group.messages();
+      const message = messages[0]!;
+      const result = filter.hasContent(message);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("isDM", () => {
+    it("should return true for DM conversations", async () => {
+      const client = await createClient();
+      const otherClient = await createClient();
+      const dm = await client.conversations.createDm(otherClient.inboxId);
+      const result = filter.isDM(dm);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for group conversations", async () => {
+      const client = await createClient();
+      const group = await client.conversations.createGroup([]);
+      const result = filter.isDM(group);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("isGroup", () => {
+    it("should return true for group conversations", async () => {
+      const client = await createClient();
+      const group = await client.conversations.createGroup([]);
+      const result = filter.isGroup(group);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for DM conversations", async () => {
+      const client = await createClient();
+      const otherClient = await createClient();
+      const dm = await client.conversations.createDm(otherClient.inboxId);
+      const result = filter.isGroup(dm);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("isGroupAdmin", () => {
+    it("should return true when sender is a group admin", async () => {
+      const client = await createClient();
+      const otherClient = await createClient();
+      const g = await client.conversations.createGroup([otherClient.inboxId]);
+      await g.addAdmin(otherClient.inboxId);
+      await otherClient.conversations.sync();
+      const group = otherClient.conversations.listGroups()[0]!;
+      await group.sendText("Hello world");
+      const messages = await group.messages();
+      const message = messages[2]!;
+      const result = filter.isGroupAdmin(group, message);
+      expect(result).toBe(true);
+    });
+
+    it("should return false when sender is not a group admin", async () => {
+      const client = await createClient();
+      const otherClient = await createClient();
+      await client.conversations.createGroup([otherClient.inboxId]);
+      await otherClient.conversations.sync();
+      const group = otherClient.conversations.listGroups()[0]!;
+      await group.sendText("Hello world");
+      const messages = await group.messages();
+      const message = messages[0]!;
+      const result = filter.isGroupAdmin(group, message);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when conversation is not a group", async () => {
+      const client = await createClient();
+      const otherClient = await createClient();
+      const dm = await client.conversations.createDm(otherClient.inboxId);
+      const messages = await dm.messages();
+      const message = messages[0]!;
+      const result = filter.isGroupAdmin(dm, message);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("isGroupSuperAdmin", () => {
+    it("should return true when sender is a group super admin", async () => {
+      const client = await createClient();
+      const group = await client.conversations.createGroup([]);
+      await group.sendText("Hello world");
+      const messages = await group.messages();
+      const message = messages[0]!;
+      const result = filter.isGroupSuperAdmin(group, message);
+      expect(result).toBe(true);
+    });
+
+    it("should return false when sender is not a group super admin", async () => {
+      const client = await createClient();
+      const otherClient = await createClient();
+      await client.conversations.createGroup([otherClient.inboxId]);
+      await otherClient.conversations.sync();
+      const group = otherClient.conversations.listGroups()[0]!;
+      await group.sendText("Hello world");
+      const messages = await group.messages();
+      const message = messages[1]!;
+      const result = filter.isGroupSuperAdmin(group, message);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when conversation is not a group", async () => {
+      const client = await createClient();
+      const otherClient = await createClient();
+      const dm = await client.conversations.createDm(otherClient.inboxId);
+      const messages = await dm.messages();
+      const message = messages[0]!;
+      const result = filter.isGroupSuperAdmin(dm, message);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when sender is regular admin but not super admin", async () => {
+      const client = await createClient();
+      const otherClient = await createClient();
+      const g = await client.conversations.createGroup([otherClient.inboxId]);
+      await g.addAdmin(otherClient.inboxId);
+      await otherClient.conversations.sync();
+      const group = otherClient.conversations.listGroups()[0]!;
+      await group.sendText("Hello world");
+      const messages = await group.messages();
+      const message = messages[2]!;
+      const result = filter.isGroupSuperAdmin(group, message);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("usesCodec", () => {
+    it("should return true for messages using a custom codec", async () => {
+      const testCodec = new TestCodec();
+      const client = await createClient({
+        codecs: [testCodec],
+      });
+      const group = await client.conversations.createGroup([]);
+      const messageId = await group.send(testCodec.encode({ test: "test" }));
+      const message = client.conversations.getMessageById(messageId)!;
+      const result = filter.usesCodec(message, TestCodec);
+      if (result) {
+        assertType<Record<string, string>>(message.content);
+      }
+      expect(result).toBe(true);
+    });
+
+    it("should return false for messages using a different codec", async () => {
+      const client = await createClient();
+      const group = await client.conversations.createGroup([]);
+      const messageId = await group.sendText("Hello world");
+      const message = client.conversations.getMessageById(messageId)!;
+      const result = filter.usesCodec(message, TestCodec);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/sdks/js/agent-sdk/src/core/filter.ts
+++ b/sdks/js/agent-sdk/src/core/filter.ts
@@ -1,0 +1,76 @@
+import {
+  contentTypesAreEqual,
+  type ContentCodec,
+} from "@xmtp/content-type-primitives";
+import {
+  Dm,
+  Group,
+  type Client,
+  type Conversation,
+  type DecodedMessage,
+} from "@xmtp/node-sdk";
+
+export type DecodedMessageWithContent<ContentTypes = unknown> =
+  DecodedMessage<ContentTypes> & {
+    content: ContentTypes;
+  };
+
+const fromSelf = <ContentTypes>(
+  message: DecodedMessage<ContentTypes>,
+  client: Client<ContentTypes>,
+) => {
+  return message.senderInboxId === client.inboxId;
+};
+
+const hasContent = <ContentTypes>(
+  message: DecodedMessage<ContentTypes>,
+): message is DecodedMessageWithContent<ContentTypes> => {
+  return message.content !== undefined && message.content !== null;
+};
+
+const isDM = (conversation: Conversation): conversation is Dm => {
+  return conversation instanceof Dm;
+};
+
+const isGroup = (conversation: Conversation): conversation is Group => {
+  return conversation instanceof Group;
+};
+
+const isGroupAdmin = (conversation: Conversation, message: DecodedMessage) => {
+  if (isGroup(conversation)) {
+    return conversation.isAdmin(message.senderInboxId);
+  }
+  return false;
+};
+
+const isGroupSuperAdmin = (
+  conversation: Conversation,
+  message: DecodedMessage,
+) => {
+  if (isGroup(conversation)) {
+    return conversation.isSuperAdmin(message.senderInboxId);
+  }
+  return false;
+};
+
+const usesCodec = <T extends ContentCodec>(
+  message: DecodedMessage,
+  codecClass: new () => T,
+): message is DecodedMessageWithContent<ReturnType<T["decode"]>> => {
+  return contentTypesAreEqual(
+    message.contentType,
+    new codecClass().contentType,
+  );
+};
+
+export const filter = {
+  fromSelf,
+  hasContent,
+  isDM,
+  isGroup,
+  isGroupAdmin,
+  isGroupSuperAdmin,
+  usesCodec,
+};
+
+export const f = filter;

--- a/sdks/js/agent-sdk/src/core/index.ts
+++ b/sdks/js/agent-sdk/src/core/index.ts
@@ -1,0 +1,6 @@
+export * from "./Agent";
+export * from "./AgentError";
+export * from "./ClientContext";
+export * from "./ConversationContext";
+export * from "./filter";
+export * from "./MessageContext";

--- a/sdks/js/agent-sdk/src/debug/index.ts
+++ b/sdks/js/agent-sdk/src/debug/index.ts
@@ -1,0 +1,1 @@
+export * from "./log";

--- a/sdks/js/agent-sdk/src/debug/log.test.ts
+++ b/sdks/js/agent-sdk/src/debug/log.test.ts
@@ -1,0 +1,64 @@
+import { LogLevel } from "@xmtp/node-sdk";
+import { describe, expect, it } from "vitest";
+import { getValidLogLevels, parseLogLevel } from "@/debug/log";
+
+describe("parseLogLevel", () => {
+  it("should parse lowercase log levels", () => {
+    expect(parseLogLevel("off")).toBe(LogLevel.Off);
+    expect(parseLogLevel("error")).toBe(LogLevel.Error);
+    expect(parseLogLevel("warn")).toBe(LogLevel.Warn);
+    expect(parseLogLevel("info")).toBe(LogLevel.Info);
+    expect(parseLogLevel("debug")).toBe(LogLevel.Debug);
+    expect(parseLogLevel("trace")).toBe(LogLevel.Trace);
+  });
+
+  it("should parse uppercase log levels", () => {
+    expect(parseLogLevel("OFF")).toBe(LogLevel.Off);
+    expect(parseLogLevel("ERROR")).toBe(LogLevel.Error);
+    expect(parseLogLevel("WARN")).toBe(LogLevel.Warn);
+    expect(parseLogLevel("INFO")).toBe(LogLevel.Info);
+    expect(parseLogLevel("DEBUG")).toBe(LogLevel.Debug);
+    expect(parseLogLevel("TRACE")).toBe(LogLevel.Trace);
+  });
+
+  it("should parse properly cased log levels", () => {
+    expect(parseLogLevel("Off")).toBe(LogLevel.Off);
+    expect(parseLogLevel("Error")).toBe(LogLevel.Error);
+    expect(parseLogLevel("Warn")).toBe(LogLevel.Warn);
+    expect(parseLogLevel("Info")).toBe(LogLevel.Info);
+    expect(parseLogLevel("Debug")).toBe(LogLevel.Debug);
+    expect(parseLogLevel("Trace")).toBe(LogLevel.Trace);
+  });
+
+  it("should parse mixed case log levels", () => {
+    expect(parseLogLevel("dEBUG")).toBe(LogLevel.Debug);
+    expect(parseLogLevel("WaRn")).toBe(LogLevel.Warn);
+  });
+
+  it("should return null for invalid log levels", () => {
+    expect(parseLogLevel("invalid")).toBeNull();
+    expect(parseLogLevel("")).toBeNull();
+    expect(parseLogLevel("verbose")).toBeNull();
+    expect(parseLogLevel("warning")).toBeNull();
+  });
+});
+
+describe("getValidLogLevels", () => {
+  it("should return all valid log levels", () => {
+    const levels = getValidLogLevels();
+    expect(levels).toContain(LogLevel.Off);
+    expect(levels).toContain(LogLevel.Error);
+    expect(levels).toContain(LogLevel.Warn);
+    expect(levels).toContain(LogLevel.Info);
+    expect(levels).toContain(LogLevel.Debug);
+    expect(levels).toContain(LogLevel.Trace);
+    expect(levels).toHaveLength(6);
+  });
+
+  it("should return a new array each time", () => {
+    const levels1 = getValidLogLevels();
+    const levels2 = getValidLogLevels();
+    expect(levels1).not.toBe(levels2);
+    expect(levels1).toEqual(levels2);
+  });
+});

--- a/sdks/js/agent-sdk/src/debug/log.ts
+++ b/sdks/js/agent-sdk/src/debug/log.ts
@@ -1,0 +1,149 @@
+import { Client, LogLevel } from "@xmtp/node-sdk";
+import type { Agent } from "@/core/Agent";
+
+const validLogLevels: LogLevel[] = [
+  LogLevel.Off,
+  LogLevel.Error,
+  LogLevel.Warn,
+  LogLevel.Info,
+  LogLevel.Debug,
+  LogLevel.Trace,
+];
+
+const isLogLevel = (level: string): level is LogLevel => {
+  return validLogLevels.includes(level as LogLevel);
+};
+
+export const getValidLogLevels = (): LogLevel[] => {
+  return [...validLogLevels];
+};
+
+export const parseLogLevel = (rawLevel: string) => {
+  const normalizedLevel =
+    rawLevel.charAt(0).toUpperCase() + rawLevel.slice(1).toLowerCase();
+
+  if (isLogLevel(normalizedLevel)) {
+    return normalizedLevel;
+  }
+
+  return null;
+};
+
+export const logDetails = async <ContentTypes>(agent: Agent<ContentTypes>) => {
+  const xmtp = `\x1b[38;2;252;76;52m
+    ██╗  ██╗███╗   ███╗████████╗██████╗
+    ╚██╗██╔╝████╗ ████║╚══██╔══╝██╔══██╗
+     ╚███╔╝ ██╔████╔██║   ██║   ██████╔╝
+     ██╔██╗ ██║╚██╔╝██║   ██║   ██╔═══╝
+    ██╔╝ ██╗██║ ╚═╝ ██║   ██║   ██║
+    ╚═╝  ╚═╝╚═╝     ╚═╝   ╚═╝   ╚═╝
+  \x1b[0m`;
+
+  const client = agent.client;
+  const clientsByAddress = client.accountIdentifier?.identifier;
+  const inboxId = client.inboxId;
+  const installationId = client.installationId;
+  const env = client.env;
+
+  const urls = [`http://xmtp.chat/${env}/dm/${clientsByAddress}`];
+
+  const conversations = await client.conversations.list();
+  const inboxState = await client.preferences.inboxState();
+  const keyPackageStatuses = await client.fetchKeyPackageStatuses([
+    installationId,
+  ]);
+
+  let createdDate = new Date();
+  let expiryDate = new Date();
+
+  // Extract key package status for the specific installation
+  const keyPackageStatus = keyPackageStatuses[installationId] ?? {};
+  if (keyPackageStatus.lifetime) {
+    createdDate = new Date(Number(keyPackageStatus.lifetime.notBefore) * 1000);
+    expiryDate = new Date(Number(keyPackageStatus.lifetime.notAfter) * 1000);
+  }
+  console.log(`
+    ${xmtp}
+
+    ✓ XMTP Client:
+    • InboxId: ${inboxId}
+    • LibXMTP Version: ${agent.libxmtpVersion}
+    • Address: ${clientsByAddress}
+    • Conversations: ${conversations.length}
+    • Installations: ${inboxState.installations.length}
+    • InstallationId: ${installationId}
+    • Key Package created: ${createdDate.toLocaleString()}
+    • Key Package valid until: ${expiryDate.toLocaleString()}
+    • Networks: ${env}
+    ${urls.map((url) => `• URL: ${url}`).join("\n")}`);
+};
+
+/**
+ * Returns a URL to test your agent on https://xmtp.chat/ (for development purposes only).
+ *
+ * @param client - Your XMTP client
+ * @returns The URL to test your agent with
+ */
+export const getTestUrl = <ContentTypes>(client: Client<ContentTypes>) => {
+  const address = client.accountIdentifier?.identifier;
+  const env = client.env;
+  return `http://xmtp.chat/${env}/dm/${address}`;
+};
+
+type InstallationInfo = {
+  totalInstallations: number;
+  installationId: string;
+  mostRecentInstallationId: null | string;
+  isMostRecent: boolean;
+};
+
+export const getInstallationInfo = async <ContentTypes>(
+  client: Client<ContentTypes>,
+): Promise<InstallationInfo> => {
+  const myInboxId = client.inboxId;
+  const myInstallationId = client.installationId;
+
+  const env = client.env;
+  const gatewayHost =
+    client.options && "gatewayHost" in client.options
+      ? client.options.gatewayHost
+      : undefined;
+  const inboxStates = await Client.fetchInboxStates(
+    [myInboxId],
+    env,
+    gatewayHost,
+  );
+
+  const installations =
+    inboxStates.find((state) => state.inboxId === myInboxId)?.installations ||
+    [];
+
+  const sortedInstallations = [...installations].sort((a, b) => {
+    const aTime = a.clientTimestampNs ?? 0n;
+    const bTime = b.clientTimestampNs ?? 0n;
+    return bTime > aTime ? 1 : bTime < aTime ? -1 : 0;
+  });
+
+  const mostRecentInstallation = sortedInstallations[0];
+
+  const myInstallationIdHex = Buffer.from(client.installationIdBytes).toString(
+    "hex",
+  );
+
+  const info: InstallationInfo = {
+    totalInstallations: installations.length,
+    installationId: myInstallationId,
+    mostRecentInstallationId: null,
+    isMostRecent: false,
+  };
+
+  if (mostRecentInstallation) {
+    const mostRecentIdHex = Buffer.from(mostRecentInstallation.bytes).toString(
+      "hex",
+    );
+    info.mostRecentInstallationId = mostRecentIdHex;
+    info.isMostRecent = myInstallationIdHex === mostRecentIdHex;
+  }
+
+  return info;
+};

--- a/sdks/js/agent-sdk/src/demo/actions.ts
+++ b/sdks/js/agent-sdk/src/demo/actions.ts
@@ -1,0 +1,35 @@
+import { ActionWizard } from "@/middleware/ActionWizard";
+import { getAgent } from "./getAgent";
+
+const agent = await getAgent();
+
+const wizard = new ActionWizard("api-setup", { dm: true, cancel: true })
+  .select("provider", {
+    description: "Select your API provider",
+    actions: [
+      { id: "railway", label: "Railway" },
+      { id: "render", label: "Render.com" },
+      { id: "vercel", label: "Vercel" },
+    ],
+  })
+  .text("username", {
+    description: "Enter your API username:",
+  })
+  .text("apiKey", {
+    description: "Enter your API key:",
+  })
+  .onComplete(async (answers, ctx) => {
+    await ctx.conversation.sendMarkdown(
+      `**Setup complete!**\n\n` +
+        `Provider ID: ${answers.provider}\n` +
+        `Username: ${answers.username}\n` +
+        `API Key: ${answers.apiKey}`,
+    );
+  })
+  .onCancel(async (ctx) => {
+    await ctx.conversation.sendText("Setup cancelled.");
+  });
+
+agent.use(wizard.middleware());
+
+await agent.start();

--- a/sdks/js/agent-sdk/src/demo/getAgent.ts
+++ b/sdks/js/agent-sdk/src/demo/getAgent.ts
@@ -1,0 +1,25 @@
+import { loadEnvFile } from "node:process";
+import { Agent } from "@/core/index";
+import { getTestUrl } from "@/debug/log";
+import { createSigner, createUser } from "@/user/User";
+
+try {
+  loadEnvFile();
+  console.info(`Loaded keys from ".env" file.`);
+} catch {
+  // no .env file present
+}
+
+export async function getAgent() {
+  const agent = process.env.XMTP_WALLET_KEY
+    ? await Agent.createFromEnv()
+    : await Agent.create(createSigner(createUser()), { dbPath: null });
+
+  agent.on("start", (ctx) => {
+    console.log(`Address: ${agent.address}`);
+    console.log(`Link: ${getTestUrl(ctx.client)}`);
+    console.log("Agent started. Waiting for messages...");
+  });
+
+  return agent;
+}

--- a/sdks/js/agent-sdk/src/demo/main.ts
+++ b/sdks/js/agent-sdk/src/demo/main.ts
@@ -1,0 +1,125 @@
+import { isHexString } from "@xmtp/node-sdk";
+import { AgentError } from "@/core/index";
+import { logDetails } from "@/debug/log";
+import { CommandRouter } from "@/middleware/CommandRouter";
+import { PerformanceMonitor } from "@/middleware/PerformanceMonitor";
+import { createNameResolver } from "@/user";
+import { downloadRemoteAttachment } from "@/util/AttachmentUtil";
+import { getAgent } from "./getAgent";
+
+const agent = await getAgent();
+
+const performanceMonitor = new PerformanceMonitor({
+  healthReportInterval: 10_000,
+  criticalThresholdInterval: 5_000,
+  onResponse: (duration) => {
+    console.log(`[PerformanceMonitor] Message loop completed in ${duration}ms`);
+  },
+  onCriticalResponse: (duration) => {
+    console.warn(
+      `[PerformanceMonitor] Slow response detected: ${duration.toFixed(0)}ms (threshold: 5000ms)`,
+    );
+  },
+});
+const commandRouter = new CommandRouter({ helpCommand: "/help" });
+
+commandRouter.command("/version", "Show Agent SDK version", async (ctx) => {
+  await ctx.conversation.sendText(`v${process.env.npm_package_version}`);
+});
+
+commandRouter.command("/test-actions", async (ctx) => {
+  await ctx.conversation.sendActions({
+    id: `actions-${Date.now()}`,
+    description: "Would you like to proceed?",
+    actions: [
+      { id: "action-yes", label: "Yes" },
+      { id: "action-no", label: "No" },
+    ],
+  });
+});
+
+agent.use(performanceMonitor.middleware());
+agent.use(commandRouter.middleware());
+
+agent.on("attachment", async (ctx) => {
+  const receivedAttachment = await downloadRemoteAttachment(
+    ctx.message.content,
+  );
+  console.log(`Received attachment: ${receivedAttachment.filename}`);
+});
+
+agent.on("text", (ctx) => {
+  console.log("Got text:", ctx.message.content);
+});
+
+agent.on("reaction", (ctx) => {
+  console.log("Got reaction:", ctx.message.content);
+});
+
+agent.on("reply", (ctx) => {
+  console.log("Got reply:", ctx.message.content);
+});
+
+agent.on("intent", async (ctx) => {
+  const { actionId } = ctx.message.content;
+  console.log("Got intent:", ctx.message.content);
+  await ctx.conversation.sendText(`You selected action ID "${actionId}".`);
+});
+
+agent.on("text", async (ctx) => {
+  if (ctx.message.content.startsWith("@agent")) {
+    await ctx.conversation.sendText("How can I help you?");
+  }
+});
+
+agent.on("transaction-reference", (ctx) => {
+  const { networkId, reference } = ctx.message.content;
+  if (!isHexString(reference)) {
+    console.warn(`Invalid transaction ID: ${reference}`);
+  }
+  console.log(`Transaction "${reference}" on network "${networkId}".`);
+});
+
+agent.on("wallet-send-calls", (ctx) => {
+  const { chainId, calls } = ctx.message.content;
+  console.log(
+    `Wallet request for "${calls.length}" calls on chain "${chainId}".`,
+  );
+});
+
+agent.on("read-receipt", (ctx) => {
+  console.log(`Message ID "${ctx.message.id}" was read.`);
+});
+
+const errorHandler = (error: unknown) => {
+  if (error instanceof AgentError) {
+    console.log(`Caught error ID "${error.code}"`, error);
+    console.log("Original error", error.cause);
+  } else {
+    console.log(`Caught error`, error);
+  }
+};
+
+agent.on("unhandledError", errorHandler);
+
+agent.on("stop", (ctx) => {
+  performanceMonitor.shutdown();
+  console.log("Agent stopped", ctx);
+});
+
+agent.on("unknownMessage", (ctx) => {
+  console.log(
+    `Unknown message type, displaying fallback content: ${ctx.message.fallback}`,
+  );
+});
+
+agent.on("group", async (ctx) => {
+  await ctx.conversation.sendMarkdown("**Hello, World!**");
+});
+
+await agent.start();
+console.log("Agent has started.");
+await logDetails(agent);
+
+const resolveName = createNameResolver(process.env.WEB3BIO_API_KEY);
+console.log(await resolveName("vitalik.eth"));

--- a/sdks/js/agent-sdk/src/demo/reconnect.ts
+++ b/sdks/js/agent-sdk/src/demo/reconnect.ts
@@ -1,0 +1,27 @@
+import { once } from "node:events";
+import { setTimeout } from "node:timers/promises";
+import { createToxicAgent, enableBackend } from "@/core/Agent.reconnect.test";
+
+console.log("Scenario: Streams break while agent is running");
+const agent = await createToxicAgent();
+agent.errors.use((error, _ctx, next) => {
+  console.error("Error occurred", error);
+  void next();
+});
+
+await agent.start();
+console.log("Agent started");
+await setTimeout(2000);
+
+// Set up a promise that resolves on the next "start" event (= reconnect)
+const reconnected = once(agent, "start");
+
+await enableBackend(false);
+await setTimeout(5000);
+await enableBackend(true);
+
+await reconnected;
+console.log("Agent reconnected");
+
+await agent.stop();
+process.exit(0);

--- a/sdks/js/agent-sdk/src/demo/transactions.ts
+++ b/sdks/js/agent-sdk/src/demo/transactions.ts
@@ -1,0 +1,82 @@
+import { validHex } from "@xmtp/node-sdk";
+import { formatUnits, hexToNumber, parseUnits } from "viem";
+import { base } from "viem/chains";
+import { CommandRouter } from "@/middleware/CommandRouter";
+import {
+  createERC20TransferCalls,
+  getERC20Balance,
+  getERC20Decimals,
+} from "@/util/TransactionUtil";
+import { getAgent } from "./getAgent";
+
+const CHAIN = base;
+/** USDC Token address on Base chain: https://basescan.org/token/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 */
+const USDC_TOKEN_CONTRACT =
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as const;
+const USDC_DECIMALS = await getERC20Decimals({
+  chain: CHAIN,
+  tokenAddress: USDC_TOKEN_CONTRACT,
+}).catch(() => 6);
+
+const agent = await getAgent();
+const router = new CommandRouter({ helpCommand: "/help" });
+
+router.command("/my-balance", "Check your USDC balance", async (ctx) => {
+  const senderAddress = await ctx.getSenderAddress();
+  const senderBalance = await getERC20Balance({
+    chain: CHAIN,
+    tokenAddress: USDC_TOKEN_CONTRACT,
+    address: validHex(senderAddress),
+  });
+  await ctx.conversation.sendText(
+    `Your USDC balance is: ${formatUnits(senderBalance, USDC_DECIMALS)}`,
+  );
+});
+
+router.command(
+  "/your-balance",
+  "Check the agent's USDC balance",
+  async (ctx) => {
+    const ownAddress = ctx.getClientAddress();
+    const ownBalance = await getERC20Balance({
+      chain: CHAIN,
+      tokenAddress: USDC_TOKEN_CONTRACT,
+      address: validHex(ownAddress),
+    });
+    await ctx.conversation.sendText(
+      `My USDC balance is: ${formatUnits(ownBalance, USDC_DECIMALS)}`,
+    );
+  },
+);
+
+router.command("/tx", "Send USDC to the agent (e.g. /tx 0.1)", async (ctx) => {
+  const senderAddress = await ctx.getSenderAddress();
+  const receiverAddress = agent.address;
+  const amount = parseUnits(ctx.message.content, USDC_DECIMALS);
+  const currency = "USDC";
+
+  const walletSendCalls = createERC20TransferCalls({
+    chain: CHAIN,
+    tokenAddress: USDC_TOKEN_CONTRACT,
+    from: validHex(senderAddress),
+    to: validHex(receiverAddress),
+    amount,
+    description: `Transfer "${ctx.message.content} ${currency}" on chain "${CHAIN.name}" to address "${receiverAddress}".`,
+  });
+
+  await ctx.conversation.sendWalletSendCalls(walletSendCalls);
+});
+
+agent.use(router.middleware());
+
+agent.on("transaction-reference", async (ctx) => {
+  const { networkId, reference } = ctx.message.content;
+  const networkIdDecimal = hexToNumber(validHex(networkId));
+  await ctx.conversation.sendMarkdown(
+    `Transaction confirmed!\n` +
+      `Chain ID: [${networkIdDecimal}](https://chainlist.org/chain/${networkIdDecimal})\n` +
+      `Transaction Hash: [${reference}](https://basescan.org/tx/${reference})`,
+  );
+});
+
+await agent.start();

--- a/sdks/js/agent-sdk/src/index.ts
+++ b/sdks/js/agent-sdk/src/index.ts
@@ -1,0 +1,7 @@
+export * from "@xmtp/node-sdk";
+// Agent SDK
+export * from "./core/index";
+export * from "./debug/index";
+export * from "./middleware/index";
+export * from "./user/index";
+export * from "./util/index";

--- a/sdks/js/agent-sdk/src/middleware/ActionWizard.test.ts
+++ b/sdks/js/agent-sdk/src/middleware/ActionWizard.test.ts
@@ -1,0 +1,573 @@
+import {
+  isActions,
+  isMarkdown,
+  isText,
+  type BuiltInContentTypes,
+  type Client,
+} from "@xmtp/node-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Agent } from "@/core/Agent";
+import { ActionWizard } from "@/middleware/ActionWizard";
+import { createClient } from "@/util/test";
+
+describe("ActionWizard", () => {
+  describe("static helpers", () => {
+    it("builds a session key", () => {
+      expect(ActionWizard.sessionKey("conv-1", "sender-1")).toBe(
+        "conv-1:sender-1",
+      );
+    });
+
+    it("builds a step key", () => {
+      expect(ActionWizard.stepKey("setup", "color")).toBe("setup:color");
+    });
+  });
+
+  describe("Builder API", () => {
+    it("returns this from all methods for chaining", () => {
+      const wizard = new ActionWizard("w");
+      expect(
+        wizard.select("s", {
+          description: "Pick",
+          actions: [{ id: "a", label: "A" }],
+        }),
+      ).toBe(wizard);
+      expect(wizard.text("name-label", { description: "Enter name" })).toBe(
+        wizard,
+      );
+      expect(wizard.onComplete(vi.fn())).toBe(wizard);
+      expect(wizard.onCancel(vi.fn())).toBe(wizard);
+    });
+  });
+
+  describe("select step", () => {
+    let agent: Agent<BuiltInContentTypes>;
+    let client: Client;
+
+    beforeEach(async () => {
+      client = await createClient();
+      agent = new Agent({ client });
+    });
+
+    it("sends actions when the trigger command is received", async () => {
+      const completeHandler = vi.fn();
+      const wizard = new ActionWizard("setup");
+      wizard
+        .select("color", {
+          description: "Pick a color",
+          actions: [
+            { id: "red", label: "Red" },
+            { id: "blue", label: "Blue" },
+          ],
+        })
+        .onComplete(completeHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/setup");
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        const actionsMessage = messages.find((m) => isActions(m));
+        expect(actionsMessage?.content).toMatchObject({
+          id: "setup:color",
+          description: "Pick a color",
+        });
+      });
+    });
+
+    it("records the answer and completes when an intent is received", async () => {
+      const completeHandler = vi.fn();
+      const wizard = new ActionWizard("setup");
+      wizard
+        .select("color", {
+          description: "Pick a color",
+          actions: [
+            { id: "red", label: "Red" },
+            { id: "blue", label: "Blue" },
+          ],
+        })
+        .onComplete(completeHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/setup");
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        expect(messages.some((m) => isActions(m))).toBe(true);
+      });
+
+      await dm.sendIntent({ id: "setup:color", actionId: "blue" });
+
+      await vi.waitFor(() => {
+        expect(completeHandler).toHaveBeenCalledWith(
+          { color: "blue" },
+          expect.anything(),
+        );
+      });
+    });
+  });
+
+  describe("text step", () => {
+    let agent: Agent<BuiltInContentTypes>;
+    let client: Client;
+
+    beforeEach(async () => {
+      client = await createClient();
+      agent = new Agent({ client });
+    });
+
+    it("sends the description as text when the trigger command is received", async () => {
+      const wizard = new ActionWizard("config");
+      wizard.text("name", { description: "Enter your name" });
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/config");
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        const textMessages = messages.filter((m) => isText(m));
+        const descriptions = textMessages.map((m) => m.content);
+        expect(descriptions).toContain("Enter your name");
+      });
+    });
+
+    it("can send the description as markdown", async () => {
+      const wizard = new ActionWizard("config");
+      wizard.text("name", {
+        description: "**Enter your name**",
+        isMarkdown: true,
+      });
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/config");
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        const mdMessage = messages.find((m) => isMarkdown(m));
+        expect(mdMessage?.content).toBe("**Enter your name**");
+      });
+    });
+
+    it("records the answer and completes when a text reply is received", async () => {
+      const completeHandler = vi.fn();
+      const wizard = new ActionWizard("config");
+      wizard
+        .text("name", { description: "Enter your name" })
+        .onComplete(completeHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/config");
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        const textMessages = messages.filter((m) => isText(m));
+        expect(textMessages.map((m) => m.content)).toContain("Enter your name");
+      });
+
+      await dm.sendText("Alice");
+
+      await vi.waitFor(() => {
+        expect(completeHandler).toHaveBeenCalledWith(
+          { name: "Alice" },
+          expect.anything(),
+        );
+      });
+    });
+  });
+
+  describe("multi-step wizard", () => {
+    let agent: Agent<BuiltInContentTypes>;
+    let client: Client;
+
+    beforeEach(async () => {
+      client = await createClient();
+      agent = new Agent({ client });
+    });
+
+    it("advances through all steps and calls complete with all answers", async () => {
+      const completeHandler = vi.fn();
+      const wizard = new ActionWizard("onboard");
+      wizard
+        .select("plan", {
+          description: "Choose plan",
+          actions: [
+            { id: "free", label: "Free" },
+            { id: "pro", label: "Pro" },
+          ],
+        })
+        .text("email", { description: "Enter your email" })
+        .onComplete(completeHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/onboard");
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        expect(messages.some((m) => isActions(m))).toBe(true);
+      });
+
+      // Step 1: select plan
+      await dm.sendIntent({ id: "onboard:plan", actionId: "pro" });
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        const textMessages = messages.filter((m) => isText(m));
+        expect(textMessages.map((m) => m.content)).toContain(
+          "Enter your email",
+        );
+      });
+
+      // Step 2: enter email
+      await dm.sendText("user@example.com");
+
+      await vi.waitFor(() => {
+        expect(completeHandler).toHaveBeenCalledWith(
+          { plan: "pro", email: "user@example.com" },
+          expect.anything(),
+        );
+      });
+    });
+  });
+
+  describe("cancel", () => {
+    let agent: Agent<BuiltInContentTypes>;
+    let client: Client;
+
+    beforeEach(async () => {
+      client = await createClient();
+      agent = new Agent({ client });
+    });
+
+    it("adds a cancel button to select steps and handles cancel intent", async () => {
+      const cancelHandler = vi.fn();
+      const wizard = new ActionWizard("setup", { cancel: true });
+      wizard
+        .select("color", {
+          description: "Pick",
+          actions: [{ id: "red", label: "Red" }],
+        })
+        .onCancel(cancelHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/setup");
+
+      // Wait for actions to be sent, then extract the cancel action ID
+      let cancelActionId = "";
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        const actionsMessage = messages.find((m) => isActions(m));
+        const actions = actionsMessage?.content?.actions ?? [];
+        expect(actions).toHaveLength(2);
+        expect(actions[1]?.label).toBe("Cancel");
+        cancelActionId = actions[1]?.id ?? "";
+      });
+
+      // Click cancel
+      await dm.sendIntent({ id: "setup:color", actionId: cancelActionId });
+
+      await vi.waitFor(() => {
+        expect(cancelHandler).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("uses a custom cancel label", async () => {
+      const wizard = new ActionWizard("setup", {
+        cancel: { label: "Abort" },
+      });
+      wizard.select("color", {
+        description: "Pick",
+        actions: [{ id: "red", label: "Red" }],
+      });
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/setup");
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        const actionsMessage = messages.find((m) => isActions(m));
+        expect(actionsMessage?.content?.actions[1]?.label).toBe("Abort");
+      });
+    });
+  });
+
+  describe("restart", () => {
+    let agent: Agent<BuiltInContentTypes>;
+    let client: Client;
+
+    beforeEach(async () => {
+      client = await createClient();
+      agent = new Agent({ client });
+    });
+
+    it("cancels existing session and restarts when command is sent again", async () => {
+      const cancelHandler = vi.fn();
+      const wizard = new ActionWizard("setup");
+      wizard
+        .select("color", {
+          description: "Pick",
+          actions: [{ id: "red", label: "Red" }],
+        })
+        .onCancel(cancelHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/setup");
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        expect(messages.filter((m) => isActions(m))).toHaveLength(1);
+      });
+
+      // Send command again while active
+      await dm.sendText("/setup");
+
+      await vi.waitFor(() => {
+        expect(cancelHandler).toHaveBeenCalledOnce();
+      });
+
+      // Wizard re-sent the first step
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        expect(messages.filter((m) => isActions(m))).toHaveLength(2);
+      });
+    });
+  });
+
+  describe("DM mode", () => {
+    let agent: Agent<BuiltInContentTypes>;
+    let client: Client;
+
+    beforeEach(async () => {
+      client = await createClient();
+      agent = new Agent({ client });
+    });
+
+    it("creates a DM conversation and sends steps there", async () => {
+      const wizard = new ActionWizard("secret", { dm: true });
+      wizard.text("apiKey", { description: "Enter your API key" });
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const group = await otherClient.conversations.createGroup([
+        client.inboxId,
+      ]);
+      await group.sendText("/secret");
+
+      // The wizard should send the step via DM, not in the group
+      await vi.waitFor(async () => {
+        await client.conversations.sync();
+        const dms = client.conversations.listDms();
+        expect(dms.length).toBeGreaterThan(0);
+        const dm = dms[0];
+        await dm?.sync();
+        const messages = (await dm?.messages()) ?? [];
+        const textMessages = messages.filter((m) => isText(m));
+        expect(textMessages.map((m) => m.content)).toContain(
+          "Enter your API key",
+        );
+      });
+    });
+
+    it("completes a text step wizard via DM when triggered from a group", async () => {
+      const completeHandler = vi.fn();
+      const wizard = new ActionWizard("secret", { dm: true });
+      wizard
+        .text("apiKey", { description: "Enter your API key" })
+        .onComplete(completeHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const group = await otherClient.conversations.createGroup([
+        client.inboxId,
+      ]);
+      await group.sendText("/secret");
+
+      // Wait for the DM step to arrive, then reply in the DM
+      await vi.waitFor(async () => {
+        await otherClient.conversations.sync();
+        const dms = otherClient.conversations.listDms();
+        expect(dms.length).toBeGreaterThan(0);
+        const dm = dms[0];
+        await dm?.sync();
+        const messages = (await dm?.messages()) ?? [];
+        const textMessages = messages.filter((m) => isText(m));
+        expect(textMessages.map((m) => m.content)).toContain(
+          "Enter your API key",
+        );
+      });
+
+      const dm = otherClient.conversations.listDms()[0]!;
+      await dm.sendText("sk-12345");
+
+      await vi.waitFor(() => {
+        expect(completeHandler).toHaveBeenCalledWith(
+          { apiKey: "sk-12345" },
+          expect.anything(),
+        );
+      });
+    });
+
+    it("completes a multi-step wizard entirely via DM", async () => {
+      const completeHandler = vi.fn();
+      const wizard = new ActionWizard("onboard", { dm: true });
+      wizard
+        .select("plan", {
+          description: "Choose plan",
+          actions: [
+            { id: "free", label: "Free" },
+            { id: "pro", label: "Pro" },
+          ],
+        })
+        .text("email", { description: "Enter your email" })
+        .onComplete(completeHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const group = await otherClient.conversations.createGroup([
+        client.inboxId,
+      ]);
+      await group.sendText("/onboard");
+
+      // Wait for the select step to arrive in the DM
+      await vi.waitFor(async () => {
+        await otherClient.conversations.sync();
+        const dms = otherClient.conversations.listDms();
+        expect(dms.length).toBeGreaterThan(0);
+        const dm = dms[0];
+        await dm?.sync();
+        const messages = (await dm?.messages()) ?? [];
+        expect(messages.some((m) => isActions(m))).toBe(true);
+      });
+
+      // Step 1: select plan in the DM
+      const dm = otherClient.conversations.listDms()[0];
+      await dm?.sendIntent({ id: "onboard:plan", actionId: "pro" });
+
+      // Wait for step 2 to arrive in the DM
+      await vi.waitFor(async () => {
+        await dm?.sync();
+        const messages = await dm?.messages();
+        const textMessages = messages?.filter((m) => isText(m));
+        expect(textMessages?.map((m) => m.content)).toContain(
+          "Enter your email",
+        );
+      });
+
+      // Step 2: enter email in the DM
+      await dm?.sendText("user@example.com");
+
+      await vi.waitFor(() => {
+        expect(completeHandler).toHaveBeenCalledWith(
+          { plan: "pro", email: "user@example.com" },
+          expect.anything(),
+        );
+      });
+    });
+  });
+
+  describe("session isolation", () => {
+    let agent: Agent<BuiltInContentTypes>;
+    let client: Client;
+
+    beforeEach(async () => {
+      client = await createClient();
+      agent = new Agent({ client });
+    });
+
+    it("maintains separate sessions for different senders", async () => {
+      const completeHandler = vi.fn();
+      const wizard = new ActionWizard("setup");
+      wizard
+        .text("name", { description: "Enter name" })
+        .onComplete(completeHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const sender1 = await createClient();
+      const sender2 = await createClient();
+      const dm1 = await sender1.conversations.createDm(client.inboxId);
+      const dm2 = await sender2.conversations.createDm(client.inboxId);
+
+      // Both senders start the wizard
+      await dm1.sendText("/setup");
+      await dm2.sendText("/setup");
+
+      await vi.waitFor(async () => {
+        await dm1.sync();
+        await dm2.sync();
+        const msgs1 = await dm1.messages();
+        const msgs2 = await dm2.messages();
+        expect(msgs1.filter((m) => isText(m)).map((m) => m.content)).toContain(
+          "Enter name",
+        );
+        expect(msgs2.filter((m) => isText(m)).map((m) => m.content)).toContain(
+          "Enter name",
+        );
+      });
+
+      // Only sender 1 answers
+      await dm1.sendText("Alice");
+
+      await vi.waitFor(() => {
+        expect(completeHandler).toHaveBeenCalledTimes(1);
+        expect(completeHandler).toHaveBeenCalledWith(
+          { name: "Alice" },
+          expect.anything(),
+        );
+      });
+    });
+  });
+});

--- a/sdks/js/agent-sdk/src/middleware/ActionWizard.ts
+++ b/sdks/js/agent-sdk/src/middleware/ActionWizard.ts
@@ -1,0 +1,259 @@
+import { randomUUID } from "node:crypto";
+import {
+  isIntent,
+  isText,
+  type Action,
+  type Actions,
+  type Conversation,
+} from "@xmtp/node-sdk";
+import type { AgentMiddleware } from "@/core/Agent";
+import type { MessageContext } from "@/core/MessageContext";
+
+/** The cancel action ID is generated to guarantee no collision with user-defined action IDs */
+const CANCEL_ACTION_ID = randomUUID();
+
+/** User responds by clicking a button (triggers an intent) */
+type SelectStep = {
+  type: "select";
+  id: string;
+  description: string;
+  actions: Action[];
+};
+
+/** User responds by typing a message (sends a text message) */
+type TextStep = {
+  type: "text";
+  id: string;
+  description: string;
+  isMarkdown: boolean;
+};
+
+type ActionWizardStep = SelectStep | TextStep;
+
+type ActionWizardSession = {
+  currentStepIndex: number;
+  answers: Record<string, string>;
+  conversation: Conversation;
+};
+
+type ActionWizardCompleteHandler<ContentTypes> = (
+  answers: Record<string, string>,
+  ctx: MessageContext<unknown, ContentTypes>,
+) => Promise<void> | void;
+
+type ActionWizardCancelHandler<ContentTypes> = (
+  ctx: MessageContext<unknown, ContentTypes>,
+) => Promise<void> | void;
+
+export type ActionWizardCancelOptions = {
+  /** Custom label for the cancel button (default: "Cancel") */
+  label?: string;
+};
+
+export type ActionWizardOptions = {
+  /**
+   * When true, the wizard sends all steps via DM to the user.
+   * Recommended when the user is expected to enter sensitive information
+   * (e.g. API keys, passwords) to keep it out of group conversations.
+   */
+  dm?: boolean;
+  /** Enable a cancel button on each select step. Set to `true` for the default label, or pass options to customize. */
+  cancel?: boolean | ActionWizardCancelOptions;
+};
+
+/**
+ * Multi-step interactive wizard using XMTP actions and intents.
+ *
+ * Supports two step types:
+ * - **select** — presents action buttons, the user responds by clicking one (triggers an intent)
+ * - **text** — prompts the user for free-text input
+ *
+ * The wizard activates when a user sends `/{id}` (e.g. `/api-setup`).
+ * Sending the command again while a session is active restarts the wizard from the first step.
+ */
+export class ActionWizard<ContentTypes = unknown> {
+  #id: string;
+  #dm: boolean;
+  #cancelLabel: string | undefined;
+  #steps: ActionWizardStep[] = [];
+  #sessions = new Map<string, ActionWizardSession>();
+  #completeHandler?: ActionWizardCompleteHandler<ContentTypes>;
+  #cancelHandler?: ActionWizardCancelHandler<ContentTypes>;
+
+  constructor(id: string, options?: ActionWizardOptions) {
+    this.#id = id;
+    this.#dm = options?.dm ?? false;
+    if (options?.cancel) {
+      this.#cancelLabel =
+        typeof options.cancel === "object"
+          ? (options.cancel.label ?? "Cancel")
+          : "Cancel";
+    }
+  }
+
+  static sessionKey(conversationId: string, senderInboxId: string): string {
+    return `${conversationId}:${senderInboxId}`;
+  }
+
+  static stepKey(wizardId: string, stepId: string): string {
+    return `${wizardId}:${stepId}`;
+  }
+
+  select(
+    id: string,
+    options: { description: string; actions: Action[] },
+  ): this {
+    this.#steps.push({
+      type: "select",
+      id,
+      description: options.description,
+      actions: options.actions,
+    });
+    return this;
+  }
+
+  text(
+    id: string,
+    options: { description: string; isMarkdown?: boolean },
+  ): this {
+    this.#steps.push({
+      type: "text",
+      id,
+      description: options.description,
+      isMarkdown: options.isMarkdown ?? false,
+    });
+    return this;
+  }
+
+  onComplete(handler: ActionWizardCompleteHandler<ContentTypes>): this {
+    this.#completeHandler = handler;
+    return this;
+  }
+
+  onCancel(handler: ActionWizardCancelHandler<ContentTypes>): this {
+    this.#cancelHandler = handler;
+    return this;
+  }
+
+  async start(ctx: MessageContext<unknown, ContentTypes>): Promise<void> {
+    const { senderInboxId } = ctx.message;
+    const conversation = this.#dm
+      ? await ctx.client.conversations.createDm(senderInboxId)
+      : ctx.conversation;
+
+    const key = ActionWizard.sessionKey(conversation.id, senderInboxId);
+    this.#sessions.set(key, {
+      currentStepIndex: 0,
+      answers: {},
+      conversation,
+    });
+    await this.#sendCurrentStep(key);
+  }
+
+  isActive(conversationId: string, senderInboxId: string): boolean {
+    return this.#sessions.has(
+      ActionWizard.sessionKey(conversationId, senderInboxId),
+    );
+  }
+
+  async #sendCurrentStep(key: string): Promise<void> {
+    const session = this.#sessions.get(key);
+    if (!session) return;
+
+    const step = this.#steps[session.currentStepIndex];
+    if (!step) return;
+
+    if (step.type === "select") {
+      const stepActions = this.#cancelLabel
+        ? [...step.actions, { id: CANCEL_ACTION_ID, label: this.#cancelLabel }]
+        : step.actions;
+      const actions: Actions = {
+        id: ActionWizard.stepKey(this.#id, step.id),
+        description: step.description,
+        actions: stepActions,
+      };
+      await session.conversation.sendActions(actions);
+    } else if (step.isMarkdown) {
+      await session.conversation.sendMarkdown(step.description);
+    } else {
+      await session.conversation.sendText(step.description);
+    }
+  }
+
+  async #handleCancel(
+    key: string,
+    ctx: MessageContext<unknown, ContentTypes>,
+  ): Promise<void> {
+    this.#sessions.delete(key);
+    await this.#cancelHandler?.(ctx);
+  }
+
+  async #advance(
+    key: string,
+    ctx: MessageContext<unknown, ContentTypes>,
+  ): Promise<void> {
+    const session = this.#sessions.get(key);
+    if (!session) return;
+
+    session.currentStepIndex++;
+
+    const isComplete = session.currentStepIndex >= this.#steps.length;
+    if (isComplete) {
+      const answers = { ...session.answers };
+      this.#sessions.delete(key);
+      await this.#completeHandler?.(answers, ctx);
+    } else {
+      await this.#sendCurrentStep(key);
+    }
+  }
+
+  middleware(): AgentMiddleware<ContentTypes> {
+    return async (ctx, next) => {
+      const key = ActionWizard.sessionKey(
+        ctx.conversation.id,
+        ctx.message.senderInboxId,
+      );
+      if (isText(ctx.message) && ctx.message.content === `/${this.#id}`) {
+        if (this.#sessions.has(key)) {
+          await this.#handleCancel(key, ctx);
+        }
+        await this.start(ctx);
+        return;
+      }
+
+      const session = this.#sessions.get(key);
+
+      if (!session) {
+        await next();
+        return;
+      }
+
+      const step = this.#steps[session.currentStepIndex];
+      if (!step) {
+        await next();
+        return;
+      }
+
+      if (isIntent(ctx.message) && ctx.message.content) {
+        const { actionId } = ctx.message.content;
+        if (this.#cancelLabel && actionId === CANCEL_ACTION_ID) {
+          await this.#handleCancel(key, ctx);
+          return;
+        }
+        if (step.type === "select") {
+          session.answers[step.id] = actionId;
+          await this.#advance(key, ctx);
+          return;
+        }
+      }
+
+      if (step.type === "text" && isText(ctx.message) && ctx.message.content) {
+        session.answers[step.id] = ctx.message.content;
+        await this.#advance(key, ctx);
+        return;
+      }
+
+      await next();
+    };
+  }
+}

--- a/sdks/js/agent-sdk/src/middleware/CommandRouter.test.ts
+++ b/sdks/js/agent-sdk/src/middleware/CommandRouter.test.ts
@@ -1,0 +1,168 @@
+import { type BuiltInContentTypes, type Client } from "@xmtp/node-sdk";
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { Agent } from "@/core/Agent";
+import type { DecodedMessageWithContent } from "@/core/filter";
+import { MessageContext } from "@/core/MessageContext";
+import { CommandRouter } from "@/middleware/CommandRouter";
+import { createClient } from "@/util/test";
+
+describe("CommandRouter", () => {
+  let agent: Agent<BuiltInContentTypes>;
+  let client: Client;
+
+  beforeEach(async () => {
+    client = await createClient();
+    agent = new Agent({
+      client,
+    });
+  });
+
+  describe("types", () => {
+    it("types the message content as string in command handlers", () => {
+      const router = new CommandRouter();
+      router.command("/test", (ctx) => {
+        expectTypeOf(ctx.message.content).toEqualTypeOf<string>();
+      });
+    });
+  });
+
+  describe("command arguments", () => {
+    it("should pass only arguments to the handler, not the command itself", async () => {
+      const router = new CommandRouter();
+      const handler = vi.fn();
+      router.command("/tx", handler);
+
+      agent.use(router.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      const messageId = await dm.sendText("/tx 0.1");
+      const message = otherClient.conversations.getMessageById(
+        messageId,
+      )! as DecodedMessageWithContent<string>;
+
+      await vi.waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(1);
+      });
+      expect(handler).toHaveBeenCalledWith(
+        new MessageContext({
+          message,
+          conversation: dm,
+          client: otherClient,
+        }),
+      );
+    });
+
+    it("should pass empty string for commands without arguments", async () => {
+      const router = new CommandRouter();
+      const handler = vi.fn();
+      router.command("/balance", handler);
+
+      agent.use(router.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      const messageId = await dm.sendText("/balance");
+      const message = otherClient.conversations.getMessageById(
+        messageId,
+      )! as DecodedMessageWithContent<string>;
+
+      await vi.waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(1);
+      });
+      expect(handler).toHaveBeenCalledWith(
+        new MessageContext({
+          message,
+          conversation: dm,
+          client: otherClient,
+        }),
+      );
+    });
+
+    it("should preserve multiple arguments with spaces", async () => {
+      const router = new CommandRouter();
+      const handler = vi.fn();
+      router.command("/send", handler);
+
+      agent.use(router.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      const messageId = await dm.sendText("/send 5 USDC to Alix");
+      const message = otherClient.conversations.getMessageById(
+        messageId,
+      )! as DecodedMessageWithContent<string>;
+
+      await vi.waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(1);
+      });
+      expect(handler).toHaveBeenCalledWith(
+        new MessageContext({
+          message,
+          conversation: dm,
+          client: otherClient,
+        }),
+      );
+    });
+  });
+
+  describe("commandList", () => {
+    it("returns an empty array when no commands are registered", () => {
+      const router = new CommandRouter();
+      expect(router.commandList).toEqual([]);
+    });
+
+    it("returns commands in lowercase as they are stored", () => {
+      const router = new CommandRouter();
+      router.command("/HELP", vi.fn());
+      router.command("/Balance", vi.fn());
+      expect(router.commandList).toEqual(["/help", "/balance"]);
+    });
+
+    it("does not include the default handler in the command list", () => {
+      const router = new CommandRouter();
+      router.command("/help", vi.fn());
+      router.default(vi.fn());
+      expect(router.commandList).toEqual(["/help"]);
+    });
+  });
+
+  describe("command descriptions", () => {
+    it("should accept a description as the second parameter", () => {
+      const router = new CommandRouter();
+      const handler = vi.fn();
+      router.command("/ping", "Check if the bot is alive", handler);
+      expect(router.commandList).toEqual(["/ping"]);
+    });
+
+    it("should work without a description (backwards compatible)", () => {
+      const router = new CommandRouter();
+      const handler = vi.fn();
+      router.command("/ping", handler);
+      expect(router.commandList).toEqual(["/ping"]);
+    });
+
+    it("should throw an error when description is provided but handler is missing", () => {
+      const router = new CommandRouter();
+      expect(() => {
+        // @ts-expect-error - Testing runtime error when handler is missing
+        router.command("/ping", "Description without handler");
+      }).toThrow();
+    });
+  });
+
+  describe("helpCommand config", () => {
+    it("should auto-register a help command when helpCommand is provided", () => {
+      const router = new CommandRouter({ helpCommand: "/help" });
+      expect(router.commandList).toContain("/help");
+    });
+
+    it("should not register help command when helpCommand is not provided", () => {
+      const router = new CommandRouter();
+      expect(router.commandList).not.toContain("/help");
+    });
+  });
+});

--- a/sdks/js/agent-sdk/src/middleware/CommandRouter.ts
+++ b/sdks/js/agent-sdk/src/middleware/CommandRouter.ts
@@ -1,0 +1,137 @@
+import { type AgentMessageHandler, type AgentMiddleware } from "@/core/Agent";
+import type { MessageContext } from "@/core/MessageContext";
+
+/** Content type supported by the "CommandRouter" */
+type SupportedType = string;
+
+interface CommandEntry {
+  handler: AgentMessageHandler<SupportedType>;
+  description?: string;
+}
+
+export interface CommandRouterConfig {
+  /** Command string to trigger help output (e.g., "/help") */
+  helpCommand?: `/${string}`;
+}
+
+export class CommandRouter<ContentTypes = unknown> {
+  #commandMap = new Map<string, CommandEntry>();
+  #defaultHandler: AgentMessageHandler<SupportedType> | null = null;
+
+  constructor(config: CommandRouterConfig = {}) {
+    if (config.helpCommand) {
+      this.#registerHelpCommand(config.helpCommand);
+    }
+  }
+
+  #registerHelpCommand(command: string): void {
+    const helpHandler: AgentMessageHandler<SupportedType> = async (ctx) => {
+      const lines: string[] = [];
+
+      const sortedCommands = [...this.#commandMap.entries()].sort((a, b) =>
+        a[0].localeCompare(b[0]),
+      );
+
+      sortedCommands.forEach(([cmd, entry], index) => {
+        if (entry.description) {
+          lines.push(`${index + 1}. \`${cmd}\` - ${entry.description}`);
+        } else {
+          lines.push(`${index + 1}. \`${cmd}\``);
+        }
+      });
+
+      await ctx.sendMarkdownReply(lines.join("\n"));
+    };
+
+    this.command(command, "Show available commands", helpHandler);
+  }
+
+  get commandList(): string[] {
+    return Array.from(this.#commandMap.keys());
+  }
+
+  command(command: string, handler: AgentMessageHandler<SupportedType>): this;
+  command(
+    command: string,
+    description: string,
+    handler: AgentMessageHandler<SupportedType>,
+  ): this;
+  command(
+    command: string,
+    handlerOrDescription: AgentMessageHandler<SupportedType> | string,
+    handler?: AgentMessageHandler<SupportedType>,
+  ): this {
+    if (!command.startsWith("/")) {
+      throw new Error('Command must start with "/"');
+    }
+
+    let resolvedHandler: AgentMessageHandler<SupportedType>;
+    let description: string | undefined;
+
+    if (typeof handlerOrDescription === "function") {
+      resolvedHandler = handlerOrDescription;
+    } else {
+      description = handlerOrDescription;
+      if (!handler) {
+        throw new Error(
+          "Handler implementation is required when description is provided.",
+        );
+      }
+      resolvedHandler = handler;
+    }
+
+    this.#commandMap.set(command.toLowerCase(), {
+      handler: resolvedHandler,
+      description,
+    });
+    return this;
+  }
+
+  default(handler: AgentMessageHandler<SupportedType>): this {
+    this.#defaultHandler = handler;
+    return this;
+  }
+
+  async handle(ctx: MessageContext<SupportedType>): Promise<boolean> {
+    const messageText = ctx.message.content;
+    const parts = messageText.split(" ");
+    const command = parts[0]?.toLowerCase();
+
+    if (!command) {
+      return false;
+    }
+
+    // Check if this is a command message
+    if (command.startsWith("/")) {
+      const entry = this.#commandMap.get(command);
+      if (entry) {
+        // Create a new context with modified content (everything after the command)
+        const argsText = parts.slice(1).join(" ");
+        ctx.message.content = argsText;
+        await entry.handler(ctx);
+        return true;
+      }
+    }
+
+    // If no command matched and there's a default handler, use it
+    if (this.#defaultHandler) {
+      await this.#defaultHandler(ctx);
+      return true;
+    }
+
+    return false;
+  }
+
+  middleware(): AgentMiddleware<ContentTypes> {
+    return async (ctx, next) => {
+      if (ctx.isText()) {
+        const handled = await this.handle(ctx);
+        if (!handled) {
+          await next();
+        }
+      } else {
+        await next();
+      }
+    };
+  }
+}

--- a/sdks/js/agent-sdk/src/middleware/PerformanceMonitor.test.ts
+++ b/sdks/js/agent-sdk/src/middleware/PerformanceMonitor.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PerformanceMonitor,
+  type HealthReport,
+} from "@/middleware/PerformanceMonitor";
+
+describe("PerformanceMonitor", () => {
+  let monitor: PerformanceMonitor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    monitor.shutdown();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("logs an initial health report", () => {
+      const spy = vi.spyOn(console, "log");
+      monitor = new PerformanceMonitor();
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("CPU:"));
+    });
+
+    it("uses default config values", () => {
+      const spy = vi.spyOn(console, "log");
+      monitor = new PerformanceMonitor();
+      // Advance past the default 60s interval
+      vi.advanceTimersByTime(60_000);
+      // Initial health report + interval report
+      const healthReportCalls = spy.mock.calls.filter((call) =>
+        String(call[0]).includes("CPU:"),
+      );
+      expect(healthReportCalls).toHaveLength(2);
+    });
+
+    it("accepts a custom reporting interval", () => {
+      const spy = vi.spyOn(console, "log");
+      monitor = new PerformanceMonitor({ healthReportInterval: 5_000 });
+      vi.advanceTimersByTime(15_000);
+      const healthReportCalls = spy.mock.calls.filter((call) =>
+        String(call[0]).includes("CPU:"),
+      );
+      // 1 initial + 3 interval reports
+      expect(healthReportCalls).toHaveLength(4);
+    });
+
+    it("calls custom health report handler instead of logging", () => {
+      const onHealthReport = vi.fn<(report: HealthReport) => void>();
+      monitor = new PerformanceMonitor({
+        healthReportInterval: 5_000,
+        onHealthReport,
+      });
+      // 1 initial call
+      expect(onHealthReport).toHaveBeenCalledOnce();
+      const report: HealthReport = onHealthReport.mock.calls[0]![0];
+      expect(report.cpuPercent).toBeTypeOf("number");
+      expect(report.eventLoopDelayMs).toBeTypeOf("number");
+      expect(report.heapMB).toBeTypeOf("number");
+      expect(report.heapPercent).toBeTypeOf("number");
+      expect(report.heapLimitMB).toBeTypeOf("number");
+      expect(report.totalMB).toBeTypeOf("number");
+      // Interval calls
+      vi.advanceTimersByTime(10_000);
+      expect(onHealthReport).toHaveBeenCalledTimes(3);
+    });
+
+    it("disables health reports when reporting interval is 0", () => {
+      const spy = vi.spyOn(console, "log");
+      monitor = new PerformanceMonitor({ healthReportInterval: 0 });
+      vi.advanceTimersByTime(120_000);
+      const healthReportCalls = spy.mock.calls.filter((call) =>
+        String(call[0]).includes("CPU:"),
+      );
+      expect(healthReportCalls).toHaveLength(0);
+    });
+  });
+
+  describe("shutdown", () => {
+    it("logs shutdown message by default", () => {
+      const spy = vi.spyOn(console, "log");
+      monitor = new PerformanceMonitor();
+      monitor.shutdown();
+      expect(spy).toHaveBeenCalledWith(
+        "[PerformanceMonitor] Monitoring shut down",
+      );
+    });
+
+    it("calls custom shutdown handler instead of logging", () => {
+      const onShutdown = vi.fn();
+      monitor = new PerformanceMonitor({ onShutdown });
+      monitor.shutdown();
+      expect(onShutdown).toHaveBeenCalledOnce();
+    });
+
+    it("is idempotent when called multiple times", () => {
+      const onShutdown = vi.fn();
+      monitor = new PerformanceMonitor({ onShutdown });
+      monitor.shutdown();
+      monitor.shutdown();
+      expect(onShutdown).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("middleware", () => {
+    it("returns a function", () => {
+      monitor = new PerformanceMonitor();
+      expect(typeof monitor.middleware()).toBe("function");
+    });
+
+    it("calls next middleware", async () => {
+      vi.useRealTimers();
+      monitor = new PerformanceMonitor({ healthReportInterval: 999_999 });
+      const mw = monitor.middleware();
+      const next = vi.fn();
+      await mw({} as never, next);
+      expect(next).toHaveBeenCalledOnce();
+    });
+
+    it("calls a response callback for every message", async () => {
+      vi.useRealTimers();
+      const onResponse = vi.fn();
+      monitor = new PerformanceMonitor({
+        healthReportInterval: 999_999,
+        onResponse,
+      });
+      const mw = monitor.middleware();
+      await mw({} as never, vi.fn());
+      await mw({} as never, vi.fn());
+      expect(onResponse).toHaveBeenCalledTimes(2);
+      expect(onResponse).toHaveBeenCalledWith(expect.any(Number));
+    });
+
+    it("calls critical response callback when duration exceeds threshold", async () => {
+      vi.useRealTimers();
+      const onCriticalResponse = vi.fn();
+      monitor = new PerformanceMonitor({
+        healthReportInterval: 999_999,
+        criticalThresholdInterval: 100,
+        onCriticalResponse,
+      });
+      const mw = monitor.middleware();
+      const slowNext = vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 150));
+      });
+      await mw({} as never, slowNext);
+      expect(onCriticalResponse).toHaveBeenCalledOnce();
+      expect(onCriticalResponse).toHaveBeenCalledWith(expect.any(Number));
+      const duration = onCriticalResponse.mock.calls[0]![0] as number;
+      expect(duration).toBeGreaterThan(100);
+    });
+
+    it("does not call critical response callback when duration is below threshold", async () => {
+      vi.useRealTimers();
+      const onCriticalResponse = vi.fn();
+      monitor = new PerformanceMonitor({
+        healthReportInterval: 999_999,
+        criticalThresholdInterval: 100,
+        onCriticalResponse,
+      });
+      const mw = monitor.middleware();
+      const fastNext = vi.fn();
+      await mw({} as never, fastNext);
+      expect(onCriticalResponse).not.toHaveBeenCalled();
+    });
+
+    it("uses default critical response handler when not provided", async () => {
+      vi.useRealTimers();
+      const spy = vi.spyOn(console, "warn");
+      monitor = new PerformanceMonitor({
+        healthReportInterval: 999_999,
+        criticalThresholdInterval: 100,
+      });
+      const mw = monitor.middleware();
+      const slowNext = vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 150));
+      });
+      await mw({} as never, slowNext);
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining("Critical: Response time exceeded"),
+      );
+    });
+  });
+});

--- a/sdks/js/agent-sdk/src/middleware/PerformanceMonitor.ts
+++ b/sdks/js/agent-sdk/src/middleware/PerformanceMonitor.ts
@@ -1,0 +1,158 @@
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+import v8 from "node:v8";
+import type { AgentMiddleware } from "@/core/Agent";
+
+export interface HealthReport {
+  cpuPercent: number;
+  eventLoopDelayMs: number;
+  heapMB: number;
+  heapPercent: number;
+  heapLimitMB: number;
+  totalMB: number;
+}
+
+export interface PerformanceMonitorConfig {
+  /** Interval in ms between health reports (default: 60000). Set to 0 to disable. */
+  healthReportInterval?: number;
+  /** Threshold in ms for critical warning (default: 10000) */
+  criticalThresholdInterval?: number;
+  /** Called when a message takes longer than the critical threshold to process. Defaults to logging a warning. */
+  onCriticalResponse?: (durationMs: number) => void;
+  /** Called on each health report interval. Defaults to logging CPU and memory stats. */
+  onHealthReport?: (report: HealthReport) => void;
+  /** Called after every message with the processing duration in ms. */
+  onResponse?: (durationMs: number) => void;
+  /** Called when shutdown is invoked. Defaults to logging a message. */
+  onShutdown?: () => void;
+}
+
+/**
+ * Middleware that measures message processing time and logs periodic
+ * CPU / memory health reports.
+ *
+ * Register it as the first middleware so the timer wraps all downstream
+ * middleware and handlers, giving you the total processing time independent
+ * of other logic.
+ */
+export class PerformanceMonitor<ContentTypes = unknown> {
+  #interval: ReturnType<typeof setInterval> | undefined;
+  #isShutdown: boolean;
+  #lastCpuUsage: NodeJS.CpuUsage;
+  #lastCpuTime: number;
+  #criticalThresholdInterval: number;
+  #onCriticalResponse: (durationMs: number) => void;
+  #onHealthReport: (report: HealthReport) => void;
+  #onResponse?: (durationMs: number) => void;
+  #onShutdown: () => void;
+  #eventLoopHistogram: ReturnType<typeof monitorEventLoopDelay>;
+
+  constructor(config: PerformanceMonitorConfig = {}) {
+    const {
+      healthReportInterval = 60_000,
+      criticalThresholdInterval = 10_000,
+    } = config;
+
+    this.#criticalThresholdInterval = criticalThresholdInterval;
+
+    const defaultCriticalResponseHandler = (durationMs: number) => {
+      console.warn(
+        `[PerformanceMonitor] Critical: Response time exceeded ${criticalThresholdInterval / 1000}s (${durationMs.toFixed(0)}ms)`,
+      );
+    };
+
+    const defaultHealthReportHandler = (report: HealthReport) => {
+      console.log(
+        `[${new Date().toISOString()}] CPU: ${report.cpuPercent.toFixed(1)}% | Event Loop: ${report.eventLoopDelayMs.toFixed(1)}ms | Heap: ${report.heapPercent.toFixed(1)}% (${report.heapMB.toFixed(0)}MB/${report.totalMB.toFixed(1)}MB)`,
+      );
+    };
+
+    const defaultShutdownHandler = () => {
+      console.log("[PerformanceMonitor] Monitoring shut down");
+    };
+
+    this.#onCriticalResponse =
+      config.onCriticalResponse ?? defaultCriticalResponseHandler;
+
+    this.#onHealthReport = config.onHealthReport ?? defaultHealthReportHandler;
+    this.#onResponse = config.onResponse;
+    this.#onShutdown = config.onShutdown ?? defaultShutdownHandler;
+    this.#isShutdown = false;
+    this.#eventLoopHistogram = monitorEventLoopDelay();
+    this.#eventLoopHistogram.enable();
+    this.#lastCpuUsage = process.cpuUsage();
+    this.#lastCpuTime = Date.now();
+
+    if (healthReportInterval > 0) {
+      this.#logHealthReport();
+      this.#interval = setInterval(() => {
+        this.#logHealthReport();
+      }, healthReportInterval).unref();
+    }
+  }
+
+  #getCpuPercent(): number {
+    const currentCpuUsage = process.cpuUsage(this.#lastCpuUsage);
+    const elapsedMs = Date.now() - this.#lastCpuTime;
+    const totalCpuMicros = currentCpuUsage.user + currentCpuUsage.system;
+    const elapsedMicros = elapsedMs * 1000;
+    const percent =
+      elapsedMicros > 0 ? (totalCpuMicros / elapsedMicros) * 100 : 0;
+
+    this.#lastCpuUsage = process.cpuUsage();
+    this.#lastCpuTime = Date.now();
+
+    return percent;
+  }
+
+  #getMemory() {
+    const memoryUsage = process.memoryUsage();
+    const heapStats = v8.getHeapStatistics();
+    const heapUsedMB = memoryUsage.heapUsed / 1024 / 1024;
+    const heapLimitMB = heapStats.heap_size_limit / 1024 / 1024;
+    return {
+      heapMB: heapUsedMB,
+      heapPercent: (heapUsedMB / heapLimitMB) * 100,
+      heapLimitMB,
+      totalMB: memoryUsage.rss / 1024 / 1024,
+    };
+  }
+
+  #logHealthReport() {
+    const cpuPercent = this.#getCpuPercent();
+    const mem = this.#getMemory();
+    const mean = this.#eventLoopHistogram.mean;
+    const eventLoopDelayMs = Number.isNaN(mean) ? 0 : mean / 1e6;
+    this.#eventLoopHistogram.reset();
+    this.#onHealthReport({
+      cpuPercent,
+      eventLoopDelayMs,
+      ...mem,
+    });
+  }
+
+  shutdown() {
+    if (this.#isShutdown) {
+      return;
+    }
+    this.#isShutdown = true;
+    clearInterval(this.#interval);
+    this.#interval = undefined;
+    this.#eventLoopHistogram.disable();
+    this.#onShutdown();
+  }
+
+  middleware(): AgentMiddleware<ContentTypes> {
+    return async (_, next) => {
+      const start = performance.now();
+      try {
+        await next();
+      } finally {
+        const duration = performance.now() - start;
+        this.#onResponse?.(duration);
+        if (duration > this.#criticalThresholdInterval) {
+          this.#onCriticalResponse(duration);
+        }
+      }
+    };
+  }
+}

--- a/sdks/js/agent-sdk/src/middleware/index.ts
+++ b/sdks/js/agent-sdk/src/middleware/index.ts
@@ -1,0 +1,3 @@
+export * from "./CommandRouter";
+export * from "./PerformanceMonitor";
+export * from "./ActionWizard";

--- a/sdks/js/agent-sdk/src/user/NameResolver.test.ts
+++ b/sdks/js/agent-sdk/src/user/NameResolver.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createNameResolver } from "@/user/NameResolver";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("NameResolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("caching behavior", () => {
+    it("should return address immediately without API call for valid addresses", async () => {
+      const nameResolver = createNameResolver();
+      const validAddress = "0x1234567890123456789012345678901234567890";
+
+      const result = await nameResolver(validAddress);
+      expect(result).toBe(validAddress);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should cache resolved names and not make duplicate API calls", async () => {
+      const mockResponse = [
+        { address: "0x1234567890123456789012345678901234567890" },
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const nameResolver = createNameResolver();
+      const testName = "test.eth";
+
+      const firstRequest = await nameResolver(testName);
+      expect(firstRequest).toBe("0x1234567890123456789012345678901234567890");
+      expect(
+        mockFetch,
+        "First call should make an API request",
+      ).toHaveBeenCalledTimes(1);
+
+      const secondRequest = await nameResolver(testName);
+      expect(secondRequest).toBe("0x1234567890123456789012345678901234567890");
+      expect(mockFetch, "Still only 1 call").toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/sdks/js/agent-sdk/src/user/NameResolver.ts
+++ b/sdks/js/agent-sdk/src/user/NameResolver.ts
@@ -1,0 +1,64 @@
+import { escape } from "node:querystring";
+import { isAddress } from "viem";
+import { AgentError } from "@/core/AgentError";
+import { LimitedMap } from "@/util/LimitedMap";
+
+const cache = new LimitedMap<string, string | null>(1000);
+
+const fetchFromWeb3Bio = async (
+  name: string,
+  apiKey?: string,
+): Promise<{ address: string | null }[]> => {
+  const endpoint = `https://api.web3.bio/ns/${escape(name)}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (apiKey) {
+    headers["X-API-KEY"] = `Bearer ${apiKey}`;
+  }
+
+  const response = await fetch(endpoint, {
+    method: "GET",
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new AgentError(
+      2000,
+      `Could not resolve address for name "${name}": ${response.statusText} (${response.status})`,
+    );
+  }
+
+  return response.json() as Promise<{ address: string | null }[]>;
+};
+
+const resolveName = async (
+  name: string,
+  apiKey?: string,
+): Promise<string | null> => {
+  if (isAddress(name)) {
+    return name;
+  }
+
+  const cachedAddress = cache.get(name);
+
+  if (cachedAddress !== undefined) {
+    return cachedAddress;
+  }
+
+  const response = await fetchFromWeb3Bio(name, apiKey);
+  if (response.length === 0) {
+    return null;
+  }
+  const address = response[0]?.address;
+  if (!address) {
+    return null;
+  }
+  cache.set(name, address);
+  return address;
+};
+
+export const createNameResolver = (apiKey?: string) => {
+  return (name: string) => resolveName(name, apiKey);
+};

--- a/sdks/js/agent-sdk/src/user/User.ts
+++ b/sdks/js/agent-sdk/src/user/User.ts
@@ -1,0 +1,57 @@
+import {
+  IdentifierKind,
+  type HexString,
+  type Identifier,
+  type Signer,
+} from "@xmtp/node-sdk";
+import {
+  createWalletClient,
+  http,
+  toBytes,
+  type Chain,
+  type Hex,
+  type PrivateKeyAccount,
+  type WalletClient,
+} from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+
+export type User = {
+  key: Hex;
+  account: PrivateKeyAccount;
+  wallet: WalletClient;
+};
+
+export const createUser = (key?: HexString, chain: Chain = sepolia): User => {
+  const accountKey = key ?? generatePrivateKey();
+  const account = privateKeyToAccount(accountKey);
+  return {
+    key: accountKey,
+    account,
+    wallet: createWalletClient({
+      account,
+      chain,
+      transport: http(),
+    }),
+  };
+};
+
+export const createIdentifier = (user: User): Identifier => ({
+  identifier: user.account.address.toLowerCase(),
+  identifierKind: IdentifierKind.Ethereum,
+});
+
+export const createSigner = (user: User): Signer => {
+  const identifier = createIdentifier(user);
+  return {
+    type: "EOA",
+    getIdentifier: () => identifier,
+    signMessage: async (message: string) => {
+      const signature = await user.wallet.signMessage({
+        account: user.account,
+        message,
+      });
+      return toBytes(signature);
+    },
+  };
+};

--- a/sdks/js/agent-sdk/src/user/index.ts
+++ b/sdks/js/agent-sdk/src/user/index.ts
@@ -1,0 +1,2 @@
+export * from "./User";
+export * from "./NameResolver";

--- a/sdks/js/agent-sdk/src/util/AttachmentUtil.test.ts
+++ b/sdks/js/agent-sdk/src/util/AttachmentUtil.test.ts
@@ -1,0 +1,100 @@
+import { encryptAttachment } from "@xmtp/node-sdk";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import {
+  createRemoteAttachment,
+  createRemoteAttachmentFromFile,
+  downloadRemoteAttachment,
+} from "@/util/AttachmentUtil";
+
+describe("AttachmentUtil", () => {
+  const testUrl = "https://localhost/test_file";
+  let mockFetch: Mock;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("createRemoteAttachmentFromFile", () => {
+    it("creates a remote attachment", async () => {
+      const fileContent = "createRemoteAttachmentFromFile";
+      const fileName = "hello.txt";
+      const mimeType = "text/plain";
+      const unencryptedFile = new File([fileContent], fileName, {
+        type: mimeType,
+      });
+      const uploadCallback = () => {
+        return Promise.resolve(testUrl);
+      };
+      const remoteAttachment = await createRemoteAttachmentFromFile(
+        unencryptedFile,
+        uploadCallback,
+      );
+      expect(remoteAttachment.url).toBe(testUrl);
+      expect(remoteAttachment.filename).toBe(fileName);
+    });
+  });
+
+  describe("Round-trip test", () => {
+    it("encrypts and decrypts a file", async () => {
+      const fileContent = "Hello, World!";
+      const fileName = "hello.txt";
+      const mimeType = "text/plain";
+      const unencryptedFile = new File([fileContent], fileName, {
+        type: mimeType,
+      });
+      const arrayBuffer = await unencryptedFile.arrayBuffer();
+      const attachment = new Uint8Array(arrayBuffer);
+
+      const encryptedAttachment = encryptAttachment({
+        filename: unencryptedFile.name,
+        content: attachment,
+        mimeType: unencryptedFile.type,
+      });
+
+      // Mock fetch to return the encrypted payload
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () =>
+          Promise.resolve(encryptedAttachment.payload.buffer),
+      });
+
+      const remoteAttachment = createRemoteAttachment(
+        encryptedAttachment,
+        testUrl,
+      );
+
+      expect(remoteAttachment.url).toBe(testUrl);
+      expect(remoteAttachment.filename).toBe(fileName);
+
+      const receivedAttachment =
+        await downloadRemoteAttachment(remoteAttachment);
+
+      // Verify fetch was called with the correct URL
+      expect(mockFetch).toHaveBeenCalledWith(testUrl);
+
+      // Verify the decrypted attachment matches the original
+      expect(receivedAttachment.filename).toBe(fileName);
+      expect(receivedAttachment.mimeType).toBe(mimeType);
+      expect(receivedAttachment.content).toEqual(attachment);
+
+      // Verify the content matches
+      const decryptedContent = new TextDecoder().decode(
+        receivedAttachment.content,
+      );
+      expect(decryptedContent).toBe(fileContent);
+    });
+  });
+});

--- a/sdks/js/agent-sdk/src/util/AttachmentUtil.ts
+++ b/sdks/js/agent-sdk/src/util/AttachmentUtil.ts
@@ -1,0 +1,85 @@
+import {
+  decryptAttachment,
+  encryptAttachment,
+  type Attachment,
+  type EncryptedAttachment,
+  type RemoteAttachment,
+} from "@xmtp/node-sdk";
+
+export type AttachmentUploadCallback = (
+  attachment: EncryptedAttachment,
+) => Promise<string>;
+
+/**
+ * Downloads and decrypts a remote attachment.
+ *
+ * @param remoteAttachment - The remote attachment metadata containing the downloadd URL and encryption keys
+ * @param agent - The agent instance used to lookup the necessary decoding codec
+ * @returns A promise that resolves with the decrypted attachment
+ */
+export async function downloadRemoteAttachment(
+  remoteAttachment: RemoteAttachment,
+) {
+  const response = await fetch(remoteAttachment.url);
+  if (!response.ok) {
+    throw new Error(
+      `unable to fetch remote attachment at "${remoteAttachment.url}": [${response.status}] ${response.statusText}`,
+    );
+  }
+  const payload = new Uint8Array(await response.arrayBuffer());
+  return decryptAttachment(payload, remoteAttachment);
+}
+
+/**
+ * Creates a remote attachment object from an encrypted attachment and file URL.
+ *
+ * @param encryptedAttachment - The encrypted attachment containing encryption keys and metadata
+ * @param fileUrl - The URL where the encrypted attachment can be downloaded
+ * @returns A remote attachment object with all necessary metadata for retrieval and decryption
+ */
+export function createRemoteAttachment(
+  encryptedAttachment: EncryptedAttachment,
+  fileUrl: string,
+): RemoteAttachment {
+  const url = new URL(fileUrl);
+
+  return {
+    contentDigest: encryptedAttachment.contentDigest,
+    contentLength: encryptedAttachment.payload.length,
+    filename: encryptedAttachment.filename,
+    nonce: encryptedAttachment.nonce,
+    salt: encryptedAttachment.salt,
+    scheme: url.protocol,
+    secret: encryptedAttachment.secret,
+    url: url.toString(),
+  };
+}
+
+/**
+ * Creates a remote attachment from a file by encrypting it and uploading it to a remote storage.
+ * This is a convenience function that combines file processing, encryption, uploading, and
+ * remote attachment creation into a single operation.
+ *
+ * @param unencryptedFile - The unencrypted file to process and upload
+ * @param uploadCallback - A callback function that receives the encrypted attachment and returns the URL where it was uploaded
+ * @returns A promise that resolves with a remote attachment containing all necessary metadata for retrieval and decryption
+ */
+export async function createRemoteAttachmentFromFile(
+  unencryptedFile: File,
+  uploadCallback: AttachmentUploadCallback,
+) {
+  const arrayBuffer = await unencryptedFile.arrayBuffer();
+  const attachment = new Uint8Array(arrayBuffer);
+
+  const attachmentData: Attachment = {
+    content: attachment,
+    filename: unencryptedFile.name,
+    mimeType: unencryptedFile.type,
+  };
+
+  const encryptedAttachment = encryptAttachment(attachmentData);
+
+  const fileUrl = await uploadCallback(encryptedAttachment);
+
+  return createRemoteAttachment(encryptedAttachment, fileUrl);
+}

--- a/sdks/js/agent-sdk/src/util/LimitedMap.ts
+++ b/sdks/js/agent-sdk/src/util/LimitedMap.ts
@@ -1,0 +1,22 @@
+export class LimitedMap<K, V> {
+  #map = new Map<K, V>();
+  #limit: number;
+
+  constructor(limit: number) {
+    this.#limit = limit;
+  }
+
+  set(key: K, value: V) {
+    if (this.#map.size >= this.#limit) {
+      const it = this.#map.keys().next();
+      if (!it.done) {
+        this.#map.delete(it.value);
+      }
+    }
+    this.#map.set(key, value);
+  }
+
+  get(key: K) {
+    return this.#map.get(key);
+  }
+}

--- a/sdks/js/agent-sdk/src/util/TransactionUtil.test.ts
+++ b/sdks/js/agent-sdk/src/util/TransactionUtil.test.ts
@@ -1,0 +1,208 @@
+import { toHex } from "viem";
+import { base } from "viem/chains";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createERC20TransferCalls,
+  createNativeTransferCalls,
+  erc20Abi,
+  getERC20Balance,
+  getERC20Decimals,
+} from "@/util/TransactionUtil";
+
+const mockReadContract = vi.fn();
+
+vi.mock("viem", async () => {
+  const actual = await vi.importActual("viem");
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({
+      readContract: mockReadContract,
+    })),
+  };
+});
+
+const testChain = base;
+const testTokenAddress = "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as const;
+const testFrom = "0x1234567890abcdef1234567890abcdef12345678" as const;
+const testTo = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as const;
+
+describe("TransactionUtil", () => {
+  beforeEach(() => {
+    mockReadContract.mockReset();
+  });
+
+  describe("erc20Abi", () => {
+    it("contains transfer, balanceOf, and decimals", () => {
+      expect(erc20Abi).toHaveLength(3);
+      const names = erc20Abi.map((entry) => entry.name);
+      expect(names).toContain("transfer");
+      expect(names).toContain("balanceOf");
+      expect(names).toContain("decimals");
+    });
+  });
+
+  describe("createERC20TransferCalls", () => {
+    it("returns a valid WalletSendCalls object", () => {
+      const result = createERC20TransferCalls({
+        chain: testChain,
+        tokenAddress: testTokenAddress,
+        from: testFrom,
+        to: testTo,
+        amount: 1_000_000n,
+        description: "Transfer 1 USDC",
+      });
+
+      expect(result.version).toBe("1.0");
+      expect(result.chainId).toBe(toHex(testChain.id));
+      expect(result.from).toBe(testFrom);
+      expect(result.calls).toHaveLength(1);
+
+      const call = result.calls[0];
+      expect(call?.to).toBe(testTokenAddress);
+      expect(call?.value).toBe("0x0");
+    });
+
+    it("encodes transfer data correctly", () => {
+      const result = createERC20TransferCalls({
+        chain: testChain,
+        tokenAddress: testTokenAddress,
+        from: testFrom,
+        to: testTo,
+        amount: 1_000_000n,
+        description: "Transfer 1 USDC",
+      });
+
+      const call = result.calls[0];
+      // ERC-20 transfer function selector
+      expect(call?.data).toMatch(/^0xa9059cbb/);
+    });
+
+    it("includes description in metadata", () => {
+      const description = "Send 1 USDC";
+
+      const result = createERC20TransferCalls({
+        chain: testChain,
+        tokenAddress: testTokenAddress,
+        from: testFrom,
+        to: testTo,
+        amount: 1_000_000n,
+        description,
+      });
+
+      const call = result.calls[0];
+      expect(call?.metadata).toEqual({
+        description,
+        transactionType: "transfer",
+      });
+    });
+
+    it("converts chain ID to hex", () => {
+      const result = createERC20TransferCalls({
+        chain: { ...testChain, id: 8453 },
+        tokenAddress: testTokenAddress,
+        from: testFrom,
+        to: testTo,
+        amount: 1n,
+        description: "Transfer USDC",
+      });
+
+      expect(result.chainId).toBe(toHex(8453));
+    });
+  });
+
+  describe("createNativeTransferCalls", () => {
+    it("returns a valid WalletSendCalls object", () => {
+      const amount = 1_000_000_000_000_000_000n; // 1 ETH in wei
+
+      const result = createNativeTransferCalls({
+        chain: testChain,
+        from: testFrom,
+        to: testTo,
+        amount,
+        description: "Transfer 1 ETH",
+      });
+
+      expect(result.version).toBe("1.0");
+      expect(result.chainId).toBe(toHex(testChain.id));
+      expect(result.from).toBe(testFrom);
+      expect(result.calls).toHaveLength(1);
+
+      const call = result.calls[0];
+      expect(call?.to).toBe(testTo);
+      expect(call?.value).toBe(toHex(amount));
+    });
+
+    it("does not set data field", () => {
+      const result = createNativeTransferCalls({
+        chain: testChain,
+        from: testFrom,
+        to: testTo,
+        amount: 1n,
+        description: "Transfer ETH",
+      });
+
+      const call = result.calls[0];
+      expect(call?.data).toBeUndefined();
+    });
+
+    it("includes description in metadata", () => {
+      const description = "Send 0.5 ETH";
+
+      const result = createNativeTransferCalls({
+        chain: testChain,
+        from: testFrom,
+        to: testTo,
+        amount: 500_000_000_000_000_000n,
+        description,
+      });
+
+      const call = result.calls[0];
+      expect(call?.metadata).toEqual({
+        description,
+        transactionType: "transfer",
+      });
+    });
+  });
+
+  describe("getERC20Balance", () => {
+    it("reads balance from the chain", async () => {
+      const expectedBalance = 5_000_000n;
+      mockReadContract.mockResolvedValue(expectedBalance);
+
+      const balance = await getERC20Balance({
+        chain: testChain,
+        tokenAddress: testTokenAddress,
+        address: testFrom,
+      });
+
+      expect(balance).toBe(expectedBalance);
+      expect(mockReadContract).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: testTokenAddress,
+          functionName: "balanceOf",
+          args: [testFrom],
+        }),
+      );
+    });
+  });
+
+  describe("getERC20Decimals", () => {
+    it("reads decimals from the chain", async () => {
+      const expectedDecimals = 6;
+      mockReadContract.mockResolvedValue(expectedDecimals);
+
+      const decimals = await getERC20Decimals({
+        chain: testChain,
+        tokenAddress: testTokenAddress,
+      });
+
+      expect(decimals).toBe(expectedDecimals);
+      expect(mockReadContract).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: testTokenAddress,
+          functionName: "decimals",
+        }),
+      );
+    });
+  });
+});

--- a/sdks/js/agent-sdk/src/util/TransactionUtil.ts
+++ b/sdks/js/agent-sdk/src/util/TransactionUtil.ts
@@ -1,0 +1,193 @@
+import type { WalletSendCalls } from "@xmtp/node-sdk";
+import {
+  createPublicClient,
+  encodeFunctionData,
+  http,
+  toHex,
+  type Chain,
+  type Hex,
+  type Transport,
+} from "viem";
+
+/**
+ * Minimal ERC-20 ABI containing transfer, balanceOf, and decimals functions.
+ * Can be used with viem's encodeFunctionData for custom ERC-20 interactions.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-20#methods
+ */
+export const erc20Abi = [
+  {
+    type: "function",
+    name: "transfer",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "decimals",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+    stateMutability: "view",
+  },
+] as const;
+
+export type CreateERC20TransferCallsOptions = {
+  /** The viem Chain object (e.g., baseSepolia from "viem/chains"). */
+  chain: Chain;
+  /** The ERC-20 token contract address (e.g., Base Token Contract List: https://basescan.org/tokens). */
+  tokenAddress: Hex;
+  /** The sender's address. */
+  from: Hex;
+  /** The recipient's address. */
+  to: Hex;
+  /** The amount to transfer in the token's base units (e.g., 1_000_000 for 1 USDC). */
+  amount: bigint;
+  /** Description that will be shown in the app with the transaction. */
+  description: string;
+};
+
+export type CreateNativeTransferCallsOptions = Omit<
+  CreateERC20TransferCallsOptions,
+  "tokenAddress"
+>;
+
+export type GetERC20BalanceOptions = {
+  /** The viem Chain object. */
+  chain: Chain;
+  /** The ERC-20 token contract address. */
+  tokenAddress: Hex;
+  /** The address to query the balance of. */
+  address: Hex;
+  /** Optional custom viem transport. Defaults to http(). */
+  transport?: Transport;
+};
+
+export type GetERC20DecimalsOptions = {
+  /** The viem Chain object. */
+  chain: Chain;
+  /** The ERC-20 token contract address. */
+  tokenAddress: Hex;
+  /** Optional custom viem transport. Defaults to http(). */
+  transport?: Transport;
+};
+
+/**
+ * Creates a WalletSendCalls payload for an ERC-20 token transfer.
+ *
+ * @param options - The transfer options
+ * @returns A WalletSendCalls object ready to send
+ */
+export function createERC20TransferCalls(
+  options: CreateERC20TransferCallsOptions,
+): WalletSendCalls {
+  const { chain, tokenAddress, from, to, amount, description } = options;
+
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: "transfer",
+    args: [to, amount],
+  });
+
+  return {
+    version: "1.0",
+    chainId: toHex(chain.id),
+    from,
+    calls: [
+      {
+        to: tokenAddress,
+        data,
+        value: "0x0",
+        metadata: {
+          description,
+          transactionType: "transfer",
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Creates a WalletSendCalls payload for a native token transfer (ETH, MATIC, etc.).
+ *
+ * @param options - The transfer options
+ * @returns A WalletSendCalls object ready to send
+ */
+export function createNativeTransferCalls(
+  options: CreateNativeTransferCallsOptions,
+): WalletSendCalls {
+  const { chain, from, to, amount, description } = options;
+
+  return {
+    version: "1.0",
+    chainId: toHex(chain.id),
+    from,
+    calls: [
+      {
+        to,
+        value: toHex(amount),
+        metadata: {
+          description,
+          transactionType: "transfer",
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Reads the ERC-20 token balance for a given address from the blockchain.
+ *
+ * @param options - The query options including chain, token address, and wallet address
+ * @returns The token balance in base units as a bigint
+ */
+export async function getERC20Balance(
+  options: GetERC20BalanceOptions,
+): Promise<bigint> {
+  const { chain, tokenAddress, address, transport: customTransport } = options;
+
+  const client = createPublicClient({
+    chain,
+    transport: customTransport ?? http(),
+  });
+
+  return client.readContract({
+    address: tokenAddress,
+    abi: erc20Abi,
+    functionName: "balanceOf",
+    args: [address],
+  });
+}
+
+/**
+ * Reads the number of decimals for an ERC-20 token from the blockchain.
+ *
+ * @param options - The query options including chain and token address
+ * @returns The number of decimals (typically 6 or 18)
+ */
+export async function getERC20Decimals(
+  options: GetERC20DecimalsOptions,
+): Promise<number> {
+  const { chain, tokenAddress, transport: customTransport } = options;
+
+  const client = createPublicClient({
+    chain,
+    transport: customTransport ?? http(),
+  });
+
+  return client.readContract({
+    address: tokenAddress,
+    abi: erc20Abi,
+    functionName: "decimals",
+  });
+}

--- a/sdks/js/agent-sdk/src/util/index.ts
+++ b/sdks/js/agent-sdk/src/util/index.ts
@@ -1,0 +1,2 @@
+export * from "./AttachmentUtil";
+export * from "./TransactionUtil";

--- a/sdks/js/agent-sdk/src/util/test.ts
+++ b/sdks/js/agent-sdk/src/util/test.ts
@@ -1,0 +1,66 @@
+import {
+  type ContentCodec,
+  type ContentTypeId,
+  type EncodedContent,
+} from "@xmtp/content-type-primitives";
+import {
+  Client,
+  generateInboxId,
+  type ClientOptions,
+  type NetworkOptions,
+} from "@xmtp/node-sdk";
+import { createSigner, createUser } from "@/user/User";
+
+export const createClient = async <ContentCodecs extends ContentCodec[] = []>(
+  options?: Omit<ClientOptions & NetworkOptions, "codecs"> & {
+    codecs?: ContentCodecs;
+  },
+) => {
+  const signer = createSigner(createUser());
+  const identifier = await signer.getIdentifier();
+  const inboxId = generateInboxId(identifier);
+
+  let dbPath: string;
+  if (typeof options?.dbPath === "function") {
+    dbPath = options.dbPath(inboxId);
+  } else {
+    dbPath = options?.dbPath ?? `./test-${inboxId}.db3`;
+  }
+
+  return Client.create<ContentCodecs>(signer, {
+    ...options,
+    dbPath,
+    historySyncUrl: undefined,
+    disableDeviceSync: true,
+    env: "local",
+  });
+};
+
+export const ContentTypeTest: ContentTypeId = {
+  authorityId: "xmtp.org",
+  typeId: "test",
+  versionMajor: 1,
+  versionMinor: 0,
+};
+
+export class TestCodec implements ContentCodec {
+  contentType = ContentTypeTest;
+  encode(content: Record<string, string>): EncodedContent {
+    return {
+      type: this.contentType,
+      parameters: {},
+      content: new TextEncoder().encode(JSON.stringify(content)),
+    };
+  }
+  decode(content: EncodedContent): Record<string, string> {
+    const decoded = new TextDecoder().decode(content.content);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return JSON.parse(decoded);
+  }
+  fallback() {
+    return undefined;
+  }
+  shouldPush() {
+    return false;
+  }
+}

--- a/sdks/js/agent-sdk/tsconfig.json
+++ b/sdks/js/agent-sdk/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@/*": ["./src/*"],
+      "@test/*": ["./test/*"],
+      "~/*": ["./*"]
+    },
+    "preserveConstEnums": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ESNext",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["rollup.config.js", "src", "vitest.config.ts", "vitest.setup.ts"]
+}

--- a/sdks/js/agent-sdk/vitest.config.ts
+++ b/sdks/js/agent-sdk/vitest.config.ts
@@ -1,0 +1,13 @@
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    globals: true,
+    environment: "node",
+    testTimeout: 120000,
+    hookTimeout: 60000,
+    globalSetup: ["./vitest.setup.ts"],
+  },
+});

--- a/sdks/js/agent-sdk/vitest.setup.ts
+++ b/sdks/js/agent-sdk/vitest.setup.ts
@@ -1,0 +1,10 @@
+import { unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { glob } from "fast-glob";
+
+export const teardown = async () => {
+  const files = await glob("**/*.db3*", { cwd: import.meta.dirname });
+  await Promise.all(
+    files.map((file) => unlink(join(import.meta.dirname, file))),
+  );
+};

--- a/sdks/js/eslint.config.js
+++ b/sdks/js/eslint.config.js
@@ -77,7 +77,9 @@ export default tseslint.config(
     },
   },
   {
-    files: ["**/test/**/*.ts"],
+    // agent-sdk co-locates tests in src/ as *.test.ts; give them the same
+    // relaxations as the test/ directories
+    files: ["**/test/**/*.ts", "**/*.test.ts"],
     rules: {
       "@typescript-eslint/no-floating-promises": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
@@ -101,6 +103,19 @@ export default tseslint.config(
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
       "no-empty": "off",
+    },
+  },
+  {
+    // agent-sdk's event-driven API passes async handlers into void-returning
+    // callbacks throughout; tightening this is tracked as a migration follow-up
+    files: ["agent-sdk/src/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        {
+          checksVoidReturn: false,
+        },
+      ],
     },
   },
   {

--- a/sdks/js/js.just
+++ b/sdks/js/js.just
@@ -14,22 +14,26 @@ install-ci:
 bindings:
     ./dev/bindings
 
-# Typecheck both SDKs
-check: install
+# Typecheck all SDKs (agent-sdk resolves types from node-sdk's dist)
+check: install bindings
+    yarn workspace @xmtp/node-sdk run build
     yarn workspaces foreach -A run typecheck
 
-# Build both SDKs (needs bindings present)
+# Build all SDKs in topological order (needs bindings present)
 build: install bindings
-    yarn workspaces foreach -A run build
+    yarn workspaces foreach -At run build
 
-# Lint (eslint) both SDKs (needs bindings for type-aware rules)
+# Lint (eslint) all SDKs (needs bindings for type-aware rules)
 lint: install bindings
+    yarn workspace @xmtp/node-sdk run build
     yarn lint
 
 # Run all JS SDK tests locally (builds bindings first)
 test: install bindings
     yarn workspace @xmtp/node-sdk run test
     yarn workspace @xmtp/browser-sdk run test
+    yarn workspace @xmtp/node-sdk run build
+    yarn workspace @xmtp/agent-sdk run test
 
 # CI: node-sdk tests. Bindings are a nix cache hit (built by test-node job).
 # Extra args (e.g. --shard N/M) are forwarded to vitest.
@@ -39,3 +43,9 @@ test-node-sdk-ci *args="": install-ci bindings
 # CI: browser-sdk tests (Playwright). Bindings are a nix cache hit (test-wasm).
 test-browser-sdk-ci *args="": install-ci bindings
     yarn workspace @xmtp/browser-sdk run test {{ args }}
+
+# CI: agent-sdk tests. Runs against the local node-sdk (workspace dependency),
+# which must be built first so its dist exists at runtime.
+test-agent-sdk-ci *args="": install-ci bindings
+    yarn workspace @xmtp/node-sdk run build
+    yarn workspace @xmtp/agent-sdk run test {{ args }}

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -5,12 +5,13 @@
   "type": "module",
   "packageManager": "yarn@4.10.3",
   "workspaces": [
+    "agent-sdk",
     "browser-sdk",
     "node-sdk"
   ],
   "scripts": {
-    "typecheck": "yarn workspaces foreach -A run typecheck",
-    "build": "yarn workspaces foreach -A run build",
+    "typecheck": "yarn workspaces foreach -At run typecheck",
+    "build": "yarn workspaces foreach -At run build",
     "lint": "eslint .",
     "test": "yarn workspaces foreach -A run test"
   },

--- a/sdks/js/yarn.lock
+++ b/sdks/js/yarn.lock
@@ -1430,6 +1430,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/agent-sdk@workspace:agent-sdk":
+  version: 0.0.0-use.local
+  resolution: "@xmtp/agent-sdk@workspace:agent-sdk"
+  dependencies:
+    "@rollup/plugin-json": "npm:^6.1.0"
+    "@rollup/plugin-typescript": "npm:^12.3.0"
+    "@types/node": "npm:^24.10.9"
+    "@vitest/coverage-v8": "npm:^4.0.18"
+    "@xmtp/content-type-primitives": "npm:3.0.1"
+    "@xmtp/node-sdk": "workspace:^"
+    rollup: "npm:^4.59.0"
+    rollup-plugin-dts: "npm:^6.3.0"
+    rollup-plugin-tsconfig-paths: "npm:^1.5.2"
+    ts-retry-promise: "npm:^0.8.1"
+    tsx: "npm:^4.21.0"
+    typescript: "npm:^5.9.3"
+    viem: "npm:^2.37.6"
+    vite: "npm:^7.3.1"
+    vite-tsconfig-paths: "npm:^6.0.4"
+    vitest: "npm:^4.0.18"
+  languageName: unknown
+  linkType: soft
+
 "@xmtp/browser-sdk@workspace:browser-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/browser-sdk@workspace:browser-sdk"
@@ -1471,6 +1494,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/content-type-primitives@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@xmtp/content-type-primitives@npm:3.0.1"
+  dependencies:
+    "@xmtp/node-bindings": "npm:1.9.1"
+  checksum: 10c0/8a10ed42f07fa043ab9ab34c8878039433f99d8fc184ff3afdb1b70906e78c6a77885917de881fcd34fb9d8c8b2b69ff073732ac53447fcfb5bc9e3b43dc09f9
+  languageName: node
+  linkType: hard
+
 "@xmtp/js-sdks@workspace:.":
   version: 0.0.0-use.local
   resolution: "@xmtp/js-sdks@workspace:."
@@ -1491,13 +1523,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/node-bindings@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@xmtp/node-bindings@npm:1.9.1"
+  checksum: 10c0/b1a2b435c20c8e3a761446b472f80b5238fe8acb4f43d2ebf1a5d1824852eaa8cc4474e94ba030058390c69463557146c94d7f1936210911506af98489117468
+  languageName: node
+  linkType: hard
+
 "@xmtp/node-bindings@portal:../../../bindings/node::locator=%40xmtp%2Fnode-sdk%40workspace%3Anode-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/node-bindings@portal:../../../bindings/node::locator=%40xmtp%2Fnode-sdk%40workspace%3Anode-sdk"
   languageName: node
   linkType: soft
 
-"@xmtp/node-sdk@workspace:node-sdk":
+"@xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:node-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/node-sdk@workspace:node-sdk"
   dependencies:
@@ -3695,6 +3734,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-retry-promise@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "ts-retry-promise@npm:0.8.1"
+  checksum: 10c0/69758255f9b185c6bf24da848b5b5102fa7a233c1fb04747076132799116d13eb3ec30bd35eb18bfda1522232a77b97275ad99cee9597b2449f0474d6d9261dd
+  languageName: node
+  linkType: hard
+
 "tsconfck@npm:^3.0.3":
   version: 3.1.6
   resolution: "tsconfck@npm:3.1.6"
@@ -3811,6 +3857,27 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"viem@npm:^2.37.6":
+  version: 2.55.15
+  resolution: "viem@npm:2.55.15"
+  dependencies:
+    "@noble/curves": "npm:1.9.1"
+    "@noble/hashes": "npm:1.8.0"
+    "@scure/bip32": "npm:1.7.0"
+    "@scure/bip39": "npm:1.6.0"
+    abitype: "npm:1.2.3"
+    isows: "npm:1.0.7"
+    ox: "npm:0.14.33"
+    ws: "npm:8.21.0"
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/17a669a607cc394ec844fd22e8a8df2e428415a74828d7deb8a863f450a8e18775250fa6db87a22c5027094dbd2dfb04f59a7b6a5d92afbd2683bdda622ac52f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Migrates `@xmtp/agent-sdk` (v2.3.0) from the xmtp-js repo into this monorepo, joining node-sdk and browser-sdk. Agent SDK was the last package remaining in xmtp-js, and that repo no longer has a release path — this restores one, and lets agent-sdk build and test against the in-repo node-sdk.

Source is byte-identical to `xmtp-js@615d4e71` (the current upstream main; agent-sdk last changed by `8ee0d18c`, the v2.3.0 release) except for three deliberate deltas, called out below.

## Why now

The zombie-stream investigation (#3978) showed the cost of splitting one recovery story across two repos: Agent SDK's stream teardown/backoff could not be integration-tested against node-sdk's retry timer, and the interaction between them shipped a self-amplifying stream leak. In-repo, that integration test becomes an ordinary vitest test against the working tree.

## Deltas from upstream

1. **`@xmtp/node-sdk` is now `workspace:^`** — agent-sdk always builds/tests against the local node-sdk. At publish time, `npm-publish.yml` pins it to a published version via the existing `dep-name`/`dep-version` machinery (same pattern node-sdk uses for `@xmtp/node-bindings`).
2. **ToxiProxy API port 8475 → 8474** in `Agent.reconnect.test.ts` — this repo's dev backend already ships the exact `node-go` proxy the reconnect tests need; only the API port mapping differed.
3. **Lint fixes** for this repo's stricter eslint: a comment in an empty catch, removal of an unnecessary type assertion. Additionally, `eslint.config.js` extends the existing test-file relaxations to co-located `*.test.ts` files and scopes `no-misused-promises` `checksVoidReturn` off for agent-sdk src — its event-driven API passes async handlers into void-returning callbacks throughout; tightening that properly (real error paths) is part of the follow-up below.

## Wiring

- **Workspace:** added to `sdks/js` workspaces; `typecheck`/`build` run topologically; `js.just` `check`/`lint`/`test` build node-sdk first (agent-sdk resolves its types/runtime from node-sdk's `dist`).
- **CI:** new `test-agent-sdk.yml` (backend + toxiproxy, mirrors test-node-sdk), gated on `test-node` with an `agent_sdk` paths filter that includes `sdks/js/node-sdk/**` — node-sdk changes now run agent-sdk's suite. Added to the required `test` aggregate.
- **Release — full parity with node-sdk:** `agent-sdk` registered in `dev/release-tools` (tag prefix `agent-sdk-`, independent version track, `nightly`/`rc`/`final` channels) with a new `release-agent-sdk.yml` (workflow_call from the train + standalone workflow_dispatch) publishing through `npm-publish.yml`. Wired into the `release.yml` train end-to-end: nightly cron enables it alongside the other SDKs (same gate-skip / nothing-pending blocking), `release-agent-sdk` depends on `release-node-sdk` so the published package pins the node-sdk version shipped by the same run (falls back to npm `latest` when node-sdk is deselected), and it participates in `merge-pr` gating, the hub rollup table, and the Slack notify line. `create-release-branch` (workflow + CLI) gains an `--agent-sdk` bump for rc/final branch cuts. Verified with the release-tools CLI: dev computes `2.3.0-dev.<sha>`, nightly resolves `2.4.0-nightly.<date>.<sha>` — identical semantics to node-sdk.

## Verification

- `yarn lint` — clean (two pre-existing deprecation warnings, one of which is agent-sdk's use of a deprecated node-sdk API, noted for follow-up)
- `yarn workspaces foreach -A run typecheck` — all three SDKs clean
- agent-sdk suite vs local backend: **118/118** across 11 files, including the three toxiproxy reconnect tests
- `dev/release-tools` suite: **173/173**
- `nix fmt -- --ci` — clean
- rollup build verified: `dist/index.d.ts` keeps `@xmtp/node-sdk` external (416 lines, no type inlining)

## Follow-ups (tracked, not in this PR)

- Agent SDK passes `retryOnFail: false` to node-sdk streams so there is exactly one recovery owner (defense-in-depth for #3978), with real error paths in its async stream handlers
- Agent SDK ↔ node-sdk stream-recovery integration regression test
- Archive xmtp-js with a pointer here; migrate open issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add @xmtp/agent-sdk package migrated from xmtp-js with middleware, utilities, and CI pipeline
> - Introduces the `@xmtp/agent-sdk` package under `sdks/js/agent-sdk/` with core classes (`Agent`, `MessageContext`, `ConversationContext`), middleware (`CommandRouter`, `ActionWizard`, `PerformanceMonitor`), and utilities (`AttachmentUtil`, `TransactionUtil`, `NameResolver`).
> - Adds a full CI pipeline: a dedicated test workflow ([test-agent-sdk.yml](.github/workflows/test-agent-sdk.yml)), a release workflow ([release-agent-sdk.yml](.github/workflows/release-agent-sdk.yml)), and integration into the top-level release orchestration ([release.yml](.github/workflows/release.yml)).
> - Extends release tooling with an `agent-sdk` SDK config entry and `--agent-sdk` CLI flag for version bump control in the `create-release-branch` command.
> - Propagates a `ref` input to `npm-publish.yml` and uses it in browser-sdk, node-sdk, node, and wasm publish jobs so tagging and publishing always target the intended commit.
> - Includes runnable demos for transactions, reconnect behavior, and wizard-style action flows, plus a `generateKeys` bin script that writes a `.env` file with fresh XMTP credentials.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ab89ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->