### PR TITLE
chore(deny): patch h2 to 0.4.16, ignore residual test-only advisory (RUSTSEC-2026-0258)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4219,9 +4219,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4707,7 +4707,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.1.0",
  "httparse",
@@ -4778,7 +4778,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -7794,7 +7794,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7851,7 +7851,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8762,7 +8762,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9134,7 +9134,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
@@ -10724,7 +10724,7 @@ dependencies = [
  "futures",
  "futures-test",
  "getrandom 0.4.3",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body-util",
  "hyper 1.11.0",

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ ignore = [
   { id = "RUSTSEC-2024-0436", reason = "required by uniffi" },
   { id = "RUSTSEC-2025-0141", reason = "migrate from bincode" },
   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive via alloy-sol-macro, no upstream fix yet" },
+  { id = "RUSTSEC-2026-0258", reason = "h2 empty DATA frames DoS. The production stack (hyper 1.x) is patched to h2 0.4.16; the only residual is h2 0.3.x, pulled solely by the test-only toxiproxy_rust via reqwest 0.11, which has no 0.3.x fix. Not reachable in shipped code." },
 ]
 
 # This rustsec can be added to ignore list if using mls `test_utils` for tests


### PR DESCRIPTION
## What

Fixes the failing `cargo-deny (advisories)` check — [`RUSTSEC-2026-0258`](https://rustsec.org/advisories/RUSTSEC-2026-0258) (h2 unbounded empty DATA frames, DoS, affects **h2 < 0.4.16**). The advisory currently fails every PR and `main`.

Two copies of `h2` were affected, handled differently by root cause:

1. **`h2 0.4.15` → `0.4.16` (patched).** This is the copy the production stack pulls (hyper 1.x / reqwest 0.13 / tonic). A `cargo update -p h2 --precise 0.4.16` bumps it to the patched release — the real fix. Lockfile-only.

2. **`h2 0.3.27` — ignored, test-only.** This copy is pulled **solely** by `toxiproxy_rust` (a dev/test fault-injection dependency) via its `reqwest 0.11`, which drags in `hyper 0.14` + `h2 0.3.x` regardless of feature slimming. The 0.4.16 fix does **not** backport to the 0.3.x line, so there's no upstream patch to move to. It never reaches shipped SDK code. Added a `deny.toml` ignore matching the existing pattern for test/transitive advisories with no clean fix.

## Why not just update toxiproxy

`toxiproxy_rust` already slims reqwest (`default-features = false, features = ["blocking", "json"]`), but reqwest 0.11 pins hyper's http2 internally, so h2 0.3.x comes along anyway. Dropping it would require bumping the `ephemeraHQ/toxiproxy_rust` fork from reqwest 0.11 → 0.12 (hyper 1.x) and re-pinning here — a cross-repo change for a test-only dep. Tracked as a possible follow-up; not worth blocking the advisory fix on it.

## Verification

```
cargo deny check    →  advisories ok, bans ok, licenses ok, sources ok
```
(`cargo-deny 0.19.0`, locally). Build unaffected — the h2 bump is a semver-patch release.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Patch `h2` to 0.4.16 and ignore advisory `RUSTSEC-2026-0258` in cargo-deny
> - Updates [Cargo.lock](https://github.com/xmtp/libxmtp/pull/4024/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) to bump the `h2` crate to 0.4.16.
> - Adds an ignore entry for advisory `RUSTSEC-2026-0258` in [deny.toml](https://github.com/xmtp/libxmtp/pull/4024/files#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3de), noting the vulnerable path is only reachable through `reqwest` 0.11 in test code and not in shipped binaries.
> - Risk: advisory `RUSTSEC-2026-0258` is now suppressed globally in cargo-deny; future regressions that introduce the same advisory in shipped code paths will not be flagged until the ignore entry is revisited.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60499cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->