### PR TITLE
fix(agent-sdk): prevent in-place message content mutation in CommandRouter

### DIFF
--- a/sdks/js/agent-sdk/src/middleware/CommandRouter.test.ts
+++ b/sdks/js/agent-sdk/src/middleware/CommandRouter.test.ts
@@ -107,6 +107,35 @@ describe("CommandRouter", () => {
         }),
       );
     });
+
+    it("should not mutate the original message content on the caller context", async () => {
+      const router = new CommandRouter();
+      let receivedContent = "";
+      router.command("/echo", (ctx) => {
+        receivedContent = ctx.message.content;
+      });
+
+      agent.use(router.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      const messageId = await dm.sendText("/echo hello world");
+      const message = otherClient.conversations.getMessageById(
+        messageId,
+      )! as DecodedMessageWithContent<string>;
+
+      const ctx = new MessageContext({
+        message,
+        conversation: dm,
+        client: otherClient,
+      });
+
+      const handled = await router.handle(ctx);
+      expect(handled).toBe(true);
+      expect(receivedContent).toBe("hello world");
+      expect(ctx.message.content).toBe("/echo hello world");
+    });
   });
 
   describe("commandList", () => {

--- a/sdks/js/agent-sdk/src/middleware/CommandRouter.ts
+++ b/sdks/js/agent-sdk/src/middleware/CommandRouter.ts
@@ -1,5 +1,6 @@
 import { type AgentMessageHandler, type AgentMiddleware } from "@/core/Agent";
-import type { MessageContext } from "@/core/MessageContext";
+import type { DecodedMessageWithContent } from "@/core/filter";
+import { MessageContext } from "@/core/MessageContext";
 
 /** Content type supported by the "CommandRouter" */
 type SupportedType = string;
@@ -107,8 +108,18 @@ export class CommandRouter<ContentTypes = unknown> {
       if (entry) {
         // Create a new context with modified content (everything after the command)
         const argsText = parts.slice(1).join(" ");
-        ctx.message.content = argsText;
-        await entry.handler(ctx);
+        const proto = Reflect.getPrototypeOf(ctx.message);
+        const commandMessage = Object.assign(
+          Object.create(proto),
+          ctx.message,
+          { content: argsText },
+        ) as DecodedMessageWithContent<SupportedType>;
+        const commandCtx = new MessageContext({
+          message: commandMessage,
+          conversation: ctx.conversation,
+          client: ctx.client,
+        });
+        await entry.handler(commandCtx);
         return true;
       }
     }


### PR DESCRIPTION
## Summary

Prevents in-place mutation of `ctx.message.content` when executing commands in `CommandRouter`.

Previously, `CommandRouter.handle` stripped the leading command by directly reassigning `ctx.message.content = argsText`. Because `ctx.message` is a shared object reference, this mutated the underlying message content in place, leading to loss of the original message text (`/command args`) for downstream error handlers, middleware, and event listeners.

## Changes

- **`CommandRouter.ts`**: Replaced direct in-place mutation with a cloned `MessageContext` wrapping `{ ...ctx.message, content: argsText }` with prototype preservation via `Reflect.getPrototypeOf`, matching the intended design noted in the existing comment (`// Create a new context with modified content`).
- **`CommandRouter.test.ts`**: Added a test asserting that `ctx.message.content` on the caller context remains intact after command handling.

## Verification

- `npx eslint agent-sdk/src/middleware/CommandRouter.ts agent-sdk/src/middleware/CommandRouter.test.ts` (Clean)
- GPG signed commit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix in-place mutation of `MessageContext.message.content` in `CommandRouter`
> When a command is matched, `CommandRouter` was overwriting `ctx.message.content` with the parsed arguments string, mutating the caller's context. The fix creates a new message object (via `Object.create`) and a new `MessageContext` with the arguments as content, passing that to the handler instead. The original `ctx` is now left unmodified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d79e73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->