### PR TITLE
fix(agent-sdk): do not evict entries when updating existing keys in LimitedMap

### DIFF
--- a/sdks/js/agent-sdk/src/util/LimitedMap.test.ts
+++ b/sdks/js/agent-sdk/src/util/LimitedMap.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { LimitedMap } from "./LimitedMap.js";
+
+describe("LimitedMap", () => {
+  it("stores and retrieves values", () => {
+    const map = new LimitedMap<string, number>(3);
+    map.set("a", 1);
+    map.set("b", 2);
+
+    expect(map.get("a")).toBe(1);
+    expect(map.get("b")).toBe(2);
+    expect(map.get("c")).toBeUndefined();
+  });
+
+  it("evicts oldest entry when inserting a new key at capacity", () => {
+    const map = new LimitedMap<string, number>(2);
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    expect(map.get("a")).toBeUndefined();
+    expect(map.get("b")).toBe(2);
+    expect(map.get("c")).toBe(3);
+  });
+
+  it("does not evict entries when updating an existing key at capacity", () => {
+    const map = new LimitedMap<string, number>(2);
+    map.set("a", 1);
+    map.set("b", 2);
+
+    // Update existing key "b"
+    map.set("b", 4);
+
+    expect(map.get("a")).toBe(1);
+    expect(map.get("b")).toBe(4);
+  });
+
+  it("maintains correct capacity after updates and subsequent new insertions", () => {
+    const map = new LimitedMap<string, number>(2);
+    map.set("a", 1);
+    map.set("b", 2);
+
+    // Update "a" and "b"
+    map.set("a", 10);
+    map.set("b", 20);
+
+    expect(map.get("a")).toBe(10);
+    expect(map.get("b")).toBe(20);
+
+    // Insert new key "c", should evict "a" (oldest insertion)
+    map.set("c", 30);
+    expect(map.get("a")).toBeUndefined();
+    expect(map.get("b")).toBe(20);
+    expect(map.get("c")).toBe(30);
+  });
+});

--- a/sdks/js/agent-sdk/src/util/LimitedMap.ts
+++ b/sdks/js/agent-sdk/src/util/LimitedMap.ts
@@ -7,7 +7,7 @@ export class LimitedMap<K, V> {
   }
 
   set(key: K, value: V) {
-    if (this.#map.size >= this.#limit) {
+    if (!this.#map.has(key) && this.#map.size >= this.#limit) {
       const it = this.#map.keys().next();
       if (!it.done) {
         this.#map.delete(it.value);


### PR DESCRIPTION
Resolves #3981

### Summary
`LimitedMap.set()` previously evicted the oldest entry whenever the map was at capacity (`size >= limit`), without checking whether the key being inserted already existed in the map. Updating an existing key's value does not grow the map, so triggering an eviction caused an unrelated, valid entry to be deleted and prematurely shrank the map below its capacity limit.

This affected `NameResolver` caching (`new LimitedMap<string, string | null>(1000)`), causing unnecessary re-resolutions when updating cached entries.

### Changes
- `sdks/js/agent-sdk/src/util/LimitedMap.ts`: Added `!this.#map.has(key)` guard before eviction so existing key updates do not trigger deletion.
- `sdks/js/agent-sdk/src/util/LimitedMap.test.ts`: Added unit test suite covering key storage, eviction at capacity on new insertions, preserving entries during updates, and maintaining capacity across subsequent operations.

### Verification
- Added comprehensive unit tests for `LimitedMap`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `LimitedMap.set` to skip eviction when updating an existing key
> Previously, calling `set` on an existing key while at capacity would incorrectly evict the oldest entry. The fix checks whether the key already exists before evicting, so eviction only happens when inserting a genuinely new key at capacity. A new test suite in [LimitedMap.test.ts](https://github.com/xmtp/libxmtp/pull/3996/files#diff-91a3650b4fab84b25b175dd3b152b6f997fdbc20eb4c2fd83419f58240585996) covers these eviction policy cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized faeab70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->