### PR TITLE
feat(node-sdk): expose dbIntegrityCheck and checkDatabaseIntegrity

### DIFF
--- a/sdks/js/node-sdk/src/Client.ts
+++ b/sdks/js/node-sdk/src/Client.ts
@@ -17,6 +17,8 @@ import {
   type Identifier,
   type InboxState,
   type Client as NodeClient,
+  type IntegrityCheckLevel,
+  type IntegrityCheckOutcome,
   type SignatureRequestHandle,
 } from "@xmtp/node-bindings";
 import { CodecRegistry } from "@/CodecRegistry";
@@ -318,6 +320,25 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
       throw new ClientNotInitializedError();
     }
     return this.#client.close();
+  }
+
+  /**
+   * Read-only integrity check of this client's local database. Persistent
+   * databases are checked on a dedicated read-only connection without
+   * blocking client operations; ephemeral in-memory databases are checked
+   * on the client's own connection.
+   *
+   * @param level - The integrity check level (Quick or Full). Defaults to Quick.
+   * @throws {ClientNotInitializedError} if the client is not initialized
+   * @returns Promise that resolves to the integrity check outcome
+   */
+  async dbIntegrityCheck(
+    level?: IntegrityCheckLevel
+  ): Promise<IntegrityCheckOutcome> {
+    if (!this.#client) {
+      throw new ClientNotInitializedError();
+    }
+    return this.#client.dbIntegrityCheck(level);
   }
 
   /**

--- a/sdks/js/node-sdk/src/index.ts
+++ b/sdks/js/node-sdk/src/index.ts
@@ -44,6 +44,7 @@ export type {
   InboxState,
   Installation,
   Intent,
+  IntegrityCheckOutcome,
   KeyPackageStatus,
   LeaveRequest,
   Lifetime,
@@ -75,6 +76,7 @@ export type {
 export {
   ActionStyle,
   BackupElementSelectionOption,
+  checkDatabaseIntegrity,
   ConsentEntityType,
   ConsentState,
   ContentType,
@@ -113,6 +115,7 @@ export {
   GroupPermissionsOptions,
   IdentifierKind,
   initLogging,
+  IntegrityCheckLevel,
   ListConversationsOrderBy,
   LogLevel,
   MessageSortBy,


### PR DESCRIPTION
Top of the DB-integrity-check stack (on #4032). Re-exports the node bindings' integrity API through `@xmtp/node-sdk`: `Client.dbIntegrityCheck(level?)` and the package-level `checkDatabaseIntegrity` / `IntegrityCheckLevel` / `IntegrityCheckOutcome`. Typecheck + eslint clean.

See #4029 for the feature overview and testing summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1AXHNsnQmHW174i5rRUEb

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `dbIntegrityCheck` on `Client` and re-export `checkDatabaseIntegrity` from Node SDK index
> - Adds async method `Client.dbIntegrityCheck(level?)` in [Client.ts](https://github.com/xmtp/libxmtp/pull/4028/files#diff-590aeb4c994929b74711069064b74ff63e3240251988c9e070d5e78a0c64b124) that delegates to the underlying `NodeClient` instance.
> - Re-exports `checkDatabaseIntegrity`, `IntegrityCheckLevel`, and `IntegrityCheckOutcome` from `@xmtp/node-bindings` in [index.ts](https://github.com/xmtp/libxmtp/pull/4028/files#diff-fbcb53b330816c4284d6086f4c7bb5b9bb20ec87712f03485d88da791a8d1451).
> - Behavioral Change: `Client.dbIntegrityCheck` throws `ClientNotInitializedError` if called before the client is initialized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4a43d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->