### PR TITLE
fix(agent-sdk): prevent generateKeys from overwriting .env

### DIFF
--- a/sdks/js/agent-sdk/src/bin/generateKeys.ts
+++ b/sdks/js/agent-sdk/src/bin/generateKeys.ts
@@ -16,10 +16,25 @@ const generateClientKeys = () => {
 /**
  * Generates client keys and saves them to a .env file in the project root.
  * This script creates the necessary environment variables for XMTP agent initialization.
+ *
+ * Safety: by default, refuses to overwrite an existing .env file. This uses
+ * the "wx" flag on the write itself (create-only, fails if the file already
+ * exists) rather than a separate existsSync() check beforehand, so there's
+ * no window between checking and writing where another process could create
+ * the file first. Pass --force to explicitly overwrite an existing .env.
  */
 function main() {
   try {
-    // Generate the client keys
+    if (!process.env.INIT_CWD) {
+      throw new Error(
+        `Cannot invoke script because "process.env.INIT_CWD" wasn't found.`,
+      );
+    }
+    const envFilePath = join(process.env.INIT_CWD, ".env");
+    const force = process.argv.includes("--force");
+
+    // Generate keys before the atomic create/write attempt.
+    // With "wx", the write itself determines whether the .env already exists.
     const keys = generateClientKeys();
 
     // Create the .env file content
@@ -28,14 +43,39 @@ function main() {
         .map(([key, value]) => `${key}=${value}`)
         .join("\n") + "\n";
 
-    if (!process.env.INIT_CWD) {
-      throw new Error(
-        `Cannot invoke script because "process.env.INIT_CWD" wasn't found.`,
+    if (force) {
+      console.warn(
+        `⚠️  --force passed: any previous ${envFilePath} contents will be overwritten.\n` +
+          `   Any previous XMTP_WALLET_KEY, XMTP_DB_ENCRYPTION_KEY, or other\n` +
+          `   variables in this file will be permanently lost.`,
       );
     }
-    const envFilePath = join(process.env.INIT_CWD, ".env");
 
-    writeFileSync(envFilePath, envContent, "utf8");
+    try {
+      writeFileSync(envFilePath, envContent, {
+        encoding: "utf8",
+        // "wx": create the file and fail if it already exists, unless
+        // --force was passed, in which case fall back to a normal
+        // overwrite ("w").
+        flag: force ? "w" : "wx",
+      });
+    } catch (writeError) {
+      if (
+        !force &&
+        (writeError as NodeJS.ErrnoException).code === "EEXIST"
+      ) {
+        console.error(
+          `❌ Refusing to overwrite existing file: ${envFilePath}\n` +
+            `   It may already contain XMTP_WALLET_KEY, XMTP_DB_ENCRYPTION_KEY,\n` +
+            `   or other variables that would be permanently lost.\n\n` +
+            `   Re-run with --force if you really want to regenerate credentials\n` +
+            `   and discard the current .env contents:\n\n` +
+            `       yarn gen:keys --force\n`,
+        );
+        process.exit(1);
+      }
+      throw writeError;
+    }
 
     console.log("✅ Successfully generated client keys and saved to .env file");
     console.log(`📁 File location: ${envFilePath}`);


### PR DESCRIPTION
Prevent generateKeys from accidentally overwriting an existing .env file. It now refuses to overwrite it by default and only does so with an explicit `--force`, with a warning shown first.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent `generateKeys` from overwriting an existing `.env` file without `--force`
> The script now uses `wx` (create-only) file semantics and exits with code 1 if a `.env` file already exists. Passing `--force` switches to `w` mode, overwrites the file, and prints a warning. The `INIT_CWD` presence check is also moved before key generation so no keys are produced if the environment is invalid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8d2684.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->