### PR TITLE
feat(agent-sdk): own stream recovery end-to-end (retryOnFail: false)

### DIFF
--- a/sdks/js/agent-sdk/src/core/Agent.reconnect.test.ts
+++ b/sdks/js/agent-sdk/src/core/Agent.reconnect.test.ts
@@ -1,8 +1,9 @@
 import { once } from "node:events";
 import { setTimeout } from "node:timers/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Agent } from "@/core/Agent";
 import { createSigner, createUser } from "@/user/User";
+import { createClient } from "@/util/test";
 
 const PROXY_NAME = "node-go";
 // libxmtp's dev backend maps the toxiproxy API to host port 8474
@@ -80,5 +81,111 @@ describe("Agent reconnect", () => {
     expect(error).toBeInstanceOf(Error);
 
     await agent.stop();
+  });
+});
+
+// End-to-end regression for the single-recovery-owner fix: retryOnFail: false
+// plus Agent-owned recovery/teardown. Complements node-sdk's terminal/silent
+// intentional-close change (PR #3978), which removes spurious close errors.
+//
+// "exactly one conversation stream and one message stream" is not observable
+// from outside the client, so we assert its consequence: across repeated
+// disconnect/reconnect cycles each message id reaches exactly one handler
+// invocation. A leaked/zombie stream would re-deliver, so a stable
+// one-delivery-per-id count is the practical proxy.
+describe("Agent stream recovery regression", () => {
+  it("delivers each message exactly once across recovery cycles", async () => {
+    const agent = await createToxicAgent();
+    const deliveries = new Map<string, number>();
+    agent.on("text", (ctx) => {
+      const id = ctx.message.id;
+      deliveries.set(id, (deliveries.get(id) ?? 0) + 1);
+    });
+    // Disconnects surface as unhandledError; absorb so they don't fail the run.
+    agent.on("unhandledError", () => {});
+
+    await agent.start();
+
+    // The sender connects directly (not through the toxic proxy) so it can
+    // reach the same backend node the agent's proxy fronts.
+    const sender = await createClient();
+    const dm = await sender.conversations.createDm(agent.client.inboxId);
+
+    const sendAndAwait = async (text: string) => {
+      const id = await dm.sendText(text);
+      await vi.waitFor(
+        () => {
+          expect(deliveries.get(id)).toBe(1);
+        },
+        { timeout: 45000, interval: 250 },
+      );
+      return id;
+    };
+
+    await sendAndAwait("before-cycles");
+
+    for (let cycle = 0; cycle < 2; cycle++) {
+      const reconnected = once(agent, "start", {
+        signal: AbortSignal.timeout(45000),
+      });
+      await enableBackend(false);
+      await setTimeout(3000);
+      await enableBackend(true);
+      await reconnected;
+
+      await sendAndAwait(`after-cycle-${cycle}`);
+    }
+
+    // Let any zombie/duplicate deliveries surface before asserting.
+    await setTimeout(3000);
+
+    for (const [id, count] of deliveries) {
+      expect(count, `message ${id} delivered ${count} times`).toBe(1);
+    }
+    // Sanity: we actually exercised the initial send plus each cycle.
+    expect(deliveries.size).toBeGreaterThanOrEqual(3);
+
+    await agent.stop();
+    // Generous budget: two recovery cycles plus message round-trips, which can
+    // be slow when the shared backend is under load.
+  }, 240000);
+
+  it("stop() during pending recovery yields no further deliveries or errors", async () => {
+    const agent = await createToxicAgent();
+    const onText = vi.fn();
+    const errors: unknown[] = [];
+    agent.on("text", onText);
+    agent.on("unhandledError", (error) => errors.push(error));
+
+    await agent.start();
+
+    // Register the listener before disconnecting so we can't miss the error
+    // that fires while the proxy is being disabled.
+    const recoveryStarted = once(agent, "unhandledError", {
+      signal: AbortSignal.timeout(45000),
+    });
+    await enableBackend(false);
+    await recoveryStarted;
+    await setTimeout(500);
+
+    const deliveriesAtStop = onText.mock.calls.length;
+    const errorsAtStop = errors.length;
+
+    await agent.stop();
+
+    // Restore the backend: a zombie recovery would re-create streams here.
+    await enableBackend(true);
+    await setTimeout(3000);
+
+    // A stopped agent must not receive newly sent messages.
+    const sender = await createClient();
+    const dm = await sender.conversations.createDm(agent.client.inboxId);
+    await dm.sendText("after-stop");
+    await setTimeout(3000);
+
+    expect(onText.mock.calls.length, "no deliveries after stop()").toBe(
+      deliveriesAtStop,
+    );
+    expect(errors.length, "no new errors after stop()").toBe(errorsAtStop);
   });
 });

