### PR TITLE
feat(xmtp_db): add IntentState::Superseded for abandoned guarded intents

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_intent.rs
@@ -130,6 +130,12 @@ pub enum IntentState {
     Committed = 3,
     Error = 4,
     Processed = 5,
+    /// Abandoned before publishing because its compare-and-swap guard no
+    /// longer matched the committed state — another member changed the field
+    /// first. Terminal and distinct from [`IntentState::Error`]: nothing went
+    /// wrong, the write is simply stale, and the caller is expected to
+    /// re-derive it from the value that actually landed and queue again.
+    Superseded = 6,
 }
 
 #[derive(Queryable, Identifiable, PartialEq, Clone)]
@@ -271,6 +277,10 @@ pub trait QueryGroupIntent {
     // Set the intent with the given ID to `Committed`
     fn set_group_intent_processed(&self, intent_id: ID) -> Result<(), StorageError>;
 
+    /// Set the intent with the given ID to `Superseded` — abandoned because its
+    /// compare-and-swap guard no longer matches the committed state.
+    fn set_group_intent_superseded(&self, intent_id: ID) -> Result<(), StorageError>;
+
     // Set the intent with the given ID to `ToPublish`. Wipe any values for `payload_hash` and
     // `post_commit_data`
     fn set_group_intent_to_publish(&self, intent_id: ID) -> Result<(), StorageError>;
@@ -347,6 +357,10 @@ where
 
     fn set_group_intent_processed(&self, intent_id: ID) -> Result<(), StorageError> {
         (**self).set_group_intent_processed(intent_id)
+    }
+
+    fn set_group_intent_superseded(&self, intent_id: ID) -> Result<(), StorageError> {
+        (**self).set_group_intent_superseded(intent_id)
     }
 
     fn set_group_intent_to_publish(&self, intent_id: ID) -> Result<(), StorageError> {
@@ -490,6 +504,30 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
         // If nothing matched the query, return an error. Either ID or state was wrong
         if rows_changed == 0 {
             return Err(NotFound::IntentForCommitted(intent_id).into());
+        }
+
+        Ok(())
+    }
+
+    /// Mark the intent abandoned because its compare-and-swap guard no longer
+    /// matches. Terminal, and deliberately not `Error`: the caller needs to
+    /// tell a stale write apart from a genuine failure.
+    #[tracing::instrument(level = "debug", skip(self))]
+    fn set_group_intent_superseded(&self, intent_id: ID) -> Result<(), StorageError> {
+        let rows_changed = self.raw_query(|conn| {
+            diesel::update(dsl::group_intents)
+                .filter(dsl::id.eq(intent_id))
+                // State machine requires that the only valid state transition to
+                // Superseded is from ToPublish. The guard is evaluated at publish
+                // time, so without this filter a racing caller could abandon an
+                // intent that had already been published or committed.
+                .filter(dsl::state.eq(IntentState::ToPublish))
+                .set(dsl::state.eq(IntentState::Superseded))
+                .execute(conn)
+        })?;
+
+        if rows_changed == 0 {
+            return Err(NotFound::IntentForToPublish(intent_id).into());
         }
 
         Ok(())
@@ -721,6 +759,7 @@ where
             3 => Ok(IntentState::Committed),
             4 => Ok(IntentState::Error),
             5 => Ok(IntentState::Processed),
+            6 => Ok(IntentState::Superseded),
             x => Err(format!("Unrecognized variant {}", x).into()),
         }
     }

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -299,6 +299,11 @@ mock! {
             intent_id: crate::group_intent::ID,
         ) -> Result<(), StorageError>;
 
+        fn set_group_intent_superseded(
+            &self,
+            intent_id: crate::group_intent::ID,
+        ) -> Result<(), StorageError>;
+
         fn set_group_intent_to_publish(
             &self,
             intent_id: crate::group_intent::ID,

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2445,6 +2445,14 @@ where
                             tracing::debug!("Intent [{}] moved to Processed status", intent_id);
                             db.set_group_intent_processed(intent_id)?;
                         }
+                        IntentState::Superseded => {
+                            // Supersession is decided at publish time, before
+                            // an intent has a message to process, so no
+                            // resolution path returns it here.
+                            tracing::error!(
+                                "Unexpected behaviour: returned intent state superseded from process_own_message"
+                            );
+                        }
                     }
                     Ok(Continue(intent_error))
                 })


### PR DESCRIPTION
## Stack

Merge bottom-up — each PR is based on its parent below.
**Android is the priority path: #4019 → #4011 → #4012 → #4016.**

- #4019 db — `IntentState::Superseded` (base: `main`) ← this PR
  - #4011 xmtp_mls — app-data change callbacks + compare-and-swap guard
    - #4012 bindings/mobile · **Android path**
      - #4016 sdks/android · **Android path**
      - #4015 sdks/ios
    - #4013 bindings/node
      - #4017 sdks/js/node-sdk
    - #4014 bindings/wasm

Already merged: #4018 (proto regen). Related follow-up, independent of this stack: #4020.

---

Adds `IntentState::Superseded`, a terminal state for an intent abandoned before publishing because its compare-and-swap guard no longer matched the committed value.

## Why a new state rather than reusing `Error`

`sync_until_intent_resolved` maps `IntentState::Error` to a generic `GroupError::Sync`. A caller cannot tell "another member changed the field first, re-derive and retry" from "the network is down" — and those want opposite reactions. Immediately republishing is right for the first and wrong for the second.

`Processed` is equally unusable: it reads as success, so the caller would be told a write landed that never did.

So the state has to be distinct. `Superseded` is terminal, carries no error semantics, and `update_app_data` translates it into a typed `AppDataSuperseded` error in the next PR.

## Compatibility

New variant, value `6`. The column is a plain integer and nothing migrates, but note this is one-way for local databases: a client old enough not to know the variant fails to deserialize an intent row written as `Superseded`. That is the same constraint every prior `IntentState` addition carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdY7WKkNbJmdzpmUWvW1my


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `IntentState::Superseded` for intents abandoned due to CAS guard mismatch
> - Adds a new terminal `IntentState::Superseded` (value `6`) to represent group intents abandoned when a compare-and-swap guard fails during publish.
> - Adds `set_group_intent_superseded` to `QueryGroupIntent`, which transitions an intent to `Superseded` only from `ToPublish` state; returns `NotFound::IntentForToPublish` otherwise.
> - Extends `FromSql` deserialization to map integer `6` to `Superseded` instead of erroring.
> - In `mls_sync`, a `Superseded` outcome from `process_own_message` now logs an error and takes no further action.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43d1402.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


