### PR TITLE
feat(xmtp_mls): report app data changes and guard updates against clobbering

### DIFF
--- a/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
@@ -18,7 +18,7 @@ impl HealthOp for UpdateAppData {
         ctx.for_each_group(self.name(), |primary, gid| async move {
             primary
                 .group(&gid)?
-                .update_app_data("healthcheck-app-data".into())
+                .update_app_data("healthcheck-app-data".into(), None)
                 .await?;
             Ok(())
         })

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -2987,7 +2987,7 @@ impl FfiConversation {
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn update_app_data(&self, options: FfiUpdateAppDataOptions) -> Result<(), FfiError> {
-        self.inner.update_app_data(options.value).await?;
+        self.inner.update_app_data(options.value, None).await?;
         Ok(())
     }
 

--- a/bindings/node/src/conversation/metadata.rs
+++ b/bindings/node/src/conversation/metadata.rs
@@ -129,7 +129,7 @@ impl Conversation {
     let group = self.create_mls_group();
 
     group
-      .update_app_data(options.value)
+      .update_app_data(options.value, None)
       .await
       .map_err(ErrorWrapper::from)?;
 

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -752,7 +752,7 @@ impl Conversation {
     let group = self.to_mls_group();
 
     group
-      .update_app_data(options.value)
+      .update_app_data(options.value, None)
       .await
       .map_err(ErrorWrapper::js)?;
 

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -2,6 +2,7 @@ use crate::{
     GroupCommitLock, StorageError, XmtpApi,
     client::{Client, DeviceSync},
     context::{XmtpMlsLocalContext, XmtpSharedContext},
+    groups::change_callbacks::UnstableChangeCallbacks,
     identity::{Identity, IdentityStrategy},
     identity_updates::load_identity_updates,
     mutex_registry::MutexRegistry,
@@ -100,6 +101,8 @@ pub struct ClientBuilder<ApiClient, S, Db = xmtp_db::DefaultStore> {
     pub(crate) scw_verifier: Option<Box<dyn SmartContractSignatureVerifier>>,
     pub(crate) device_sync_worker_mode: DeviceSyncMode,
     pub(crate) fork_recovery_opts: Option<ForkRecoveryOpts>,
+    /// Unstable: group-change callbacks the host registered at construction.
+    pub(crate) change_callbacks: UnstableChangeCallbacks,
     pub(crate) version_info: VersionInfo,
     pub(crate) allow_offline: bool,
     pub(crate) disable_commit_log_worker: bool,
@@ -159,6 +162,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             scw_verifier: None,
             device_sync_worker_mode: DeviceSyncMode::Enabled,
             fork_recovery_opts: None,
+            change_callbacks: UnstableChangeCallbacks::default(),
             version_info: VersionInfo::default(),
             allow_offline: false,
             disable_commit_log_worker: false,
@@ -189,6 +193,7 @@ where
             scw_verifier: Some(Box::new(client.context.scw_verifier.clone())),
             device_sync_worker_mode: client.context.device_sync.mode,
             fork_recovery_opts: Some(client.context.fork_recovery_opts.clone()),
+            change_callbacks: client.context.change_callbacks.clone(),
             version_info: client.context.version_info.clone(),
             allow_offline: false,
             disable_commit_log_worker: false,
@@ -271,6 +276,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
 
             device_sync_worker_mode,
             fork_recovery_opts,
+            change_callbacks,
             version_info,
             allow_offline,
             disable_commit_log_worker,
@@ -375,6 +381,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                 mode: device_sync_worker_mode,
             },
             fork_recovery_opts: fork_recovery_opts.unwrap_or_default(),
+            change_callbacks,
             worker_config,
 
             worker_metrics: workers.metrics().clone(),
@@ -487,6 +494,21 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
         }
     }
 
+    /// Unstable: register callbacks notified when group state changes.
+    ///
+    /// Registration is construction-time by necessity — the changes these
+    /// report arrive from the stream and sync paths, where no SDK call is on
+    /// the stack. Passing [`UnstableChangeCallbacks::default`] (nothing set)
+    /// is equivalent to not calling this at all.
+    ///
+    /// See [`crate::groups::change_callbacks`] for the delivery contract.
+    pub fn unstable_change_callbacks(self, change_callbacks: UnstableChangeCallbacks) -> Self {
+        Self {
+            change_callbacks,
+            ..self
+        }
+    }
+
     pub fn store<NewDb>(self, db: NewDb) -> ClientBuilder<ApiClient, S, NewDb> {
         ClientBuilder {
             store: Some(db),
@@ -496,6 +518,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             scw_verifier: self.scw_verifier,
             device_sync_worker_mode: self.device_sync_worker_mode,
             fork_recovery_opts: self.fork_recovery_opts,
+            change_callbacks: self.change_callbacks,
             version_info: self.version_info,
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
@@ -523,6 +546,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             scw_verifier: self.scw_verifier,
             device_sync_worker_mode: self.device_sync_worker_mode,
             fork_recovery_opts: self.fork_recovery_opts,
+            change_callbacks: self.change_callbacks,
             version_info: self.version_info,
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
@@ -550,6 +574,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             scw_verifier: self.scw_verifier,
             device_sync_worker_mode: self.device_sync_worker_mode,
             fork_recovery_opts: self.fork_recovery_opts,
+            change_callbacks: self.change_callbacks,
             version_info: self.version_info,
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
@@ -602,6 +627,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             store: self.store,
             device_sync_worker_mode: self.device_sync_worker_mode,
             fork_recovery_opts: self.fork_recovery_opts,
+            change_callbacks: self.change_callbacks,
             version_info: self.version_info,
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
@@ -692,6 +718,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
 
             device_sync_worker_mode: self.device_sync_worker_mode,
             fork_recovery_opts: self.fork_recovery_opts,
+            change_callbacks: self.change_callbacks,
             version_info: self.version_info,
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
@@ -715,6 +742,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
 
             device_sync_worker_mode: self.device_sync_worker_mode,
             fork_recovery_opts: self.fork_recovery_opts,
+            change_callbacks: self.change_callbacks,
             version_info: self.version_info,
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,
@@ -747,6 +775,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             store: self.store,
             device_sync_worker_mode: self.device_sync_worker_mode,
             fork_recovery_opts: self.fork_recovery_opts,
+            change_callbacks: self.change_callbacks,
             version_info: self.version_info,
             allow_offline: self.allow_offline,
             disable_commit_log_worker: self.disable_commit_log_worker,

--- a/crates/xmtp_mls/src/context.rs
+++ b/crates/xmtp_mls/src/context.rs
@@ -1,6 +1,7 @@
 use crate::GroupCommitLock;
 use crate::builder::{DeviceSyncMode, ForkRecoveryOpts};
 use crate::client::DeviceSync;
+use crate::groups::change_callbacks::UnstableChangeCallbacks;
 use crate::subscriptions::{LocalEvents, SyncWorkerEvent};
 use crate::utils::VersionInfo;
 use crate::worker::device_sync::worker::SyncMetric;
@@ -50,6 +51,9 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     pub(crate) scw_verifier: Arc<Box<dyn SmartContractSignatureVerifier>>,
     pub(crate) device_sync: DeviceSync,
     pub(crate) fork_recovery_opts: ForkRecoveryOpts,
+    /// Unstable: SDK-registered notifications for group-state changes. Empty
+    /// unless the host opted in at build time.
+    pub(crate) change_callbacks: UnstableChangeCallbacks,
     pub(crate) worker_config: WorkerConfig,
     // pub(crate) workers: Arc<WorkerRunner>,
     pub(crate) worker_metrics: Arc<Mutex<HashMap<WorkerKind, DynMetrics>>>,
@@ -125,6 +129,7 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
             scw_verifier: self.scw_verifier,
             device_sync: self.device_sync,
             fork_recovery_opts: self.fork_recovery_opts,
+            change_callbacks: self.change_callbacks,
             worker_config: self.worker_config,
             worker_metrics: self.worker_metrics,
             task_channels: self.task_channels,
@@ -247,6 +252,8 @@ where
     fn local_events(&self) -> &broadcast::Sender<LocalEvents>;
     fn task_channels(&self) -> &TaskWorkerChannels;
     fn disappearing_channels(&self) -> &DisappearingChannels;
+    /// Unstable: the host's registered group-change callbacks.
+    fn change_callbacks(&self) -> &UnstableChangeCallbacks;
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>>;
     fn mls_commit_lock(&self) -> &Arc<GroupCommitLock>;
     fn mutexes(&self) -> &MutexRegistry;
@@ -337,6 +344,10 @@ where
 
     fn disappearing_channels(&self) -> &DisappearingChannels {
         &self.disappearing_channels
+    }
+
+    fn change_callbacks(&self) -> &UnstableChangeCallbacks {
+        &self.change_callbacks
     }
 
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {
@@ -434,6 +445,10 @@ where
 
     fn disappearing_channels(&self) -> &DisappearingChannels {
         <T as XmtpSharedContext>::disappearing_channels(self)
+    }
+
+    fn change_callbacks(&self) -> &UnstableChangeCallbacks {
+        <T as XmtpSharedContext>::change_callbacks(self)
     }
 
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {

--- a/crates/xmtp_mls/src/groups/change_callbacks.rs
+++ b/crates/xmtp_mls/src/groups/change_callbacks.rs
@@ -1,0 +1,96 @@
+//! Unstable: post-commit notification of group-state changes.
+//!
+//! Registered once at client construction ([`crate::builder::ClientBuilder`]),
+//! not passed per call — the changes worth reacting to arrive from the stream
+//! and sync paths, where no SDK method call is on the stack to carry a
+//! parameter.
+//!
+//! # Why a struct of callbacks
+//!
+//! Only [`UnstableChangeCallbacks::app_data`] is implemented today. The
+//! registry is a struct rather than a bare callback argument so callbacks for
+//! the other mutable fields (name, description, image url, admin lists,
+//! permissions, disappearing settings) land as *additive* fields on a type the
+//! SDKs already construct — the same reason [`crate::groups::UpdateAppDataOptions`]
+//! and the FFI options records are structs.
+//!
+//! # Delivery contract
+//!
+//! Callbacks fire once the storage transaction has committed, the group commit
+//! lock has been released, **and** the per-group sync mutex has been dropped —
+//! so an implementation is free to publish the result of its merge with
+//! `update_app_data` on the same group. That call re-enters `sync_with_conn`
+//! and takes the same sync mutex, which is why dispatch cannot happen inline
+//! during message processing; see
+//! [`crate::groups::MlsGroup::dispatch_app_data_changes`].
+//!
+//! Concretely, that means the sync path delivers a batch after the whole sync
+//! completes rather than between messages, and the stream path delivers each
+//! change as its message is processed. Changes are always awaited one at a
+//! time, in the order they were observed.
+//!
+//! A callback observes the *net* change across one processed message, and fires
+//! for local commits as well as remote ones — an implementation that reacts by
+//! writing must make its merge idempotent, or it will chase its own echo.
+//!
+//! # Stability
+//!
+//! Pre-release. The shape of the payloads and of the registry may change
+//! without a major version bump until this graduates onto the stable client
+//! surface.
+
+use std::sync::Arc;
+use xmtp_common::{MaybeSend, MaybeSync};
+
+/// A change to a group's opaque `app_data` slot, observed after it was applied
+/// to local state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppDataChange {
+    /// The group whose `app_data` changed.
+    pub group_id: Vec<u8>,
+    /// Value before the message was processed. `None` when the group had no
+    /// `app_data` set (or predates the field).
+    pub old_value: Option<String>,
+    /// Value after the message was processed. `None` when the field was
+    /// cleared.
+    pub new_value: Option<String>,
+}
+
+/// Notified whenever a processed message changed a group's `app_data`.
+///
+/// Async so an implementation can do the read-modify-write of a semantic merge
+/// — including publishing the merged result — before returning.
+#[xmtp_common::async_trait]
+pub trait AppDataChangeCallback: MaybeSend + MaybeSync {
+    async fn on_app_data_changed(&self, change: AppDataChange);
+}
+
+/// The set of change callbacks registered on a client.
+///
+/// Cloned into [`crate::context::XmtpMlsLocalContext`] at build time; an unset
+/// field costs a single `Option` check on the message-processing path.
+#[derive(Default, Clone)]
+pub struct UnstableChangeCallbacks {
+    /// Fires when a processed message changed the group's `app_data`.
+    pub app_data: Option<Arc<dyn AppDataChangeCallback>>,
+    // Future fields (name, description, image_url, admin_list, permissions,
+    // disappearing_settings) go here. Each must default to `None`, and each
+    // FFI mirror must carry a binding-level default, so adding one stays
+    // non-breaking for compiled SDK callers.
+}
+
+impl UnstableChangeCallbacks {
+    /// Whether anything is watching `app_data`. Gates the before/after
+    /// snapshot in message processing so unregistered clients pay nothing.
+    pub fn watches_app_data(&self) -> bool {
+        self.app_data.is_some()
+    }
+}
+
+impl std::fmt::Debug for UnstableChangeCallbacks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnstableChangeCallbacks")
+            .field("app_data", &self.app_data.is_some())
+            .finish()
+    }
+}

--- a/crates/xmtp_mls/src/groups/error.rs
+++ b/crates/xmtp_mls/src/groups/error.rs
@@ -370,6 +370,16 @@ pub enum GroupError {
     /// Field value exceeds character limit. Not retryable.
     #[error("Exceeded max characters for this field. Must be under: {length}")]
     TooManyCharacters { length: usize },
+    /// A guarded metadata update was abandoned because another member changed
+    /// the field first.
+    ///
+    /// Not retryable as-is: the value was derived from state that no longer
+    /// exists. Re-derive it from `actual` and queue a new update. Distinct
+    /// from a sync failure — nothing went wrong, the write is just stale.
+    #[error(
+        "app data update was superseded; expected {expected:?} but the committed value is {actual:?}"
+    )]
+    AppDataSuperseded { expected: String, actual: String },
     /// Group paused until update.
     ///
     /// Group is paused until a newer version is available. Not retryable.
@@ -649,6 +659,7 @@ impl RetryableError for GroupError {
             | Self::ConversionError(_)
             | Self::CryptoError(_)
             | Self::TooManyCharacters { .. }
+            | Self::AppDataSuperseded { .. }
             | Self::GroupPausedUntilUpdate(_)
             | Self::GroupInactive
             | Self::FailedToVerifyInstallations(_)

--- a/crates/xmtp_mls/src/groups/intents.rs
+++ b/crates/xmtp_mls/src/groups/intents.rs
@@ -186,6 +186,10 @@ impl From<Vec<Vec<u8>>> for AddressesOrInstallationIds {
 pub struct UpdateMetadataIntentData {
     pub field_name: String,
     pub field_value: String,
+    /// Compare-and-swap guard. When set, publishing abandons this intent
+    /// unless the field's currently committed value still equals this.
+    /// `None` keeps the historical last-writer-wins behavior.
+    pub expected_field_value: Option<String>,
 }
 
 impl UpdateMetadataIntentData {
@@ -193,62 +197,74 @@ impl UpdateMetadataIntentData {
         Self {
             field_name,
             field_value,
+            expected_field_value: None,
+        }
+    }
+
+    /// A guarded update: publishing abandons the intent (marking it
+    /// [`xmtp_db::group_intent::IntentState::Superseded`]) unless the
+    /// committed value still equals `expected_field_value`.
+    pub fn new_guarded(
+        field_name: String,
+        field_value: String,
+        expected_field_value: String,
+    ) -> Self {
+        Self {
+            field_name,
+            field_value,
+            expected_field_value: Some(expected_field_value),
         }
     }
 
     pub fn new_update_group_name(group_name: String) -> Self {
-        Self {
-            field_name: MetadataField::GroupName.to_string(),
-            field_value: group_name,
-        }
+        Self::new(MetadataField::GroupName.to_string(), group_name)
     }
 
     pub fn new_update_group_image_url_square(group_image_url_square: String) -> Self {
-        Self {
-            field_name: MetadataField::GroupImageUrlSquare.to_string(),
-            field_value: group_image_url_square,
-        }
+        Self::new(
+            MetadataField::GroupImageUrlSquare.to_string(),
+            group_image_url_square,
+        )
     }
 
     pub fn new_update_group_description(group_description: String) -> Self {
-        Self {
-            field_name: MetadataField::Description.to_string(),
-            field_value: group_description,
-        }
+        Self::new(MetadataField::Description.to_string(), group_description)
     }
 
-    pub fn new_update_app_data(app_data: String) -> Self {
-        Self {
-            field_name: MetadataField::AppData.to_string(),
-            field_value: app_data,
+    pub fn new_update_app_data(app_data: String, expected_app_data: Option<String>) -> Self {
+        match expected_app_data {
+            Some(expected) => {
+                Self::new_guarded(MetadataField::AppData.to_string(), app_data, expected)
+            }
+            None => Self::new(MetadataField::AppData.to_string(), app_data),
         }
     }
 
     pub fn new_update_conversation_message_disappear_from_ns(from_ns: i64) -> Self {
-        Self {
-            field_name: MetadataField::MessageDisappearFromNS.to_string(),
-            field_value: from_ns.to_string(),
-        }
+        Self::new(
+            MetadataField::MessageDisappearFromNS.to_string(),
+            from_ns.to_string(),
+        )
     }
     pub fn new_update_conversation_message_disappear_in_ns(in_ns: i64) -> Self {
-        Self {
-            field_name: MetadataField::MessageDisappearInNS.to_string(),
-            field_value: in_ns.to_string(),
-        }
+        Self::new(
+            MetadataField::MessageDisappearInNS.to_string(),
+            in_ns.to_string(),
+        )
     }
 
     pub fn new_update_group_min_version_to_match_self(min_version: String) -> Self {
-        Self {
-            field_name: MetadataField::MinimumSupportedProtocolVersion.to_string(),
-            field_value: min_version,
-        }
+        Self::new(
+            MetadataField::MinimumSupportedProtocolVersion.to_string(),
+            min_version,
+        )
     }
 
     pub fn new_update_commit_log_signer(commit_log_signer: xmtp_cryptography::Secret) -> Self {
-        Self {
-            field_name: MetadataField::CommitLogSigner.to_string(),
-            field_value: hex::encode(commit_log_signer.as_slice()),
-        }
+        Self::new(
+            MetadataField::CommitLogSigner.to_string(),
+            hex::encode(commit_log_signer.as_slice()),
+        )
     }
 }
 
@@ -260,9 +276,7 @@ impl From<UpdateMetadataIntentData> for Vec<u8> {
             version: Some(UpdateMetadataVersion::V1(UpdateMetadataV1 {
                 field_name: intent.field_name.to_string(),
                 field_value: intent.field_value.clone(),
-                // Populated once the intent carries a compare-and-swap guard;
-                // absent means last-writer-wins, the existing behavior.
-                expected_field_value: None,
+                expected_field_value: intent.expected_field_value.clone(),
             })),
         }
         .encode(&mut buf)
@@ -286,8 +300,17 @@ impl TryFrom<Vec<u8>> for UpdateMetadataIntentData {
             Some(UpdateMetadataVersion::V1(ref v1)) => v1.field_value.clone(),
             None => return Err(IntentError::MissingPayload),
         };
+        // Absent on intents queued before the guard existed, and on payloads
+        // written by a client that predates it — both mean last-writer-wins.
+        let expected_field_value = match msg.version {
+            Some(UpdateMetadataVersion::V1(ref v1)) => v1.expected_field_value.clone(),
+            None => return Err(IntentError::MissingPayload),
+        };
 
-        Ok(Self::new(field_name, field_value))
+        Ok(match expected_field_value {
+            Some(expected) => Self::new_guarded(field_name, field_value, expected),
+            None => Self::new(field_name, field_value),
+        })
     }
 }
 

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2,6 +2,7 @@ use super::{
     FailedInstallationIds, GroupError, HmacKey, MlsGroup, build_extensions_for_admin_lists_update,
     build_extensions_for_metadata_update, build_extensions_for_permissions_update,
     build_group_membership_extension,
+    change_callbacks::AppDataChange,
     group_permissions::extract_group_permissions,
     intents::{
         CommitPendingProposalsIntentData, Installation, IntentError, PostCommitAction,
@@ -432,6 +433,11 @@ pub(crate) struct ProcessedMessageOutcome {
     /// (see `process_message`), so the worker's `min_expire_at_ns`
     /// query is guaranteed to observe the newly written `expire_at_ns`.
     pub(crate) disappearing_message_stored: bool,
+    /// Set when processing this message changed the group's `app_data`.
+    /// Carried out of the group commit lock so the host callback can be
+    /// awaited post-commit (see `process_message`); `None` whenever no
+    /// callback is registered, since the snapshot is skipped entirely then.
+    pub(crate) app_data_change: Option<AppDataChange>,
 }
 
 impl ProcessedMessageOutcome {
@@ -442,6 +448,7 @@ impl ProcessedMessageOutcome {
             identifier,
             intent_error: None,
             disappearing_message_stored: false,
+            app_data_change: None,
         }
     }
 }
@@ -528,6 +535,23 @@ where
     #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(err, fields(who = %self.context.inbox_id(), operation = "sync_with_conn")))]
     #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub async fn sync_with_conn(&self) -> Result<SyncSummary, SyncSummary> {
+        // App-data changes observed while processing are collected here and
+        // dispatched below, *after* the per-group mutex is released. The block
+        // exists to bound the guard's lifetime: a host callback is expected to
+        // react by publishing its merged value, which re-enters
+        // `sync_with_conn` and would deadlock on a guard still held here.
+        let mut app_data_changes = Vec::new();
+        let result = self.sync_with_conn_locked(&mut app_data_changes).await;
+        self.dispatch_app_data_changes(app_data_changes).await;
+        result
+    }
+
+    /// The body of [`Self::sync_with_conn`], holding the per-group mutex for
+    /// its whole duration. Never dispatch host callbacks from in here.
+    async fn sync_with_conn_locked(
+        &self,
+        app_data_changes: &mut Vec<AppDataChange>,
+    ) -> Result<SyncSummary, SyncSummary> {
         let _mutex = self.mutex.lock().await;
         let mut summary = SyncSummary::default();
 
@@ -560,7 +584,10 @@ where
         // Errors are collected in the summary.
         let result = self.receive().await;
         match result {
-            Ok(s) => summary.add_process(s),
+            Ok(mut s) => {
+                app_data_changes.append(&mut s.app_data_changes);
+                summary.add_process(s)
+            }
             Err(e) => {
                 summary.add_other(e);
                 // We don't return an error if receive fails, because it's possible this is caused
@@ -694,6 +721,26 @@ where
                          This is still okay, but unexpected. intent_id: {intent_id}",
                     );
                     return Ok(summary);
+                }
+
+                // Terminal: the guard no longer matched, so the intent will
+                // never publish. Returning here rather than looping is what
+                // keeps a superseded write from spinning until the sync
+                // retry budget runs out. `update_app_data` inspects the state
+                // and translates this into `AppDataSuperseded`.
+                Ok(Some(StoredGroupIntent {
+                    state: IntentState::Superseded,
+                    kind,
+                    ..
+                })) => {
+                    log_event!(
+                        Event::GroupSyncIntentErrored,
+                        self.context.installation_id(),
+                        level = warn,
+                        group_id = self.group_id, intent_id = intent_id,
+                        intent_kind = ?kind
+                    );
+                    return Err(GroupError::from(summary));
                 }
 
                 Ok(Some(StoredGroupIntent {
@@ -2217,42 +2264,148 @@ where
             }
         }
 
-        self.load_mls_group_with_lock_async(async |mut mls_group| {
-            // ensure we are processing a private message
-            match &envelope.message {
-                ProtocolMessage::PrivateMessage(_) => (),
-                other => {
-                    return Err(GroupMessageProcessingError::UnsupportedMessageType(
-                        discriminant(other),
-                    ));
-                }
-            };
-            let mut result = self
-                .process_message_inner(&mut mls_group, envelope, trust_message_order)
-                .await;
-            if trust_message_order {
-                result = self
-                    .post_process_message(&mls_group, result, envelope)
+        // Only snapshot when a host callback is actually watching — an
+        // unregistered client must not pay for the before/after reads.
+        let watch_app_data = self.context.change_callbacks().watches_app_data();
+
+        let outcome = self
+            .load_mls_group_with_lock_async(async |mut mls_group| {
+                // ensure we are processing a private message
+                match &envelope.message {
+                    ProtocolMessage::PrivateMessage(_) => (),
+                    other => {
+                        return Err(GroupMessageProcessingError::UnsupportedMessageType(
+                            discriminant(other),
+                        ));
+                    }
+                };
+                // Snapshot before/after around the whole message rather than
+                // threading an out-param through the intent state machine: it
+                // reports the *net* change (what a merge actually needs), it
+                // covers the own-intent and external paths identically, and it
+                // generalizes to the other mutable fields without touching
+                // commit processing again. Both reads are in-memory off the
+                // already-loaded group — no extra storage round-trip.
+                let before = watch_app_data
+                    .then(|| Self::read_app_data_slot(&mls_group))
+                    .flatten();
+                let mut result = self
+                    .process_message_inner(&mut mls_group, envelope, trust_message_order)
                     .await;
-            }
-            result
-        })
-        .await
-        .inspect(|outcome| {
-            // Re-arm the disappearing worker only after the storage transaction
-            // has committed, so its `min_expire_at_ns` read is sure to observe the
-            // message's `expire_at_ns`. Skipped when the worker is disabled so it
-            // never receives signals it won't drain (the channel is also
-            // capacity-1, bounding memory regardless).
-            if outcome.disappearing_message_stored
-                && self
-                    .context
-                    .worker_config()
-                    .worker_enabled(crate::worker::WorkerKind::DisappearingMessages)
-            {
-                self.context.disappearing_channels().rearm();
-            }
-        })
+                if trust_message_order {
+                    result = self
+                        .post_process_message(&mls_group, result, envelope)
+                        .await;
+                }
+                // Both reads must have succeeded to claim a change. Comparing a
+                // good `before` against a failed `after` would report a clear
+                // that never happened, and a host that trusts it would write
+                // the slot back from stale state.
+                if watch_app_data
+                    && let Ok(outcome) = result.as_mut()
+                    && let (Some(before), Some(after)) =
+                        (before, Self::read_app_data_slot(&mls_group))
+                    && before != after
+                {
+                    outcome.app_data_change = Some(AppDataChange {
+                        group_id: self.group_id.to_vec(),
+                        old_value: before,
+                        new_value: after,
+                    });
+                }
+                result
+            })
+            .await
+            .inspect(|outcome| {
+                // Re-arm the disappearing worker only after the storage transaction
+                // has committed, so its `min_expire_at_ns` read is sure to observe the
+                // message's `expire_at_ns`. Skipped when the worker is disabled so it
+                // never receives signals it won't drain (the channel is also
+                // capacity-1, bounding memory regardless).
+                if outcome.disappearing_message_stored
+                    && self
+                        .context
+                        .worker_config()
+                        .worker_enabled(crate::worker::WorkerKind::DisappearingMessages)
+                {
+                    self.context.disappearing_channels().rearm();
+                }
+            });
+
+        // Any observed change rides out in the outcome rather than being
+        // dispatched here. On the `sync_with_conn` path this runs under the
+        // per-group mutex, and a host that reacts by publishing its merged
+        // value re-enters `sync_with_conn` and would deadlock on it. Callers
+        // hand the change to `dispatch_app_data_changes` once they hold no
+        // group locks.
+        outcome
+    }
+
+    /// Hand observed app-data changes to the host's registered callback.
+    ///
+    /// **Call this only with no group locks held.** The callback exists so the
+    /// host can semantically merge and publish the result straight back into
+    /// the same group, which takes the per-group sync mutex and the commit
+    /// lock; dispatching while either is held deadlocks that host.
+    ///
+    /// Awaited in order, one at a time: a merge decides what to write from the
+    /// value it was handed, so overlapping or reordered dispatches would let a
+    /// host publish a merge derived from state that has already moved on.
+    pub(crate) async fn dispatch_app_data_changes(&self, changes: Vec<AppDataChange>) {
+        let Some(callback) = self.context.change_callbacks().app_data.clone() else {
+            return;
+        };
+
+        for change in changes {
+            callback.on_app_data_changed(change).await;
+        }
+    }
+
+    /// The group's opaque `app_data` slot as currently committed, read from the
+    /// in-memory group state.
+    ///
+    /// Reads the `APP_DATA` component on its own rather than decoding the whole
+    /// mutable-metadata composite. Decoding the composite would let a malformed
+    /// *unrelated* component — a corrupt `ADMIN_LIST`, say — fail the read and
+    /// make a perfectly good app-data change look unreadable, silently
+    /// suppressing the callback the host depends on.
+    ///
+    /// The outer `Option` separates "could not read the component at all" from
+    /// the inner "read fine, no value set" — the caller must not treat an
+    /// unreadable group as a cleared slot.
+    fn read_app_data_slot(mls_group: &OpenMlsGroup) -> Option<Option<String>> {
+        use xmtp_mls_common::app_data::components::metadata_attributes::AppDataComponent;
+
+        super::app_data::typed_facade::MlsGroupAppData::new(mls_group)
+            .get::<AppDataComponent>()
+            .inspect_err(|err| tracing::debug!("could not read the app_data component: {err}"))
+            .ok()
+    }
+
+    /// A single mutable-metadata attribute as currently committed, read from
+    /// the in-memory group state.
+    ///
+    /// The outer `Option` separates "could not read the metadata at all" from
+    /// the inner "read fine, no value set for this field" — callers must not
+    /// treat an unreadable group as an unset field.
+    fn read_metadata_field(mls_group: &OpenMlsGroup, field_name: &str) -> Option<Option<String>> {
+        // `app_data` has a typed component reader, so use it and keep the guard
+        // immune to damage in the rest of the composite. The remaining fields
+        // have no string-typed per-component read, so they still go through the
+        // full decode.
+        if field_name == MetadataField::AppData.as_str() {
+            return Self::read_app_data_slot(mls_group);
+        }
+
+        let metadata =
+            super::app_data::component_source::extract_group_mutable_metadata_capability_aware(
+                mls_group,
+            )
+            .inspect_err(|err| {
+                tracing::debug!("could not read mutable metadata for field {field_name}: {err}")
+            })
+            .ok()?;
+        Some(metadata.attributes.get(field_name).cloned())
     }
 
     #[tracing::instrument(skip(self, mls_group, envelope), level = "trace")]
@@ -2462,6 +2615,9 @@ where
                     identifier,
                     intent_error,
                     disappearing_message_stored: disappearing_stored,
+                    // Filled by `process_message`'s snapshot diff, which spans
+                    // both the own-intent and external paths.
+                    app_data_change: None,
                 })
             }
             // No matching intent found. The message did not originate here.
@@ -2666,7 +2822,12 @@ where
                     identifier,
                     intent_error,
                     disappearing_message_stored: _,
+                    app_data_change,
                 }) => {
+                    // Collected, not dispatched: this loop runs under the
+                    // per-group mutex when reached via `sync_with_conn`.
+                    summary.app_data_changes.extend(app_data_change);
+
                     // An own-intent that failed non-retryably advances the cursor and
                     // is marked Error in its row, then returns success — so the message
                     // is counted as processed. Record the swallowed cause here so the
@@ -3050,7 +3211,22 @@ where
                             installation_id = %self.context.installation_id(),
                             "Skipping intent because no publish data returned"
                         );
-                        db.set_group_intent_processed(intent.id)?
+                        // `get_publish_intent_data` may already have assigned a
+                        // terminal state (a guarded metadata update whose
+                        // compare-and-swap no longer matches is marked
+                        // `Superseded`). Overwriting that with `Processed`
+                        // would report a silently dropped write to the caller
+                        // as a success, so only advance an intent that is still
+                        // waiting to publish.
+                        // A failed read must propagate rather than be treated as
+                        // "not ToPublish": swallowing it would leave the intent
+                        // stuck in `ToPublish` while reporting success, and the
+                        // caller waiting on it would spin until it timed out.
+                        let still_to_publish = Fetch::<StoredGroupIntent>::fetch(&db, &intent.id)?
+                            .is_some_and(|intent| intent.state == IntentState::ToPublish);
+                        if still_to_publish {
+                            db.set_group_intent_processed(intent.id)?
+                        }
                     }
                 }
             }
