### PR TITLE
feat(agent-sdk): add sendReadReceipt and markAsRead to MessageContext

### DIFF
--- a/sdks/js/agent-sdk/src/core/MessageContext.test.ts
+++ b/sdks/js/agent-sdk/src/core/MessageContext.test.ts
@@ -3,7 +3,9 @@ import {
   type DecodedMessage,
   type EnrichedReply,
 } from "@xmtp/node-sdk";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import type { Client, Conversation } from "@xmtp/node-sdk";
+import type { DecodedMessageWithContent } from "@/core/filter";
 import { MessageContext } from "@/core/MessageContext";
 import { createClient } from "@/util/test";
 
@@ -33,5 +35,26 @@ describe("MessageContext", () => {
     >();
     const { content } = typedContext.message;
     expect(content.content).toBe(replyMessage.content?.content);
+  });
+
+  it("should send read receipt via sendReadReceipt and markAsRead", async () => {
+    const sendReadReceiptMock = vi.fn().mockResolvedValue("receipt-id-123");
+    const mockConversation = {
+      sendReadReceipt: sendReadReceiptMock,
+    } as unknown as Conversation;
+
+    const messageContext = new MessageContext({
+      message: {} as DecodedMessageWithContent<string>,
+      conversation: mockConversation,
+      client: {} as Client,
+    });
+
+    const result1 = await messageContext.sendReadReceipt();
+    expect(result1).toBe("receipt-id-123");
+    expect(sendReadReceiptMock).toHaveBeenCalledTimes(1);
+
+    const result2 = await messageContext.markAsRead();
+    expect(result2).toBe("receipt-id-123");
+    expect(sendReadReceiptMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/sdks/js/agent-sdk/src/core/MessageContext.ts
+++ b/sdks/js/agent-sdk/src/core/MessageContext.ts
@@ -20,6 +20,7 @@ import {
   type RemoteAttachment,
   type Reply,
   type TransactionReference,
+  type SendOpts,
   type WalletSendCalls,
 } from "@xmtp/node-sdk";
 import { filter, type DecodedMessageWithContent } from "@/core/filter";
@@ -114,6 +115,14 @@ export class MessageContext<
 
   async sendTextReply(text: string) {
     await this.#sendReply(encodeText(text));
+  }
+
+  async sendReadReceipt(opts?: SendOpts) {
+    return this.conversation.sendReadReceipt(opts);
+  }
+
+  async markAsRead(opts?: SendOpts) {
+    return this.sendReadReceipt(opts);
   }
 
   async getSenderAddress() {


### PR DESCRIPTION
## Summary

Adds `sendReadReceipt` and `markAsRead` helper methods directly to `MessageContext`.

`MessageContext` already provides convenient helpers such as `sendReaction`, `sendTextReply`, and `sendMarkdownReply`. However, marking the incoming message/conversation as read previously required navigating through `ctx.conversation.sendReadReceipt()`. Adding `sendReadReceipt(opts?: SendOpts)` and the semantic alias `markAsRead(opts?: SendOpts)` directly on `MessageContext` enhances developer ergonomics for agent handlers.

## Changes

- **`MessageContext.ts`**: Added `sendReadReceipt(opts?: SendOpts)` and `markAsRead(opts?: SendOpts)` forwarding to `this.conversation.sendReadReceipt`.
- **`MessageContext.test.ts`**: Added unit test verifying method delegation and receipt ID resolution.

## Verification

- `yarn workspace @xmtp/agent-sdk run vitest run src/core/MessageContext.test.ts` (Clean)
- `npx eslint agent-sdk/src/core/MessageContext.ts agent-sdk/src/core/MessageContext.test.ts` (Clean)
- GPG signed commit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `sendReadReceipt` and `markAsRead` methods to `MessageContext`
> Adds two async methods to [`MessageContext`](https://github.com/xmtp/libxmtp/pull/4007/files#diff-c2a355b5c941cade37ce326298e2a0fdee310ea2abae181fb9a589d0f28d6098) that delegate to the underlying `conversation.sendReadReceipt`. `markAsRead` is an alias for `sendReadReceipt`. Both accept an optional `SendOpts` parameter from `@xmtp/node-sdk`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10765fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->