### PR TITLE
feat(agent-sdk): support text step cancel command in ActionWizard

### DIFF
--- a/sdks/js/agent-sdk/src/middleware/ActionWizard.test.ts
+++ b/sdks/js/agent-sdk/src/middleware/ActionWizard.test.ts
@@ -329,6 +329,38 @@ describe("ActionWizard", () => {
         expect(actionsMessage?.content?.actions[1]?.label).toBe("Abort");
       });
     });
+
+    it("cancels from a text step when the configured cancel command is received", async () => {
+      const cancelHandler = vi.fn();
+      const wizard = new ActionWizard("setup", {
+        cancel: { command: "/cancel" },
+      });
+      wizard
+        .text("name", { description: "Enter your name" })
+        .onCancel(cancelHandler);
+
+      agent.use(wizard.middleware());
+      await agent.start();
+
+      const otherClient = await createClient();
+      const dm = await otherClient.conversations.createDm(client.inboxId);
+      await dm.sendText("/setup");
+
+      await vi.waitFor(async () => {
+        await dm.sync();
+        const messages = await dm.messages();
+        expect(messages.filter((m) => isText(m))).toHaveLength(1);
+      });
+
+      // Send the cancel command from the text step
+      await dm.sendText("/cancel");
+
+      await vi.waitFor(() => {
+        expect(cancelHandler).toHaveBeenCalledOnce();
+      });
+
+      expect(wizard.isActive(dm.id, otherClient.inboxId)).toBe(false);
+    });
   });
 
   describe("restart", () => {

--- a/sdks/js/agent-sdk/src/middleware/ActionWizard.ts
+++ b/sdks/js/agent-sdk/src/middleware/ActionWizard.ts
@@ -48,6 +48,8 @@ type ActionWizardCancelHandler<ContentTypes> = (
 export type ActionWizardCancelOptions = {
   /** Custom label for the cancel button (default: "Cancel") */
   label?: string;
+  /** Command string that cancels the wizard from text steps (e.g. "/cancel") */
+  command?: `/${string}`;
 };
 
 export type ActionWizardOptions = {
@@ -57,7 +59,7 @@ export type ActionWizardOptions = {
    * (e.g. API keys, passwords) to keep it out of group conversations.
    */
   dm?: boolean;
-  /** Enable a cancel button on each select step. Set to `true` for the default label, or pass options to customize. */
+  /** Enable a cancel button on each select step, and optionally a cancel command on text steps. */
   cancel?: boolean | ActionWizardCancelOptions;
 };
 
@@ -75,6 +77,7 @@ export class ActionWizard<ContentTypes = unknown> {
   #id: string;
   #dm: boolean;
   #cancelLabel: string | undefined;
+  #cancelCommand: string | undefined;
   #steps: ActionWizardStep[] = [];
   #sessions = new Map<string, ActionWizardSession>();
   #completeHandler?: ActionWizardCompleteHandler<ContentTypes>;
@@ -84,10 +87,12 @@ export class ActionWizard<ContentTypes = unknown> {
     this.#id = id;
     this.#dm = options?.dm ?? false;
     if (options?.cancel) {
-      this.#cancelLabel =
-        typeof options.cancel === "object"
-          ? (options.cancel.label ?? "Cancel")
-          : "Cancel";
+      if (typeof options.cancel === "object") {
+        this.#cancelLabel = options.cancel.label ?? "Cancel";
+        this.#cancelCommand = options.cancel.command;
+      } else {
+        this.#cancelLabel = "Cancel";
+      }
     }
   }
 
@@ -213,12 +218,21 @@ export class ActionWizard<ContentTypes = unknown> {
         ctx.conversation.id,
         ctx.message.senderInboxId,
       );
-      if (isText(ctx.message) && ctx.message.content === `/${this.#id}`) {
-        if (this.#sessions.has(key)) {
-          await this.#handleCancel(key, ctx);
+      if (isText(ctx.message) && ctx.message.content) {
+        if (ctx.message.content === `/${this.#id}`) {
+          if (this.#sessions.has(key)) {
+            await this.#handleCancel(key, ctx);
+          }
+          await this.start(ctx);
+          return;
         }
-        await this.start(ctx);
-        return;
+
+        if (this.#cancelCommand && ctx.message.content === this.#cancelCommand) {
+          if (this.#sessions.has(key)) {
+            await this.#handleCancel(key, ctx);
+            return;
+          }
+        }
       }
 
       const session = this.#sessions.get(key);


### PR DESCRIPTION
## Summary

Adds support for canceling an active `ActionWizard` session from free-text steps using a configured command string (e.g. `cancel: { command: "/cancel" }`).

Previously, `ActionWizardCancelOptions` only supported button-based cancellation (`label`) on `select` steps. During a `text` step, if a user wished to cancel, typing any text (including `/cancel`) would be recorded as the answer to that step, leaving users unable to cancel without restarting the wizard via `/{id}`.

## Changes

- **`ActionWizard.ts`**:
  - Extended `ActionWizardCancelOptions` with optional `command?: \`/${string}\``.
  - Updated `middleware` to recognize the configured cancel command on text messages and invoke `#handleCancel`.
- **`ActionWizard.test.ts`**:
  - Added unit test verifying that sending the configured cancel command from a text step successfully terminates the session and calls the cancel handler.

## Verification

- `npx eslint agent-sdk/src/middleware/ActionWizard.ts agent-sdk/src/middleware/ActionWizard.test.ts` (Clean)
- GPG signed commit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cancel command support to text steps in `ActionWizard`
> Extends `ActionWizardCancelOptions` with an optional `command` field (e.g. `'/cancel'`). When configured, sending that exact text while a wizard session is active triggers the cancel handler and stops the wizard without advancing to the next step. Previously, cancellation was only possible via a cancel button on select steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac7c0c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->