@@ -3118,6 +3294,36 @@ where
             }
             IntentKind::MetadataUpdate => {
                 let metadata_intent = UpdateMetadataIntentData::try_from(intent.data.clone())?;
+
+                // Compare-and-swap guard. This runs on every publish attempt,
+                // including the republish after an intent loses an epoch race,
+                // which is exactly when the frozen `field_value` has gone
+                // stale. Abandoning here is what stops the intent from
+                // silently overwriting whatever landed in the meantime.
+                //
+                // Marked `Superseded` (not `Error`) and reported as
+                // `Ok(None)`, so it is terminal without burning publish
+                // attempts or aborting the publish loop for the other intents
+                // queued on this group.
+                if let Some(expected) = &metadata_intent.expected_field_value {
+                    // A failed read is not evidence the guard was violated —
+                    // leave the intent alone and let the normal error path
+                    // surface whatever is actually wrong. The outer `Option`
+                    // separates "unreadable" from "readable but unset".
+                    if let Some(committed) =
+                        Self::read_metadata_field(openmls_group, &metadata_intent.field_name)
+                        && committed.as_deref() != Some(expected.as_str())
+                    {
+                        tracing::info!(
+                            group_id = %self.group_id,
+                            intent.id,
+                            field = %metadata_intent.field_name,
+                            "abandoning guarded metadata update: committed value no longer matches"
+                        );
+                        self.context.db().set_group_intent_superseded(intent.id)?;
+                        return Ok(None);
+                    }
+                }
 
                 // Route through AppDataUpdate only on migrated groups,
                 // via the same `is_migrated_group` predicate the

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_data;
+pub mod change_callbacks;
 pub mod commit_log;
 pub mod commit_log_key;
 mod error;
@@ -84,6 +85,7 @@ use xmtp_db::user_preferences::HmacKey;
 use xmtp_db::{Fetch, consent_record::ConsentType};
 use xmtp_db::{
     NotFound, StorageError,
+    group_intent::{IntentState, StoredGroupIntent},
     group_message::{ContentType, StoredGroupMessageWithReactions},
     refresh_state::EntityKind,
 };
@@ -2302,12 +2304,27 @@ where
         Ok(())
     }
 
