### PR TITLE
feat(node-sdk): surface app data change callbacks and the update guard

### DIFF
--- a/sdks/js/node-sdk/src/Group.ts
+++ b/sdks/js/node-sdk/src/Group.ts
@@ -93,9 +93,19 @@ export class Group<ContentTypes = unknown> extends Conversation<ContentTypes> {
    * Updates the group's app data (max 8192 bytes)
    *
    * @param appData The new app data for the group
+   * @param expectedAppData Optional compare-and-swap guard. When provided, the
+   * update is abandoned — rather than overwriting — if the committed value is
+   * no longer this, including when another member's commit wins the race after
+   * this update was published. Callers reconciling structured state should
+   * pass the value they merged against, so a concurrent write surfaces as an
+   * error instead of silently discarding someone else's change. Omit for
+   * last-writer-wins.
    */
-  async updateAppData(appData: string) {
-    return this.#conversation.updateAppData({ value: appData });
+  async updateAppData(appData: string, expectedAppData?: string) {
+    return this.#conversation.updateAppData({
+      value: appData,
+      expectedValue: expectedAppData,
+    });
   }
 
   /**

--- a/sdks/js/node-sdk/src/index.ts
+++ b/sdks/js/node-sdk/src/index.ts
@@ -18,6 +18,7 @@ export type {
   Action,
   Actions,
   ApiStats,
+  AppDataChange,
   ArchiveMetadata,
   ArchiveOptions,
   Attachment,

--- a/sdks/js/node-sdk/src/types.ts
+++ b/sdks/js/node-sdk/src/types.ts
@@ -1,6 +1,7 @@
 import type { ContentCodec } from "@xmtp/content-type-primitives";
 import {
   type Actions,
+  type AppDataChange,
   type Attachment,
   type Backend,
   type ContentTypeId,
@@ -195,6 +196,23 @@ export type OtherOptions = {
    * to confirm the registration before resolving.
    */
   waitForRegistrationVisible?: VisibilityConfirmationOptions;
+  /**
+   * Unstable: notifications for group state changes, for clients that
+   * reconcile a group's `appData` themselves.
+   *
+   * Only `appData` exists today; callbacks for the other mutable fields will
+   * be added as further optional properties. Registered at client creation
+   * because the changes they report arrive from the stream and sync paths,
+   * where no SDK call is on the stack to carry them.
+   *
+   * The `appData` callback is awaited before message processing continues, so
+   * a semantic merge — including republishing via `updateAppData` — can finish
+   * first. It fires for changes this client made as well as remote ones, so
+   * the merge must be idempotent.
+   */
+  unstableChangeCallbacks?: {
+    appData?: (change: AppDataChange) => Promise<void>;
+  };
 };
 
 export type ClientOptions = (NetworkOptions | { backend: Backend }) &

--- a/sdks/js/node-sdk/src/utils/createClient.ts
+++ b/sdks/js/node-sdk/src/utils/createClient.ts
@@ -4,6 +4,7 @@ import {
   createClientWithBackend,
   LogLevel,
   SyncWorkerMode,
+  UnstableChangeCallbacks,
   type Backend,
   type Identifier,
   type LogOptions,
@@ -89,6 +90,12 @@ export const createClient = async (
     ? Buffer.from(options.dbEncryptionKey.replace(/^0x/, ""), "hex")
     : options?.dbEncryptionKey;
 
+  // Only build the registry when something is actually registered — an empty
+  // one would make the core snapshot app_data on every processed message.
+  const changeCallbacks = options?.unstableChangeCallbacks?.appData
+    ? new UnstableChangeCallbacks(options.unstableChangeCallbacks.appData)
+    : undefined;
+
   const client = await createClientWithBackend(
     backend,
     {
@@ -105,6 +112,7 @@ export const createClient = async (
     logOptions,
     undefined, // allowOffline
     options?.nonce,
+    changeCallbacks,
   );
 
   return { client, env };


### PR DESCRIPTION
## Stack

Merge bottom-up — each PR is based on its parent below.
**Android is the priority path: #4019 → #4011 → #4012 → #4016.**

- #4019 db — `IntentState::Superseded` (base: `main`)
  - #4011 xmtp_mls — app-data change callbacks + compare-and-swap guard
    - #4012 bindings/mobile · **Android path**
      - #4016 sdks/android · **Android path**
      - #4015 sdks/ios
    - #4013 bindings/node
      - #4017 sdks/js/node-sdk ← this PR
    - #4014 bindings/wasm

Already merged: #4018 (proto regen). Related follow-up, independent of this stack: #4020.

---

Surfaces the unstable app-data change callback on the node SDK.

## Public surface

```ts
const client = await Client.create(signer, {
  unstableChangeCallbacks: {
    appData: async (change) => { /* merge and republish */ },
  },
});
```

The registry is an optional object rather than a bare callback, so handlers for the other mutable fields land as further optional properties.

The binding-level `UnstableChangeCallbacks` is only constructed when a handler is actually supplied — an empty registry would make the core snapshot `app_data` on every processed message for no benefit.

`AppDataChange` is re-exported from the SDK root so callers can type their handler.

## Not included

browser-sdk. It runs the client in a Web Worker and passes options across a structured clone, which cannot carry a function; wiring it needs a worker→main reverse-RPC that does not exist yet, plus a decision on whether awaiting the main thread from inside the worker's processing loop is an acceptable stall risk. See #4014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdY7WKkNbJmdzpmUWvW1my


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface app data change callbacks and compare-and-swap update guard in the Node SDK
> - Adds `UnstableChangeCallbacks` to the Node bindings, letting JS callers register an async `appData` change callback at client creation time via `OtherOptions.unstableChangeCallbacks.appData`.
> - Introduces `AppDataChange` (carrying `group_id`, `old_value`, `new_value`) as a JS-visible type exported from the SDK.
> - Bridges JS callbacks to the core client via a `ThreadsafeFunction`; callback failures are logged and do not abort message processing.
> - Extends `Group.updateAppData` and `UpdateAppDataOptions` to accept an optional `expectedValue`/`expectedAppData` for compare-and-swap semantics on opaque app data.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized db23929. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