--- a/sdks/js/agent-sdk/src/core/Agent.streamHandlers.test.ts
+++ b/sdks/js/agent-sdk/src/core/Agent.streamHandlers.test.ts
@@ -1,0 +1,200 @@
+import type { Client } from "@xmtp/node-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { Agent } from "@/core/Agent";
+
+// The stream `onValue`/`onError` handlers are async functions handed to
+// node-sdk's void-returning callbacks. If the recovery they trigger rejects
+// (e.g. `#handleStreamError` throwing while tearing streams down), that
+// rejection must be routed to the agent's `unhandledError` sink — never leaked
+// as an unhandled promise rejection that can crash the host process.
+describe("Agent stream handler error routing", () => {
+  const makeAgent = () => {
+    const captured: {
+      conversation?: {
+        onValue: (value: unknown) => unknown;
+        onError: (error: Error) => unknown;
+      };
+      message?: {
+        onValue: (value: unknown) => unknown;
+        onError: (error: Error) => unknown;
+      };
+    } = {};
+
+    // Closing the conversation stream rejects, so `#handleStreamError` throws
+    // mid-recovery — the failure path under test.
+    const conversationStream = {
+      end: vi.fn(() => Promise.reject(new Error("failed to close stream"))),
+    };
+    const messageStream = { end: vi.fn(() => Promise.resolve()) };
+
+    const client = {
+      conversations: {
+        stream: vi.fn((options: typeof captured.conversation) => {
+          captured.conversation = options;
+          return Promise.resolve(conversationStream);
+        }),
+        streamAllMessages: vi.fn((options: typeof captured.message) => {
+          captured.message = options;
+          return Promise.resolve(messageStream);
+        }),
+      },
+    } as unknown as Client;
+
+    return { agent: new Agent({ client }), captured };
+  };
+
+  it("routes a rejecting conversation onError to unhandledError without leaking", async () => {
+    const { agent, captured } = makeAgent();
+    const unhandled = vi.fn();
+    agent.on("unhandledError", unhandled);
+
+    await agent.start();
+
+    // node-sdk fires stream callbacks fire-and-forget; the handler must return
+    // void, never a rejecting promise.
+    const returned = captured.conversation!.onError(
+      new Error("stream disconnected"),
+    );
+    await expect(Promise.resolve(returned)).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(unhandled).toHaveBeenCalledTimes(1);
+    });
+    expect(unhandled.mock.calls[0]![0]).toBeInstanceOf(Error);
+  });
+
+  it("routes a rejecting message onError to unhandledError without leaking", async () => {
+    const { agent, captured } = makeAgent();
+    const unhandled = vi.fn();
+    agent.on("unhandledError", unhandled);
+
+    await agent.start();
+
+    const returned = captured.message!.onError(
+      new Error("stream disconnected"),
+    );
+    await expect(Promise.resolve(returned)).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(unhandled).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+// A stopped agent must never leave a resurrected stream alive: if stop() races
+// in while recovery is mid re-setup, the freshly created streams must be torn
+// down rather than left delivering.
+describe("Agent recovery ownership on stop", () => {
+  it("tears down streams re-created after stop() instead of leaking a zombie", async () => {
+    const captured: {
+      conversation?: { onError: (error: Error) => unknown };
+    } = {};
+
+    let resolveRecoverySetup!: () => void;
+    let conversationStreamCalls = 0;
+    const startConversationStream = { end: vi.fn(() => Promise.resolve()) };
+    const recoveredConversationStream = { end: vi.fn(() => Promise.resolve()) };
+    const messageStream = { end: vi.fn(() => Promise.resolve()) };
+
+    const client = {
+      conversations: {
+        stream: vi.fn((options: typeof captured.conversation) => {
+          captured.conversation = options;
+          conversationStreamCalls += 1;
+          if (conversationStreamCalls === 1) {
+            return Promise.resolve(startConversationStream);
+          }
+          // Recovery's re-setup hangs until we release it below.
+          return new Promise((resolve) => {
+            resolveRecoverySetup = () => resolve(recoveredConversationStream);
+          });
+        }),
+        streamAllMessages: vi.fn(() => Promise.resolve(messageStream)),
+      },
+    } as unknown as Client;
+
+    const agent = new Agent({ client });
+    agent.on("unhandledError", () => {});
+
+    await agent.start();
+
+    // Trigger recovery; it re-syncs, re-sets up, and blocks on the new stream.
+    captured.conversation!.onError(new Error("stream disconnected"));
+    await vi.waitFor(() => {
+      expect(conversationStreamCalls).toBe(2);
+    });
+
+    // Stop while the re-setup is still in flight.
+    await agent.stop();
+
+    // Release the re-setup: the guard must close the resurrected streams.
+    resolveRecoverySetup();
+    await vi.waitFor(() => {
+      expect(recoveredConversationStream.end).toHaveBeenCalled();
+    });
+  });
+
+  it("tears down a partially set-up stream when recovery setup rejects after stop()", async () => {
+    const captured: {
+      conversation?: { onError: (error: Error) => unknown };
+    } = {};
+
+    let conversationCalls = 0;
+    let messageCalls = 0;
+    let resolveConversationSetup!: () => void;
+    let rejectMessageSetup!: () => void;
+    const recoveredConversationStream = { end: vi.fn(() => Promise.resolve()) };
+    const okStream = () => ({ end: vi.fn(() => Promise.resolve()) });
+
+    const client = {
+      conversations: {
+        stream: vi.fn((options: typeof captured.conversation) => {
+          captured.conversation = options;
+          conversationCalls += 1;
+          if (conversationCalls === 1) {
+            return Promise.resolve(okStream());
+          }
+          // Recovery assigns this stream, then hangs on the message stream.
+          return new Promise((resolve) => {
+            resolveConversationSetup = () =>
+              resolve(recoveredConversationStream);
+          });
+        }),
+        streamAllMessages: vi.fn(() => {
+          messageCalls += 1;
+          if (messageCalls === 1) {
+            return Promise.resolve(okStream());
+          }
+          return new Promise((_resolve, reject) => {
+            rejectMessageSetup = () =>
+              reject(new Error("message stream setup failed"));
+          });
+        }),
+      },
+    } as unknown as Client;
+
+    const agent = new Agent({ client });
+    agent.on("unhandledError", () => {});
+
+    await agent.start();
+
+    captured.conversation!.onError(new Error("stream disconnected"));
+    await vi.waitFor(() => {
+      expect(conversationCalls).toBe(2);
+    });
+
+    // Stop before the conversation stream is assigned, then let setup assign it
+    // and reject on the message stream.
+    await agent.stop();
+    resolveConversationSetup();
+    await vi.waitFor(() => {
+      expect(messageCalls).toBe(2);
+    });
+    rejectMessageSetup();
+
+    // The partially created stream must be closed even though setup rejected.
+    await vi.waitFor(() => {
+      expect(recoveredConversationStream.end).toHaveBeenCalled();
+    });
+  });
+});

--- a/sdks/js/agent-sdk/src/core/Agent.ts
+++ b/sdks/js/agent-sdk/src/core/Agent.ts
@@ -131,7 +131,12 @@ export type AgentErrorMiddleware<ContentTypes = unknown> = (
 export type AgentCreateOptions<ContentCodecs extends ContentCodec[] = []> =
   Omit<ClientOptions & NetworkOptions, "codecs"> & { codecs?: ContentCodecs };
 
-export type AgentStreamingOptions = Omit<StreamOptions, "onValue" | "onError">;
+// `retryOnFail` is omitted: Agent SDK owns recovery, so node-sdk's built-in
+// retry is force-disabled in `#setupStreams` and callers cannot re-enable it.
+export type AgentStreamingOptions = Omit<
+  StreamOptions,
+  "onValue" | "onError" | "retryOnFail"
+>;
 
 export type StreamAllMessagesOptions<ContentTypes> = Parameters<
   Client<ContentTypes>["conversations"]["streamAllMessages"]
@@ -344,20 +349,38 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
 
     if (recovered && !this.#stopped) {
       await this.#retryStreams();
-      this.emit("start", new ClientContext({ client: this.#client }));
-      this.#isLocked = false;
-    } else {
-      this.#isLocked = false;
+      // stop() may have landed while retrying; don't signal a restart.
+      this.#signalStartUnlessStopped();
     }
+    this.#isLocked = false;
 
     this.#isRestarting = false;
+  }
+
+  // Fresh reads of #stopped in dedicated methods; stop() mutates it
+  // concurrently across the awaits above, which the compiler can't model.
+  #signalStartUnlessStopped() {
+    if (this.#stopped) return;
+    this.emit("start", new ClientContext({ client: this.#client }));
+  }
+
+  async #teardownIfStopped() {
+    if (this.#stopped) await this.#stopStreams();
   }
 
   async #retryStreams() {
     return retry(
       async () => {
         await this.#stopStreams();
-        await this.#setupStreams(this.#streamOptions);
+        // A stopped agent must never resurrect streams; stop() can race in
+        // before or during setup. finally: tear down even if setup rejects
+        // after partially assigning a stream.
+        if (this.#stopped) return;
+        try {
+          await this.#setupStreams(this.#streamOptions);
+        } finally {
+          await this.#teardownIfStopped();
+        }
       },
       {
         retries: 10,
@@ -370,51 +393,77 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     );
   }
 
+  /**
+   * Adapts an async stream handler to node-sdk's void-returning callback shape.
+   * node-sdk invokes these fire-and-forget, so a rejection is routed through
+   * the error chain (ending at `unhandledError`) instead of leaking as an
+   * unhandled promise rejection that could crash the host process.
+   */
+  #streamHandler<Args extends unknown[]>(
+    handler: (...args: Args) => Promise<void>,
+  ): (...args: Args) => void {
+    return (...args: Args) => {
+      void handler(...args).catch((error: unknown) =>
+        this.#runErrorChain(error, { client: this.#client }),
+      );
+    };
+  }
+
   async #setupStreams(options?: AgentStreamingOptions) {
     this.#conversationsStream = await this.#client.conversations.stream({
       ...options,
-      onValue: async (conversation) => {
-        try {
-          if (!conversation) {
-            return;
-          }
-          this.emit(
-            "conversation",
-            new ConversationContext<ContentTypes, Conversation<ContentTypes>>({
-              conversation,
-              client: this.#client,
-            }),
-          );
-          if (conversation instanceof Group) {
+      // Agent SDK is the single recovery owner (exponential backoff + re-sync
+      // in `#handleStreamError`); disable node-sdk's competing retry so it can't
+      // spawn zombie streams. After `...options` so callers can't re-enable it.
+      retryOnFail: false,
+      onValue: this.#streamHandler(
+        async (
+          conversation: Group<ContentTypes> | Dm<ContentTypes> | undefined,
+        ) => {
+          try {
+            if (!conversation) {
+              return;
+            }
             this.emit(
-              "group",
-              new ConversationContext<ContentTypes, Group<ContentTypes>>({
-                conversation,
-                client: this.#client,
-              }),
+              "conversation",
+              new ConversationContext<ContentTypes, Conversation<ContentTypes>>(
+                {
+                  conversation,
+                  client: this.#client,
+                },
+              ),
             );
-          } else if (conversation instanceof Dm) {
-            this.emit(
-              "dm",
-              new ConversationContext<ContentTypes, Dm<ContentTypes>>({
-                conversation,
-                client: this.#client,
-              }),
+            if (conversation instanceof Group) {
+              this.emit(
+                "group",
+                new ConversationContext<ContentTypes, Group<ContentTypes>>({
+                  conversation,
+                  client: this.#client,
+                }),
+              );
+            } else if (conversation instanceof Dm) {
+              this.emit(
+                "dm",
+                new ConversationContext<ContentTypes, Dm<ContentTypes>>({
+                  conversation,
+                  client: this.#client,
+                }),
+              );
+            }
+          } catch (error) {
+            const recovered = await this.#runErrorChain(
+              new AgentError(
+                1001,
+                "Emitted value from conversation stream caused an error.",
+                error,
+              ),
+              new ClientContext({ client: this.#client }),
             );
+            if (!recovered) await this.stop();
           }
-        } catch (error) {
-          const recovered = await this.#runErrorChain(
-            new AgentError(
-              1001,
-              "Emitted value from conversation stream caused an error.",
-              error,
-            ),
-            new ClientContext({ client: this.#client }),
-          );
-          if (!recovered) await this.stop();
-        }
-      },
-      onError: async (error) => {
+        },
+      ),
+      onError: this.#streamHandler(async (error: Error) => {
         await this.#handleStreamError(
           new AgentStreamingError(
             1002,
@@ -422,71 +471,75 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
             error,
           ),
         );
-      },
+      }),
     });
 
     this.#messageStream = await this.#client.conversations.streamAllMessages({
       ...options,
-      onValue: async (message) => {
-        try {
-          switch (true) {
-            case isActions(message):
-              await this.#processMessage(message, "actions");
-              break;
-            case isAttachment(message):
-              await this.#processMessage(message, "inline-attachment");
-              break;
-            case isIntent(message):
-              await this.#processMessage(message, "intent");
-              break;
-            case isGroupUpdated(message):
-              await this.#processMessage(message, "group-update");
-              break;
-            case isLeaveRequest(message):
-              await this.#processMessage(message, "leave-request");
-              break;
-            case isMultiRemoteAttachment(message):
-              await this.#processMessage(message, "multi-attachment");
-              break;
-            case isRemoteAttachment(message):
-              await this.#processMessage(message, "attachment");
-              break;
-            case isReaction(message):
-              await this.#processMessage(message, "reaction");
-              break;
-            case isReadReceipt(message):
-              await this.#processMessage(message, "read-receipt");
-              break;
-            case isReply(message):
-              await this.#processMessage(message, "reply");
-              break;
-            case isTransactionReference(message):
-              await this.#processMessage(message, "transaction-reference");
-              break;
-            case isWalletSendCalls(message):
-              await this.#processMessage(message, "wallet-send-calls");
-              break;
-            case isMarkdown(message):
-              await this.#processMessage(message, "markdown");
-              break;
-            case isText(message):
-              await this.#processMessage(message, "text");
-              break;
-            default:
-              await this.#processMessage(message);
-              break;
+      // Agent SDK owns recovery (see conversations.stream above).
+      retryOnFail: false,
+      onValue: this.#streamHandler(
+        async (message: DecodedMessage<ContentTypes>) => {
+          try {
+            switch (true) {
+              case isActions(message):
+                await this.#processMessage(message, "actions");
+                break;
+              case isAttachment(message):
+                await this.#processMessage(message, "inline-attachment");
+                break;
+              case isIntent(message):
+                await this.#processMessage(message, "intent");
+                break;
+              case isGroupUpdated(message):
+                await this.#processMessage(message, "group-update");
+                break;
+              case isLeaveRequest(message):
+                await this.#processMessage(message, "leave-request");
+                break;
+              case isMultiRemoteAttachment(message):
+                await this.#processMessage(message, "multi-attachment");
+                break;
+              case isRemoteAttachment(message):
+                await this.#processMessage(message, "attachment");
+                break;
+              case isReaction(message):
+                await this.#processMessage(message, "reaction");
+                break;
+              case isReadReceipt(message):
+                await this.#processMessage(message, "read-receipt");
+                break;
+              case isReply(message):
+                await this.#processMessage(message, "reply");
+                break;
+              case isTransactionReference(message):
+                await this.#processMessage(message, "transaction-reference");
+                break;
+              case isWalletSendCalls(message):
+                await this.#processMessage(message, "wallet-send-calls");
+                break;
+              case isMarkdown(message):
+                await this.#processMessage(message, "markdown");
+                break;
+              case isText(message):
+                await this.#processMessage(message, "text");
+                break;
+              default:
+                await this.#processMessage(message);
+                break;
+            }
+          } catch (error) {
+            const recovered = await this.#runErrorChain(error, {
+              client: this.#client,
+            });
+            if (!recovered) {
+              await this.stop();
+            }
+            this.#isLocked = false;
           }
-        } catch (error) {
-          const recovered = await this.#runErrorChain(error, {
-            client: this.#client,
-          });
-          if (!recovered) {
-            await this.stop();
-          }
-          this.#isLocked = false;
-        }
-      },
-      onError: async (error) => {
+        },
+      ),
+      onError: this.#streamHandler(async (error: Error) => {
         await this.#handleStreamError(
           new AgentStreamingError(
             1004,
@@ -494,7 +547,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
             error,
           ),
         );
-      },
+      }),
     });
   }
 

