### PR TITLE
fix(node-sdk,browser-sdk): reschedule when the native stream closes during restart

### DIFF
--- a/sdks/js/browser-sdk/src/utils/streams.ts
+++ b/sdks/js/browser-sdk/src/utils/streams.ts
@@ -123,6 +123,12 @@ export const createStream = async <T = unknown, V = T>(
   let currentCloser: (() => void) | undefined;
   let retryTimer: ReturnType<typeof setTimeout> | undefined;
   let retryInFlight = false;
+  // set when a restart's native stream closes during its own creation, so the
+  // completed attempt reschedules instead of installing an already-dead closer
+  let closePendingDuringRestart = false;
+  // read through a call so no-unnecessary-condition cannot narrow the flag to
+  // a constant; handleNativeClose mutates it across an await
+  const isClosePending = () => closePendingDuringRestart;
   // the retry budget is monotonic: it is never reset for the lifetime of
   // this wrapper, so restarts are bounded even across successful restarts
   let remainingRetries = retryAttempts;
@@ -134,6 +140,7 @@ export const createStream = async <T = unknown, V = T>(
       return;
     }
     stopped = true;
+    closePendingDuringRestart = false;
     if (retryTimer !== undefined) {
       clearTimeout(retryTimer);
       retryTimer = undefined;
@@ -228,8 +235,17 @@ export const createStream = async <T = unknown, V = T>(
       retryInFlight = false;
       return;
     }
+    // scope the pending-close flag to this attempt: a close recorded while the
+    // retry timer was merely pending belongs to the stream that scheduled it
+    closePendingDuringRestart = false;
     remainingRetries -= 1;
     onRetry?.(retryAttempts - remainingRetries, retryAttempts);
+    if (isStopped()) {
+      // onRetry may have ended the stream; do not open a native stream after
+      // termination
+      retryInFlight = false;
+      return;
+    }
     try {
       // attempt to restart the stream
       const streamCloser = await streamFunction(
@@ -242,6 +258,15 @@ export const createStream = async <T = unknown, V = T>(
         retryInFlight = false;
         return;
       }
+      if (isClosePending()) {
+        // the replacement stream closed during its own creation; discard it
+        // and schedule a fresh attempt instead of installing a dead closer
+        closePendingDuringRestart = false;
+        streamCloser();
+        retryInFlight = false;
+        scheduleRetry();
+        return;
+      }
       currentCloser = streamCloser;
       retryInFlight = false;
       // stream restarted, call the onRestart callback
@@ -251,6 +276,7 @@ export const createStream = async <T = unknown, V = T>(
       if (isStopped()) {
         return;
       }
+      closePendingDuringRestart = false;
       onError?.(error as Error);
       scheduleRetry();
     }
@@ -265,6 +291,13 @@ export const createStream = async <T = unknown, V = T>(
     currentCloser = undefined;
     onFail?.();
     if (retryOnFail) {
+      // a native close during an in-flight restart is dropped by the
+      // single-flight guard; record it so the completed attempt reschedules
+      // instead of installing a stream that already died
+      if (retryInFlight) {
+        closePendingDuringRestart = true;
+        return;
+      }
       scheduleRetry();
     } else {
       void asyncStream.end();

--- a/sdks/js/browser-sdk/test/streams.test.ts
+++ b/sdks/js/browser-sdk/test/streams.test.ts
@@ -1129,4 +1129,69 @@ describe("createStream lifecycle", () => {
     expect(mutator).toHaveBeenCalled();
     expect(onValue).not.toHaveBeenCalled();
   });
+
+  it("reschedules when the native stream closes during restart creation", async () => {
+    const instances: StreamInstance[] = [];
+    let resolveSecond!: () => void;
+    const secondCloser = vi.fn();
+    const streamFunction = vi.fn(
+      (callback: StreamCallback<number>, onFail: () => void) => {
+        if (instances.length === 1) {
+          // the restart stream's creation stays in flight so the test can
+          // close it while it is still being created
+          instances.push({ callback, onFail, closer: secondCloser });
+          return new Promise<() => void>((resolve) => {
+            resolveSecond = () => resolve(secondCloser as () => void);
+          });
+        }
+        const closer = vi.fn();
+        instances.push({ callback, onFail, closer });
+        return Promise.resolve(closer as () => void);
+      },
+    );
+    const onRestart = vi.fn();
+    await createStream<number>(streamFunction, undefined, {
+      onRestart,
+      retryDelay: 1000,
+    });
+
+    // the original stream closes and a retry is scheduled
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(streamFunction).toHaveBeenCalledTimes(2);
+
+    // the replacement stream closes while its creation is still in flight
+    instances[1].onFail();
+    resolveSecond();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // instead of installing the dead stream, the wrapper schedules a fresh
+    // attempt; advancing past it opens a third native stream
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(streamFunction).toHaveBeenCalledTimes(3);
+    // the dead replacement was discarded, and only the live stream is announced
+    expect(secondCloser).toHaveBeenCalled();
+    expect(onRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create a native stream when onRetry ends the stream", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const streamRef: { end?: () => Promise<unknown> } = {};
+    const onRetry = vi.fn(() => {
+      void streamRef.end?.();
+    });
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onRetry,
+      retryDelay: 1000,
+    });
+    streamRef.end = () => stream.end();
+
+    // the native close schedules a retry; onRetry ends the stream when it fires
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(onRetry).toHaveBeenCalled();
+    expect(streamFunction).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/sdks/js/node-sdk/src/utils/streams.ts
+++ b/sdks/js/node-sdk/src/utils/streams.ts
@@ -116,6 +116,12 @@ export const createStream = async <T = unknown, V = T>(
   let currentCloser: StreamCloser | undefined;
   let retryTimer: ReturnType<typeof setTimeout> | undefined;
   let retryInFlight = false;
+  // set when a restart's native stream closes during its own creation, so the
+  // completed attempt reschedules instead of installing an already-dead closer
+  let closePendingDuringRestart = false;
+  // read through a call so no-unnecessary-condition cannot narrow the flag to
+  // a constant; handleNativeClose mutates it across an await
+  const isClosePending = () => closePendingDuringRestart;
   // the retry budget is monotonic: it is never reset for the lifetime of
   // this wrapper, so restarts are bounded even across successful restarts
   let remainingRetries = retryAttempts;
@@ -127,6 +133,7 @@ export const createStream = async <T = unknown, V = T>(
       return;
     }
     stopped = true;
+    closePendingDuringRestart = false;
     if (retryTimer !== undefined) {
       clearTimeout(retryTimer);
       retryTimer = undefined;
@@ -221,8 +228,17 @@ export const createStream = async <T = unknown, V = T>(
       retryInFlight = false;
       return;
     }
+    // scope the pending-close flag to this attempt: a close recorded while the
+    // retry timer was merely pending belongs to the stream that scheduled it
+    closePendingDuringRestart = false;
     remainingRetries -= 1;
     onRetry?.(retryAttempts - remainingRetries, retryAttempts);
+    if (isStopped()) {
+      // onRetry may have ended the stream; do not open a native stream after
+      // termination
+      retryInFlight = false;
+      return;
+    }
     try {
       // attempt to restart the stream
       const streamCloser = await streamFunction(
@@ -241,6 +257,15 @@ export const createStream = async <T = unknown, V = T>(
         retryInFlight = false;
         return;
       }
+      if (isClosePending()) {
+        // the replacement stream closed during its own creation; discard it
+        // and schedule a fresh attempt instead of installing a dead closer
+        closePendingDuringRestart = false;
+        streamCloser.end();
+        retryInFlight = false;
+        scheduleRetry();
+        return;
+      }
       currentCloser = streamCloser;
       retryInFlight = false;
       // stream restarted, call the onRestart callback
@@ -250,6 +275,7 @@ export const createStream = async <T = unknown, V = T>(
       if (isStopped()) {
         return;
       }
+      closePendingDuringRestart = false;
       onError?.(error as Error);
       scheduleRetry();
     }
@@ -264,6 +290,13 @@ export const createStream = async <T = unknown, V = T>(
     currentCloser = undefined;
     onFail?.();
     if (retryOnFail) {
+      // a native close during an in-flight restart is dropped by the
+      // single-flight guard; record it so the completed attempt reschedules
+      // instead of installing a stream that already died
+      if (retryInFlight) {
+        closePendingDuringRestart = true;
+        return;
+      }
       scheduleRetry();
     } else {
       fail(new StreamFailedError(0));

--- a/sdks/js/node-sdk/test/streams.test.ts
+++ b/sdks/js/node-sdk/test/streams.test.ts
@@ -346,6 +346,72 @@ describe("createStream lifecycle", () => {
     expect(mutator).toHaveBeenCalled();
     expect(onValue).not.toHaveBeenCalled();
   });
+
+  it("reschedules when the native stream closes during restart creation", async () => {
+    const instances: StreamInstance[] = [];
+    let resolveSecondReady!: () => void;
+    const streamFunction = vi.fn(
+      (callback: StreamCallback<number>, onFail: () => void) => {
+        const closer = makeCloser();
+        if (instances.length === 1) {
+          // the restart stream holds waitForReady open so the test can close
+          // it while its creation is still in flight
+          closer.waitForReady = vi.fn(
+            () =>
+              new Promise<void>((resolve) => {
+                resolveSecondReady = resolve;
+              }),
+          );
+        }
+        instances.push({ callback, onFail, closer });
+        return Promise.resolve(closer as unknown as StreamCloser);
+      },
+    );
+    const onRestart = vi.fn();
+    await createStream<number>(streamFunction, undefined, {
+      onRestart,
+      retryDelay: 1000,
+    });
+
+    // the original stream closes and a retry is scheduled
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(streamFunction).toHaveBeenCalledTimes(2);
+
+    // the replacement stream closes while its waitForReady is still pending
+    instances[1].onFail();
+    resolveSecondReady();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // instead of installing the dead stream, the wrapper schedules a fresh
+    // attempt; advancing past it opens a third native stream
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(streamFunction).toHaveBeenCalledTimes(3);
+    // the dead replacement was discarded, and only the live stream is announced
+    expect(instances[1].closer.end).toHaveBeenCalled();
+    expect(onRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create a native stream when onRetry ends the stream", async () => {
+    const { instances, streamFunction } = makeHarness();
+    const streamRef: { end?: () => Promise<unknown> } = {};
+    const onRetry = vi.fn(() => {
+      void streamRef.end?.();
+    });
+    const stream = await createStream<number>(streamFunction, undefined, {
+      onRetry,
+      retryDelay: 1000,
+    });
+    streamRef.end = () => stream.end();
+
+    // the native close schedules a retry; onRetry ends the stream when it fires
+    instances[0].onFail();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(onRetry).toHaveBeenCalled();
+    expect(streamFunction).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });
 
 describe("createStream", () => {


### PR DESCRIPTION
## Summary

Follow-up to #3978. That PR made `createStream`'s `end()` terminal and race-safe and merged with the two review findings folded in. Its review surfaced **two more** correctness findings in the restart path that were verified after the merge landed — this PR addresses both. No behavior from #3978 is changed; these are additive guards on the retry/restart machinery.

## Finding 1 — reschedule when a replacement stream closes during its own creation (High)

**Symptom:** under reconnect churn a wrapper could end up permanently open with no active native stream and no scheduled retry, hanging any consumer awaiting `next()`.

**Root cause:** the single-flight retry guard (`retryInFlight`) is held for the entire duration of a restart attempt. If the replacement native stream fires its `on_close` while the attempt's own creation is still in flight — during `streamFunction()` (browser) or `waitForReady()` (node) — `handleNativeClose` calls `scheduleRetry()`, which early-returns because `retryInFlight` is still `true`. The close notification is dropped. The pending attempt then resolves, passes its `isStopped()` checks, and installs the **already-closed** closer as `currentCloser`, clearing `retryInFlight`. The wrapper is now "restarted" but dead: no live stream, no retry, consumers blocked forever.

**Fix:** a `closePendingDuringRestart` latch. `handleNativeClose` records a close that arrives while a restart is in flight instead of dropping it; when the attempt completes it detects the latch, discards the dead closer (calls its close), and schedules a fresh retry (consuming budget, since a real failure occurred) rather than installing it or announcing `onRestart`. The latch is **scoped to the active creation window** (reset at the top of each `attemptRestart`), so redundant closes recorded during the retry-timer wait — where there is no live native stream — do not trigger a second reschedule and cannot reintroduce retry amplification. The latch is read through an `isClosePending()` helper for the same reason `isStopped()` exists: typescript-eslint's `no-unnecessary-condition` cannot see the closure mutation across awaits.

## Finding 2 — do not open a native stream after `onRetry` ends the stream (Medium)

**Symptom:** a consumer that calls `end()` from within its `onRetry` callback would still cause one avoidable native stream to be created (and immediately torn down). No leak or hang — the existing post-creation `isStopped()` guard closes it — but an unnecessary native/network round-trip.

**Fix:** `attemptRestart` re-checks `isStopped()` immediately after invoking `onRetry`, returning before `streamFunction()` is called if the stream was ended.

## Tests

TDD, red-first for both, in both SDKs (vitest fake timers): 2 new lifecycle tests per SDK.
- "reschedules when the native stream closes during restart creation" — drives the original close to schedule a retry, closes the replacement mid-creation, and asserts a third native stream is opened (pre-fix stuck at 2), the dead replacement is closed, and only the live stream announces `onRestart`.
- "does not create a native stream when onRetry ends the stream" — `onRetry` ends the stream and the test asserts `streamFunction` is called exactly once with no pending timers (pre-fix: 2 calls).

Full verification: node-sdk streams + AsyncStream **36/36**, browser-sdk streams + AsyncStream **64/64**, node/browser lint clean, `nix fmt --ci` clean. The existing single-flight test stays green — the creation-window scoping is what preserves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `createStream` to reschedule retry when native stream closes during restart
> - When a native stream closes while a replacement stream is being created (restart in-flight), the completed attempt is now discarded and a new retry is scheduled instead of installing an already-closed stream closer.
> - A `pendingClose` flag is introduced in both [browser-sdk streams.ts](https://github.com/xmtp/libxmtp/pull/3980/files#diff-b9236321cc1ed9d7c7020e6f57582d7f3cf4bb6a3fd861240efc5dabbc7c70a1) and [node-sdk streams.ts](https://github.com/xmtp/libxmtp/pull/3980/files#diff-1e43156ae5c6cfb7ff7b28db20ea7f13a2f8a373f5b4199b4662dce30e46da16) to track this condition; `handleNativeClose` sets the flag and skips immediate retry scheduling when a restart is in flight.
> - If `onRetry` ends the stream, `attemptRestart` now returns early to prevent creating a new native stream.
> - Tests for both rescheduling and early-exit behaviors are added in the respective `streams.test.ts` files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d979a87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->