### PR TITLE
fix(xmtp_mls): defer unknown task kinds instead of deleting them

### DIFF
--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -19,6 +19,11 @@ use xmtp_proto::{
     xmtp::mls::database::Task as TaskProto,
 };
 
+/// How far out to push a task whose kind this build does not understand. Long
+/// enough that an old client sharing the database does not spin on it, short
+/// enough that a newer client picks it up soon after it starts.
+const UNKNOWN_TASK_DEFER_NS: i64 = 60 * 60 * 1_000_000_000;
+
 /// `Done` = one-shot, row deleted. `RescheduleAt(ns)` = recurring, row kept and
 /// advanced to that absolute deadline.
 #[derive(Debug, PartialEq, Eq)]
@@ -445,13 +450,18 @@ where
             Some(xmtp_proto::xmtp::mls::database::task::Task::KpLiveness(_)) => {
                 // The variant exists in the regenerated protos but nothing in
                 // this crate schedules it yet, so a row can only appear from a
-                // newer client sharing this database. Drop it rather than
-                // retrying forever; the owning feature will add real handling.
+                // newer client sharing this database. Leave it for that client
+                // rather than deleting it: falling through to `Done` would drop
+                // work this build simply cannot see, and the owning feature will
+                // add real handling. `expires_at_ns` still bounds how long an
+                // unclaimed row can sit here, so deferring cannot leak rows.
                 tracing::warn!(
-                    "Task {} is a KpLiveness task, which this version does not handle. Deleting.",
+                    "Task {} is a KpLiveness task, which this version does not handle. Deferring.",
                     task.id
                 );
-                context.db().delete_task(task.id)?;
+                return Ok(TaskOutcome::RescheduleAt(
+                    xmtp_common::time::now_ns() + UNKNOWN_TASK_DEFER_NS,
+                ));
             }
             None => {
                 tracing::error!("Task {} has no data. Deleting.", task.id);


### PR DESCRIPTION
Follow-up to #4018, addressing a Macroscope finding raised on #4011.

#4018 added a `KpLiveness` arm to `run_task` for the task variant the proto regen introduced. Nothing in this crate schedules that kind yet, so the arm deleted the row.

A row of an unknown kind can only appear one way: a **newer** client wrote it into a database this build also opens. Deleting it discards work that newer client still expects to run, and it is not recoverable — the scheduling decision lived in the row.

Reschedule instead. The row survives for whichever client understands it, and `expires_at_ns` (checked at the top of `run_and_reschedule_task`) still bounds how long an unclaimed row can sit there, so an old client running alone cannot accumulate them.

One hour was picked so an old client sharing the database wakes on it rarely, while a newer client still picks it up promptly after a restart.

Independent of the app-data callback stack — it touches only `worker/tasks.rs` and is based directly on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdY7WKkNbJmdzpmUWvW1my

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer unknown task kinds instead of deleting them in MLS worker
> Previously, unrecognized task kinds (such as `KpLiveness` in older builds) were deleted when encountered. Now they are rescheduled 1 hour into the future using a new `UNKNOWN_TASK_DEFER_NS` constant, preserving tasks for future processing by a compatible build.
>
> Behavioral Change: unknown tasks are no longer permanently deleted; they persist and retry every hour until a build that recognizes them is deployed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38ff2e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->