### PR TITLE
feat(android-sdk): surface app data change callbacks and the update guard

### DIFF
--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -60,6 +60,11 @@ data class ClientOptions(
     val forkRecoveryOptions: ForkRecoveryOptions? = null,
     val dbPoolOptions: DbPoolOptions? = null,
     val waitForRegistrationVisible: VisibilityConfirmationOptions? = null,
+    /**
+     * Unstable: notifications for group state changes, for clients that
+     * reconcile a group's `appData` themselves. See [UnstableChangeCallbacks].
+     */
+    val unstableChangeCallbacks: UnstableChangeCallbacks? = null,
 ) {
     data class Api(
         val env: XMTPEnvironment = XMTPEnvironment.DEV,
@@ -369,6 +374,9 @@ class Client(
                         allowOffline = false,
                         forkRecoveryOpts = null,
                         workerConfig = null,
+                        // Identity-probe client: never processes messages, so
+                        // nothing to notify about.
+                        changeCallbacks = null,
                     )
 
                 useClient(ffiClient)
@@ -595,6 +603,7 @@ class Client(
                             allowOffline = buildOffline,
                             forkRecoveryOpts = options.forkRecoveryOptions?.toFfi(),
                             workerConfig = null,
+                            changeCallbacks = options.unstableChangeCallbacks?.toFfi(),
                         )
                     return@withContext Pair(ffiClient, IN_MEMORY_DB_PATH)
                 }
@@ -640,6 +649,7 @@ class Client(
                         allowOffline = buildOffline,
                         forkRecoveryOpts = options.forkRecoveryOptions?.toFfi(),
                         workerConfig = null,
+                        changeCallbacks = options.unstableChangeCallbacks?.toFfi(),
                     )
                 Pair(ffiClient, dbPath)
             }

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -614,14 +614,29 @@ class Group(
             }
         }
 