+    /// Set the group's opaque `app_data` slot.
+    ///
+    /// `expected_app_data` is an optional compare-and-swap guard. When
+    /// `Some`, the update is abandoned with [`GroupError::AppDataSuperseded`]
+    /// unless the committed value still equals it — including when another
+    /// member's commit wins the epoch race *after* this intent was published.
+    /// Callers reconciling structured state should pass the value they merged
+    /// against, so a concurrent write is reported rather than overwritten.
+    ///
+    /// `None` keeps the historical last-writer-wins behavior: whatever landed
+    /// in the meantime is overwritten.
     #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
     )]
-    pub async fn update_app_data(&self, app_data: String) -> Result<(), GroupError> {
+    pub async fn update_app_data(
+        &self,
+        app_data: String,
+        expected_app_data: Option<String>,
+    ) -> Result<(), GroupError> {
         self.ensure_not_paused().await?;
 
         if app_data.len() > MAX_APP_DATA_LENGTH {
@@ -2318,13 +2335,64 @@ where
         if self.metadata().await?.conversation_type == ConversationType::Dm {
             return Err(MetadataPermissionsError::DmGroupMetadataForbidden.into());
         }
-        let intent_data: Vec<u8> = UpdateMetadataIntentData::new_update_app_data(app_data).into();
+
+        // Fail the already-stale case before touching the network. The
+        // authoritative check runs again at publish time, which is what
+        // catches a change that lands between here and the commit.
+        if let Some(expected) = &expected_app_data {
+            // Read the slot itself rather than going through `app_data()`: a
+            // group whose `app_data` has never been set is a legitimate "not
+            // what you expected", and reporting it as `MissingExtension` would
+            // hand the caller an error where it asked a question. A genuine
+            // read failure still propagates — an unreadable group is not
+            // evidence that someone else wrote the field.
+            let actual = self.read_single_component::<AppDataComponent>()?;
+            if actual.as_deref() != Some(expected.as_str()) {
+                return Err(GroupError::AppDataSuperseded {
+                    expected: expected.clone(),
+                    // An unset slot reports as empty. The guard cannot yet
+                    // *express* "I expect this to be unset" — the intent's
+                    // `expected_field_value` is an optional string, where
+                    // absent already means "no guard" — so an unset slot can
+                    // only ever be a mismatch here, never an expectation.
+                    actual: actual.unwrap_or_default(),
+                });
+            }
+        }
+
+        let intent_data: Vec<u8> =
+            UpdateMetadataIntentData::new_update_app_data(app_data, expected_app_data.clone())
+                .into();
         let intent = QueueIntent::metadata_update()
             .data(intent_data)
             .queue(self)?;
 
-        let _ = self.sync_until_intent_resolved(intent.id).await?;
-        Ok(())
+        match self.sync_until_intent_resolved(intent.id).await {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                // A guarded intent that lost the race is marked `Superseded`
+                // rather than `Error`; translate it into the typed error so a
+                // stale write is distinguishable from a genuine sync failure.
+                if let Some(expected) = expected_app_data
+                    && matches!(
+                        self.context.db().fetch(&intent.id),
+                        Ok(Some(StoredGroupIntent {
+                            state: IntentState::Superseded,
+                            ..
+                        }))
+                    )
+                {
+                    // Superseded is only set after the publish path read the
+                    // committed value successfully, so this read should too;
+                    // if it somehow fails, that error is the honest one.
+                    return Err(GroupError::AppDataSuperseded {
+                        expected,
+                        actual: self.app_data()?,
+                    });
+                }
+                Err(err)
+            }
+        }
     }
 
     /// Updates min version of the group to match this client's version.

--- a/crates/xmtp_mls/src/groups/summary.rs
+++ b/crates/xmtp_mls/src/groups/summary.rs
@@ -6,7 +6,7 @@ use xmtp_common::RetryableError;
 use xmtp_db::group_intent::IntentKind;
 use xmtp_proto::types::Cursor;
 
-use super::{GroupError, mls_sync::GroupMessageProcessingError};
+use super::{GroupError, change_callbacks::AppDataChange, mls_sync::GroupMessageProcessingError};
 use xmtp_proto::types::GroupId;
 
 #[derive(Default)]
@@ -253,6 +253,12 @@ pub struct ProcessSummary {
     pub total_messages: HashSet<Cursor>,
     pub new_messages: Vec<MessageIdentifier>,
     pub errored: Vec<(Cursor, GroupMessageProcessingError)>,
+    /// App-data changes seen while processing, in the order they were observed.
+    ///
+    /// Carried rather than dispatched because processing runs under the
+    /// per-group sync mutex; the caller fires them once it holds no group
+    /// locks. See `MlsGroup::dispatch_app_data_changes`.
+    pub app_data_changes: Vec<AppDataChange>,
 }
 
 impl std::fmt::Debug for ProcessSummary {

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -1,3 +1,4 @@
+mod test_change_callbacks;
 mod test_commit_log_fork_detection;
 mod test_commit_log_local;
 mod test_commit_log_readd_requests;
@@ -4045,7 +4046,7 @@ async fn test_respects_character_limits_for_group_metadata() {
 
     // Verify that updating the app data with an excessive length fails
     let overlong_app_data = "d".repeat(MAX_APP_DATA_LENGTH + 1);
-    let result = amal_group.update_app_data(overlong_app_data).await;
+    let result = amal_group.update_app_data(overlong_app_data, None).await;
     assert!(
         matches!(result, Err(GroupError::TooManyCharacters { length }) if length == MAX_APP_DATA_LENGTH)
     );
@@ -4069,7 +4070,7 @@ async fn test_respects_character_limits_for_group_metadata() {
         .await
         .unwrap();
     amal_group
-        .update_app_data(valid_app_data.clone())
+        .update_app_data(valid_app_data.clone(), None)
         .await
         .unwrap();
 
@@ -4118,7 +4119,10 @@ async fn test_update_app_data() {
 
     // Update app data with a valid value
     let app_data = "Test application data".to_string();
-    amal_group.update_app_data(app_data.clone()).await.unwrap();
+    amal_group
+        .update_app_data(app_data.clone(), None)
+        .await
+        .unwrap();
     amal_group.sync().await.unwrap();
 
     // Verify the app data was updated using the getter
@@ -4128,7 +4132,7 @@ async fn test_update_app_data() {
     // Update with maximum allowed size (8KB)
     let max_size_data = "x".repeat(MAX_APP_DATA_LENGTH);
     amal_group
-        .update_app_data(max_size_data.clone())
+        .update_app_data(max_size_data.clone(), None)
         .await
         .unwrap();
     amal_group.sync().await.unwrap();
@@ -4149,7 +4153,7 @@ async fn test_app_data_in_dm() {
         .unwrap();
 
     // Verify that updating app_data on a DM fails
-    let result = dm.update_app_data("test data".to_string()).await;
+    let result = dm.update_app_data("test data".to_string(), None).await;
     assert!(matches!(
         result,
         Err(GroupError::MetadataPermissionsError(
@@ -4187,7 +4191,7 @@ async fn test_create_group_with_app_data() {
     // Verify we can also update it
     let updated_app_data = "Updated app data".to_string();
     group
-        .update_app_data(updated_app_data.clone())
+        .update_app_data(updated_app_data.clone(), None)
         .await
         .unwrap();
     group.sync().await.unwrap();

--- a/crates/xmtp_mls/src/groups/tests/test_change_callbacks.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_change_callbacks.rs
@@ -1,0 +1,382 @@
+//! Coverage for the unstable group-change callbacks
+//! ([`crate::groups::change_callbacks`]).
+
+use crate::groups::change_callbacks::{
+    AppDataChange, AppDataChangeCallback, UnstableChangeCallbacks,
+};
+use crate::groups::intents::{QueueIntent, UpdateMetadataIntentData};
+use crate::groups::send_message_opts::SendMessageOpts;
+use crate::tester;
+use crate::utils::TestMlsGroup;
+use std::sync::{Arc, Mutex, OnceLock};
+use xmtp_db::group_intent::{IntentState, StoredGroupIntent};
+use xmtp_db::prelude::*;
+
+/// Records every change it is handed, so a test can assert on both the fact of
+/// delivery and the payload.
+#[derive(Default)]
+struct RecordingCallback {
+    changes: Mutex<Vec<AppDataChange>>,
+}
+
+impl RecordingCallback {
+    fn recorded(&self) -> Vec<AppDataChange> {
+        self.changes.lock().expect("lock poisoned").clone()
+    }
+}
+
+#[xmtp_common::async_trait]
+impl AppDataChangeCallback for RecordingCallback {
+    async fn on_app_data_changed(&self, change: AppDataChange) {
+        self.changes.lock().expect("lock poisoned").push(change);
+    }
+}
+
+fn recording() -> (Arc<RecordingCallback>, UnstableChangeCallbacks) {
+    let callback = Arc::new(RecordingCallback::default());
+    let callbacks = UnstableChangeCallbacks {
+        app_data: Some(callback.clone() as Arc<dyn AppDataChangeCallback>),
+    };
+    (callback, callbacks)
+}
+
+/// A remote member's `app_data` update reaches the receiver's callback with
+/// both sides of the change — the case a semantic merge is built on.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_app_data_callback_fires_for_remote_change() {
+    let (recorder, callbacks) = recording();
+    tester!(alix);
+    tester!(bo, change_callbacks: callbacks);
+
+    let group = alix.create_group(None, None)?;
+    group.add_members(&[bo.inbox_id()]).await?;
+    group.update_app_data("from alix".to_string(), None).await?;
+
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&group.group_id)?;
+    bo_group.sync().await?;
+
+    let recorded = recorder.recorded();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "expected exactly one app_data change, got {recorded:?}"
+    );
+    assert_eq!(recorded[0].group_id, group.group_id.to_vec());
+    assert_eq!(recorded[0].new_value.as_deref(), Some("from alix"));
+    // The welcome carries alix's pre-add state, so bo's first *processed*
+    // change starts from the empty slot the group was created with.
+    assert_eq!(recorded[0].old_value.as_deref(), Some(""));
+}
+
+/// The callback also observes changes this client made itself — an
+/// implementation that reacts by writing has to be idempotent, so the contract
+/// is pinned here rather than left to chance.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_app_data_callback_fires_for_local_change() {
+    let (recorder, callbacks) = recording();
+    tester!(alix, change_callbacks: callbacks);
+
+    let group = alix.create_group(None, None)?;
+    group.update_app_data("from alix".to_string(), None).await?;
+
+    let recorded = recorder.recorded();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "expected exactly one app_data change, got {recorded:?}"
+    );
+    assert_eq!(recorded[0].new_value.as_deref(), Some("from alix"));
+}
+
+/// Messages that leave `app_data` alone must not wake the callback — a
+/// reconciler woken by every chat message would be worse than none.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_app_data_callback_silent_for_unrelated_changes() {
+    let (recorder, callbacks) = recording();
+    tester!(alix);
+    tester!(bo, change_callbacks: callbacks);
+
+    let group = alix.create_group(None, None)?;
+    group.add_members(&[bo.inbox_id()]).await?;
+    group.update_group_name("renamed".to_string()).await?;
+    group
+        .send_message(b"hello", SendMessageOpts::default())
+        .await?;
+
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&group.group_id)?;
+    bo_group.sync().await?;
+
+    assert!(
+        recorder.recorded().is_empty(),
+        "app_data callback fired for a non-app_data change: {:?}",
+        recorder.recorded()
+    );
+}
+
+/// Publishing a merged value straight back into the same group is the whole
+/// point of the callback, and it is also the one thing that can deadlock:
+/// `update_app_data` waits on `sync_until_intent_resolved`, which re-enters
+/// `sync_with_conn` and takes the per-group sync mutex. Dispatching while sync
+/// still held that mutex hung the caller forever.
+///
+/// Wrapped in a timeout so a regression fails the run instead of parking it
+/// until the CI job's own limit.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_callback_can_publish_back_into_the_same_group() {
+    /// Reacts to the peer's write by publishing a merge. The merge is echoed
+    /// back to this same callback, so it must react exactly once or it would
+    /// chase itself.
+    #[derive(Default)]
+    struct RepublishingCallback {
+        group: OnceLock<TestMlsGroup>,
+        published: Mutex<Vec<String>>,
+    }
+
+    #[xmtp_common::async_trait]
+    impl AppDataChangeCallback for RepublishingCallback {
+        async fn on_app_data_changed(&self, change: AppDataChange) {
+            if change.new_value.as_deref() != Some("from alix") {
+                return;
+            }
+            let group = self.group.get().expect("group registered before sync");
+            let merged = "from alix + from bo".to_string();
+            group
+                .update_app_data(merged.clone(), None)
+                .await
+                .expect("republish from callback");
+            self.published.lock().expect("lock poisoned").push(merged);
+        }
+    }
+
+    let callback = Arc::new(RepublishingCallback::default());
+    let callbacks = UnstableChangeCallbacks {
+        app_data: Some(callback.clone() as Arc<dyn AppDataChangeCallback>),
+    };
+
+    tester!(alix);
+    tester!(bo, change_callbacks: callbacks);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group.add_members(&[bo.inbox_id()]).await?;
+
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&alix_group.group_id)?;
+    callback
+        .group
+        .set(bo_group.clone())
+        .map_err(|_| "group already set")
+        .unwrap();
+
+    alix_group
+        .update_app_data("from alix".to_string(), None)
+        .await?;
+
+    xmtp_common::time::timeout(std::time::Duration::from_secs(30), bo_group.sync())
+        .await
+        .expect("sync deadlocked: the callback was dispatched while sync held the group mutex")?;
+
+    assert_eq!(
+        callback.published.lock().expect("lock poisoned").as_slice(),
+        ["from alix + from bo".to_string()],
+        "callback should have published its merge exactly once"
+    );
+    assert_eq!(bo_group.app_data()?, "from alix + from bo");
+
+    alix_group.sync().await?;
+    assert_eq!(alix_group.app_data()?, "from alix + from bo");
+}
+
+/// A published-but-unresolved local `update_app_data` is a blind absolute set:
+/// `UpdateMetadataIntentData` freezes the value at queue time, and an intent
+/// that loses an epoch race is rebuilt from that same frozen data and
+/// republished. So a remote change that lands in between is reported to the
+/// host and then silently overwritten by the local intent.
+///
+/// This pins the hazard rather than endorsing it — a host reconciling
+/// `app_data` must treat the callback as "state moved", not "state settled",
+/// and re-assert its merge after its own in-flight write lands.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_pending_local_intent_clobbers_a_remote_change() {
+    let (recorder, callbacks) = recording();
+    tester!(alix, change_callbacks: callbacks);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group.add_members(&[bo.inbox_id()]).await?;
+    alix_group
+        .update_app_data("start".to_string(), None)
+        .await?;
+
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&alix_group.group_id)?;
+    bo_group.sync().await?;
+
+    // Bo commits a change alix has not seen yet.
+    bo_group
+        .update_app_data("from-bo".to_string(), None)
+        .await?;
+
+    // Alix, still on the pre-bo view, queues and publishes its own absolute
+    // set. The intent is now Published and unresolved.
+    let intent_data: Vec<u8> =
+        UpdateMetadataIntentData::new_update_app_data("from-alix".to_string(), None).into();
+    QueueIntent::metadata_update()
+        .data(intent_data)
+        .queue(&alix_group)?;
+    alix_group.publish_intents().await?;
+
+    // First sync applies bo's commit and bounces the losing intent back to
+    // ToPublish; the second lets it republish on the new epoch.
+    alix_group.sync().await?;
+    alix_group.sync().await?;
+
+    let values: Vec<_> = recorder
+        .recorded()
+        .into_iter()
+        .filter_map(|c| c.new_value)
+        .collect();
+
+    // Alix is told about bo's value, and then about its own write replacing it.
+    assert!(
+        values.contains(&"from-bo".to_string()),
+        "expected the remote change to be reported, got {values:?}"
+    );
+    assert_eq!(
+        values.last().map(String::as_str),
+        Some("from-alix"),
+        "expected the stale local intent to land last, got {values:?}"
+    );
+    assert_eq!(
+        alix_group.app_data()?,
+        "from-alix",
+        "the frozen local intent overwrites the remote value"
+    );
+}
+
+/// The same race as [`test_pending_local_intent_clobbers_a_remote_change`],
+/// but with a compare-and-swap guard. The guard is re-checked on every publish
+/// attempt — including the republish after the intent loses the epoch race —
+/// so the stale write is abandoned instead of overwriting bo's value.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_guarded_update_is_abandoned_instead_of_clobbering() {
+    let (recorder, callbacks) = recording();
+    tester!(alix, change_callbacks: callbacks);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group.add_members(&[bo.inbox_id()]).await?;
+    alix_group
+        .update_app_data("start".to_string(), None)
+        .await?;
+
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&alix_group.group_id)?;
+    bo_group.sync().await?;
+
+    bo_group
+        .update_app_data("from-bo".to_string(), None)
+        .await?;
+
+    // Alix publishes a guarded write derived from the pre-bo value.
+    let intent_data: Vec<u8> = UpdateMetadataIntentData::new_update_app_data(
+        "from-alix".to_string(),
+        Some("start".to_string()),
+    )
+    .into();
+    let queued = QueueIntent::metadata_update()
+        .data(intent_data)
+        .queue(&alix_group)?;
+    alix_group.publish_intents().await?;
+
+    alix_group.sync().await?;
+    alix_group.sync().await?;
+
+    assert_eq!(
+        alix_group.app_data()?,
+        "from-bo",
+        "the guard must abandon the stale write rather than overwrite"
+    );
+    // Abandoning is only half the contract — the intent must land in a state
+    // the caller can tell apart from success, or `update_app_data` reports a
+    // silent no-op.
+    let intent: Option<StoredGroupIntent> = alix.context.db().fetch(&queued.id)?;
+    assert_eq!(
+        intent.map(|i| i.state),
+        Some(IntentState::Superseded),
+        "an abandoned guarded intent must be Superseded, not Processed"
+    );
+    let values: Vec<_> = recorder
+        .recorded()
+        .into_iter()
+        .filter_map(|c| c.new_value)
+        .collect();
+    assert_eq!(
+        values.last().map(String::as_str),
+        Some("from-bo"),
+        "the host's last observed value should be bo's, got {values:?}"
+    );
+}
+
+/// The synchronous pre-flight: a guard that is already stale when the caller
+/// asks fails immediately with a typed error carrying the value that actually
+/// landed, so the host can re-derive without a network round trip.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_guarded_update_reports_the_value_that_landed() {
+    tester!(alix);
+
+    let group = alix.create_group(None, None)?;
+    group.update_app_data("current".to_string(), None).await?;
+
+    let err = group
+        .update_app_data("next".to_string(), Some("stale".to_string()))
+        .await
+        .expect_err("a stale guard must not be applied");
+
+    match err {
+        crate::groups::GroupError::AppDataSuperseded { expected, actual } => {
+            assert_eq!(expected, "stale");
+            assert_eq!(actual, "current");
+        }
+        other => panic!("expected AppDataSuperseded, got {other:?}"),
+    }
+    assert_eq!(group.app_data()?, "current");
+}
+
+/// A superseded intent must terminate `sync_until_intent_resolved` promptly
+/// with an error. If the state were not treated as terminal the call would
+/// spin until the sync retry budget expired, turning a lost race into a long
+/// hang and then a misleading timeout.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_superseded_intent_resolves_promptly_as_an_error() {
+    tester!(alix);
+
+    let group = alix.create_group(None, None)?;
+    group.update_app_data("current".to_string(), None).await?;
+
+    // Queue a guarded write whose guard is already stale, bypassing the
+    // synchronous pre-flight so the publish-time check is what fires.
+    let intent_data: Vec<u8> = UpdateMetadataIntentData::new_update_app_data(
+        "next".to_string(),
+        Some("stale".to_string()),
+    )
+    .into();
+    let queued = QueueIntent::metadata_update()
+        .data(intent_data)
+        .queue(&group)?;
+
+    let result = group.sync_until_intent_resolved(queued.id).await;
+    assert!(
+        result.is_err(),
+        "a superseded intent must not resolve as success"
+    );
+
+    let intent: Option<StoredGroupIntent> = alix.context.db().fetch(&queued.id)?;
+    assert_eq!(intent.map(|i| i.state), Some(IntentState::Superseded));
+    assert_eq!(
+        group.app_data()?,
+        "current",
+        "the guarded write must not have been applied"
+    );
+}