--- a/sdks/js/eslint.config.js
+++ b/sdks/js/eslint.config.js
@@ -106,9 +106,11 @@ export default tseslint.config(
     },
   },
   {
-    // agent-sdk's event-driven API passes async handlers into void-returning
-    // callbacks throughout; tightening this is tracked as a migration follow-up
-    files: ["agent-sdk/src/**/*.ts"],
+    // Demos illustrate the ergonomic public API of attaching async listeners to
+    // agent events (`agent.on("text", async (ctx) => ...)`); EventEmitter typing
+    // makes these void-return. Non-demo src routes every async stream handler
+    // deliberately, so the relaxation is confined here.
+    files: ["agent-sdk/src/demo/**/*.ts"],
     rules: {
       "@typescript-eslint/no-misused-promises": [
         "error",


### PR DESCRIPTION
## Why

Agent SDK and node-sdk were both retrying streams. node-sdk's `createStream`
reconnected on every native close — including the closes Agent SDK itself
causes while tearing streams down for its own recovery — producing orphaned
native streams that re-delivered messages. A downstream agent-sdk consumer saw
a single message id fan out into a large number of duplicate handler
invocations.

The architectural fix is exactly one recovery owner. Agent SDK already has the
richer recovery (exponential backoff, stream replacement, re-sync) that
node-sdk's blind reconnect can't do, so node-sdk's built-in retry must be
disabled for the streams Agent SDK manages.

## What changed

1. **`retryOnFail: false` on both streams.** Passed to `conversations.stream`
   and `streamAllMessages` after the `...options` spread so callers cannot
   re-enable it, and removed from `AgentStreamingOptions`. Agent SDK is the
   single recovery owner, full stop.

2. **Real error paths in the async stream handlers.** The `onValue`/`onError`
   handlers are async functions handed to node-sdk's void-returning callbacks;
   a rejection inside one (e.g. `#handleStreamError` throwing) was an unhandled
   promise rejection that could crash the process. A new `#streamHandler`
   wrapper adapts each async handler to the void callback shape and routes any
   rejection through the error chain, ending at the agent's `unhandledError`
   sink. This let me remove the agent-sdk-wide `no-misused-promises`
   (`checksVoidReturn: false`) override in `eslint.config.js` — the follow-up
   its comment tracked. core/middleware/user/util are now clean; the override
   is scoped to `src/demo/**`, whose illustrative `agent.on("text", async …)`
   listeners are the ergonomic public API.

3. **Recovery no longer resurrects streams after `stop()`.** `stop()` can race a
   pending retry attempt before or during setup; guards ensure a stopped agent
   creates no new streams, tears down any it raced into existence, and does not
   emit a spurious `start`.

## Tests

- **Unit** (deterministic, mock client): a rejecting stream handler is routed to
  `unhandledError` instead of leaking; `stop()` during an in-flight recovery
  re-setup tears down the resurrected streams. Both are red without the fix.
- **Integration** (toxiproxy, `Agent.reconnect.test.ts`): kill and restore the
  backend to force Agent recovery, then assert (a) each message id triggers
  exactly one handler invocation across repeated recovery cycles — the
  measurable proxy for "exactly one conversation stream and one message stream",
  since stream count isn't observable from outside the client; and (b) `stop()`
  with a recovery pending produces no further deliveries or errors.

Completes the defense-in-depth planned in #3978 (node-sdk terminal/silent
intentional close) and migration #3979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Own stream recovery end-to-end in Agent SDK with `retryOnFail: false`
> - Forces `retryOnFail: false` on both conversation and message streams so the Agent SDK owns reconnection logic exclusively; callers can no longer pass `retryOnFail` via `AgentStreamingOptions`.
> - Prevents `start` from being emitted and stops resurrecting streams when `stop()` is called during recovery, using new `#signalStartUnlessStopped` and `#teardownIfStopped` helpers.
> - Wraps async stream handlers with a new `#streamHandler` utility that routes rejections to the Agent's error chain (`unhandledError`) instead of leaking unhandled promise rejections.
> - Narrows the `@typescript-eslint/no-misused-promises` ESLint rule relaxation to `demo/**` only, since non-demo sources now deliberately route async stream handlers.
> - Risk: the lock (`#isLocked`) is now released in both success and failure branches of recovery, which changes prior behavior where a failed recovery could leave the agent locked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37e6bf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->