### PR TITLE
fix(node): forward streamAllMessages errors to JavaScript callbacks

### DIFF
--- a/bindings/node/src/conversations/streams.rs
+++ b/bindings/node/src/conversations/streams.rs
@@ -8,8 +8,33 @@ use crate::{client::RustXmtpClient, streams::StreamCloser};
 use napi::bindgen_prelude::{Error, Result, Uint8Array};
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
-use xmtp_db::consent_record::ConsentState as XmtpConsentState;
+use xmtp_db::{
+  consent_record::ConsentState as XmtpConsentState, group_message::StoredGroupMessage,
+};
 use xmtp_mls::worker::device_sync::preference_sync::PreferenceUpdate as XmtpUserPreferenceUpdate;
+
+fn forward_message<F>(
+  inbox_id: &str,
+  message: std::result::Result<StoredGroupMessage, xmtp_mls::subscriptions::SubscribeError>,
+  mut callback: F,
+) where
+  F: FnMut(Result<Message>),
+{
+  if let Err(error) = &message {
+    tracing::warn!(
+      inbox_id,
+      error = ?error,
+      "[received] forwarding message error to callback"
+    );
+  }
+
+  callback(
+    message
+      .map(Message::from)
+      .map_err(ErrorWrapper::from)
+      .map_err(Error::from),
+  );
+}
 
 #[napi(discriminant = "type")]
 pub enum UserPreferenceUpdate {
@@ -93,40 +118,10 @@ impl Conversations {
             "[received] message result"
         );
 
-        // Skip any messages that are errors
-        if let Err(err) = &message {
-          tracing::warn!(
-            inbox_id,
-            error = ?err,
-            "[received] message error, swallowing to continue stream"
-          );
-          return; // Skip this message entirely
-        }
-
-        // For successful messages, try to transform and pass to JS
-        // otherwise log error and continue stream
-        match message
-          .map(Into::into)
-          .map_err(ErrorWrapper::from)
-          .map_err(Error::from)
-        {
-          Ok(transformed_msg) => {
-            tracing::trace!(
-              inbox_id,
-              "[received] calling tsfn callback with successful message"
-            );
-            let status = callback.call(Ok(transformed_msg), ThreadsafeFunctionCallMode::Blocking);
-            tracing::info!("Stream status: {:?}", status);
-          }
-          Err(err) => {
-            // Just in case the transformation itself fails
-            tracing::error!(
-              inbox_id,
-              error = ?err,
-              "[received] error during message transformation, swallowing to continue stream"
-            );
-          }
-        }
+        forward_message(inbox_id.as_str(), message, |result| {
+          let status = callback.call(result, ThreadsafeFunctionCallMode::Blocking);
+          tracing::info!("Stream status: {:?}", status);
+        });
       };
     let on_close = move || {
       on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
@@ -247,5 +242,24 @@ impl Conversations {
     );
 
     Ok(StreamCloser::new(stream_closer))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn forwards_item_errors_to_callback() {
+    let mut callbacks = Vec::new();
+
+    forward_message(
+      "test-inbox",
+      Err(xmtp_mls::subscriptions::SubscribeError::GroupMessageNotFound),
+      |result| callbacks.push(result),
+    );
+
+    assert_eq!(callbacks.len(), 1);
+    assert!(callbacks.pop().unwrap().is_err());
   }
 }

--- a/sdks/js/node-sdk/test/streams.test.ts
+++ b/sdks/js/node-sdk/test/streams.test.ts
@@ -447,4 +447,40 @@ describe("createStream", () => {
 
     expect(onErrorSpy).toHaveBeenCalledWith(expect.any(StreamFailedError));
   });
+
+  it("should report item errors without ending the stream", async () => {
+    const itemError = new Error("message processing failed");
+    const onErrorSpy = vi.fn();
+    const onFailSpy = vi.fn();
+    const onValueSpy = vi.fn();
+    let emit!: StreamCallback<number>;
+
+    const mockStreamFunction = vi.fn(
+      async (callback: StreamCallback<number>) => {
+        emit = callback;
+        return {
+          end: vi.fn(),
+          endAndWait: vi.fn().mockResolvedValue(undefined),
+          isClosed: vi.fn().mockReturnValue(false),
+          waitForReady: vi.fn().mockResolvedValue(undefined),
+        };
+      },
+    );
+
+    const stream = await createStream<number>(mockStreamFunction, undefined, {
+      onError: onErrorSpy,
+      onFail: onFailSpy,
+      onValue: onValueSpy,
+    });
+
+    emit(itemError, undefined);
+    emit(null, 42);
+
+    expect(onErrorSpy).toHaveBeenCalledOnce();
+    expect(onErrorSpy).toHaveBeenCalledWith(itemError);
+    expect(onValueSpy).toHaveBeenCalledWith(42);
+    expect(onFailSpy).not.toHaveBeenCalled();
+
+    await stream.end();
+  });
 });


### PR DESCRIPTION
## What this does

`Conversations::stream_all_messages` was logging a `SubscribeError` and returning before it reached the Node callback. That quietly threw away item errors from the Node SDK, even though the stream itself was still alive.

The binding now forwards both successful messages and errors through the existing `ThreadsafeFunction`. An item error reaches JavaScript as `(error, undefined)`, and later items can still reach `onValue`.

## Why

The other Node stream adapters already pass their errors through. `createStream` treats an item error as `onError` and keeps the stream running, so `stream_all_messages` was the odd path that never let the error reach JavaScript.

I added the Node contract test and a Rust adapter regression test. I also put the old early return back temporarily and ran the Rust test against it. It failed with zero callbacks. After removing the return, the same test passed with one callback.

This keeps the change at the binding boundary. It doesn't change retry, cursor advancement, transport delivery, or MLS behavior.

## Testing

- `cargo fmt --check`
- `cargo check --locked -p bindings_node --lib`
- `cargo clippy --locked --package bindings_node --lib --all-features -- -D warnings`
- Rust regression test with the old behavior and the fixed behavior
- Native Node binding build
- `yarn workspace @xmtp/node-sdk test test/streams.test.ts` (18/18)
- `yarn workspace @xmtp/node-sdk typecheck`
- `yarn eslint node-sdk/test/streams.test.ts`
- `git diff --check`

Fixes #3844


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward `streamAllMessages` item-level errors to JavaScript callbacks in Node bindings
> - Previously, errors from individual messages in `stream_all_messages_with_callback_dispatch` were silently dropped in the Node bindings; they are now forwarded to the JS callback as `napi::Error`.
> - Adds a `forward_message` helper in [streams.rs](https://github.com/xmtp/libxmtp/pull/4000/files#diff-edc104dda75b2781fb522cd8ffd44157f838b155816dd1ada9ccf50c0ff64560) that maps `StoredGroupMessage` results to `Message` and wraps errors via `ErrorWrapper`, invoking the callback for both success and failure.
> - Adds a Node SDK integration test in [streams.test.ts](https://github.com/xmtp/libxmtp/pull/4000/files#diff-64e7b5b5481133421730affb2a831c2c0155f7450b0c2c4e9210e3c95a640295) verifying that item-level errors trigger `onError` without blocking subsequent successful messages.
> - Behavioral Change: JS stream consumers will now receive errors via the callback where previously those errors were silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1da857.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->