--- a/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -160,6 +160,7 @@ async fn test_spoofed_inbox_id() {
         scw_verifier: alix.context.scw_verifier.clone(),
         device_sync: alix.context.device_sync.clone(),
         fork_recovery_opts: alix.context.fork_recovery_opts.clone(),
+        change_callbacks: alix.context.change_callbacks.clone(),
         worker_config: alix.context.worker_config.clone(),
         task_channels: alix.context.task_channels.clone(),
         disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(),

--- a/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -111,16 +111,24 @@ where
             epoch,
         );
 
-        group
+        let outcome = group
             .process_message(msg, false)
             .instrument(tracing::debug_span!("process_message"))
             .await
-            // Streaming path (trust_message_order = false): any captured
-            // intent_error is intentionally discarded — intent-resolution
-            // reporting belongs to the query/sync path, not the stream. Surface
-            // only the identifier, matching prior behavior.
-            .map(|outcome| outcome.identifier)
-            .map_err(|e| SubscribeError::ReceiveGroup(Box::new(e)))
+            .map_err(|e| SubscribeError::ReceiveGroup(Box::new(e)))?;
+
+        // Safe to dispatch inline: unlike `sync_with_conn`, this path holds no
+        // per-group mutex, so a host is free to publish a merged value back
+        // into this group from the callback.
+        group
+            .dispatch_app_data_changes(outcome.app_data_change.into_iter().collect())
+            .await;
+
+        // Streaming path (trust_message_order = false): any captured
+        // intent_error is intentionally discarded — intent-resolution
+        // reporting belongs to the query/sync path, not the stream. Surface
+        // only the identifier, matching prior behavior.
+        Ok(outcome.identifier)
     }
 
     async fn recover(&self, msg: &xmtp_proto::types::GroupMessage) -> SyncSummary {

--- a/crates/xmtp_mls/src/test/mock.rs
+++ b/crates/xmtp_mls/src/test/mock.rs
@@ -89,6 +89,7 @@ impl Clone for NewMockContext {
             scw_verifier: self.scw_verifier.clone(),
             device_sync: self.device_sync.clone(),
             fork_recovery_opts: self.fork_recovery_opts.clone(),
+            change_callbacks: self.change_callbacks.clone(),
             worker_config: self.worker_config.clone(),
             task_channels: self.task_channels.clone(),
             disappearing_channels: crate::worker::disappearing_messages::DisappearingChannels::new(
@@ -170,6 +171,10 @@ impl XmtpSharedContext for NewMockContext {
 
     fn disappearing_channels(&self) -> &crate::worker::disappearing_messages::DisappearingChannels {
         &self.disappearing_channels
+    }
+
+    fn change_callbacks(&self) -> &crate::groups::change_callbacks::UnstableChangeCallbacks {
+        &self.change_callbacks
     }
 
     fn sync_metrics(&self) -> Option<Arc<crate::worker::metrics::WorkerMetrics<SyncMetric>>> {

--- a/crates/xmtp_mls/src/test/mock/generate.rs
+++ b/crates/xmtp_mls/src/test/mock/generate.rs
@@ -35,6 +35,7 @@ pub fn context() -> NewMockContext {
             mode: DeviceSyncMode::Disabled,
         },
         fork_recovery_opts: Default::default(),
+        change_callbacks: Default::default(),
         worker_config: Default::default(),
         mls_storage: SqlKeyStore::new(MemoryStorage::new()),
         task_channels: TaskWorkerChannels::default(),
@@ -78,6 +79,7 @@ pub fn generate_successful_summary(messages: &[xmtp_proto::types::GroupMessage])
             total_messages: HashSet::from_iter(messages.iter().map(|m| m.cursor)),
             new_messages: messages.iter().map(Into::into).collect(),
             errored: Vec::new(),
+            app_data_changes: Vec::new(),
         },
         post_commit_errors: vec![],
         other: None,
@@ -108,6 +110,7 @@ pub fn generate_errored_summary(error_cursors: &[u64], successful_cursors: &[u64
                     )
                 })
                 .collect(),
+            app_data_changes: Vec::new(),
         },
         post_commit_errors: vec![],
         other: None,
@@ -147,6 +150,7 @@ pub fn generate_errored_summary_with_group(
                     )
                 })
                 .collect(),
