### PR TITLE
feat(bindings_node): expose the app data change callback and update guard

### DIFF
--- a/bindings/node/src/client/change_callbacks.rs
+++ b/bindings/node/src/client/change_callbacks.rs
@@ -1,0 +1,100 @@
+//! Unstable: node mirror of [`xmtp_mls::groups::change_callbacks`].
+//!
+//! Registered once, at client creation. See the core module for the delivery
+//! contract; the short version is that a callback fires after the commit is
+//! durable and the group lock is released, so it may publish the result of its
+//! merge from inside the callback.
+
+use napi::{bindgen_prelude::Promise, threadsafe_function::ThreadsafeFunction};
+use napi_derive::napi;
+use std::sync::Arc;
+use xmtp_mls::groups::change_callbacks::{
+  AppDataChange as RustAppDataChange, AppDataChangeCallback as RustAppDataChangeCallback,
+  UnstableChangeCallbacks as RustUnstableChangeCallbacks,
+};
+
+/// A change to a group's opaque `appData`, as observed after it was applied.
+#[napi(object)]
+pub struct AppDataChange {
+  /// The group whose `appData` changed, hex-encoded.
+  pub group_id: String,
+  /// Value before the change. `undefined` when nothing was set.
+  pub old_value: Option<String>,
+  /// Value after the change. `undefined` when the field was cleared.
+  pub new_value: Option<String>,
+}
+
+impl From<RustAppDataChange> for AppDataChange {
+  fn from(change: RustAppDataChange) -> Self {
+    Self {
+      group_id: hex::encode(change.group_id),
+      old_value: change.old_value,
+      new_value: change.new_value,
+    }
+  }
+}
+
+/// Unstable: the set of group-change callbacks to register on a client.
+///
+/// Only `appData` exists today. This is one object rather than a bare callback
+/// argument so callbacks for the other mutable fields (name, description,
+/// imageUrl, admin lists, permissions, disappearing settings) can be added as
+/// further optional constructor arguments — additive for existing callers.
+///
+/// A `#[napi]` class rather than an object because `ThreadsafeFunction` cannot
+/// be an object field (it is not `ToNapiValue`).
+#[napi]
+#[derive(Clone, Default)]
+pub struct UnstableChangeCallbacks {
+  app_data: Option<Arc<ThreadsafeFunction<AppDataChange, Promise<()>>>>,
+}
+
+#[napi]
+impl UnstableChangeCallbacks {
+  /// `appData` is called when a processed message changed the group's
+  /// `appData`. The returned promise is awaited before message processing
+  /// continues, so a semantic merge — including republishing via
+  /// `updateAppData` — can finish first. It fires for local changes as well as
+  /// remote ones, so the merge must be idempotent.
+  #[napi(
+    constructor,
+    ts_args_type = "appData?: (change: AppDataChange) => Promise<void>"
+  )]
+  pub fn new(app_data: Option<ThreadsafeFunction<AppDataChange, Promise<()>>>) -> Self {
+    Self {
+      app_data: app_data.map(Arc::new),
+    }
+  }
+}
+
+impl From<&UnstableChangeCallbacks> for RustUnstableChangeCallbacks {
+  fn from(callbacks: &UnstableChangeCallbacks) -> Self {
+    Self {
+      app_data: callbacks.app_data.clone().map(|cb| {
+        Arc::new(AppDataChangeBridge { callback: cb }) as Arc<dyn RustAppDataChangeCallback>
+      }),
+    }
+  }
+}
+
+/// Adapts a JS async function to the core callback trait.
+struct AppDataChangeBridge {
+  callback: Arc<ThreadsafeFunction<AppDataChange, Promise<()>>>,
+}
+
+#[xmtp_common::async_trait]
+impl RustAppDataChangeCallback for AppDataChangeBridge {
+  async fn on_app_data_changed(&self, change: RustAppDataChange) {
+    // A host callback that throws must not derail message processing — the
+    // commit is already durable by the time we get here, and the only sane
+    // recovery is to let the next change re-trigger the merge.
+    match self.callback.call_async(Ok(change.into())).await {
+      Ok(promise) => {
+        if let Err(err) = promise.await {
+          tracing::warn!("appData change callback rejected: {err}");
+        }
+      }
+      Err(err) => tracing::warn!("could not invoke appData change callback: {err}"),
+    }
+  }
+}

--- a/bindings/node/src/client/create_client.rs
+++ b/bindings/node/src/client/create_client.rs
@@ -1,6 +1,7 @@
 use crate::ErrorWrapper;
 use crate::client::Client;
 use crate::client::backend::Backend;