-    suspend fun updateAppData(appData: String) =
-        withContext(Dispatchers.IO) {
-            try {
-                libXMTPGroup.updateAppData(FfiUpdateAppDataOptions(value = appData))
-            } catch (e: Exception) {
-                throw XMTPException("Permission denied: Unable to update group app data", e)
-            }
+    /**
+     * Set the group's opaque `appData`.
+     *
+     * [expectedAppData] is an optional compare-and-swap guard. When provided,
+     * the update is abandoned — rather than overwriting — if the committed
+     * value is no longer that, including when another member's commit wins the
+     * race after this update was published. Callers reconciling structured
+     * state should pass the value they merged against, so a concurrent write
+     * surfaces as an error instead of silently discarding someone else's
+     * change. Omit it for last-writer-wins.
+     */
+    suspend fun updateAppData(
+        appData: String,
+        expectedAppData: String? = null,
+    ) = withContext(Dispatchers.IO) {
+        try {
+            libXMTPGroup.updateAppData(
+                FfiUpdateAppDataOptions(value = appData, expectedValue = expectedAppData),
+            )
+        } catch (e: Exception) {
+            throw XMTPException("Permission denied: Unable to update group app data", e)
         }
+    }
 
     /**
      * Pre-release APIs, grouped under [UnstableGroup]. The `@UnstableApi`

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/UnstableChangeCallbacks.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/UnstableChangeCallbacks.kt
@@ -1,0 +1,75 @@
+package org.xmtp.android.library
+
+import uniffi.xmtpv3.FfiAppDataChange
+import uniffi.xmtpv3.FfiAppDataChangeCallback
+import uniffi.xmtpv3.FfiUnstableChangeCallbacks
+
+/**
+ * A change to a group's opaque `appData`, as observed after it was applied.
+ */
+data class AppDataChange(
+    /** The group whose `appData` changed, hex-encoded. */
+    val groupId: String,
+    /** Value before the change. `null` when nothing was set. */
+    val oldValue: String?,
+    /** Value after the change. `null` when the field was cleared. */
+    val newValue: String?,
+)
+
+/**
+ * Notified when a processed message changed a group's `appData`.
+ *
+ * [onAppDataChanged] is awaited before message processing continues, so a
+ * semantic merge — including republishing via `Group.updateAppData` — can
+ * finish first. It fires for changes this client made as well as remote ones,
+ * so the merge must be idempotent.
+ */
+interface AppDataChangeHandler {
+    suspend fun onAppDataChanged(change: AppDataChange)
+}
+
+/**
+ * Unstable: the set of group-change callbacks to register on a client.
+ *
+ * Only [appData] exists today. This is one class rather than a bare callback so
+ * handlers for the other mutable fields (name, description, image url, admin
+ * lists, permissions, disappearing settings) can be added as further defaulted
+ * properties — additive for existing callers.
+ *
+ * Registered at client creation via [ClientOptions.unstableChangeCallbacks],
+ * because the changes it reports arrive from the stream and sync paths, where
+ * no SDK call is on the stack to carry them.
+ *
+ * Pre-release: the shape of the payloads and of this class may change without a
+ * major version bump until it graduates.
+ */
+data class UnstableChangeCallbacks(
+    val appData: AppDataChangeHandler? = null,
+) {
+    /**
+     * `null` when nothing is registered, so the core never pays for the
+     * before/after snapshot on the message-processing path.
+     */
+    fun toFfi(): FfiUnstableChangeCallbacks? {
+        val handler = appData ?: return null
+        return FfiUnstableChangeCallbacks(appData = FfiAppDataChangeHandlerBridge(handler))
+    }
+}
+
+/**
+ * Adapts the SDK-level [AppDataChangeHandler] to the generated FFI interface,
+ * keeping [FfiAppDataChange] out of the public surface.
+ */
+private class FfiAppDataChangeHandlerBridge(
+    private val handler: AppDataChangeHandler,
+) : FfiAppDataChangeCallback {
+    override suspend fun onAppDataChanged(change: FfiAppDataChange) {
+        handler.onAppDataChanged(
+            AppDataChange(
+                groupId = change.groupId.toHex(),
+                oldValue = change.oldValue,
+                newValue = change.newValue,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Stack

Merge bottom-up — each PR is based on its parent below.
**Android is the priority path: #4019 → #4011 → #4012 → #4016.**

- #4019 db — `IntentState::Superseded` (base: `main`)
  - #4011 xmtp_mls — app-data change callbacks + compare-and-swap guard
    - #4012 bindings/mobile · **Android path**
      - #4016 sdks/android · **Android path** ← this PR
      - #4015 sdks/ios
    - #4013 bindings/node
      - #4017 sdks/js/node-sdk
    - #4014 bindings/wasm

Already merged: #4018 (proto regen). Related follow-up, independent of this stack: #4020.

---

Surfaces the unstable app-data change callback on the Android SDK.

## Public surface

```kotlin
ClientOptions(
    appContext = context,
    dbEncryptionKey = key,
    unstableChangeCallbacks = UnstableChangeCallbacks(appData = MyReconciler()),
)
```

`unstableChangeCallbacks` defaults to `null`, so this is source-compatible for every existing caller.

`AppDataChangeHandler` is an SDK-level interface with a `suspend fun` taking an `AppDataChange` with a hex `groupId`; a private bridge adapts it to the generated `FfiAppDataChangeCallback` so `FfiAppDataChange` stays out of the public surface. `toFfi()` returns `null` when nothing is registered, so a client that does not use this never pays for the before/after snapshot on the message-processing path.

The identity-probe client passes `null` explicitly — it never processes messages, so there is nothing to notify about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdY7WKkNbJmdzpmUWvW1my


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface app data change callbacks and update guard in Android SDK
> - Adds [`UnstableChangeCallbacks`](https://github.com/xmtp/libxmtp/pull/4016/files#diff-e0709bec217caa9c2f1f8d25a313a0fcb300bb5ccb187967a0363085c5b9ad33) with `AppDataChangeHandler` interface and FFI bridge, allowing callers to receive notifications when a group's `appData` changes.
> - Extends `ClientOptions` with an optional `unstableChangeCallbacks` field; callbacks are forwarded to the FFI client on construction for both in-memory and persistent DB clients (identity-probe client explicitly skips them).
> - Adds an optional `expectedAppData` parameter to `Group.updateAppData` implementing a compare-and-swap guard — the core rejects the update if the committed value differs from the expected value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c072dae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