+            app_data_changes: Vec::new(),
         },
         post_commit_errors: vec![],
         other: None,

--- a/crates/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/crates/xmtp_mls/src/utils/test/tester_utils.rs
@@ -224,7 +224,8 @@ where
             .maybe_version(self.version.clone())
             .with_commit_log_worker(self.commit_log_worker)
             .fork_recovery_opts(self.fork_recovery_opts.clone().unwrap_or_default())
-            .worker_config(self.worker_config.clone().unwrap_or_default());
+            .worker_config(self.worker_config.clone().unwrap_or_default())
+            .unstable_change_callbacks(self.change_callbacks.clone());
 
         if self.in_memory_cursors {
             client = client.cursor_store(Arc::new(InMemoryCursorStore::new()) as Arc<_>);
@@ -426,6 +427,7 @@ where
     pub installation: bool,
     pub disable_workers: bool,
     pub worker_config: Option<crate::worker::WorkerConfig>,
+    pub change_callbacks: crate::groups::change_callbacks::UnstableChangeCallbacks,
 }
 
 #[derive(Clone)]
@@ -462,6 +464,7 @@ impl Default for TesterBuilder<PrivateKeySigner> {
             snapshot_path: None,
             disable_workers: false,
             worker_config: None,
+            change_callbacks: Default::default(),
         }
     }
 }
