### PR TITLE
test: restore global.fetch after mocking in AttachmentUtil tests

### DIFF
--- a/sdks/js/agent-sdk/src/util/AttachmentUtil.test.ts
+++ b/sdks/js/agent-sdk/src/util/AttachmentUtil.test.ts
@@ -17,13 +17,16 @@ import {
 describe("AttachmentUtil", () => {
   const testUrl = "https://localhost/test_file";
   let mockFetch: Mock;
+  let originalFetch: typeof global.fetch;
 
   beforeEach(() => {
+    originalFetch = global.fetch;
     mockFetch = vi.fn();
     global.fetch = mockFetch;
   });
 
   afterEach(() => {
+    global.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
I am fixing a global.fetch mock leak in the `AttachmentUtil` tests. Previously, `global.fetch` was replaced with a mock in `beforeEach` but never restored `vi.restoreAllMocks()` does not revert direct property assignments, only spies created via `vi.spyOn()`. As a result, `global.fetch` could remain mocked for subsequent tests

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `global.fetch` after mocking in `AttachmentUtil` tests
> Saves the original `global.fetch` reference before each test and restores it in `afterEach`, preventing the mock from leaking into subsequent tests. See [AttachmentUtil.test.ts](https://github.com/xmtp/libxmtp/pull/4008/files#diff-67b9aa8af8b2fc93b6956f43c3059df3372c8cfca67b39b6ed87de1dcce7d5a6).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78db17a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->