### PR TITLE
feat(release): automated consumer bump PRs for dev releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
     outputs:
       release-type: ${{ steps.resolve.outputs.release-type }}
       ref: ${{ steps.resolve.outputs.ref }}
+      branch: ${{ steps.branch.outputs.branch }}
       ios: ${{ steps.resolve.outputs.ios }}
       android: ${{ steps.resolve.outputs.android }}
       node-sdk: ${{ steps.resolve.outputs.node-sdk }}
@@ -105,6 +106,16 @@ jobs:
             echo "agent-sdk=$INPUT_AGENT_SDK" >> "$GITHUB_OUTPUT"
             echo "dry-run=${INPUT_DRY_RUN:-false}" >> "$GITHUB_OUTPUT"
           fi
+      # `ref` can arrive as either `refs/heads/x` or `x` (inputs.ref is free
+      # text, github.ref is always fully qualified). `branch` is the single
+      # normalized form, so anything that keys off branch IDENTITY — the
+      # open-consumer-prs concurrency group, which must agree with the
+      # manifests' pipelineid hash — can't be fooled by the spelling.
+      - name: Normalize ref to a branch name
+        id: branch
+        env:
+          REF: ${{ steps.resolve.outputs.ref }}
+        run: echo "branch=${REF#refs/heads/}" >> "$GITHUB_OUTPUT"
       - name: Validate dev release
         if: steps.resolve.outputs.release-type == 'dev'
         env:
@@ -258,6 +269,85 @@ jobs:
       pending-kind: ${{ needs.plan.outputs.kind }}
       dry-run: ${{ needs.validate.outputs.dry-run == 'true' }}
     secrets: inherit
+
+  # Dev releases only: open (or update) a version-bump PR in each xmtplabs
+  # consumer repo for the SDKs this run published. All logic lives in the
+  # updatecli manifests under dev/updatecli/; this job only mints a token per
+  # consumer and invokes them. A leg whose SDK wasn't selected (empty version)
+  # no-ops. The convos-cli/convos-assistants manifests run `corepack pnpm` in
+  # the consumer clone, relying on the runner image's default Node still
+  # bundling corepack.
+  open-consumer-prs:
+    needs: [validate, release-ios, release-android, release-node-sdk]
+    if: >-
+      !cancelled()
+      && needs.validate.outputs.release-type == 'dev'
+      && needs.validate.outputs.dry-run != 'true'
+      && (needs.release-ios.result == 'success'
+          || needs.release-android.result == 'success'
+          || needs.release-node-sdk.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # One writer at a time per (consumer, source branch): the working branch and
+    # PR are shared by every dev release from that branch, so a slow older run
+    # could otherwise force-push its stale pins over a newer one. The group MUST
+    # include matrix.consumer — legs of one run are separate job instances, and
+    # a consumer-less group would make them cancel each other.
+    # Residual (unfixable here): concurrency only binds once a job is queued, so
+    # an older run whose leg starts after a newer run already finished still
+    # writes last. Re-run the newer release if that ever happens.
+    concurrency:
+      group: open-consumer-prs-${{ matrix.consumer }}-${{ needs.validate.outputs.branch }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - consumer: convos-ios
+            version: ${{ needs.release-ios.outputs.version }}
+          - consumer: convos-client
+            version: ${{ needs.release-android.outputs.version }}
+          - consumer: convos-cli
+            version: ${{ needs.release-node-sdk.outputs.version }}
+            binding-version: ${{ needs.release-node-sdk.outputs.binding-version }}
+          - consumer: convos-assistants
+            version: ${{ needs.release-node-sdk.outputs.version }}
+            binding-version: ${{ needs.release-node-sdk.outputs.binding-version }}
+    steps:
+      # Trust boundary: this job holds a token that can write to the xmtplabs
+      # consumer repos, and the manifests it runs can execute shell. So check the
+      # automation out from main — NEVER from the (caller-supplied) release ref,
+      # which would let a dev release from any branch run that branch's manifests
+      # with the token. The release ref crosses the boundary as data only
+      # (SOURCE_BRANCH below); nothing else here reads the checkout, so main's
+      # copy is sufficient. Corollary: manifest edits only take effect once
+      # merged to main — verify them locally with `updatecli pipeline diff`
+      # (see docs/create-a-release.md).
+      - uses: actions/checkout@v6
+        if: matrix.version != ''
+        with:
+          ref: main
+          persist-credentials: false
+      # The action tag pins the updatecli binary (v3.6.0 -> updatecli v0.120.1); bumping the tag bumps the binary.
+      - uses: updatecli/updatecli-action@v3.6.0
+        if: matrix.version != ''
+      - uses: actions/create-github-app-token@v2
+        if: matrix.version != ''
+        id: app-token
+        with:
+          app-id: ${{ secrets.CONSUMER_PR_APP_ID }}
+          private-key: ${{ secrets.CONSUMER_PR_APP_PRIVATE_KEY }}
+          owner: xmtplabs
+          repositories: ${{ matrix.consumer }}
+      - name: Open consumer PR
+        if: matrix.version != ''
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ matrix.version }}
+          BINDING_VERSION: ${{ matrix.binding-version }}
+          SOURCE_BRANCH: ${{ needs.validate.outputs.ref }}
+        run: updatecli pipeline apply --config dev/updatecli/${{ matrix.consumer }}.yaml
 
   merge-pr:
     # dry-run must not mutate the repo: a final + dry-run would otherwise merge