@@ -494,6 +497,7 @@ where
             snapshot_path: self.snapshot_path,
             disable_workers: self.disable_workers,
             worker_config: self.worker_config,
+            change_callbacks: self.change_callbacks,
         }
     }
 
@@ -562,6 +566,14 @@ where
 
     pub fn worker_config(mut self, cfg: crate::worker::WorkerConfig) -> Self {
         self.worker_config = Some(cfg);
+        self
+    }
+
+    pub fn change_callbacks(
+        mut self,
+        callbacks: crate::groups::change_callbacks::UnstableChangeCallbacks,
+    ) -> Self {
+        self.change_callbacks = callbacks;
         self
     }
 


### PR DESCRIPTION
## Stack

Merge bottom-up — each PR is based on its parent below.
**Android is the priority path: #4019 → #4011 → #4012 → #4016.**

- #4019 db — `IntentState::Superseded` (base: `main`)
  - #4011 xmtp_mls — app-data change callbacks + compare-and-swap guard ← this PR
    - #4012 bindings/mobile · **Android path**
      - #4016 sdks/android · **Android path**
      - #4015 sdks/ios
    - #4013 bindings/node
      - #4017 sdks/js/node-sdk
    - #4014 bindings/wasm

Already merged: #4018 (proto regen). Related follow-up, independent of this stack: #4020.

