### PR TITLE
fix(xmtp_mls): enforce MAX_GROUP_SIZE in add_members (by inbox_id)

### DIFF
--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -1908,6 +1908,13 @@ where
             .iter()
             .map(AsIdRef::as_ref)
             .collect::<Vec<&str>>();
+
+        // get current number of users in group
+        let member_count = self.members().await?.len();
+        if member_count + ids.len() > MAX_GROUP_SIZE {
+            return Err(GroupError::UserLimitExceeded);
+        }
+
         let intent_data = self
             .get_membership_update_intent(ids.as_slice(), &[])
             .await?;

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -2456,7 +2456,15 @@ async fn test_group_options() {
     );
 }
 
+/// Creates 250 real clients to exercise the MAX_GROUP_SIZE boundary. On
+/// native this is fast and reliable. On wasm, running this alongside the
+/// full parallel wasm test suite (883+ tests sharing one local backend +
+/// IndexedDB) pushes execution time past the wasm CI slow-timeout (60s),
+/// causing spurious failures under contention even though the test
+/// consistently passes in isolation (~25s). Native coverage is sufficient
+/// to guard the regression this test targets.
 #[xmtp_common::test]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 async fn test_max_limit_add() {
     tester!(amal);
     let amal_group = amal

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -2457,7 +2457,6 @@ async fn test_group_options() {
 }
 
 #[xmtp_common::test]
-#[ignore]
 async fn test_max_limit_add() {
     tester!(amal);
     let amal_group = amal


### PR DESCRIPTION
Fixes #4009

## Problem
`Group::add_members_by_identity` enforces `MAX_GROUP_SIZE` (250) before queuing a membership update intent. `Group::add_members` -- the inbox_id-based counterpart -- had no equivalent check, so a group already at the 250-member cap could still be grown past the limit through this entry point.

## Fix
Mirrors the existing `add_members_by_identity` guard: compute `member_count` via `self.members()`, return `GroupError::UserLimitExceeded` before building the intent if `member_count + new_ids.len() > MAX_GROUP_SIZE`. Un-ignores `test_max_limit_add`, which was disabled pending this fix.

## Testing
- `cargo test -p xmtp_mls --release --lib groups::tests::test_max_limit_add` -- previously failed (add succeeded when it should have errored, group ended up with 251 members), now passes.
- Ran the full `groups::tests` suite (~720 tests) multiple times, with and without this change. A handful of unrelated tests intermittently fail when run as part of the full suite in parallel against the local backend (`test_commit_log_remote::*`, `test_failed_installations::*`, `test_dm_creation_with_user_two_installations_one_malformed`), but each passes reliably in isolation, and the specific failing set changes between runs. Verified the same intermittent behavior exists on unmodified `main` -- this is resource contention against the shared local backend under parallel load, not a regression from this change.
- `cargo clippy -p xmtp_mls --lib -- -D warnings`: clean.

## Note on process
I used AI assistance (Claude) to investigate the codebase and draft this fix, disclosed per your AI-contributions policy. I reviewed and understand the change, and independently verified the bug against a live backend before writing the fix.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce MAX_GROUP_SIZE limit in `add_members` before building membership update intent
> - Adds a preflight check in the membership update method that fetches the current member count and returns `GroupError::UserLimitExceeded` if adding the requested members would exceed `MAX_GROUP_SIZE`.
> - Updates `test_max_limit_add` in [tests/mod.rs](https://github.com/xmtp/libxmtp/pull/4010/files#diff-7e88444b74ccb84133e462081b5d5a9177ec5ab36d4e7dd7898a987a0e247db5) to run on native targets by replacing `#[ignore]` with `#[cfg_attr(target_arch = "wasm32", ignore)]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0766854.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->