### PR TITLE
feat(bindings_wasm): expose the app data change callback and update guard

### DIFF
--- a/bindings/wasm/src/client.rs
+++ b/bindings/wasm/src/client.rs
@@ -29,6 +29,7 @@ pub type RustXmtpClient = MlsClient<xmtp_mls::MlsContext>;
 pub type RustMlsGroup = MlsGroup<xmtp_mls::MlsContext>;
 
 pub mod backend;
+pub mod change_callbacks;
 pub mod gateway_auth;
 
 #[wasm_bindgen]
@@ -383,6 +384,7 @@ pub(crate) async fn create_client_inner(
   allow_offline: Option<bool>,
   app_version: Option<String>,
   nonce: u64,
+  change_callbacks: Option<change_callbacks::UnstableChangeCallbacks>,
 ) -> Result<Client, JsError> {
   let identity_strategy = IdentityStrategy::new(
     inbox_id,
@@ -404,6 +406,10 @@ pub(crate) async fn create_client_inner(
 
   if let Some(worker_config) = worker_config {
     builder = builder.worker_config(worker_config.into());
+  }
+
+  if let Some(change_callbacks) = change_callbacks {
+    builder = builder.unstable_change_callbacks(change_callbacks.into());
   }
 
   let xmtp_client = builder
@@ -438,6 +444,9 @@ pub async fn create_client(
   #[wasm_bindgen(js_name = authCallback)] auth_callback: Option<gateway_auth::AuthCallback>,
   #[wasm_bindgen(js_name = authHandle)] auth_handle: Option<gateway_auth::AuthHandle>,
   #[wasm_bindgen(js_name = clientMode)] client_mode: Option<ClientMode>,
+  #[wasm_bindgen(js_name = changeCallbacks)] change_callbacks: Option<
+    change_callbacks::UnstableChangeCallbacks,
+  >,
 ) -> Result<Client, JsError> {
   init_logging(log_options.unwrap_or_default())?;
   tracing::info!(host, gateway_host, "Creating client in rust");
@@ -469,6 +478,7 @@ pub async fn create_client(
     allow_offline,
     app_version,
     nonce.unwrap_or(1),
+    change_callbacks,
   )
   .await
 }

--- a/bindings/wasm/src/client/backend.rs
+++ b/bindings/wasm/src/client/backend.rs
@@ -118,6 +118,9 @@ pub async fn create_client_with_backend(
   #[wasm_bindgen(js_name = logOptions)] log_options: Option<super::LogOptions>,
   #[wasm_bindgen(js_name = allowOffline)] allow_offline: Option<bool>,
   nonce: Option<u64>,
+  #[wasm_bindgen(js_name = changeCallbacks)] change_callbacks: Option<
+    super::change_callbacks::UnstableChangeCallbacks,
+  >,
 ) -> Result<super::Client, JsError> {
   super::init_logging(log_options.unwrap_or_default())?;
 
@@ -140,6 +143,7 @@ pub async fn create_client_with_backend(
     allow_offline,
     Some(backend.app_version()),
     nonce.unwrap_or(1),
+    change_callbacks,
   )
   .await
 }

--- a/bindings/wasm/src/client/change_callbacks.rs
+++ b/bindings/wasm/src/client/change_callbacks.rs
@@ -1,0 +1,115 @@
+//! Unstable: wasm mirror of [`xmtp_mls::groups::change_callbacks`].
+//!
+//! Registered once, at client creation. See the core module for the delivery
+//! contract; the short version is that a callback fires after the commit is
+//! durable and the group lock is released, so it may publish the result of its
+//! merge from inside the callback.
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+use xmtp_mls::groups::change_callbacks::{
+  AppDataChange as RustAppDataChange, AppDataChangeCallback as RustAppDataChangeCallback,
+  UnstableChangeCallbacks as RustUnstableChangeCallbacks,
+};
+
+/// A change to a group's opaque `appData`, as observed after it was applied.
+#[derive(Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct AppDataChange {
+  /// The group whose `appData` changed, hex-encoded.
+  pub group_id: String,
+  /// Value before the change. Absent when nothing was set.
+  #[tsify(optional)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub old_value: Option<String>,
+  /// Value after the change. Absent when the field was cleared.
+  #[tsify(optional)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub new_value: Option<String>,
+}
+
+impl From<RustAppDataChange> for AppDataChange {
+  fn from(change: RustAppDataChange) -> Self {
+    Self {
+      group_id: hex::encode(change.group_id),
+      old_value: change.old_value,
+      new_value: change.new_value,
+    }
+  }
+}
+
+#[wasm_bindgen]
+extern "C" {
+  /// Notified when a processed message changed a group's `appData`.
+  ///
+  /// `onAppDataChanged` is awaited before message processing continues, so a
+  /// semantic merge — including republishing via `updateAppData` — can finish
+  /// first. It fires for local changes as well as remote ones, so the merge
+  /// must be idempotent.
+  pub type AppDataChangeCallback;
+
+  #[wasm_bindgen(catch, method, js_name = onAppDataChanged)]
+  pub async fn on_app_data_changed(
+    this: &AppDataChangeCallback,
+    change: JsValue,
+  ) -> Result<JsValue, JsValue>;
+}
+
+#[xmtp_common::async_trait]
+impl RustAppDataChangeCallback for AppDataChangeCallback {
+  async fn on_app_data_changed(&self, change: RustAppDataChange) {
+    let change: AppDataChange = change.into();
+    let value = match serde_wasm_bindgen::to_value(&change) {
+      Ok(value) => value,
+      Err(err) => {
+        tracing::warn!("could not serialize appData change for callback: {err}");
+        return;
+      }
+    };
+    // A host callback that throws must not derail message processing — the
+    // commit is already durable by the time we get here, and the only sane
+    // recovery is to let the next change re-trigger the merge.
+    if let Err(err) = self.on_app_data_changed(value).await {
+      tracing::warn!("appData change callback rejected: {err:?}");
+    }
+  }
+}
+
+/// Unstable: the set of group-change callbacks to register on a client.
+///
+/// Only `appData` exists today. This is one object rather than a bare callback
+/// argument so callbacks for the other mutable fields (name, description,
+/// imageUrl, admin lists, permissions, disappearing settings) can be added as
+/// further optional fields — additive for existing callers.
+#[wasm_bindgen]
+#[derive(Default)]
+pub struct UnstableChangeCallbacks {
+  app_data: Option<AppDataChangeCallback>,
+}
+
+#[wasm_bindgen]
+impl UnstableChangeCallbacks {
+  #[wasm_bindgen(constructor)]
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  #[wasm_bindgen(js_name = "appData")]
+  pub fn app_data(&mut self, callback: AppDataChangeCallback) {
+    self.app_data = Some(callback);
+  }
+}
+
+impl From<UnstableChangeCallbacks> for RustUnstableChangeCallbacks {
+  fn from(mut callbacks: UnstableChangeCallbacks) -> Self {
+    Self {
+      app_data: callbacks
+        .app_data
+        .take()
+        .map(|cb| Arc::new(cb) as Arc<dyn RustAppDataChangeCallback>),
+    }
+  }
+}

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -181,6 +181,14 @@ impl UnstableConversation {
 pub struct UpdateAppDataOptions {
   /// The new value for the group's opaque `APP_DATA` string slot.
   pub value: String,
+  /// Optional compare-and-swap guard. When set, the update is abandoned with
+  /// an `AppDataSuperseded` error — rather than overwriting — if the committed
+  /// value is no longer this, including when another member's commit wins the
+  /// race after this update was published. Omit for the historical
+  /// last-writer-wins behavior.
+  #[tsify(optional)]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub expected_value: Option<String>,
 }
 #[derive(Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
@@ -752,7 +760,7 @@ impl Conversation {
     let group = self.to_mls_group();
 
     group
-      .update_app_data(options.value, None)
+      .update_app_data(options.value, options.expected_value)
       .await
       .map_err(ErrorWrapper::js)?;
 

--- a/bindings/wasm/src/tests/mod.rs
+++ b/bindings/wasm/src/tests/mod.rs
@@ -36,6 +36,7 @@ pub async fn create_test_client(path: Option<String>) -> Client {
     None,
     None,
     None,
+    None,
   )
   .await
   .unwrap();
@@ -79,6 +80,7 @@ pub async fn create_auth_test_client(
     None,
     auth_callback,
     auth_handle,
+    None,
     None,
   )
   .await?;


### PR DESCRIPTION
## Stack

Merge bottom-up — each PR is based on its parent below.
**Android is the priority path: #4019 → #4011 → #4012 → #4016.**

- #4019 db — `IntentState::Superseded` (base: `main`)
  - #4011 xmtp_mls — app-data change callbacks + compare-and-swap guard
    - #4012 bindings/mobile · **Android path**
      - #4016 sdks/android · **Android path**
      - #4015 sdks/ios
    - #4013 bindings/node
      - #4017 sdks/js/node-sdk
    - #4014 bindings/wasm ← this PR

Already merged: #4018 (proto regen). Related follow-up, independent of this stack: #4020.

---

Exposes the unstable app-data change callback to the wasm bindings.

## Shape

`AppDataChangeCallback` is an `extern "C"` JS object with an async `onAppDataChanged` method — the same pattern as `AuthCallback` in `client/gateway_auth.rs`. `UnstableChangeCallbacks` is a `#[wasm_bindgen]` object with a setter per callback, mirroring `BackendBuilder::authCallback`, so handlers for the other mutable fields are added as further setters.

`group_id` is hex-encoded on this boundary, matching the rest of the wasm surface.

A host callback that rejects is logged and swallowed: the commit is already durable by the time it runs, so there is nothing to roll back, and aborting message processing over a host-side bug would be worse than letting the next change re-trigger the merge.

## Registration

A trailing `changeCallbacks` parameter on `createClient` and `createClientWithBackend`.

## browser-sdk is deliberately not wired up here

The browser SDK runs the client inside a Web Worker and passes client options across a structured clone, which cannot carry a function. Exposing this there needs a worker→main reverse-RPC that does not exist yet — today the worker only sends responses and stream events, never requests.

There is also a design question worth settling before building it: the callback is awaited from inside the worker's message-processing loop, so a slow or blocked main thread would stall sync for that client. That trade-off should be decided deliberately rather than inherited. Filed as a follow-up.

Anyone driving `@xmtp/wasm-bindings` directly can use this today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdY7WKkNbJmdzpmUWvW1my


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose app data change callbacks and guarded update support to WASM, mobile, and Node bindings
> - Adds `AppDataChangeCallback` trait and `UnstableChangeCallbacks` registry in the MLS core so hosts can receive async notifications when group `app_data` changes after commit.
> - Introduces a compare-and-swap guard on `update_app_data`: callers can pass an `expected_value`; mismatches fail fast locally or surface as `AppDataSuperseded` after an epoch race.
> - Adds a new `IntentState::Superseded` DB state for guarded intents that lose a race, marked non-retryable and distinct from `Error`.
> - Callbacks are dispatched after the per-group mutex is released (or off the sync path entirely for streaming) to prevent deadlocks; callbacks may republish into the same group safely.
> - Wires the full stack through FFI: WASM (`UnstableChangeCallbacks` JS class, `onAppDataChanged` extern), mobile UniFFI (`FfiUnstableChangeCallbacks`, `FfiAppDataChangeCallback`), Node (`update_app_data` passes `None` guard), and Android SDK (`Group.updateAppData` with optional `expectedAppData`).
> - Risk: `AppDataChangeCallback` and associated types are marked unstable; delivery semantics and API shape may change.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d7b4a09. 19 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