---

## Reporting changes

`ClientBuilder::unstable_change_callbacks` → `XmtpMlsLocalContext`. Registration is construction-time by necessity: remote changes surface from the stream and sync paths, where no SDK method is on the stack to carry a parameter. A per-call hook would only cover changes you caused yourself.

`UnstableChangeCallbacks` has one field today; callbacks for the other mutable fields land as additive fields later.

`MlsGroup::process_message` snapshots the group's mutable metadata before and after processing, inside the lock closure, and diffs the `app_data` slot — both reads in-memory off the already-loaded group, gated on a callback being registered. That is deliberately not an out-param threaded through the intent state machine: it reports the *net* change, covers the own-intent and external paths identically, and generalizes to the other fields without touching commit processing again.

Dispatch happens after `load_mls_group_with_lock_async` returns — lock released, transaction committed — so a callback may publish its merged result on the same group. Dispatching from inside `save_transcript_message` would hold a write transaction across a hop into Swift/Kotlin/JS and deadlock the moment the host called `update_app_data`. `DeferredEvents` looks like the natural hook and is not: its `send_all` runs inside the lock.

Both reads must succeed before a change is reported. Comparing a good `before` against a failed `after` would report a clear that never happened, and a host trusting it would write the slot back from stale state.

## Guarding updates

