### PR TITLE
integrity core

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/database/native.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/native.rs
@@ -1,5 +1,5 @@
 mod pool;
-mod sqlcipher_connection;
+pub(crate) mod sqlcipher_connection;
 
 use crate::StorageError;
 use crate::database::instrumentation::TestInstrumentation;
@@ -39,6 +39,11 @@ trait ConnectionOptions {
     fn options(&self) -> &StorageOption;
     fn is_persistent(&self) -> bool {
         matches!(self.options(), StorageOption::Persistent(_))
+    }
+    /// SQLCipher session-setup pragmas (key + plaintext header + salt) for
+    /// encrypted connections; `None` when the database is unencrypted.
+    fn session_pragmas(&self) -> Option<String> {
+        None
     }
 }
 
@@ -394,6 +399,24 @@ impl XmtpDb for NativeDb {
     fn validate(&self, conn: &mut SqliteConnection) -> Result<(), ConnectionError> {
         self.customizer.validate(conn)?;
         Ok(())
+    }
+
+    fn integrity_check(
+        &self,
+        level: crate::integrity::IntegrityCheckLevel,
+    ) -> Result<crate::integrity::IntegrityCheckResult, ConnectionError> {
+        match self.opts.path() {
+            Some(path) => Ok(crate::integrity::check_database_path(
+                path,
+                self.customizer.session_pragmas().as_deref(),
+                level,
+            )),
+            // Ephemeral: nothing on disk to open by path; run on the
+            // existing connection (documented spec exception).
+            None => self
+                .conn()
+                .raw_query(|conn| Ok(crate::integrity::run_checks(conn, level, false))),
+        }
     }
 
     fn disconnect(&self) -> Result<(), ConnectionError> {

--- a/crates/xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs
@@ -9,7 +9,7 @@ use diesel::{
 use std::{
     fmt::Display,
     fs::File,
-    io::{BufReader, Read, Write},
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -75,10 +75,7 @@ impl EncryptedConnection {
                             db_pathbuf.display(),
                             salt_path.display(),
                         );
-                        let file = BufReader::new(File::open(salt_path)?);
-                        salt = <Salt as hex::FromHex>::from_hex(
-                            file.bytes().take(32).collect::<Result<Vec<u8>, _>>()?,
-                        )?;
+                        salt = <Salt as hex::FromHex>::from_hex(read_salt_hex(db_path)?)?;
                     }
                     // the db exists and needs to be migrated
                     (false, true) => {
@@ -225,23 +222,9 @@ impl EncryptedConnection {
     }
 
     /// Output the correct order of PRAGMAS to instantiate a connection
-    fn pragmas(&self) -> impl Display {
+    fn pragmas(&self) -> String {
         let Self { key, salt, .. } = self;
-
-        if let Some(s) = salt {
-            format!(
-                "{}\n{}\n{}",
-                pragma_key(hex::encode(key)),
-                pragma_plaintext_header(),
-                pragma_salt(hex::encode(s))
-            )
-        } else {
-            format!(
-                "{}\n{}",
-                pragma_key(hex::encode(key)),
-                pragma_plaintext_header()
-            )
-        }
+        assemble_session_pragmas(key, salt.map(hex::encode).as_deref())
     }
 
     fn check_for_sqlcipher(
@@ -267,6 +250,10 @@ impl EncryptedConnection {
 impl ConnectionOptions for EncryptedConnection {
     fn options(&self) -> &StorageOption {
         &self.options
+    }
+
+    fn session_pragmas(&self) -> Option<String> {
+        Some(self.pragmas().to_string())
     }
 }
 
@@ -314,22 +301,71 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
         if cfg!(any(test, feature = "test-utils")) {
             conn.set_instrumentation(TestInstrumentation);
         }
-        conn.batch_execute(&format!("{}", self.pragmas(),))
+        conn.batch_execute(&self.pragmas())
             .map_err(diesel::r2d2::Error::QueryError)?;
         connection_pragmas(conn)?;
         Ok(())
     }
 }
 
-fn pragma_key(key: impl Display) -> impl Display {
+/// Assemble the SQLCipher session pragmas (key, plaintext header, then salt)
+/// in the order SQLCipher requires. Single source of truth for connection
+/// setup and the by-path integrity checker.
+pub(crate) fn assemble_session_pragmas(key: &EncryptionKey, salt_hex: Option<&str>) -> String {
+    match salt_hex {
+        Some(salt) => format!(
+            "{}\n{}\n{}",
+            pragma_key(hex::encode(key)),
+            pragma_plaintext_header(),
+            pragma_salt(salt)
+        ),
+        None => format!(
+            "{}\n{}",
+            pragma_key(hex::encode(key)),
+            pragma_plaintext_header()
+        ),
+    }
+}
+
+/// Read the hex salt from `<db>.sqlcipher_salt`, validating it is exactly
+/// 32 hex chars (16 bytes). Contents are untrusted input — they get
+/// interpolated into a PRAGMA — so anything malformed is rejected, and the
+/// read is bounded so an oversized sidecar can't exhaust memory.
+pub(crate) fn read_salt_hex<P: AsRef<Path>>(db_path: P) -> std::io::Result<String> {
+    use std::io::Read;
+    let salt_path = EncryptedConnection::salt_file(db_path)?;
+    let invalid = || {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "invalid SQLCipher salt sidecar: expected 32 hexadecimal characters",
+        )
+    };
+    // 64 bytes comfortably covers 32 hex chars plus trailing whitespace;
+    // a file that fills the bound is malformed by definition.
+    let mut bytes = Vec::with_capacity(64);
+    File::open(&salt_path)?.take(64).read_to_end(&mut bytes)?;
+    if bytes.len() == 64 {
+        return Err(invalid());
+    }
+    let salt_hex = std::str::from_utf8(&bytes)
+        .map_err(|_| invalid())?
+        .trim()
+        .to_string();
+    if salt_hex.len() != 32 || !salt_hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(invalid());
+    }
+    Ok(salt_hex)
+}
+
+pub(crate) fn pragma_key(key: impl Display) -> impl Display {
     format!(r#"PRAGMA key = "x'{key}'";"#)
 }
 
-fn pragma_salt(salt: impl Display) -> impl Display {
+pub(crate) fn pragma_salt(salt: impl Display) -> impl Display {
     format!(r#"PRAGMA cipher_salt="x'{salt}'";"#)
 }
 
-fn pragma_plaintext_header() -> impl Display {
+pub(crate) fn pragma_plaintext_header() -> impl Display {
     format!(r#"PRAGMA cipher_plaintext_header_size={PLAINTEXT_HEADER_SIZE};"#)
 }
 
@@ -338,6 +374,7 @@ mod tests {
     use crate::{EncryptedMessageStore, NativeDb, XmtpTestDb};
     use diesel_migrations::MigrationHarness;
     use std::fs::File;
+    use std::io::Read;
     use xmtp_common::tmp_path;
 
     use super::*;

--- a/crates/xmtp_db/src/encrypted_store/integrity/mod.rs
+++ b/crates/xmtp_db/src/encrypted_store/integrity/mod.rs
@@ -1,0 +1,155 @@
+//! Read-only SQLite integrity checking (PRAGMA quick_check / integrity_check /
+//! cipher_integrity_check). No entry point creates, migrates, or writes user
+//! data (opening may run SQLite's standard crash recovery — see
+//! `check_database_path`); every failure is classified into
+//! [`IntegrityCheckResult`] instead of propagated, so callers branch on one enum.
+use diesel::prelude::*;
+use diesel::sql_query;
+
+xmtp_common::if_native! {
+    mod native;
+    pub use native::check_database_integrity;
+    pub(crate) use native::check_database_path;
+}
+
+xmtp_common::if_wasm! {
+    mod wasm;
+    pub use wasm::check_database_integrity;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IntegrityCheckLevel {
+    /// `PRAGMA quick_check` — page/b-tree structure only, skips
+    /// index↔table cross-validation. Fast.
+    ///
+    /// On encrypted (SQLCipher) databases this does NOT reliably detect
+    /// ciphertext/page corruption — only [`IntegrityCheckLevel::Full`]'s
+    /// `cipher_integrity_check` pass validates per-page HMACs.
+    #[default]
+    Quick,
+    /// `PRAGMA integrity_check`, plus `PRAGMA cipher_integrity_check`
+    /// (per-page HMAC validation) when the database is encrypted.
+    Full,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntegrityCheckResult {
+    /// All checks passed.
+    Ok,
+    /// One or more checks reported findings (rows other than "ok"), or a
+    /// check failed with a corruption-shaped error.
+    Corrupt { findings: Vec<String> },
+    /// SQLITE_NOTADB-shaped failure: wrong key OR mangled header/ciphertext.
+    /// Indistinguishable by design; both alert-worthy.
+    Unreadable { reason: String },
+    /// Encrypted database whose `.sqlcipher_salt` sidecar file is missing.
+    SaltMissing,
+    /// Could not obtain a read snapshot within busy_timeout.
+    Locked,
+    /// Filesystem or unexpected query failure.
+    Failed { error: String },
+}
+
+/// Both built-in pragmas are queried through their table-valued form with an
+/// alias, so one row-struct covers both.
+#[derive(QueryableByName, Debug)]
+struct CheckRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    result: String,
+}
+
+fn quick_check(conn: &mut SqliteConnection) -> QueryResult<Vec<String>> {
+    let rows =
+        sql_query("SELECT quick_check AS result FROM pragma_quick_check").load::<CheckRow>(conn)?;
+    Ok(rows
+        .into_iter()
+        .map(|r| r.result)
+        .filter(|r| r != "ok")
+        .collect())
+}
+
+fn integrity_check(conn: &mut SqliteConnection) -> QueryResult<Vec<String>> {
+    let rows = sql_query("SELECT integrity_check AS result FROM pragma_integrity_check")
+        .load::<CheckRow>(conn)?;
+    Ok(rows
+        .into_iter()
+        .map(|r| r.result)
+        .filter(|r| r != "ok")
+        .collect())
+}
+
+pub(crate) fn classify_check_error(e: diesel::result::Error) -> IntegrityCheckResult {
+    let msg = e.to_string();
+    let lower = msg.to_lowercase();
+    if lower.contains("malformed") || lower.contains("corrupt") {
+        IntegrityCheckResult::Corrupt {
+            findings: vec![msg],
+        }
+    } else if lower.contains("not a database") || lower.contains("sql logic error") {
+        // SQLITE_NOTADB, or the bare SQLITE_ERROR fallback that page-decrypt
+        // failures surface as under our plaintext-header setup. Both mean
+        // "can't read this page with this key" — see `Unreadable`'s doc.
+        IntegrityCheckResult::Unreadable { reason: msg }
+    } else if lower.contains("database is locked") || lower.contains("database table is locked") {
+        IntegrityCheckResult::Locked
+    } else {
+        IntegrityCheckResult::Failed { error: msg }
+    }
+}
+
+/// Run the checks for `level` on an already-configured connection.
+/// `encrypted` gates the SQLCipher HMAC pass on `Full` (native only).
+pub(crate) fn run_checks(
+    conn: &mut SqliteConnection,
+    level: IntegrityCheckLevel,
+    encrypted: bool,
+) -> IntegrityCheckResult {
+    let mut findings = Vec::new();
+    let structural = match level {
+        IntegrityCheckLevel::Quick => quick_check(conn),
+        IntegrityCheckLevel::Full => integrity_check(conn),
+    };
+    match structural {
+        Ok(f) => findings.extend(f),
+        Err(e) => return classify_check_error(e),
+    }
+    xmtp_common::if_native! {@
+        if encrypted && matches!(level, IntegrityCheckLevel::Full) {
+            match native::cipher_integrity_check(conn) {
+                Ok(f) => findings.extend(f),
+                Err(e) => return classify_check_error(e),
+            }
+        }
+    }
+    xmtp_common::if_wasm! {@
+        let _ = encrypted;
+    }
+    if findings.is_empty() {
+        IntegrityCheckResult::Ok
+    } else {
+        IntegrityCheckResult::Corrupt { findings }
+    }
+}
+
+/// Escape the URI delimiters SQLite would misparse in a `file:` open path
+/// ('%' first — it is the escape introducer); otherwise a path containing
+/// '?' or '#' would open a different file than the intended one.
+/// On Windows, also normalize to SQLite's URI form: forward slashes, and a
+/// leading '/' before drive-letter absolute paths (`file:/C:/...`).
+fn escape_uri_path(path: &str) -> String {
+    let escaped = path
+        .replace('%', "%25")
+        .replace('?', "%3F")
+        .replace('#', "%23");
+    #[cfg(windows)]
+    {
+        let escaped = escaped.replace('\\', "/");
+        let mut chars = escaped.chars();
+        if chars.next().is_some_and(|c| c.is_ascii_alphabetic()) && chars.next() == Some(':') {
+            return format!("/{escaped}");
+        }
+        return escaped;
+    }
+    #[cfg(not(windows))]
+    escaped
+}

--- a/crates/xmtp_db/src/encrypted_store/integrity/native.rs
+++ b/crates/xmtp_db/src/encrypted_store/integrity/native.rs
@@ -1,0 +1,518 @@
+//! Native by-path integrity checking: opens a dedicated read-only checker
+//! connection, rebuilding the SQLCipher session pragmas from the key and the
+//! `.sqlcipher_salt` sidecar. Never creates, migrates, or writes.
+use super::*;
+use crate::EncryptionKey;
+use crate::database::native::sqlcipher_connection::{assemble_session_pragmas, read_salt_hex};
+use diesel::connection::SimpleConnection;
+use xmtp_configuration::BUSY_TIMEOUT;
+
+/// `PRAGMA cipher_integrity_check` is a SQLCipher extension pragma (no
+/// table-valued form); its result column is named after the pragma.
+/// Empty result set means every page's HMAC validated.
+#[derive(QueryableByName, Debug)]
+struct CipherCheckRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    cipher_integrity_check: String,
+}
+
+pub(super) fn cipher_integrity_check(conn: &mut SqliteConnection) -> QueryResult<Vec<String>> {
+    let rows = sql_query("PRAGMA cipher_integrity_check").load::<CipherCheckRow>(conn)?;
+    Ok(rows.into_iter().map(|r| r.cipher_integrity_check).collect())
+}
+
+fn missing_db(db_path: &str) -> IntegrityCheckResult {
+    IntegrityCheckResult::Failed {
+        error: format!("database file does not exist: {db_path}"),
+    }
+}
+
+/// Open a dedicated checking connection and run the checks.
+/// `session_pragmas` is the SQLCipher session setup for encrypted
+/// databases. Never creates, migrates, or writes user data. Opening
+/// read-write lets SQLite run its standard crash recovery (journal/WAL) —
+/// deliberate: the check then sees the same recovered state the owning
+/// client would on next open, and dormant WAL databases can't be opened
+/// read-only at all. For strict no-touch forensics, check a copy or make
+/// the files read-only, which engages the `mode=ro` fallback.
+pub(crate) fn check_database_path(
+    db_path: &str,
+    session_pragmas: Option<&str>,
+    level: IntegrityCheckLevel,
+) -> IntegrityCheckResult {
+    if !std::path::Path::new(db_path).exists() {
+        return missing_db(db_path);
+    }
+    // `mode=rw` (not `rwc`) never creates: a file deleted after the check
+    // above fails to open instead of yielding an empty DB and a false Ok.
+    // Read-write is preferred so SQLite can perform WAL recovery on open;
+    // for read-only media/copies (e.g. preserved diagnostic files) fall
+    // back to `mode=ro`, where WAL recovery is impossible anyway.
+    let escaped_path = escape_uri_path(db_path);
+    let mut conn = match diesel::SqliteConnection::establish(&format!(
+        "file:{escaped_path}?mode=rw"
+    )) {
+        Ok(c) => c,
+        Err(rw_err) => {
+            match diesel::SqliteConnection::establish(&format!("file:{escaped_path}?mode=ro")) {
+                Ok(c) => c,
+                Err(_) => {
+                    return IntegrityCheckResult::Failed {
+                        error: format!("failed to open {db_path}: {rw_err}"),
+                    };
+                }
+            }
+        }
+    };
+    if let Some(pragmas) = session_pragmas
+        && let Err(e) = conn.batch_execute(pragmas)
+    {
+        return classify_check_error(e);
+    }
+    if let Err(e) = conn.batch_execute(&format!(
+        "PRAGMA busy_timeout = {BUSY_TIMEOUT}; PRAGMA query_only = ON;"
+    )) {
+        return classify_check_error(e);
+    }
+    run_checks(&mut conn, level, session_pragmas.is_some())
+}
+
+/// Standalone integrity check of a database file, without a client.
+/// For encrypted databases pass the 32-byte encryption key; the
+/// SQLCipher salt is read from the `<db>.sqlcipher_salt` sidecar file.
+pub fn check_database_integrity(
+    db_path: &str,
+    key: Option<&EncryptionKey>,
+    level: IntegrityCheckLevel,
+) -> IntegrityCheckResult {
+    // DB existence first: a mistyped path must report the missing
+    // database, not `SaltMissing` (which implies the DB exists).
+    if !std::path::Path::new(db_path).exists() {
+        return missing_db(db_path);
+    }
+    let pragmas = match key {
+        None => None,
+        Some(key) => match read_salt_hex(db_path) {
+            Ok(salt_hex) => Some(assemble_session_pragmas(key, Some(&salt_hex))),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return IntegrityCheckResult::SaltMissing;
+            }
+            Err(e) => {
+                return IntegrityCheckResult::Failed {
+                    error: format!("salt sidecar: {e}"),
+                };
+            }
+        },
+    };
+    check_database_path(db_path, pragmas.as_deref(), level)
+}
+
+#[cfg(test)]
+mod tests {
+    // clippy's `unwrap_used` restriction lint only exempts functions
+    // directly annotated `#[test]`/`#[tokio::test]`, not plain helpers
+    // (like `mem_conn`/`create_encrypted_db` below) that tests call into —
+    // matching the existing `test_util` module's override in `lib.rs`.
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::{EncryptedMessageStore, NativeDb};
+    use std::io::{Seek, SeekFrom, Write};
+
+    fn mem_conn() -> SqliteConnection {
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+        conn.batch_execute(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t (v) VALUES ('a');",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn escape_uri_path_windows_forms() {
+        assert_eq!(escape_uri_path(r"C:\data\xmtp.db3"), "/C:/data/xmtp.db3");
+        assert_eq!(escape_uri_path(r"C:\d\a?b.db3"), "/C:/d/a%3Fb.db3");
+        assert_eq!(escape_uri_path(r"rel\path.db3"), "rel/path.db3");
+    }
+
+    #[tokio::test]
+    async fn quick_and_full_ok_on_healthy_db() {
+        let mut conn = mem_conn();
+        assert_eq!(
+            run_checks(&mut conn, IntegrityCheckLevel::Quick, false),
+            IntegrityCheckResult::Ok
+        );
+        assert_eq!(
+            run_checks(&mut conn, IntegrityCheckLevel::Full, false),
+            IntegrityCheckResult::Ok
+        );
+    }
+
+    #[tokio::test]
+    async fn classify_maps_error_strings() {
+        use diesel::result::{DatabaseErrorKind, Error};
+        fn db_err(msg: &str) -> Error {
+            Error::DatabaseError(DatabaseErrorKind::Unknown, Box::new(msg.to_string()))
+        }
+        assert!(matches!(
+            classify_check_error(db_err("database disk image is malformed")),
+            IntegrityCheckResult::Corrupt { .. }
+        ));
+        assert!(matches!(
+            classify_check_error(db_err("file is not a database")),
+            IntegrityCheckResult::Unreadable { .. }
+        ));
+        assert!(matches!(
+            classify_check_error(db_err("database is locked")),
+            IntegrityCheckResult::Locked
+        ));
+        assert!(matches!(
+            classify_check_error(db_err("sql logic error")),
+            IntegrityCheckResult::Unreadable { .. }
+        ));
+        assert!(matches!(
+            classify_check_error(db_err("no such table: whatever")),
+            IntegrityCheckResult::Failed { .. }
+        ));
+    }
+
+    /// Build a real encrypted store at `db_path`, write schema, close it.
+    /// Forces a full WAL checkpoint before closing so all data lands in the
+    /// main file — a fresh WAL-mode store otherwise leaves the migrated
+    /// schema sitting in the `-wal` sidecar, which a byte-flipping test
+    /// against the main file would never touch (SQLite transparently reads
+    /// through the WAL on open).
+    fn create_encrypted_db(db_path: &str) -> crate::EncryptionKey {
+        use crate::ConnectionExt;
+
+        let key = EncryptedMessageStore::<()>::generate_enc_key();
+        let db = NativeDb::builder()
+            .persistent(db_path.to_string())
+            .key(key)
+            .build()
+            .unwrap();
+        let store = EncryptedMessageStore::new(db).unwrap();
+        store
+            .conn()
+            .raw_query(|c| c.batch_execute("PRAGMA wal_checkpoint(TRUNCATE);"))
+            .unwrap();
+        drop(store);
+        key.into()
+    }
+
+    #[tokio::test]
+    async fn by_path_ok_on_healthy_encrypted_db() {
+        let db_path = xmtp_common::tmp_path();
+        let key = create_encrypted_db(&db_path);
+        for level in [IntegrityCheckLevel::Quick, IntegrityCheckLevel::Full] {
+            assert_eq!(
+                check_database_integrity(&db_path, Some(&key), level),
+                IntegrityCheckResult::Ok,
+                "level {level:?}"
+            );
+        }
+        EncryptedMessageStore::<()>::remove_db_files(db_path)
+    }
+
+    #[tokio::test]
+    async fn by_path_detects_corruption() {
+        let db_path = xmtp_common::tmp_path();
+        let key = create_encrypted_db(&db_path);
+        // Flip bytes in the middle of the file (past the 32-byte plaintext
+        // header, inside encrypted page data) so the page's HMAC fails.
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&db_path)
+            .unwrap();
+        let len = f.metadata().unwrap().len();
+        f.seek(SeekFrom::Start(len / 2)).unwrap();
+        f.write_all(&[0xFF; 512]).unwrap();
+        drop(f);
+
+        // Only `Full` is asserted here. `Full` always catches it:
+        // `cipher_integrity_check` verifies every declared page's HMAC
+        // directly (empirically 100% reliable across corruption shapes).
+        // Quick/integrity_check only walk reachable b-tree pages and do NOT
+        // reliably re-verify HMACs in this SQLCipher build — asserting Quick
+        // would assert behavior its own contract doesn't promise (see
+        // `IntegrityCheckLevel::Quick`'s doc). `by_path_wrong_key_is_unreadable`
+        // covers the corruption shape Quick IS documented to catch.
+        let res = check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Full);
+        assert!(
+            matches!(
+                res,
+                IntegrityCheckResult::Corrupt { .. } | IntegrityCheckResult::Unreadable { .. }
+            ),
+            "got {res:?}"
+        );
+        EncryptedMessageStore::<()>::remove_db_files(db_path)
+    }
+
+    #[tokio::test]
+    async fn by_path_wrong_key_is_unreadable() {
+        let db_path = xmtp_common::tmp_path();
+        let _key = create_encrypted_db(&db_path);
+        let wrong: crate::EncryptionKey = EncryptedMessageStore::<()>::generate_enc_key().into();
+        let res = check_database_integrity(&db_path, Some(&wrong), IntegrityCheckLevel::Quick);
+        assert!(
+            matches!(res, IntegrityCheckResult::Unreadable { .. }),
+            "got {res:?}"
+        );
+        EncryptedMessageStore::<()>::remove_db_files(db_path)
+    }
+
+    #[tokio::test]
+    async fn by_path_missing_db_reports_missing_db_not_salt() {
+        // A nonexistent encrypted DB (no db file, no sidecar) must report
+        // the missing database, not SaltMissing.
+        let db_path = xmtp_common::tmp_path();
+        let key = EncryptedMessageStore::<()>::generate_enc_key().into();
+        let res = check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Quick);
+        assert!(
+            matches!(&res, IntegrityCheckResult::Failed { error } if error.contains("does not exist")),
+            "got {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn by_path_rejects_malformed_salt_sidecar() {
+        let db_path = xmtp_common::tmp_path();
+        let key = create_encrypted_db(&db_path);
+        let salt = crate::database::EncryptedConnection::salt_file(&db_path).unwrap();
+        let mut perms = std::fs::metadata(&salt).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        perms.set_readonly(false);
+        std::fs::set_permissions(&salt, perms).unwrap();
+        // Anything that isn't exactly 32 hex chars must be rejected before
+        // interpolation — including SQL-injection-shaped contents, since the
+        // session pragmas run before `query_only = ON`.
+        for bad in [
+            "",
+            "zz",
+            "0123456789abcdef0123456789abcde",   // 31 chars
+            "0123456789abcdef0123456789abcdef0", // 33 chars
+            "x'00'\"; DROP TABLE user_preferences; --",
+        ] {
+            std::fs::write(&salt, bad).unwrap();
+            let res = check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Quick);
+            assert!(
+                matches!(&res, IntegrityCheckResult::Failed { error } if error.contains("salt")),
+                "salt {bad:?} got {res:?}"
+            );
+        }
+        // Oversized sidecar: the reader is bounded, so a huge file is
+        // rejected without being slurped into memory.
+        std::fs::write(&salt, "f".repeat(1_000_000)).unwrap();
+        let res = check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Quick);
+        assert!(
+            matches!(&res, IntegrityCheckResult::Failed { error } if error.contains("salt")),
+            "oversized salt got {res:?}"
+        );
+        // A well-formed (but wrong) salt still goes through and fails as
+        // unreadable, not as a sidecar error.
+        std::fs::write(&salt, "00000000000000000000000000000000").unwrap();
+        let res = check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Quick);
+        assert!(
+            matches!(res, IntegrityCheckResult::Unreadable { .. }),
+            "got {res:?}"
+        );
+        EncryptedMessageStore::<()>::remove_db_files(db_path)
+    }
+
+    // Unix-only: Windows forbids '?' in filenames, so the fixture below
+    // could not be created there at all. The escaping it exercises is
+    // platform-independent (`escape_uri_path`); only the fixture is not.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn by_path_handles_uri_delimiters_in_path() {
+        // '?', '#', and '%' are legal filename bytes on Unix but URI
+        // delimiters/escapes in SQLite's `file:` open path — the checker
+        // must open the same file it validated.
+        let dir = xmtp_common::tmp_path();
+        std::fs::create_dir_all(&dir).unwrap();
+        let db_path = format!("{dir}/we?ird#100%.db3");
+        let key = create_encrypted_db(&db_path);
+        assert_eq!(
+            check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Full),
+            IntegrityCheckResult::Ok
+        );
+        EncryptedMessageStore::<()>::remove_db_files(db_path);
+        // remove_db_files only deletes the db + sidecar; drop the fixture dir.
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn by_path_checks_read_only_files() {
+        // Preserved diagnostic copies are often read-only (or on read-only
+        // media); the checker must fall back to mode=ro instead of failing.
+        use std::os::unix::fs::PermissionsExt;
+        let db_path = xmtp_common::tmp_path();
+        let key = create_encrypted_db(&db_path);
+        std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o444)).unwrap();
+        assert_eq!(
+            check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Full),
+            IntegrityCheckResult::Ok
+        );
+        std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        EncryptedMessageStore::<()>::remove_db_files(db_path)
+    }
+
+    #[tokio::test]
+    async fn by_path_missing_salt_file() {
+        let db_path = xmtp_common::tmp_path();
+        let key = create_encrypted_db(&db_path);
+        let salt = crate::database::EncryptedConnection::salt_file(&db_path).unwrap();
+        // salt file is write-protected; lift perms then remove
+        let mut perms = std::fs::metadata(&salt).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        perms.set_readonly(false);
+        std::fs::set_permissions(&salt, perms).unwrap();
+        std::fs::remove_file(&salt).unwrap();
+        assert_eq!(
+            check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Quick),
+            IntegrityCheckResult::SaltMissing
+        );
+        // Not `remove_db_files`: it unconditionally tries to delete the salt
+        // sidecar too, which this test already removed.
+        std::fs::remove_file(&db_path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn by_path_unencrypted_db() {
+        let db_path = xmtp_common::tmp_path();
+        {
+            let db = NativeDb::builder()
+                .persistent(db_path.clone())
+                .build_unencrypted()
+                .unwrap();
+            let _store = EncryptedMessageStore::new(db).unwrap();
+        }
+        assert_eq!(
+            check_database_integrity(&db_path, None, IntegrityCheckLevel::Full),
+            IntegrityCheckResult::Ok
+        );
+        // Not `remove_db_files`: an unencrypted db has no salt sidecar file.
+        std::fs::remove_file(&db_path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn full_check_does_not_block_concurrent_writer() {
+        let db_path = xmtp_common::tmp_path();
+        let key = create_encrypted_db(&db_path);
+        let db = NativeDb::builder()
+            .persistent(db_path.clone())
+            .key(key.clone())
+            .build()
+            .unwrap();
+        let store = EncryptedMessageStore::new(db).unwrap();
+
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+        let written = Arc::new(AtomicU64::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        // The writer loop only exits when `stop` is set. Setting it on the
+        // success path alone would turn any failed assertion below into a
+        // hang: the panic unwinds past the `stop.store`, the blocking task
+        // spins forever, and tokio's runtime drop waits on it. Stopping in
+        // `Drop` bounds the failure instead.
+        struct StopOnDrop(Arc<AtomicBool>);
+        impl Drop for StopOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Relaxed);
+            }
+        }
+        let _stop_guard = StopOnDrop(stop.clone());
+        let (writer_written, writer_stop) = (written.clone(), stop.clone());
+        let writer = tokio::task::spawn_blocking(move || {
+            use crate::ConnectionExt;
+            let db = store;
+            // `user_preferences` is a singleton row (CHECK id = 0); use
+            // `key_package_history` instead — it accepts unlimited rows and
+            // only requires a unique blob + a timestamp, so every insert
+            // succeeds and genuinely exercises concurrent WAL writes.
+            let mut i = 0i64;
+            while !writer_stop.load(Ordering::Relaxed) {
+                db.conn()
+                    .raw_query(|c| {
+                        diesel::sql_query(format!(
+                            "INSERT INTO key_package_history (key_package_hash_ref, created_at_ns) VALUES (randomblob(32), {})",
+                            1_700_000_000_000i64 + i
+                        ))
+                        .execute(c)
+                    })
+                    .unwrap();
+                i += 1;
+                writer_written.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        // Gate each check on observed writer progress since the previous
+        // check, so a check can only run while the writer is demonstrably
+        // mid-stream — the writer/check overlap is guaranteed, not
+        // coincidental. If a Full check blocked WAL writers, the progress
+        // wait after it would hang and the deadline below would fire.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        for _ in 0..5 {
+            let before = written.load(Ordering::Relaxed);
+            while written.load(Ordering::Relaxed) <= before {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "writer made no progress: a check appears to block WAL writers"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+            let res = check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Full);
+            assert!(
+                matches!(res, IntegrityCheckResult::Ok | IntegrityCheckResult::Locked),
+                "got {res:?}"
+            );
+        }
+        stop.store(true, Ordering::Relaxed);
+        tokio::time::timeout(std::time::Duration::from_secs(30), writer)
+            .await
+            .expect("writer did not finish after checks — blocked by checker?")
+            .unwrap();
+        // After the writer finishes, the check must be cleanly Ok.
+        assert_eq!(
+            check_database_integrity(&db_path, Some(&key), IntegrityCheckLevel::Full),
+            IntegrityCheckResult::Ok
+        );
+        EncryptedMessageStore::<()>::remove_db_files(db_path)
+    }
+
+    #[tokio::test]
+    async fn store_level_check_uses_dedicated_connection() {
+        use crate::XmtpDb;
+        let db_path = xmtp_common::tmp_path();
+        let key = create_encrypted_db(&db_path);
+        let db = NativeDb::builder()
+            .persistent(db_path.clone())
+            .key(key)
+            .build()
+            .unwrap();
+        let store = EncryptedMessageStore::new(db).unwrap();
+        assert_eq!(
+            store.integrity_check(IntegrityCheckLevel::Full).unwrap(),
+            IntegrityCheckResult::Ok
+        );
+        drop(store);
+        EncryptedMessageStore::<()>::remove_db_files(db_path)
+    }
+
+    #[tokio::test]
+    async fn ephemeral_check_runs_on_existing_connection() {
+        use crate::XmtpDb;
+        // `NativeDb::builder().ephemeral(true)` from the brief doesn't match
+        // this codebase's builder API: `ephemeral()` takes no argument, and
+        // `.build()` requires a key to be set (or `.build_unencrypted()`).
+        // Existing ephemeral tests (e.g. `test_utils.rs`) use
+        // `.ephemeral().build_unencrypted()`; matched here.
+        let db = NativeDb::builder().ephemeral().build_unencrypted().unwrap();
+        let store = EncryptedMessageStore::new(db).unwrap();
+        assert_eq!(
+            store.integrity_check(IntegrityCheckLevel::Quick).unwrap(),
+            IntegrityCheckResult::Ok
+        );
+    }
+}

--- a/crates/xmtp_db/src/encrypted_store/integrity/wasm.rs
+++ b/crates/xmtp_db/src/encrypted_store/integrity/wasm.rs
@@ -1,0 +1,73 @@
+//! Wasm by-path integrity checking over the OPFS SAH-pool VFS.
+use super::*;
+use crate::database::wasm::init_sqlite;
+use diesel::connection::SimpleConnection;
+
+/// Standalone integrity check of an OPFS-backed database. Wasm databases
+/// are unencrypted, so there is no key parameter. Opens a second
+/// connection through the shared SAH-pool VFS in this JS context.
+pub async fn check_database_integrity(
+    db_path: &str,
+    level: IntegrityCheckLevel,
+) -> IntegrityCheckResult {
+    init_sqlite().await;
+    // `mode=rw` (not `rwc`) drops SQLite's CREATE flag: a typo'd or
+    // deleted OPFS path fails to open instead of being silently created
+    // as an empty pool entry that would report a false `Ok`.
+    let escaped_path = escape_uri_path(db_path);
+    let mut conn = match SqliteConnection::establish(&format!("file:{escaped_path}?mode=rw")) {
+        Ok(c) => c,
+        Err(e) => {
+            return IntegrityCheckResult::Failed {
+                error: format!("failed to open {db_path}: {e}"),
+            };
+        }
+    };
+    // The checker must never mutate; mirror the native checker's guard.
+    if let Err(e) = conn.batch_execute("PRAGMA query_only = ON;") {
+        return classify_check_error(e);
+    }
+    run_checks(&mut conn, level, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{XmtpDb, XmtpTestDb};
+
+    // This test binary (the crate's `--lib` unit tests) has no other wasm
+    // test needing a browser, so without this it defaults to the Node.js
+    // runner — which can't run OPFS (a browser-only API) and isn't even
+    // installed in the wasm dev shell. Matches `tests/opfs.rs`'s setup.
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn wasm_static_and_store_checks_ok() {
+        let db_path = xmtp_common::tmp_path();
+        let store = crate::TestDb::create_persistent_store(Some(db_path.clone())).await;
+        assert_eq!(
+            store.integrity_check(IntegrityCheckLevel::Full)?,
+            IntegrityCheckResult::Ok
+        );
+        drop(store);
+        assert_eq!(
+            check_database_integrity(&db_path, IntegrityCheckLevel::Quick).await,
+            IntegrityCheckResult::Ok
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn wasm_missing_db_reports_failed_not_ok() {
+        // A typo'd or deleted OPFS path must fail, not be silently created
+        // as an empty database that reports a false Ok.
+        let res = check_database_integrity(
+            "nonexistent-integrity-probe.db3",
+            IntegrityCheckLevel::Quick,
+        )
+        .await;
+        assert!(
+            matches!(res, IntegrityCheckResult::Failed { .. }),
+            "got {res:?}"
+        );
+    }
+}

--- a/crates/xmtp_db/src/encrypted_store/mod.rs
+++ b/crates/xmtp_db/src/encrypted_store/mod.rs
@@ -23,6 +23,7 @@ pub mod icebox;
 pub mod identity;
 pub mod identity_cache;
 pub mod identity_update;
+pub mod integrity;
 pub mod key_package_history;
 pub mod key_store_entry;
 pub mod local_commit_log;
@@ -332,6 +333,19 @@ pub trait XmtpDb: MaybeSend + MaybeSync {
     /// Validate a connection is as expected
     fn validate(&self, _conn: &mut SqliteConnection) -> Result<(), ConnectionError> {
         Ok(())
+    }
+
+    /// Run a read-only database integrity check. The default implementation
+    /// runs on this database's existing connection (correct for ephemeral,
+    /// wasm, and mock databases); backends with a persistent file override
+    /// this to use a dedicated read-only checker connection so the check
+    /// never contends with the database's own connections.
+    fn integrity_check(
+        &self,
+        level: crate::integrity::IntegrityCheckLevel,
+    ) -> Result<crate::integrity::IntegrityCheckResult, ConnectionError> {
+        self.conn()
+            .raw_query(|conn| Ok(crate::integrity::run_checks(conn, level, false)))
     }
 
     /// Returns the Connection implementation for this Database

--- a/crates/xmtp_db/src/encrypted_store/store.rs
+++ b/crates/xmtp_db/src/encrypted_store/store.rs
@@ -66,6 +66,13 @@ where
         self.db.validate(conn)
     }
 
+    fn integrity_check(
+        &self,
+        level: crate::integrity::IntegrityCheckLevel,
+    ) -> Result<crate::integrity::IntegrityCheckResult, ConnectionError> {
+        self.db.integrity_check(level)
+    }
+
     fn opts(&self) -> &StorageOption {
         self.db.opts()
     }

--- a/crates/xmtp_db/src/lib.rs
+++ b/crates/xmtp_db/src/lib.rs
@@ -53,6 +53,9 @@ pub mod prelude {
     pub use super::identity::QueryIdentity;
     pub use super::identity_cache::QueryIdentityCache;
     pub use super::identity_update::QueryIdentityUpdates;
+    pub use super::integrity::{
+        IntegrityCheckLevel, IntegrityCheckResult, check_database_integrity,
+    };
     pub use super::key_package_history::QueryKeyPackageHistory;
     pub use super::key_store_entry::QueryKeyStoreEntry;
     pub use super::local_commit_log::QueryLocalCommitLog;


### PR DESCRIPTION
## Summary

Bottom of the DB-integrity-check stack. Adds read-only SQLite corruption detection to `xmtp_db`:

- `PRAGMA quick_check` / `integrity_check` / `cipher_integrity_check` behind a structured `IntegrityCheckResult` (`Ok | Corrupt | Unreadable | SaltMissing | Locked | Failed`)
- Standalone `check_database_integrity(db_path, key?, level)`: dedicated short-lived read-only connection (`file:…?mode=rw`, `query_only=ON`), SQLCipher session pragmas rebuilt from the same builders `EncryptedConnection` uses (key + plaintext header + validated salt sidecar); never creates or migrates; URI-delimiter-safe paths
- `XmtpDb::integrity_check` defaulted trait method; `NativeDb` overrides with the dedicated checker connection; `EncryptedMessageStore` forwards; wasm gets an async by-path check over OPFS
- In WAL mode the checker is a concurrent reader — proven by a check-while-writing test

Note: `quick_check` does **not** reliably detect ciphertext corruption on SQLCipher DBs — only `Full`'s `cipher_integrity_check` validates per-page HMACs (documented on `IntegrityCheckLevel::Quick`). Interval sweeps should run `Full`.

Testing: 13 integrity tests (healthy/corrupt/wrong-key/malformed-salt/missing-salt/missing-db/unencrypted/ephemeral/URI-delimiters/concurrent-writer), full xmtp_db suite 227/227, wasm suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1AXHNsnQmHW174i5rRUEb

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `integrity_check` API to `XmtpDb` and new `integrity` module
> - Adds a cross-platform `integrity` module ([mod.rs](https://github.com/xmtp/libxmtp/pull/4029/files#diff-85f3fc171718e09889ef36f3a1586af46c6321bbaff968964c98c2110ea99d55)) that runs `PRAGMA quick_check`/`integrity_check` and native SQLCipher HMAC checks, returning a structured `IntegrityCheckResult`.
> - Adds `integrity_check` to the `XmtpDb` trait with a default that runs on the current connection; `NativeDb` overrides it to open a dedicated checker connection by path.
> - Adds `session_pragmas` to `ConnectionOptions` so encrypted backends can supply SQLCipher pragmas for the by-path checker; `assemble_session_pragmas` centralizes their construction.
> - Hardens salt sidecar reading via `read_salt_hex`, which bounds I/O to 64 bytes and requires exactly 32 hex characters.
> - Behavioral Change: `EncryptedConnection::new` now returns `InvalidData` for malformed or oversized salt files instead of partially reading them; `EncryptedConnection::pragmas` now returns `String` instead of `impl Display`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b41bb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->