--- a/dev/release-tools/src/lib/classify-notes.ts
+++ b/dev/release-tools/src/lib/classify-notes.ts
@@ -25,14 +25,22 @@ export interface ClassifyResult {
 export function parseFrontmatter(text: string): ReleaseNoteFrontmatter {
   const match = text.match(/^---\n([\s\S]*?)\n---/);
   if (!match) {
-    return { sdk: null, previousReleaseVersion: null, previousReleaseTag: null };
+    return {
+      sdk: null,
+      previousReleaseVersion: null,
+      previousReleaseTag: null,
+    };
   }
 
   let parsed: Record<string, unknown>;
   try {
     parsed = parse(match[1]);
   } catch {
-    return { sdk: null, previousReleaseVersion: null, previousReleaseTag: null };
+    return {
+      sdk: null,
+      previousReleaseVersion: null,
+      previousReleaseTag: null,
+    };
   }
 
   const sdk = typeof parsed.sdk === "string" ? parsed.sdk : null;

--- a/dev/release-tools/src/lib/devcontainer.ts
+++ b/dev/release-tools/src/lib/devcontainer.ts
@@ -55,7 +55,11 @@ export function setDevcontainerImage(
   };
 
   let result = source;
-  const edit = (path: (string | number)[], value: unknown, extra = {}): void => {
+  const edit = (
+    path: (string | number)[],
+    value: unknown,
+    extra = {},
+  ): void => {
     result = applyEdits(
       result,
       modify(result, path, value, { formattingOptions, ...extra }),
@@ -66,7 +70,8 @@ export function setDevcontainerImage(
     edit([IMAGE_KEY], image);
   } else {
     edit([IMAGE_KEY], image, {
-      getInsertionIndex: (properties: string[]) => properties.indexOf(BUILD_KEY),
+      getInsertionIndex: (properties: string[]) =>
+        properties.indexOf(BUILD_KEY),
     });
     edit([BUILD_KEY], undefined);
   }

--- a/dev/release-tools/src/lib/sdk-config.ts
+++ b/dev/release-tools/src/lib/sdk-config.ts
@@ -67,10 +67,20 @@ export const SDK_CONFIGS: Record<Sdk, SdkConfig> = {
     manifestPath: "sdks/js/browser-sdk/package.json",
     tagPrefix: "browser-sdk-",
     artifactTagSuffix: "",
-    manifest: createPackageJsonManifestProvider("sdks/js/browser-sdk/package.json"),
+    manifest: createPackageJsonManifestProvider(
+      "sdks/js/browser-sdk/package.json",
+    ),
     versionTrack: "independent",
-    notesIncludeGlobs: ["crates/**", "bindings/wasm/**", "sdks/js/browser-sdk/**"],
-    notesExcludeGlobs: ["bindings/node/**", "bindings/mobile/**", "sdks/js/node-sdk/**"],
+    notesIncludeGlobs: [
+      "crates/**",
+      "bindings/wasm/**",
+      "sdks/js/browser-sdk/**",
+    ],
+    notesExcludeGlobs: [
+      "bindings/node/**",
+      "bindings/mobile/**",
+      "sdks/js/node-sdk/**",
+    ],
     releaseWorkflow: "release-browser-sdk.yml",
     channels: ["nightly", "rc", "final"],
   },
@@ -79,10 +89,16 @@ export const SDK_CONFIGS: Record<Sdk, SdkConfig> = {
     manifestPath: "sdks/js/node-sdk/package.json",
     tagPrefix: "node-sdk-",
     artifactTagSuffix: "",
-    manifest: createPackageJsonManifestProvider("sdks/js/node-sdk/package.json"),
+    manifest: createPackageJsonManifestProvider(
+      "sdks/js/node-sdk/package.json",
+    ),
     versionTrack: "independent",
     notesIncludeGlobs: ["crates/**", "bindings/node/**", "sdks/js/node-sdk/**"],
-    notesExcludeGlobs: ["bindings/wasm/**", "bindings/mobile/**", "sdks/js/browser-sdk/**"],
+    notesExcludeGlobs: [
+      "bindings/wasm/**",
+      "bindings/mobile/**",
+      "sdks/js/browser-sdk/**",
+    ],
     releaseWorkflow: "release-node-sdk.yml",
     channels: ["nightly", "rc", "final"],
   },
@@ -91,7 +107,9 @@ export const SDK_CONFIGS: Record<Sdk, SdkConfig> = {
     manifestPath: "sdks/js/agent-sdk/package.json",
     tagPrefix: "agent-sdk-",
     artifactTagSuffix: "",
-    manifest: createPackageJsonManifestProvider("sdks/js/agent-sdk/package.json"),
+    manifest: createPackageJsonManifestProvider(
+      "sdks/js/agent-sdk/package.json",
+    ),
     versionTrack: "independent",
     notesIncludeGlobs: ["sdks/js/agent-sdk/**"],
     notesExcludeGlobs: [

--- a/dev/release-tools/tests/commands/list-sdks.test.ts
+++ b/dev/release-tools/tests/commands/list-sdks.test.ts
@@ -5,7 +5,15 @@ describe("listSdksForChannel", () => {
   it("returns fan-out targets for nightly, excluding the hub", () => {
     const rows = listSdksForChannel("nightly");
     const names = rows.map((r) => r.sdk).sort();
-    expect(names).toEqual(["agent-sdk", "android", "browser-sdk", "ios", "node-bindings", "node-sdk", "wasm-bindings"]);
+    expect(names).toEqual([
+      "agent-sdk",
+      "android",
+      "browser-sdk",
+      "ios",
+      "node-bindings",
+      "node-sdk",
+      "wasm-bindings",
+    ]);
     // hub (libxmtp, empty releaseWorkflow) is excluded
     expect(rows.every((r) => r.releaseWorkflow !== "")).toBe(true);
   });

--- a/dev/release-tools/tests/commands/set-dependency-version.test.ts
+++ b/dev/release-tools/tests/commands/set-dependency-version.test.ts
@@ -20,9 +20,7 @@ describe("setPackageJsonDependency", () => {
   let packageJsonPath: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "release-tools-set-dep-"),
-    );
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-tools-set-dep-"));
     packageJsonPath = path.join(tmpDir, "package.json");
     fs.writeFileSync(packageJsonPath, SAMPLE_PACKAGE_JSON);
   });
@@ -44,11 +42,7 @@ describe("setPackageJsonDependency", () => {
   });
 
   it("leaves all other fields and formatting intact", () => {
-    setPackageJsonDependency(
-      packageJsonPath,
-      "@xmtp/node-bindings",
-      "1.11.0",
-    );
+    setPackageJsonDependency(packageJsonPath, "@xmtp/node-bindings", "1.11.0");
     const content = fs.readFileSync(packageJsonPath, "utf-8");
     const parsed = JSON.parse(content);
 

--- a/dev/release-tools/tests/devcontainer.test.ts
+++ b/dev/release-tools/tests/devcontainer.test.ts
@@ -104,9 +104,10 @@ describe("setDevcontainerImage", () => {
 
     setDevcontainerImage(jsonPath, NEW_IMAGE);
 
-    const parsed = parseJsonc(
-      fs.readFileSync(jsonPath, "utf-8"),
-    ) as Record<string, unknown>;
+    const parsed = parseJsonc(fs.readFileSync(jsonPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
     expect(parsed.name).toBe("libxmtp (Nix)");
     expect(parsed.runArgs).toEqual(["--ulimit", "stack=-1:-1"]);
     expect(parsed.workspaceFolder).toBe("/workspaces/libxmtp");

--- a/dev/release-tools/tests/manifest/package-json.test.ts
+++ b/dev/release-tools/tests/manifest/package-json.test.ts
@@ -65,10 +65,7 @@ describe("package.json manifest", () => {
   });
 
   it("throws if version field is missing", () => {
-    fs.writeFileSync(
-      packageJsonPath,
-      '{"name": "test"}\n',
-    );
+    fs.writeFileSync(packageJsonPath, '{"name": "test"}\n');
     expect(() => readPackageJsonVersion(packageJsonPath)).toThrow(
       "Could not find version",
     );

--- a/dev/release-tools/tests/scaffold-and-classify.test.ts
+++ b/dev/release-tools/tests/scaffold-and-classify.test.ts
@@ -9,9 +9,7 @@ describe("scaffold → classify end-to-end", () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "release-tools-e2e-"),
-    );
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-tools-e2e-"));
     // Create iOS SDK structure
     fs.mkdirSync(path.join(tmpDir, "sdks/ios"), { recursive: true });
     fs.writeFileSync(
@@ -109,7 +107,12 @@ describe("scaffold → classify end-to-end", () => {
 
   it("classifies a mix of empty and modified scaffolds across SDKs", () => {
     const iosPath = scaffoldNotes("ios", tmpDir, "1.9.0", "ios-1.9.0");
-    const androidPath = scaffoldNotes("android", tmpDir, "3.0.0", "android-3.0.0");
+    const androidPath = scaffoldNotes(
+      "android",
+      tmpDir,
+      "3.0.0",
+      "android-3.0.0",
+    );
 
     // Modify only the Android notes
     const androidContent = fs.readFileSync(androidPath, "utf-8");

--- a/dev/release-tools/tsconfig.json
+++ b/dev/release-tools/tsconfig.json
@@ -6,8 +6,8 @@
     "strict": true,
     "esModuleInterop": true,
     "noEmit": true,
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/dev/updatecli/convos-assistants.yaml
+++ b/dev/updatecli/convos-assistants.yaml
@@ -1,0 +1,82 @@
+# Opens/updates the libxmtp dev-release bump PR in xmtplabs/convos-assistants.
+# Invoked by the open-consumer-prs job in .github/workflows/release.yml with
+# VERSION, BINDING_VERSION, SOURCE_BRANCH, UPDATECLI_GITHUB_TOKEN in env.
+name: 'convos-assistants: bump libxmtp to {{ requiredEnv "VERSION" }}'
+
+# One PR per libxmtp source branch: hash of the real branch name keys the
+# working branch, so feature/foo and feature-foo never collide and both ref
+# forms (refs/heads/x and x) key identically.
+pipelineid: '{{ requiredEnv "SOURCE_BRANCH" | trimPrefix "refs/heads/" | sha256sum | trunc 8 }}'
+
+scms:
+  consumer:
+    kind: github
+    spec:
+      owner: xmtplabs
+      repository: convos-assistants
+      branch: dev
+      username: x-access-token
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      user: 'xmtp-dev-release[bot]'
+      email: '319876561+xmtp-dev-release[bot]@users.noreply.github.com'
+      workingbranchprefix: libxmtp-dev
+      force: true
+
+actions:
+  pr:
+    kind: github/pullrequest
+    scmid: consumer
+    spec:
+      title: 'chore(deps): bump libxmtp to {{ requiredEnv "VERSION" }}'
+      labels:
+        - dependencies
+      description: |
+        Automated dev-release bump from [xmtp/libxmtp](https://github.com/xmtp/libxmtp) branch `{{ requiredEnv "SOURCE_BRANCH" | trimPrefix "refs/heads/" }}`.
+
+        | Package | Version |
+        | --- | --- |
+        | `@xmtp/node-sdk` | `{{ requiredEnv "VERSION" }}` |
+        | `@xmtp/node-bindings` | `{{ requiredEnv "BINDING_VERSION" }}` |
+
+        Release run: {{ env "GITHUB_SERVER_URL" }}/{{ env "GITHUB_REPOSITORY" }}/actions/runs/{{ env "GITHUB_RUN_ID" }}
+
+        Re-running a dev release from the same branch updates this PR in place; close it if the branch is abandoned.
+
+targets:
+  catalog-pin:
+    name: 'pin @xmtp/node-sdk {{ requiredEnv "VERSION" }} in pnpm catalog'
+    kind: file
+    scmid: consumer
+    disablesourceinput: true
+    spec:
+      file: pnpm-workspace.yaml
+      matchpattern: '(?m)^(\s*''@xmtp/node-sdk''\s*:\s*)\S+$'
+      replacepattern: '${1}{{ requiredEnv "VERSION" }}'
+  overrides-pin:
+    name: 'pin @xmtp/node-bindings {{ requiredEnv "BINDING_VERSION" }} in overrides'
+    kind: file
+    scmid: consumer
+    disablesourceinput: true
+    spec:
+      file: package.json
+      matchpattern: '("@xmtp/node-bindings"\s*:\s*")\d+\.\d+\.\d+-(?:dev|nightly)\.[^"]+(")'
+      replacepattern: '${1}{{ requiredEnv "BINDING_VERSION" }}${2}'
+  pnpm-lockfile:
+    name: refresh pnpm-lock.yaml
+    kind: shell
+    scmid: consumer
+    disablesourceinput: true
+    dependson:
+      - catalog-pin
+      - overrides-pin
+    spec:
+      # Retries absorb npm registry propagation lag right after publish.
+      command: 'ok=0; for attempt in 1 2 3; do COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm install --lockfile-only && { ok=1; break; }; [ "$attempt" = 3 ] || sleep 30; done; [ "$ok" = 1 ]'
+      environments:
+        - name: PATH
+        - name: HOME
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - pnpm-lock.yaml

--- a/dev/updatecli/convos-cli.yaml
+++ b/dev/updatecli/convos-cli.yaml
@@ -1,0 +1,82 @@
+# Opens/updates the libxmtp dev-release bump PR in xmtplabs/convos-cli.
+# Invoked by the open-consumer-prs job in .github/workflows/release.yml with
+# VERSION, BINDING_VERSION, SOURCE_BRANCH, UPDATECLI_GITHUB_TOKEN in env.
+name: 'convos-cli: bump libxmtp to {{ requiredEnv "VERSION" }}'
+
+# One PR per libxmtp source branch: hash of the real branch name keys the
+# working branch, so feature/foo and feature-foo never collide and both ref
+# forms (refs/heads/x and x) key identically.
+pipelineid: '{{ requiredEnv "SOURCE_BRANCH" | trimPrefix "refs/heads/" | sha256sum | trunc 8 }}'
+
+scms:
+  consumer:
+    kind: github
+    spec:
+      owner: xmtplabs
+      repository: convos-cli
+      branch: main
+      username: x-access-token
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      user: 'xmtp-dev-release[bot]'
+      email: '319876561+xmtp-dev-release[bot]@users.noreply.github.com'
+      workingbranchprefix: libxmtp-dev
+      force: true
+
+actions:
+  pr:
+    kind: github/pullrequest
+    scmid: consumer
+    spec:
+      title: 'chore(deps): bump libxmtp to {{ requiredEnv "VERSION" }}'
+      labels:
+        - dependencies
+      description: |
+        Automated dev-release bump from [xmtp/libxmtp](https://github.com/xmtp/libxmtp) branch `{{ requiredEnv "SOURCE_BRANCH" | trimPrefix "refs/heads/" }}`.
+
+        | Package | Version |
+        | --- | --- |
+        | `@xmtp/node-sdk` | `{{ requiredEnv "VERSION" }}` |
+        | `@xmtp/node-bindings` | `{{ requiredEnv "BINDING_VERSION" }}` |
+
+        Release run: {{ env "GITHUB_SERVER_URL" }}/{{ env "GITHUB_REPOSITORY" }}/actions/runs/{{ env "GITHUB_RUN_ID" }}
+
+        Re-running a dev release from the same branch updates this PR in place; close it if the branch is abandoned.
+
+targets:
+  node-sdk-pin:
+    name: 'pin @xmtp/node-sdk {{ requiredEnv "VERSION" }}'
+    kind: file
+    scmid: consumer
+    disablesourceinput: true
+    spec:
+      file: package.json
+      matchpattern: '("@xmtp/node-sdk"\s*:\s*")\d+\.\d+\.\d+-(?:dev|nightly)\.[^"]+(")'
+      replacepattern: '${1}{{ requiredEnv "VERSION" }}${2}'
+  node-bindings-pin:
+    name: 'pin @xmtp/node-bindings {{ requiredEnv "BINDING_VERSION" }}'
+    kind: file
+    scmid: consumer
+    disablesourceinput: true
+    spec:
+      file: package.json
+      matchpattern: '("@xmtp/node-bindings"\s*:\s*")\d+\.\d+\.\d+-(?:dev|nightly)\.[^"]+(")'
+      replacepattern: '${1}{{ requiredEnv "BINDING_VERSION" }}${2}'
+  pnpm-lockfile:
+    name: refresh pnpm-lock.yaml
+    kind: shell
+    scmid: consumer
+    disablesourceinput: true
+    dependson:
+      - node-sdk-pin
+      - node-bindings-pin
+    spec:
+      # Retries absorb npm registry propagation lag right after publish.
+      command: 'ok=0; for attempt in 1 2 3; do COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm install --lockfile-only && { ok=1; break; }; [ "$attempt" = 3 ] || sleep 30; done; [ "$ok" = 1 ]'
+      environments:
+        - name: PATH
+        - name: HOME
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - pnpm-lock.yaml

--- a/dev/updatecli/convos-client.yaml
+++ b/dev/updatecli/convos-client.yaml
@@ -1,0 +1,57 @@
+# Opens/updates the libxmtp dev-release bump PR in xmtplabs/convos-client.
+# Invoked by the open-consumer-prs job in .github/workflows/release.yml with
+# VERSION, SOURCE_BRANCH, UPDATECLI_GITHUB_TOKEN in env.
+name: 'convos-client: bump libxmtp to {{ requiredEnv "VERSION" }}'
+
+# One PR per libxmtp source branch: hash of the real branch name keys the
+# working branch, so feature/foo and feature-foo never collide and both ref
+# forms (refs/heads/x and x) key identically.
+pipelineid: '{{ requiredEnv "SOURCE_BRANCH" | trimPrefix "refs/heads/" | sha256sum | trunc 8 }}'
+
+scms:
+  consumer:
+    kind: github
+    spec:
+      owner: xmtplabs
+      repository: convos-client
+      branch: dev
+      username: x-access-token
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      user: 'xmtp-dev-release[bot]'
+      email: '319876561+xmtp-dev-release[bot]@users.noreply.github.com'
+      workingbranchprefix: libxmtp-dev
+      force: true
+      # convos-shared is declared with an SSH url in .gitmodules, which the
+      # HTTP token auth cannot clone ("invalid auth method"). Nothing we pin
+      # lives in it, so skip submodules entirely.
+      submodules: false
+
+actions:
+  pr:
+    kind: github/pullrequest
+    scmid: consumer
+    spec:
+      title: 'chore(deps): bump libxmtp to {{ requiredEnv "VERSION" }}'
+      labels:
+        - dependencies
+      description: |
+        Automated dev-release bump from [xmtp/libxmtp](https://github.com/xmtp/libxmtp) branch `{{ requiredEnv "SOURCE_BRANCH" | trimPrefix "refs/heads/" }}`.
+
+        | Package | Version |
+        | --- | --- |
+        | `org.xmtp:android` | `{{ requiredEnv "VERSION" }}` |
+
+        Release run: {{ env "GITHUB_SERVER_URL" }}/{{ env "GITHUB_REPOSITORY" }}/actions/runs/{{ env "GITHUB_RUN_ID" }}
+
+        Re-running a dev release from the same branch updates this PR in place; close it if the branch is abandoned.
+
+targets:
+  gradle-catalog-pin:
+    name: 'pin org.xmtp:android {{ requiredEnv "VERSION" }}'
+    kind: file
+    scmid: consumer
+    disablesourceinput: true
+    spec:
+      file: android/gradle/libs.versions.toml
+      matchpattern: '(?m)^(xmtp\s*=\s*")[^"]+(")'
+      replacepattern: '${1}{{ requiredEnv "VERSION" }}${2}'

--- a/dev/updatecli/convos-ios.yaml
+++ b/dev/updatecli/convos-ios.yaml
@@ -1,0 +1,134 @@
+# Opens/updates the libxmtp dev-release bump PR in xmtplabs/convos-ios.
+# Invoked by the open-consumer-prs job in .github/workflows/release.yml with
+# VERSION, SOURCE_BRANCH, UPDATECLI_GITHUB_TOKEN in env.
+name: 'convos-ios: bump libxmtp to {{ requiredEnv "VERSION" }}'
+
+# One PR per libxmtp source branch: hash of the real branch name keys the
+# working branch, so feature/foo and feature-foo never collide and both ref
+# forms (refs/heads/x and x) key identically.
+pipelineid: '{{ requiredEnv "SOURCE_BRANCH" | trimPrefix "refs/heads/" | sha256sum | trunc 8 }}'
+
+scms:
+  consumer:
+    kind: github
+    spec:
+      owner: xmtplabs
+      repository: convos-ios
+      branch: dev
+      username: x-access-token
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      user: 'xmtp-dev-release[bot]'
+      email: '319876561+xmtp-dev-release[bot]@users.noreply.github.com'
+      workingbranchprefix: libxmtp-dev
+      force: true
+
+sources:
+  ios-tag-sha:
+    name: 'peeled commit sha of tag ios-{{ requiredEnv "VERSION" }}'
+    kind: shell
+    spec:
+      # The glob is only a server-side prefilter; awk matches the ref name
+      # EXACTLY, so ios-4.10.0 can never pick up ios-4.10.0-dev.x's sha.
+      # grep asserts the shape so a malformed/empty result fails loudly.
+      command: >-
+        git ls-remote --tags https://github.com/xmtp/libxmtp.git
+        'refs/tags/ios-{{ requiredEnv "VERSION" }}*'
+        | awk -v t='refs/tags/ios-{{ requiredEnv "VERSION" }}'
+        '$2 == t "^{}" {peeled=$1} $2 == t {plain=$1}
+        END {if (peeled) print peeled; else if (plain) print plain; else exit 1}'
+        | grep -E '^[0-9a-f]{40}$'
+      environments:
+        - name: PATH
+        - name: HOME
+
+actions:
+  pr:
+    kind: github/pullrequest
+    scmid: consumer
+    spec:
+      title: 'chore(deps): bump libxmtp to {{ requiredEnv "VERSION" }}'
+      labels:
+        - dependencies
+      description: |
+        Automated dev-release bump from [xmtp/libxmtp](https://github.com/xmtp/libxmtp) branch `{{ requiredEnv "SOURCE_BRANCH" | trimPrefix "refs/heads/" }}`.
+
+        | Package | Version |
+        | --- | --- |
+        | `xmtp/libxmtp` (iOS SDK) | `ios-{{ requiredEnv "VERSION" }}` |
+
+        Release run: {{ env "GITHUB_SERVER_URL" }}/{{ env "GITHUB_REPOSITORY" }}/actions/runs/{{ env "GITHUB_RUN_ID" }}
+
+        Re-running a dev release from the same branch updates this PR in place; close it if the branch is abandoned.
+
+targets:
+  # The targets below hardcode their file lists. If a NEW package ever gains a
+  # libxmtp pin it would be silently left un-bumped, so fail the pipeline
+  # instead: every file mentioning the dep must be one we already rewrite.
+  # This is a shell TARGET, not a condition, because a failed condition skips
+  # with a green check — a coverage violation would silently suppress the PR.
+  # As a target, a violation fails the leg loudly. Semantics (probe-verified):
+  # success with empty stdout = "No change detected", so no spurious commit;
+  # dependson on an unchanged dependency still runs its dependents; failure =
+  # exit 1, dependents skipped, nothing pushed.
+  pin-coverage:
+    name: every libxmtp SPM pin is covered by this manifest's target file lists
+    kind: shell
+    scmid: consumer
+    disablesourceinput: true
+    spec:
+      command: >-
+        uncovered=$(grep -rl --include=Package.swift --include=Package.resolved
+        xmtp/libxmtp .
+        | grep -vxF -e ./ConvosCore/Package.swift
+        -e ./ConvosInvites/Package.swift
+        -e ./ConvosCore/Package.resolved
+        -e ./ConvosInvites/Package.resolved
+        -e ./Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved);
+        [ -z "$uncovered" ] || { echo "uncovered libxmtp pins: $uncovered" >&2; exit 1; }
+      environments:
+        - name: PATH
+        - name: HOME
+  package-swift:
+    name: 'pin libxmtp revision ios-{{ requiredEnv "VERSION" }} in Package.swift'
+    kind: file
+    scmid: consumer
+    disablesourceinput: true
+    dependson:
+      - pin-coverage
+    spec:
+      files:
+        - ConvosCore/Package.swift
+        - ConvosInvites/Package.swift
+      # [^)]*? bounds the span to this .package(...) call — format drift fails
+      # loudly instead of rewriting a neighboring dependency's pin.
+      matchpattern: '(url:\s*"https://github\.com/xmtp/libxmtp\.git",?[^)]*?revision:\s*")ios-[^"]+(")'
+      replacepattern: '${1}ios-{{ requiredEnv "VERSION" }}${2}'
+  resolved-branch:
+    name: 'pin libxmtp branch field in Package.resolved'
+    kind: file
+    scmid: consumer
+    disablesourceinput: true
+    dependson:
+      - pin-coverage
+    spec:
+      files:
+        - ConvosCore/Package.resolved
+        - ConvosInvites/Package.resolved
+        - Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+      # [^}]*? bounds the span to the libxmtp pin object.
+      matchpattern: '("identity"\s*:\s*"libxmtp"[^}]*?"branch"\s*:\s*")ios-[^"]+(")'
+      replacepattern: '${1}ios-{{ requiredEnv "VERSION" }}${2}'
+  resolved-revision:
+    name: pin libxmtp revision field in Package.resolved
+    kind: file
+    scmid: consumer
+    disablesourceinput: true
+    dependson:
+      - resolved-branch
+    spec:
+      files:
+        - ConvosCore/Package.resolved
+        - ConvosInvites/Package.resolved
+        - Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+      matchpattern: '("identity"\s*:\s*"libxmtp"[^}]*?"revision"\s*:\s*")[a-f0-9]{40}(")'
+      replacepattern: '${1}{{ source "ios-tag-sha" }}${2}'

--- a/docs/create-a-release.md
+++ b/docs/create-a-release.md
@@ -31,6 +31,20 @@ A Slack notification is sent to `#notify-dev-releases` when complete.
 
 Dev releases are always drafts, and any pushed changes in the dev release (for example, updating manifests to match the release version) happen in a detached HEAD.
 
+### Consumer bump PRs
+
+A dev release also opens (or updates) a version-bump PR in the `xmtplabs` consumer repos — `convos-ios`, `convos-client`, `convos-cli`, and `convos-assistants` — from the `open-consumer-prs` job, driven by the updatecli manifests in `dev/updatecli/`.
+
+- Each consumer is its own matrix leg, so a red leg never blocks or rolls back the SDK publishes — they already happened. It does turn the run red on purpose: that is the only signal that a bump was not applied. It usually means that consumer's pin format drifted; fix the matching `dev/updatecli/<consumer>.yaml`.
+- One PR per libxmtp source branch. Re-releasing from the same branch updates that PR in place, and overlapping runs from the same branch are serialized by the job's concurrency group so the newest release wins.
+- Auth comes from the `xmtp-dev-release` GitHub App via the `CONSUMER_PR_APP_ID` and `CONSUMER_PR_APP_PRIVATE_KEY` secrets.
+- The job checks the manifests out from `main`, not from the branch being released, because it runs them with a token that can write to the consumer repos. **Manifest changes therefore only take effect once merged to `main`** — releasing from a branch runs `main`'s manifests against that branch's version. Verify manifest edits with the local dry-run below.
+- To dry-run a manifest locally (read-only, opens nothing):
+
+  ```bash
+  UPDATECLI_GITHUB_TOKEN=$(gh auth token) VERSION=<v> BINDING_VERSION=<v> SOURCE_BRANCH=<branch> updatecli pipeline diff --config dev/updatecli/<consumer>.yaml
+  ```
+
 ---
 
 ## Final Releases


### PR DESCRIPTION
## Summary

Dev releases now automatically open (or update) version-bump PRs in the four xmtplabs consumer repos, closing the gap where nightlies flow via renovate but dev bumps were manual (dev versions aren't semantically orderable, so renovate can't track them — instead, the release run *tells* each consumer the exact version).

- **convos-ios** — `Package.swift` `revision:` pins + `Package.resolved` tag/SHA pairs (regexes mirror the repo's own renovate matchStrings, block-bounded so format drift fails safe instead of editing a neighboring pin)
- **convos-client** — `xmtp = "…"` in the Gradle version catalog
- **convos-cli** — exact `@xmtp/node-sdk` + `@xmtp/node-bindings` pins + `pnpm-lock.yaml` regen
- **convos-assistants** — pnpm catalog + `pnpm.overrides` + lockfile regen (satisfies its `xmtp-lockstep` check)

## Design

All logic lives in four declarative [updatecli](https://www.updatecli.io) manifests (`dev/updatecli/`): pin edits via file regex targets that fail loudly on drift, pnpm lockfile regeneration via shell targets, iOS tag-SHA resolution via an exact-ref shell source with a pin-coverage guard, and deterministic per-source-branch PR create-or-update via a hashed `pipelineid`. The workflow contribution is one thin matrix job (`open-consumer-prs`, dev-only, `fail-fast: false`, never blocks publishes/notify): mint a GitHub App token scoped to one consumer, run `updatecli apply`.


## Testing

- `updatecli diff` dry-runs of every manifest against the real consumer repos (read-only), including a negative check proving the exact-ref tag lookup rejects prefix-colliding tags (`ios-4.10.0` vs its rc/dev tags)
- Live E2E dry-run of the pnpm path against real convos-cli + npm registry
- Known issue: the convos-assistants leg fails at clone until `runtime/hermes/src/convos/debug/aux.py` is renamed upstream (go-git rejects Windows reserved device names on all platforms); legs are non-blocking by design


## Rollout (before first use)

1. Create a GitHub App with contents + pull-requests write; install on the four xmtplabs repos
2. Add `CONSUMER_PR_APP_ID` / `CONSUMER_PR_APP_PRIVATE_KEY` secrets to this repo
3. Scratch-branch dev release to verify end-to-end (until then, failed legs are non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automated consumer bump PRs for dev releases using updatecli
> - Adds an `open-consumer-prs` job to [release.yml](https://github.com/xmtp/libxmtp/pull/4027/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) that runs after successful dev releases for the iOS, Android, or Node SDKs, using a matrix to open or update version-bump PRs in consumer repositories.
> - Adds four updatecli manifests under [dev/updatecli/](https://github.com/xmtp/libxmtp/pull/4027/files#diff-5f6d86c415e6fa958811913469c167e0e97dfa0defad9adff83b0132cb3ee721) to handle authentication, pin dependencies, and refresh lockfiles for `convos-ios`, `convos-client`, `convos-cli`, and `convos-assistants`.
> - Reflows formatting in several `dev/release-tools/` source and test files without altering logic or assertions.
> - Documents the new automated consumer bump process in [docs/create-a-release.md](https://github.com/xmtp/libxmtp/pull/4027/files#diff-2585916296ef7c055cf349c0533c2612c90c1f4c1c5d9eb2e080f57dcf96b78d).
> - Behavioral Change: Dev-release runs now automatically create or update dependency bump PRs in `xmtplabs/convos-ios`, `convos-client`, `convos-cli`, and `convos-assistants`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18d7099.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