`update_app_data` takes an optional `expected_app_data`. `UpdateMetadataIntentData` freezes an **absolute** value at queue time, and an intent that loses an epoch race is rebuilt from that same frozen payload and republished — so without a guard a concurrent change is observed and then silently overwritten. `test_pending_local_intent_clobbers_a_remote_change` pins that behavior; `test_guarded_update_is_abandoned_instead_of_clobbering` shows the guard preventing it.

The authoritative check runs in `get_publish_intent_data` on **every** publish attempt, including the republish after an epoch loss. A mismatch marks the intent `Superseded` and returns `Ok(None)` — terminal without burning publish attempts or aborting the publish loop for other intents on the group. A synchronous pre-flight in `update_app_data` fails the already-stale case without a network round trip.

Passing `None` keeps last-writer-wins, so nothing existing changes behavior.

Two things worth a reviewer's attention:

- The `Ok(None)` arm of `publish_intents` no longer blindly marks an intent `Processed`. It would otherwise overwrite the `Superseded` state set moments earlier and report a dropped write to the caller as success — a silent no-op, worse than the clobber it replaces. It now only advances an intent still in `ToPublish`. The full `xmtp_mls` suite (724 tests) passes with that change.
- A failed metadata read is never treated as a guard violation. An unreadable group is not evidence that someone else wrote the field.

## Known trade-off

The change payload carries no actor identity, so the callback fires for local commits as well as remote ones and merges must be idempotent. Documented on the trait and pinned by a test.

## Not covered

The welcome path (`groups/welcomes/xmtp_welcome.rs`) fires nothing — joining never goes through `process_message`, so first sight of `app_data` on join is silent. Worth a follow-up for clients that reconcile on join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdY7WKkNbJmdzpmUWvW1my


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add guarded app_data updates and change callbacks to MLS group sync
> - Introduces `UnstableChangeCallbacks` and `AppDataChangeCallback` in [`change_callbacks.rs`](https://github.com/xmtp/libxmtp/pull/4011/files#diff-368589f9a48de1c00f487cf003a418e63a3ce64ed9833e043693335bb27e5068), allowing callers to register async callbacks that fire when `app_data` changes during sync or message processing.
> - Adds an `expected_field_value` compare-and-swap guard to `UpdateMetadataIntentData`; if the committed value differs at publish time, the intent is marked `Superseded` instead of overwriting concurrent changes.
> - `update_app_data` now accepts an `Option<String>` guard parameter; stale guards are rejected pre-queue or at publish time and return a new `GroupError::AppDataSuperseded` variant.
> - Callbacks are dispatched after releasing the per-group sync mutex to prevent deadlocks and allow the callback to publish back into the same group.
> - Risk: `update_app_data` signature change is breaking for all call sites (bindings and apps updated to pass `None`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c625372.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