+use crate::client::change_callbacks::UnstableChangeCallbacks;
 use crate::client::gateway_auth::{AuthCallback, AuthHandle};
 use crate::client::options::{
   ClientMode, LogLevel, LogOptions, SyncWorkerMode, WorkerConfigOptions,
@@ -225,6 +226,7 @@ async fn create_client_inner(
   allow_offline: Option<bool>,
   app_version: Option<String>,
   nonce: u64,
+  change_callbacks: Option<&UnstableChangeCallbacks>,
 ) -> Result<Client> {
   // Install the rustls crypto provider explicitly rather than relying solely on the
   // `#[ctor::ctor(unsafe)]` in `xmtp_cryptography`, whose constructor link section does not run on
@@ -251,6 +253,10 @@ async fn create_client_inner(
 
   if let Some(worker_config) = worker_config {
     builder = builder.worker_config(worker_config.into());
+  }
+
+  if let Some(change_callbacks) = change_callbacks {
+    builder = builder.unstable_change_callbacks(change_callbacks.into());
   }
 
   let xmtp_client = builder
@@ -292,6 +298,7 @@ pub async fn create_client(
   auth_callback: Option<&AuthCallback>,
   auth_handle: Option<&AuthHandle>,
   client_mode: Option<ClientMode>,
+  change_callbacks: Option<&UnstableChangeCallbacks>,
 ) -> Result<Client> {
   let client_mode = client_mode.unwrap_or_default();
   init_logging(log_options.unwrap_or_default())?;
@@ -322,6 +329,7 @@ pub async fn create_client(
     allow_offline,
     app_version,
     nonce,
+    change_callbacks,
   )
   .await
 }
@@ -343,6 +351,7 @@ pub async fn create_client_with_backend(
   log_options: Option<LogOptions>,
   allow_offline: Option<bool>,
   nonce: Option<BigInt>,
+  change_callbacks: Option<&UnstableChangeCallbacks>,
 ) -> Result<Client> {
   init_logging(log_options.unwrap_or_default())?;
 
@@ -366,6 +375,7 @@ pub async fn create_client_with_backend(
     allow_offline,
     Some(backend.app_version()),
     nonce,
+    change_callbacks,
   )
   .await
 }

--- a/bindings/node/src/client/mod.rs
+++ b/bindings/node/src/client/mod.rs
@@ -11,6 +11,7 @@ use xmtp_mls::groups::MlsGroup;
 
 pub mod backend;
 mod catch_up;
+pub mod change_callbacks;
 mod consent_state;
 pub mod create_client;
 pub(crate) mod gateway_auth;

--- a/bindings/node/src/conversation/metadata.rs
+++ b/bindings/node/src/conversation/metadata.rs
@@ -129,7 +129,7 @@ impl Conversation {
     let group = self.create_mls_group();
 
     group
-      .update_app_data(options.value, None)
+      .update_app_data(options.value, options.expected_value)
       .await
       .map_err(ErrorWrapper::from)?;
 
@@ -146,4 +146,10 @@ impl Conversation {
 pub struct UpdateAppDataOptions {
   /// The new value for the group's opaque `APP_DATA` string slot.
   pub value: String,
+  /// Optional compare-and-swap guard. When set, the update is abandoned with
+  /// an `AppDataSuperseded` error — rather than overwriting — if the committed
+  /// value is no longer this, including when another member's commit wins the
+  /// race after this update was published. Omit for the historical
+  /// last-writer-wins behavior.
+  pub expected_value: Option<String>,
 }

--- a/bindings/node/src/test_utils.rs
+++ b/bindings/node/src/test_utils.rs
@@ -49,6 +49,7 @@ pub async fn create_local_toxic_client(
     None,
     None,
     None,
+    None,
   )
   .await?;
   Ok(TestClient { inner: c, proxy })


### PR DESCRIPTION
## Stack

Merge bottom-up — each PR is based on its parent below.
**Android is the priority path: #4019 → #4011 → #4012 → #4016.**

- #4019 db — `IntentState::Superseded` (base: `main`)
  - #4011 xmtp_mls — app-data change callbacks + compare-and-swap guard
    - #4012 bindings/mobile · **Android path**
      - #4016 sdks/android · **Android path**
      - #4015 sdks/ios
    - #4013 bindings/node ← this PR
      - #4017 sdks/js/node-sdk
    - #4014 bindings/wasm

Already merged: #4018 (proto regen). Related follow-up, independent of this stack: #4020.

---

Exposes the unstable app-data change callback to the node bindings.

## Shape

`UnstableChangeCallbacks` is a `#[napi]` class rather than an object, because `ThreadsafeFunction` is not `ToNapiValue` and so cannot be an object field. Its constructor takes the callbacks as optional arguments, so adding a handler for another mutable field later is an additional optional parameter — additive for existing TS callers.

```ts
new UnstableChangeCallbacks(async (change) => { /* merge */ })
```

The JS function returns a promise, which is awaited before message processing continues, so a semantic merge can finish before the next message is handled.

`group_id` is hex-encoded on this boundary, matching how the node bindings surface every other id.

## Error handling

A host callback that throws is logged and swallowed. The commit is already durable by the time the callback runs, so there is nothing to roll back; the only sane recovery is to let the next change re-trigger the merge. Propagating would abort message processing for a group over a host-side bug.

## Registration

A trailing `changeCallbacks` parameter on `createClient`, `createClientWithBackend`, and the shared inner constructor. `undefined` registers nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdY7WKkNbJmdzpmUWvW1my


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose app data change callbacks and compare-and-swap guard for group updates in Node bindings
> - Adds an `UnstableChangeCallbacks` registry (core, FFI, and Node/mobile/Android bindings) that lets callers register an async callback to receive `AppDataChange` notifications after a group's `app_data` commits, dispatched outside group locks.
> - Introduces an optional compare-and-swap guard to `update_app_data`: callers may supply an `expected_value`; if the committed value no longer matches at publish time, the intent is marked `Superseded` and a non-retryable `AppDataSuperseded` error is returned.
> - Adds `IntentState::Superseded` to the DB schema and intent state machine, with a new `set_group_intent_superseded` DB method that only transitions from `ToPublish`.
> - Callbacks are wired through `ClientBuilder` → `XmtpMlsLocalContext` → `XmtpSharedContext` trait and dispatched in `sync_with_conn` (after mutex release) and in the streaming `ProcessMessageFactory` path.
> - Risk: `AppDataSuperseded` is a new non-retryable error surface visible to all callers of `update_app_data`; existing callers must pass `None` as the new second argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 314ae86. 21 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


