### PR TITLE
fix(agent-sdk): LimitedMap.set no longer evicts on update at capacity

### DIFF
--- a/sdks/js/agent-sdk/src/util/LimitedMap.test.ts
+++ b/sdks/js/agent-sdk/src/util/LimitedMap.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { LimitedMap } from "@/util/LimitedMap";
+
+describe("LimitedMap", () => {
+  it("evicts the oldest entry when a new key is added at capacity", () => {
+    const map = new LimitedMap<string, number>(2);
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    expect(map.get("a")).toBeUndefined();
+    expect(map.get("b")).toBe(2);
+    expect(map.get("c")).toBe(3);
+  });
+
+  it("does not evict any entry when updating an existing key at capacity", () => {
+    const map = new LimitedMap<string, number>(2);
+    map.set("a", 1);
+    map.set("b", 2);
+
+    // Updating an existing key doesn't grow the map, so nothing should be
+    // evicted: both "a" and "b" must remain, with "b"'s value updated.
+    map.set("b", 20);
+
+    expect(map.get("a")).toBe(1);
+    expect(map.get("b")).toBe(20);
+  });
+
+  it("still evicts to make room for a genuinely new key after an update", () => {
+    const map = new LimitedMap<string, number>(2);
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("b", 20); // update, no eviction
+    map.set("c", 3); // new key, must evict "a"
+
+    expect(map.get("a")).toBeUndefined();
+    expect(map.get("b")).toBe(20);
+    expect(map.get("c")).toBe(3);
+  });
+});

--- a/sdks/js/agent-sdk/src/util/LimitedMap.ts
+++ b/sdks/js/agent-sdk/src/util/LimitedMap.ts
@@ -7,7 +7,7 @@ export class LimitedMap<K, V> {
   }
 
   set(key: K, value: V) {
-    if (this.#map.size >= this.#limit) {
+    if (!this.#map.has(key) && this.#map.size >= this.#limit) {
       const it = this.#map.keys().next();
       if (!it.done) {
         this.#map.delete(it.value);


### PR DESCRIPTION
Re-opening xmtp/xmtp-js#1846, which was closed when xmtp-js was archived and agent-sdk moved into this repo (per @insipx's note on the original PR).

`set()` evicted the oldest entry whenever the map was at capacity, without checking whether the incoming key already existed. Updating the value of an existing key doesn't grow the map, so evicting in that case drops an unrelated, still-valid entry for no reason.

Now checks `has(key)` first and only evicts when the key is genuinely new and the map is already full.

Added three tests: normal eviction on a new key at capacity, no eviction when updating an existing key at capacity (the bug this fixes), and correct eviction resuming once a genuinely new key is added afterward. Verified the new test fails against the old implementation and passes against the fix.

`yarn vitest run src/util/LimitedMap.test.ts` - 3/3 passing. `yarn typecheck`, `eslint`, and `prettier` clean on both changed files.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `LimitedMap.set` to skip eviction when updating an existing key at capacity
> Previously, `LimitedMap.set` evicted the oldest entry whenever the map was at capacity, even when updating an existing key. The fix checks whether the key is new before evicting, so updates no longer shrink the map. New tests in [LimitedMap.test.ts](https://github.com/xmtp/libxmtp/pull/3998/files#diff-91a3650b4fab84b25b175dd3b152b6f997fdbc20eb4c2fd83419f58240585996) cover insert-at-capacity, update-at-capacity, and insert-after-update scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b68171.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->