### PR TITLE
feat(agent-sdk): add getNativeBalance helper in TransactionUtil

### DIFF
--- a/sdks/js/agent-sdk/src/util/TransactionUtil.test.ts
+++ b/sdks/js/agent-sdk/src/util/TransactionUtil.test.ts
@@ -7,9 +7,11 @@ import {
   erc20Abi,
   getERC20Balance,
   getERC20Decimals,
+  getNativeBalance,
 } from "@/util/TransactionUtil";
 
 const mockReadContract = vi.fn();
+const mockGetBalance = vi.fn();
 
 vi.mock("viem", async () => {
   const actual = await vi.importActual("viem");
@@ -17,6 +19,7 @@ vi.mock("viem", async () => {
     ...actual,
     createPublicClient: vi.fn(() => ({
       readContract: mockReadContract,
+      getBalance: mockGetBalance,
     })),
   };
 });
@@ -29,6 +32,7 @@ const testTo = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as const;
 describe("TransactionUtil", () => {
   beforeEach(() => {
     mockReadContract.mockReset();
+    mockGetBalance.mockReset();
   });
 
   describe("erc20Abi", () => {
@@ -203,6 +207,23 @@ describe("TransactionUtil", () => {
           functionName: "decimals",
         }),
       );
+    });
+  });
+
+  describe("getNativeBalance", () => {
+    it("reads native balance from the chain", async () => {
+      const expectedBalance = 1_500_000_000_000_000_000n; // 1.5 ETH
+      mockGetBalance.mockResolvedValue(expectedBalance);
+
+      const balance = await getNativeBalance({
+        chain: testChain,
+        address: testFrom,
+      });
+
+      expect(balance).toBe(expectedBalance);
+      expect(mockGetBalance).toHaveBeenCalledWith({
+        address: testFrom,
+      });
     });
   });
 });

--- a/sdks/js/agent-sdk/src/util/TransactionUtil.ts
+++ b/sdks/js/agent-sdk/src/util/TransactionUtil.ts
@@ -82,6 +82,15 @@ export type GetERC20DecimalsOptions = {
   transport?: Transport;
 };
 
+export type GetNativeBalanceOptions = {
+  /** The viem Chain object. */
+  chain: Chain;
+  /** The address to query the balance of. */
+  address: Hex;
+  /** Optional custom viem transport. Defaults to http(). */
+  transport?: Transport;
+};
+
 /**
  * Creates a WalletSendCalls payload for an ERC-20 token transfer.
  *
@@ -189,5 +198,26 @@ export async function getERC20Decimals(
     address: tokenAddress,
     abi: erc20Abi,
     functionName: "decimals",
+  });
+}
+
+/**
+ * Reads the native token balance (ETH, MATIC, etc.) for a given address from the blockchain.
+ *
+ * @param options - The query options including chain and wallet address
+ * @returns The native token balance in wei as a bigint
+ */
+export async function getNativeBalance(
+  options: GetNativeBalanceOptions,
+): Promise<bigint> {
+  const { chain, address, transport: customTransport } = options;
+
+  const client = createPublicClient({
+    chain,
+    transport: customTransport ?? http(),
+  });
+
+  return client.getBalance({
+    address,
   });
 }


### PR DESCRIPTION
## Summary

Adds `getNativeBalance` helper and `GetNativeBalanceOptions` to `@xmtp/agent-sdk` under `sdks/js/agent-sdk/src/util/TransactionUtil.ts`.

While `TransactionUtil` provides both ERC-20 (`createERC20TransferCalls`) and native token transfer helpers (`createNativeTransferCalls`), it previously only provided balance querying utilities for ERC-20 tokens (`getERC20Balance`, `getERC20Decimals`). This addition completes the API symmetry by allowing agents to query native token (ETH/MATIC) balances directly via viem's `client.getBalance({ address })`.

## Changes

- **`TransactionUtil.ts`**: Added `GetNativeBalanceOptions` type and `getNativeBalance(options: GetNativeBalanceOptions): Promise<bigint>` implementation using viem `createPublicClient`.
- **`TransactionUtil.test.ts`**: Added unit test verifying native balance retrieval with mocked viem `getBalance`.

## Verification

- `yarn workspace @xmtp/agent-sdk run vitest run src/util/TransactionUtil.test.ts` (11/11 tests pass)
- `npx eslint agent-sdk/src/util/TransactionUtil.ts agent-sdk/src/util/TransactionUtil.test.ts` (Clean)
- GPG signed commit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `getNativeBalance` helper to `TransactionUtil` in the agent SDK
> Adds an exported `getNativeBalance` async function to [`TransactionUtil.ts`](https://github.com/xmtp/libxmtp/pull/4004/files#diff-2d8ae5265cf82316547bf079de920eb3e2b38869e35ff5245c0ab32f39e5daab) that queries the native token balance (in wei) for a given address using viem's `getBalance`. It accepts a `GetNativeBalanceOptions` type with `chain`, `address`, and an optional `transport` (defaults to `http()`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00fe180.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->