### PR TITLE
perf(xmtp_mls): read group metadata from GroupContext, not a full MlsGroup load

### DIFF
--- a/crates/xmtp_db/Cargo.toml
+++ b/crates/xmtp_db/Cargo.toml
@@ -63,6 +63,10 @@ libsqlite3-sys = { version = "0.35", features = [
 ] }
 diesel = { workspace = true, features = ["r2d2"] }
 dyn-clone.workspace = true
+# Only pulled in under `test-utils` — powers the task-local KV read counter used
+# by the metadata read-amplification test. Already present transitively via
+# xmtp-workspace-hack, so this adds nothing to production builds.
+tokio = { workspace = true, optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 sqlite-wasm-rs = { version = "0.5", default-features = false }
@@ -102,6 +106,7 @@ test-utils = [
   "xmtp_common/test-utils",
   "dep:mockall",
   "dep:ascii_table",
+  "dep:tokio",
   "xmtp_configuration/test-utils",
   "xmtp_cryptography/test-utils",
   "xmtp_proto/test-utils",

--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -87,6 +87,46 @@ pub struct SqlKeyStore<T> {
     conn: T,
 }
 
+// Test-only instrumentation (compiled out of release/production builds): counts
+// openmls KV read round-trips (`select_query`) so the metadata
+// read-amplification fix can be measured. Every `read`/`read_list`/
+// `group_context` bottoms out in `select_query`, so this is the single point
+// that observes an actual storage read.
+//
+// The counter is a **tokio task-local**, established for the duration of a
+// [`count_kv_reads`] call. Being task-scoped (not thread- or process-scoped) it
+// follows the measured work across `.await` points and across worker threads on
+// a multi-threaded runtime, and stays isolated from any other concurrently
+// running task. Reads performed outside a `count_kv_reads` scope — production
+// code and unrelated tests — are ignored, so the measurement is deterministic
+// regardless of runtime flavor or whether the measured accessors are sync or
+// async.
+// Native-only: the sole consumer is the native metadata read-amplification test,
+// and the task-local relies on the (native-only) `tokio` dep enabled by
+// `test-utils`.
+#[cfg(all(any(test, feature = "test-utils"), not(target_arch = "wasm32")))]
+tokio::task_local! {
+    static KV_READS: std::cell::Cell<u64>;
+}
+
+/// Record one KV read round-trip against the enclosing [`count_kv_reads`] scope.
+/// Outside such a scope this is a no-op.
+#[cfg(all(any(test, feature = "test-utils"), not(target_arch = "wasm32")))]
+fn record_kv_read() {
+    let _ = KV_READS.try_with(|c| c.set(c.get() + 1));
+}
+
+/// Run `f` with a fresh KV-read counter scoped to the current task and return
+/// its result together with the number of `select_query` round-trips it made.
+#[cfg(all(any(test, feature = "test-utils"), not(target_arch = "wasm32")))]
+pub fn count_kv_reads<R>(f: impl FnOnce() -> R) -> (R, u64) {
+    KV_READS.sync_scope(std::cell::Cell::new(0), || {
+        let result = f();
+        let count = KV_READS.with(|c| c.get());
+        (result, count)
+    })
+}
+
 impl<A> SqlKeyStore<A> {
     pub fn new(conn: A) -> Self {
         Self { conn }
@@ -112,6 +152,8 @@ where
         &self,
         storage_key: &Vec<u8>,
     ) -> Result<Vec<StorageData>, crate::ConnectionError> {
+        #[cfg(all(any(test, feature = "test-utils"), not(target_arch = "wasm32")))]
+        record_kv_read();
         self.conn.raw_query(|conn| {
             sql_query(SELECT_QUERY)
                 .bind::<diesel::sql_types::Binary, _>(&storage_key)

--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -329,13 +329,13 @@ pub(crate) fn component_id_to_metadata_field(id: ComponentId) -> Option<Metadata
 /// extensions (translated into the new app-data wire format on the fly).
 pub(crate) fn read_component_bytes(
     id: ComponentId,
-    mls_group: &OpenMlsGroup,
+    extensions: &Extensions<GroupContext>,
     proposals_enabled: bool,
 ) -> Result<Option<Vec<u8>>, ComponentSourceError> {
     if proposals_enabled {
-        Ok(read_from_app_data_dict(id, mls_group))
+        Ok(read_from_app_data_dict_from_extensions(id, extensions))
     } else {
-        read_from_legacy(id, mls_group.extensions())
+        read_from_legacy(id, extensions)
     }
 }
 
@@ -448,11 +448,20 @@ pub(crate) fn read_from_app_data_dict(
     id: ComponentId,
     mls_group: &OpenMlsGroup,
 ) -> Option<Vec<u8>> {
-    let openmls_id: openmls::component::ComponentId = id.as_u16();
-    mls_group
-        .extensions()
+    read_from_app_data_dict_from_extensions(id, mls_group.extensions())
+}
+
+/// Extensions-only counterpart of [`read_from_app_data_dict`] — reads the
+/// component's bytes straight from a group's `GroupContext` extensions, with no
+/// full `OpenMlsGroup`. openmls keys the dictionary by its own `ComponentId`,
+/// which is just a `u16` alias, so `id.as_u16()` unwraps our newtype to the key.
+pub(crate) fn read_from_app_data_dict_from_extensions(
+    id: ComponentId,
+    extensions: &Extensions<GroupContext>,
+) -> Option<Vec<u8>> {
+    extensions
         .app_data_dictionary()
-        .and_then(|ext| ext.dictionary().get(&openmls_id))
+        .and_then(|ext| ext.dictionary().get(&id.as_u16()))
         .map(|bytes| bytes.to_vec())
 }
 
@@ -750,6 +759,24 @@ pub(crate) fn extract_group_mutable_metadata_capability_aware(
         Ok(base)
     } else {
         Ok(GroupMutableMetadata::try_from(mls_group)?)
+    }
+}
+
+/// Same as [`extract_group_mutable_metadata_capability_aware`], but driven from
+/// the group's `GroupContext` extensions alone — no full `OpenMlsGroup::load`.
+/// The mutable metadata lives entirely in the context extensions, so a single
+/// `StorageProvider::group_context` read (one KV round-trip, no ratchet tree)
+/// is all this needs.
+pub(crate) fn extract_group_mutable_metadata_capability_aware_from_extensions(
+    extensions: &Extensions<GroupContext>,
+) -> Result<GroupMutableMetadata, ComponentSourceError> {
+    if super::is_migrated_extensions(extensions) {
+        let mut base =
+            GroupMutableMetadata::new(std::collections::HashMap::new(), Vec::new(), Vec::new());
+        merge_app_data_into_mutable_metadata_from_extensions(&mut base, extensions)?;
+        Ok(base)
+    } else {
+        Ok(GroupMutableMetadata::try_from(extensions)?)
     }
 }
 

--- a/crates/xmtp_mls/src/groups/app_data/typed_facade.rs
+++ b/crates/xmtp_mls/src/groups/app_data/typed_facade.rs
@@ -1,7 +1,7 @@
 //! Typed read facade over an OpenMLS group's AppData dictionary.
 //!
-//! [`MlsGroupAppData`] borrows an `&OpenMlsGroup` and exposes typed,
-//! per-component reads via [`MlsGroupAppData::get`]. Write paths
+//! [`MlsGroupAppData`] borrows a group's `GroupContext` extensions and
+//! exposes typed, per-component reads via [`MlsGroupAppData::get`]. Write paths
 //! continue to use the existing intent infrastructure (`mls_sync.rs`)
 //! plus `stage_app_data_propose_and_commit`; this facade is for callers
 //! that need a single typed value (e.g. permissions checks, registry
@@ -15,35 +15,35 @@
 //! groups (post-bootstrap) the dict is authoritative. Either way the
 //! caller gets `C::Value` decoded — no manual capability switching.
 
-use openmls::group::MlsGroup as OpenMlsGroup;
+use openmls::extensions::Extensions;
+use openmls::group::GroupContext;
 use xmtp_mls_common::app_data::typed::Component;
 
 use super::component_source::{ComponentSourceError, read_component_bytes};
-use super::is_migrated_group;
+use super::is_migrated_extensions;
 
 /// A typed view over a group's AppData state.
 ///
-/// Holds nothing but the borrow + the migration flag. Cheap to
-/// construct; intended to be created locally inside a
-/// `load_mls_group_with_lock` closure and discarded.
+/// Holds nothing but a borrow of the group's `GroupContext` extensions
+/// plus the migration flag. All AppData lives in those extensions, so
+/// this deliberately does **not** need a full `OpenMlsGroup` (which would
+/// pull the ratchet tree and secrets) — a `StorageProvider::group_context`
+/// read is enough. Cheap to construct; discarded after use.
 pub(crate) struct MlsGroupAppData<'g> {
-    group: &'g OpenMlsGroup,
+    extensions: &'g Extensions<GroupContext>,
     proposals_enabled: bool,
 }
 
 impl<'g> MlsGroupAppData<'g> {
-    /// Wrap an `&OpenMlsGroup` for typed AppData reads.
+    /// Wrap a group's `GroupContext` extensions for typed AppData reads.
     ///
-    /// **Construct under the same `load_mls_group_with_lock` closure
-    /// that consumes the facade.** The cached `proposals_enabled`
-    /// flag is read once at construction, so a facade that outlives
-    /// the lock could observe a stale migration state on a subsequent
-    /// `get` call. In practice every call site lives inside one
-    /// closure and discards the facade at the end.
-    pub(crate) fn new(group: &'g OpenMlsGroup) -> Self {
-        let proposals_enabled = is_migrated_group(group);
+    /// The cached `proposals_enabled` flag is read once at construction
+    /// from the same extensions snapshot, so every `get` observes a
+    /// single consistent view.
+    pub(crate) fn new(extensions: &'g Extensions<GroupContext>) -> Self {
+        let proposals_enabled = is_migrated_extensions(extensions);
         Self {
-            group,
+            extensions,
             proposals_enabled,
         }
     }
@@ -56,7 +56,7 @@ impl<'g> MlsGroupAppData<'g> {
     /// Returns `Err` for transport-level (read) or codec-level
     /// (decode) failures.
     pub(crate) fn get<C: Component>(&self) -> Result<Option<C::Value>, ComponentSourceError> {
-        let bytes = read_component_bytes(C::ID, self.group, self.proposals_enabled)?;
+        let bytes = read_component_bytes(C::ID, self.extensions, self.proposals_enabled)?;
         match bytes {
             Some(b) => Ok(Some(C::decode_value(&b)?)),
             None => Ok(None),

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2376,7 +2376,7 @@ where
     fn read_app_data_slot(mls_group: &OpenMlsGroup) -> Option<Option<String>> {
         use xmtp_mls_common::app_data::components::metadata_attributes::AppDataComponent;
 
-        super::app_data::typed_facade::MlsGroupAppData::new(mls_group)
+        super::app_data::typed_facade::MlsGroupAppData::new(mls_group.extensions())
             .get::<AppDataComponent>()
             .inspect_err(|err| tracing::debug!("could not read the app_data component: {err}"))
             .ok()

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -2822,69 +2822,59 @@ where
         &self,
         kind: AdminListKind,
     ) -> Result<Vec<String>, GroupError> {
-        self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
-            if self::app_data::is_migrated_group(&mls_group) {
-                let facade = self::app_data::typed_facade::MlsGroupAppData::new(&mls_group);
-                let set = match kind {
-                    AdminListKind::Admin => facade.get::<AdminListComponent>(),
-                    AdminListKind::SuperAdmin => facade.get::<SuperAdminListComponent>(),
-                }
-                .map_err(|e| {
-                    GroupError::MetadataPermissionsError(
-                        MetadataPermissionsError::ComponentSource(e),
-                    )
-                })?;
-                Ok(set
-                    .map(|s| s.iter().map(|id| id.to_hex()).collect())
-                    .unwrap_or_default())
-            } else {
-                // Unmigrated: return the Vec<String> straight from the
-                // legacy GMM extension so callers keep their pre-
-                // migration insertion order. Propagate decode errors
-                // (e.g. a corrupted legacy GMM extension) via the same
-                // `MetadataPermissionsError::Mutable(...)` shape that
-                // pre-refactor `mutable_metadata()?.admin_list`
-                // produced — a soft `.ok()` here would convert a loud
-                // failure into silent "no admins" data corruption.
-                // `MissingExtension` is the legacy "no extension on
-                // the group" case and remains the soft-skip → empty
-                // Vec contract.
-                let metadata =
-                    match xmtp_mls_common::group_mutable_metadata::extract_legacy_group_mutable_metadata(
-                        &mls_group,
-                    ) {
-                        Ok(m) => Some(m),
-                        Err(
-                            xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::MissingExtension,
-                        ) => {
-                            // Expected on very old groups created before
-                            // the legacy GMM extension existed; logged at
-                            // debug to give operators visibility without
-                            // spamming warn on a legitimate state. An
-                            // empty list is the contract callers expect
-                            // (admin_list / super_admin_list return
-                            // `Ok(vec![])` here, not `Err`).
-                            tracing::debug!(
-                                group_id = %self.group_id,
-                                kind = ?kind,
-                                "unmigrated group has no legacy GroupMutableMetadata extension; returning empty admin set"
-                            );
-                            None
-                        }
-                        Err(e) => {
-                            return Err(GroupError::MetadataPermissionsError(
-                                MetadataPermissionsError::Mutable(e),
-                            ));
-                        }
-                    };
-                Ok(metadata
-                    .map(|m| match kind {
-                        AdminListKind::Admin => m.admin_list,
-                        AdminListKind::SuperAdmin => m.super_admin_list,
-                    })
-                    .unwrap_or_default())
+        let ctx = self.load_group_context()?;
+        let extensions = ctx.extensions();
+        if self::app_data::is_migrated_extensions(extensions) {
+            let facade = self::app_data::typed_facade::MlsGroupAppData::new(extensions);
+            let set = match kind {
+                AdminListKind::Admin => facade.get::<AdminListComponent>(),
+                AdminListKind::SuperAdmin => facade.get::<SuperAdminListComponent>(),
             }
-        })
+            .map_err(|e| {
+                GroupError::MetadataPermissionsError(MetadataPermissionsError::ComponentSource(e))
+            })?;
+            Ok(set
+                .map(|s| s.iter().map(|id| id.to_hex()).collect())
+                .unwrap_or_default())
+        } else {
+            // Unmigrated: return the Vec<String> straight from the legacy GMM
+            // extension so callers keep their pre-migration insertion order.
+            // Propagate decode errors (e.g. a corrupted legacy GMM extension)
+            // via the same `MetadataPermissionsError::Mutable(...)` shape that
+            // pre-refactor `mutable_metadata()?.admin_list` produced — a soft
+            // `.ok()` here would convert a loud failure into silent "no admins"
+            // data corruption. `MissingExtension` is the legacy "no extension on
+            // the group" case and remains the soft-skip → empty Vec contract.
+            let metadata = match xmtp_mls_common::group_mutable_metadata::extract_legacy_group_mutable_metadata_from_extensions(
+                extensions,
+            ) {
+                Ok(m) => Some(m),
+                Err(xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::MissingExtension) => {
+                    // Expected on very old groups created before the legacy GMM
+                    // extension existed; logged at debug to give operators
+                    // visibility without spamming warn on a legitimate state. An
+                    // empty list is the contract callers expect (admin_list /
+                    // super_admin_list return `Ok(vec![])` here, not `Err`).
+                    tracing::debug!(
+                        group_id = %self.group_id,
+                        kind = ?kind,
+                        "unmigrated group has no legacy GroupMutableMetadata extension; returning empty admin set"
+                    );
+                    None
+                }
+                Err(e) => {
+                    return Err(GroupError::MetadataPermissionsError(
+                        MetadataPermissionsError::Mutable(e),
+                    ));
+                }
+            };
+            Ok(metadata
+                .map(|m| match kind {
+                    AdminListKind::Admin => m.admin_list,
+                    AdminListKind::SuperAdmin => m.super_admin_list,
+                })
+                .unwrap_or_default())
+        }
     }
 
     /// Checks if the given inbox ID is an admin of the group at the most recently synced epoch.
@@ -3184,6 +3174,24 @@ where
         .await
     }
 
+    /// Read the group's `GroupContext` from storage — a single KV round-trip,
+    /// no ratchet tree, no secrets, no commit lock. All group metadata lives in
+    /// the context extensions, so metadata reads go through this rather than a
+    /// full `OpenMlsGroup::load`. The context key is written atomically on
+    /// commit, so a single-key read is metadata-consistent.
+    ///
+    /// (The pre-refactor sync `load_mls_group_with_lock` used only an *advisory*
+    /// lock for these reads — a failed `get_lock_sync` was ignored and the read
+    /// proceeded anyway — so dropping it changes nothing for reads.)
+    pub(crate) fn load_group_context(&self) -> Result<openmls::group::GroupContext, GroupError> {
+        use openmls_traits::storage::StorageProvider as _;
+        self.context
+            .mls_storage()
+            .group_context::<_, openmls::group::GroupContext>(&self.group_id.to_openmls())
+            .map_err(GroupError::from)?
+            .ok_or_else(|| GroupError::from(StorageError::from(NotFound::GroupById(self.group_id))))
+    }
+
     /// Get the `GroupMutableMetadata` of the group.
     ///
     /// Post-migration (dict contains `COMPONENT_REGISTRY` — see
@@ -3202,17 +3210,38 @@ where
     /// still authoritative.
     pub fn mutable_metadata(&self) -> Result<GroupMutableMetadata, GroupError> {
         use self::app_data::component_source::ComponentSourceError;
+        let ctx = self.load_group_context()?;
+        self::app_data::component_source::extract_group_mutable_metadata_capability_aware_from_extensions(
+            ctx.extensions(),
+        )
+        .map_err(|e| match e {
+            // Inner `GroupMutableMetadataError` originates from the legacy
+            // `TryFrom<&Extensions>` path on unmigrated groups; the
+            // `From<ComponentSourceError>` impl preserves it verbatim so binding
+            // consumers that pattern-match on `MetadataPermissionsError::Mutable`
+            // keep lighting up on `MissingExtension`.
+            ComponentSourceError::GroupMutableMetadata(inner) => {
+                GroupError::MetadataPermissionsError(MetadataPermissionsError::Mutable(inner))
+            }
+            other => GroupError::MetadataPermissionsError(
+                MetadataPermissionsError::ComponentSource(other),
+            ),
+        })
+    }
+
+    /// Pre-L implementation of [`Self::mutable_metadata`]: a full
+    /// `OpenMlsGroup::load`. Retained only as the baseline the
+    /// read-amplification benchmark measures the context-read path against.
+    #[cfg(test)]
+    pub(crate) fn mutable_metadata_via_full_load(
+        &self,
+    ) -> Result<GroupMutableMetadata, GroupError> {
+        use self::app_data::component_source::ComponentSourceError;
         self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
             self::app_data::component_source::extract_group_mutable_metadata_capability_aware(
                 &mls_group,
             )
             .map_err(|e| match e {
-                // Inner `GroupMutableMetadataError` originates from the
-                // legacy `TryFrom<&OpenMlsGroup>` path on unmigrated
-                // groups; the `From<ComponentSourceError>` impl
-                // preserves it verbatim so binding consumers that
-                // pattern-match on `MetadataPermissionsError::Mutable`
-                // keep lighting up on `MissingExtension`.
                 ComponentSourceError::GroupMutableMetadata(inner) => {
                     GroupError::MetadataPermissionsError(MetadataPermissionsError::Mutable(inner))
                 }
@@ -3224,18 +3253,22 @@ where
     }
 
     pub fn permissions(&self) -> Result<GroupMutablePermissions, GroupError> {
-        self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
-            Ok(extract_group_permissions(&mls_group).map_err(MetadataPermissionsError::from)?)
-        })
+        let ctx = self.load_group_context()?;
+        let permissions: GroupMutablePermissions = ctx
+            .extensions()
+            .try_into()
+            .map_err(MetadataPermissionsError::from)?;
+        Ok(permissions)
     }
 
     /// Capability-aware single-component read.
     ///
-    /// Acquires the group lock, then uses the
-    /// [`self::app_data::typed_facade::MlsGroupAppData`] facade to read
-    /// exactly one [`Component`](xmtp_mls_common::app_data::typed::Component)
-    /// — avoiding the full `GroupMutableMetadata` composite parse that
-    /// [`Self::mutable_metadata`] runs on every call.
+    /// Reads the group's `GroupContext` (via [`Self::load_group_context`]),
+    /// then uses the [`self::app_data::typed_facade::MlsGroupAppData`] facade to
+    /// read exactly one [`Component`](xmtp_mls_common::app_data::typed::Component)
+    /// out of its extensions — avoiding both the full `OpenMlsGroup::load` and
+    /// the full `GroupMutableMetadata` composite parse that a naive read would
+    /// run on every call.
     ///
     /// Returns `Ok(None)` when the component has no stored value
     /// (legacy GMM attribute missing on unmigrated groups, or dict slot
@@ -3254,16 +3287,15 @@ where
         C: xmtp_mls_common::app_data::typed::Component,
     {
         use self::app_data::component_source::ComponentSourceError;
-        self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
-            let facade = self::app_data::typed_facade::MlsGroupAppData::new(&mls_group);
-            facade.get::<C>().map_err(|e| match e {
-                ComponentSourceError::GroupMutableMetadata(inner) => {
-                    GroupError::MetadataPermissionsError(MetadataPermissionsError::Mutable(inner))
-                }
-                other => GroupError::MetadataPermissionsError(
-                    MetadataPermissionsError::ComponentSource(other),
-                ),
-            })
+        let ctx = self.load_group_context()?;
+        let facade = self::app_data::typed_facade::MlsGroupAppData::new(ctx.extensions());
+        facade.get::<C>().map_err(|e| match e {
+            ComponentSourceError::GroupMutableMetadata(inner) => {
+                GroupError::MetadataPermissionsError(MetadataPermissionsError::Mutable(inner))
+            }
+            other => GroupError::MetadataPermissionsError(
+                MetadataPermissionsError::ComponentSource(other),
+            ),
         })
     }
 

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -13,6 +13,8 @@ mod test_group_updated;
 mod test_libxmtp_version;
 mod test_message_disappearing_settings;
 #[cfg(not(target_arch = "wasm32"))]
+mod test_metadata_read_amplification;
+#[cfg(not(target_arch = "wasm32"))]
 mod test_network;
 mod test_prepare_message_for_later_publish;
 mod test_proposals;

--- a/crates/xmtp_mls/src/groups/tests/test_metadata_read_amplification.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_metadata_read_amplification.rs
@@ -1,0 +1,81 @@
+//! Measurement for the metadata read-amplification fix (plan "L").
+//!
+//! Group-metadata properties used to reach their value through a full
+//! `OpenMlsGroup::load` (ratchet tree + secrets + extensions) even though the
+//! value lives only in the `GroupContext` extensions. The public accessors now
+//! read only the `GroupContext` (`load_group_context`). This test measures the
+//! KV read round-trips of the real public API against the retained full-load
+//! baseline (`mutable_metadata_via_full_load`).
+//!
+//! The KV read counter (`xmtp_db::sql_key_store::count_kv_reads`) is a tokio
+//! task-local compiled in only under `test`/`test-utils`; it does not exist in
+//! release builds, so this measurement adds nothing to the production read path.
+
+use crate::groups::GroupError;
+use crate::tester;
+use xmtp_db::sql_key_store::count_kv_reads;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[xmtp_common::test(unwrap_try = true)]
+async fn metadata_read_amplification() {
+    tester!(alix);
+    let group = alix.create_group(None, None)?;
+    group
+        .update_group_name("Perf Test Group".to_string())
+        .await?;
+    group
+        .update_group_description("measuring reads".to_string())
+        .await?;
+
+    // Correctness: the context-read path returns the same metadata as the old
+    // full-load path, and the public accessors still return the set values.
+    let baseline = group.mutable_metadata_via_full_load()?;
+    let now = group.mutable_metadata()?;
+    assert_eq!(baseline.attributes, now.attributes, "attributes must match");
+    assert_eq!(baseline.admin_list, now.admin_list, "admin_list must match");
+    assert_eq!(
+        baseline.super_admin_list, now.super_admin_list,
+        "super_admin_list must match"
+    );
+    assert_eq!(group.group_name()?, "Perf Test Group");
+    assert_eq!(group.group_description()?, "measuring reads");
+    // permissions() now also reads the context; just ensure it still works.
+    let _ = group.permissions()?;
+
+    // Baseline: one metadata fetch via the old full `OpenMlsGroup::load`.
+    let (res, one_full_load) = count_kv_reads(|| group.mutable_metadata_via_full_load());
+    res?;
+
+    // New snapshot: one context read yields every mutable-metadata field.
+    let (res, snapshot) = count_kv_reads(|| group.mutable_metadata());
+    res?;
+
+    // A realistic conversation-header render, through the REAL public API.
+    let me = alix.inbox_id().to_string();
+    let (res, header_public) = count_kv_reads(|| -> Result<(), GroupError> {
+        group.group_name()?;
+        group.group_description()?;
+        group.admin_list()?;
+        group.super_admin_list()?;
+        group.is_admin(me)?;
+        group.permissions()?;
+        Ok(())
+    });
+    res?;
+
+    let old_header = one_full_load * 6; // each of the 6 accessors used to full-load
+    tracing::info!(
+        one_full_load,
+        snapshot,
+        header_public,
+        old_header,
+        "read amplification: single fetch full-load={one_full_load} -> snapshot={snapshot}; \
+         6-call public header {old_header} -> {header_public} reads"
+    );
+
+    assert_eq!(snapshot, 1, "context snapshot must be exactly 1 KV read");
+    assert!(
+        header_public < one_full_load,
+        "6-accessor public header ({header_public}) should cost less than ONE old full load ({one_full_load})"
+    );
+}

--- a/crates/xmtp_mls_common/src/group_mutable_metadata.rs
+++ b/crates/xmtp_mls_common/src/group_mutable_metadata.rs
@@ -391,7 +391,15 @@ pub fn find_mutable_metadata_extension(extensions: &Extensions<GroupContext>) ->
 pub fn extract_legacy_group_mutable_metadata(
     group: &OpenMlsGroup,
 ) -> Result<GroupMutableMetadata, GroupMutableMetadataError> {
-    find_mutable_metadata_extension(group.extensions())
+    extract_legacy_group_mutable_metadata_from_extensions(group.extensions())
+}
+
+/// Same as [`extract_legacy_group_mutable_metadata`], but reads directly from a
+/// group's `GroupContext` extensions — no full `OpenMlsGroup` needed.
+pub fn extract_legacy_group_mutable_metadata_from_extensions(
+    extensions: &Extensions<GroupContext>,
+) -> Result<GroupMutableMetadata, GroupMutableMetadataError> {
+    find_mutable_metadata_extension(extensions)
         .ok_or(GroupMutableMetadataError::MissingExtension)?
         .try_into()
 }


### PR DESCRIPTION
## What

Group-metadata accessors on `MlsGroup` used to reach their value through a full
`OpenMlsGroup::load` — deserializing the ratchet tree + secrets, **O(group
size)** — even though every one of these values lives entirely in the group's
`GroupContext` extensions. Nine accessors share one `mutable_metadata` source but
each reloaded the whole group independently, so a single conversation-header
render reloaded the same group many times. On a large group this is brutal (the
tree scales with membership) and it's a known pain point for the mobile team.

This changes the metadata read path to read only the `GroupContext`
(`StorageProvider::group_context` — one KV round-trip, no tree, no secrets, no
commit lock) and extract from `ctx.extensions()`.

## How

- `MlsGroup::load_group_context()` does a single `group_context` read.
- `mutable_metadata()`, `permissions()`, `read_single_component::<C>()`, and
  `read_admin_set_preserving_legacy_order()` now extract from
  `ctx.extensions()` via extensions-based extractors
  (`extract_group_mutable_metadata_capability_aware_from_extensions`,
  `extract_legacy_group_mutable_metadata_from_extensions`, and a refactored
  `MlsGroupAppData` facade that now borrows `&Extensions<GroupContext>` instead of
  an `&OpenMlsGroup`).
- The nine public accessors (`group_name`, `group_description`,
  `group_image_url_square`, `app_data`, `admin_list`, `super_admin_list`,
  `is_admin`, `is_super_admin`, `permissions`) all bottom out in these and so all
  drop the full load.

The dropped `load_mls_group_with_lock` wrapper only held an **advisory** sync lock
for these reads (a failed `get_lock_sync` was ignored and the read proceeded
anyway), so removing it changes nothing for readers.

## FFI unchanged

The accessors stay **synchronous** — no signature churn in
`bindings/mobile/src/mls.rs` or `bindings/node`. This is a pure internal read-path
change; that was the point.

## Measured (sync/SQLite, 1-member group — the floor)

```
single metadata fetch:        13 KV reads -> 1
6-call public header render:   78 KV reads -> 6   (name, description, admin_list,
                                                   super_admin_list, is_admin, permissions)
```

The gap grows with group size on the old path (tree load) and stays flat on the
new. A new test
(`crates/xmtp_mls/src/groups/tests/test_metadata_read_amplification.rs`) asserts
both the read reduction and that the context-read result equals a full-load
extraction for the same group. The KV read counter it uses
(`xmtp_db::sql_key_store::kv_read_count`) is compiled in only under
`test`/`test-utils` and does not exist in release builds — no instrumentation is
added to the production read path.

## Deferred (follow-ups, intentionally not in this PR)

- **`is_active`** needs own-leaf / membership info, not just extensions, so it
  keeps the full load. (It should not be naively routed to
  `groups.membership_state` — that column is a different concept.)
- **`hmac_keys`** derives from the epoch exporter secret, which a real load is
  required to reach. Left as a full load.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Read group metadata from `GroupContext` instead of full `MlsGroup` load
> - Adds `Group::load_group_context()` to fetch only the `GroupContext` from storage, avoiding a full `OpenMlsGroup` load for metadata reads.
> - Refactors `mutable_metadata`, `permissions`, `read_admin_set_preserving_legacy_order`, and `read_single_component` to operate on `Extensions<GroupContext>` via new extension-only helpers in [component_source.rs](https://github.com/xmtp/libxmtp/pull/4023/files#diff-47acce7b46d2cc4f9669dd42120ee90e488ceb0b15817b67b7757e631b05d113) and [group_mutable_metadata.rs](https://github.com/xmtp/libxmtp/pull/4023/files#diff-ed696106212fb67c35890c8338ccfd437eff9d62595cc6d1b73139430893a8ed).
> - Introduces task-local `KV_READS` counter in [sql_key_store.rs](https://github.com/xmtp/libxmtp/pull/4023/files#diff-8634bcb374db4ae6216e2c4af6aa38e77aaffe5e5249bb0ac7f0d2bfd4975d35) (test-only, non-wasm) to measure storage read amplification.
> - Adds a benchmark test in [test_metadata_read_amplification.rs](https://github.com/xmtp/libxmtp/pull/4023/files#diff-e76f02308a240b2a2891f5ae8ca45a0095b5de96d7b3c3d6874b9bd56761f3eb) asserting the new path costs exactly 1 KV read and is cheaper than a full load.
> - Risk: `Group::load_group_context` returns `GroupError::from(StorageError::NotFound(GroupById))` when the context is missing — callers in [mod.rs](https://github.com/xmtp/libxmtp/pull/4023/files#diff-c27dd00cf700fd888b75fdbd19738462c2549fdc881dad70f8e61c979d440966) must handle this the same way they handled the prior full-load not-found path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83330e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->