### PR TITLE
test(android): ignore empty events in group message stream

### DIFF
--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -766,7 +767,7 @@ class GroupTest : BaseInstrumentedTest() {
             val group = boClient.conversations.newGroup(listOf(alixClient.inboxId))
             alixClient.conversations.sync()
             val alixGroup = alixClient.conversations.listGroups().first()
-            group.streamMessages().test {
+            group.streamMessages().filter { it.body.isNotEmpty() }.test {
                 alixGroup.send("hi")
                 assertEquals("hi", awaitItem().body)
                 alixGroup.send(


### PR DESCRIPTION
## Summary

Fixes a flaky Android group message stream test by ignoring empty-body events before asserting on streamed text messages.

The stream can emit non-text/system events with an empty body, so assuming the first emitted item is the `"hi"` text message can cause the assertion to fail nondeterministically.

This keeps the change scoped to the test and avoids adding timing-based sleeps.

## Testing

- `git diff --check` passes.
- Local Android instrumentation testing was not available because no Android SDK/device is configured in the local environment.
- The Android Gradle project configuration was verified successfully with JDK 17 / Gradle 8.11.1.

Related to #3941.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter empty events from group message stream in Android tests
> Applies a `filter { it.body.isNotEmpty() }` to the `group.streamMessages()` flow in [GroupTest.kt](https://github.com/xmtp/libxmtp/pull/4001/files#diff-879612f07b8c36ae8a69f20e4fca486d6609ead15ee1736cc554d4fd263123cd) so test assertions only operate on non-empty messages. This prevents spurious failures caused by empty events emitted before the actual message arrives.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3246147.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->