### PR TITLE
insipx/db integrity 2 corrupt classification

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/database/native.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/native.rs
@@ -188,6 +188,12 @@ pub enum PlatformStorageError {
     /// PRAGMA key or salt has wrong value. Not retryable.
     #[error("PRAGMA key or salt has incorrect value")]
     SqlCipherKeyIncorrect,
+    /// Database corrupt.
+    ///
+    /// The database file failed SQLCipher/SQLite validation with a
+    /// corruption-shaped error (not a key mismatch). Not retryable.
+    #[error("Database file is corrupt: {0}")]
+    DatabaseCorrupt(String),
     /// Database locked.
     ///
     /// Database file is locked by another process. Retryable.
@@ -236,6 +242,7 @@ impl RetryableError for PlatformStorageError {
             Self::SqlCipherNotLoaded => true,
             Self::PoolNeedsConnection => true,
             Self::SqlCipherKeyIncorrect => false,
+            Self::DatabaseCorrupt(_) => false,
             Self::DatabaseLocked => true,
             Self::DieselResult(result) => retryable!(result),
             Self::Io(_) => true,
@@ -991,5 +998,11 @@ mod tests {
             );
         }
         EncryptedMessageStore::<()>::remove_db_files(db_path)
+    }
+
+    #[tokio::test]
+    async fn database_corrupt_is_not_retryable() {
+        use xmtp_common::RetryableError;
+        assert!(!PlatformStorageError::DatabaseCorrupt("x".into()).is_retryable());
     }
 }

--- a/crates/xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs
@@ -270,7 +270,15 @@ impl super::ValidatedConnection for EncryptedConnection {
         ))
         .map_err(|e| {
             tracing::error!("SQLCipher PRAGMA batch_execute failed: {:?}", e);
-            PlatformStorageError::SqlCipherKeyIncorrect
+            let msg = e.to_string().to_lowercase();
+            if msg.contains("malformed") || msg.contains("corrupt") {
+                PlatformStorageError::DatabaseCorrupt(e.to_string())
+            } else {
+                // Everything else stays a key problem. Under plaintext headers
+                // wrong-key failure shapes are data-dependent, so a wrong key
+                // can still surface as DatabaseCorrupt; both are non-retryable.
+                PlatformStorageError::SqlCipherKeyIncorrect
+            }
         })?;
 
         let CipherProviderVersion {
@@ -462,6 +470,64 @@ mod tests {
                 String::from_utf8(plaintext_header.into()).unwrap()
             );
         }
+        EncryptedMessageStore::<()>::remove_db_files(db_path)
+    }
+
+    #[tokio::test]
+    async fn corrupt_db_reports_corrupt_not_wrong_key() {
+        use crate::ConnectionExt;
+        use std::io::{Seek, SeekFrom, Write};
+        let db_path = tmp_path();
+        let key = EncryptedMessageStore::<()>::generate_enc_key();
+        {
+            let db = NativeDb::builder()
+                .persistent(db_path.clone())
+                .key(key)
+                .single_connection()
+                .build()
+                .unwrap();
+            let store = EncryptedMessageStore::new(db).unwrap();
+            // Force all migrated schema/data out of the `-wal` sidecar and
+            // into the main file: a byte-flip against the main file would
+            // otherwise never touch it. `single_connection()` above ensures
+            // there is exactly one connection (no pooled readers holding a
+            // snapshot open), so the TRUNCATE checkpoint always fully
+            // applies deterministically.
+            store
+                .conn()
+                .raw_query(|c| c.batch_execute("PRAGMA wal_checkpoint(TRUNCATE);"))
+                .unwrap();
+        }
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&db_path)
+            .unwrap();
+        let len = f.metadata().unwrap().len();
+        // Truncate to half length (header still declares the original page
+        // count), then flip encrypted page bytes within the remaining data —
+        // both classic corruption shapes.
+        f.set_len(len / 2).unwrap();
+        f.seek(SeekFrom::Start(len / 4)).unwrap();
+        f.write_all(&[0xFF; 512]).unwrap();
+        drop(f);
+
+        let err_msg = match NativeDb::builder()
+            .persistent(db_path.clone())
+            .key(key)
+            .single_connection()
+            .build()
+        {
+            Err(e) => e.to_string(),
+            Ok(db) => EncryptedMessageStore::new(db).unwrap_err().to_string(),
+        };
+        assert!(
+            err_msg.contains("corrupt") || err_msg.contains("malformed"),
+            "expected corruption error, got: {err_msg}"
+        );
+        assert!(
+            !err_msg.contains("PRAGMA key or salt has incorrect value"),
+            "corruption misreported as wrong key: {err_msg}"
+        );
         EncryptedMessageStore::<()>::remove_db_files(db_path)
     }
 }


### PR DESCRIPTION
Stacked on #4029. A corrupted-but-correctly-keyed encrypted DB previously failed client-open as `SqlCipherKeyIncorrect` ("PRAGMA key or salt has incorrect value"), indistinguishable from a wrong key. Corruption-shaped validate failures now surface as the new non-retryable `PlatformStorageError::DatabaseCorrupt`; wrong-key behavior is unchanged, and the comment documents why the two remain ambiguous in general under plaintext headers. Includes a deterministic corruption regression test (truncate + byte-flip, 10/10) and a retryability assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1AXHNsnQmHW174i5rRUEb

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `DatabaseCorrupt` variant to `PlatformStorageError` and detect corruption in `EncryptedConnection::validate`
> - Adds `DatabaseCorrupt(String)` to the `PlatformStorageError` enum and returns `false` from `is_retryable()` for this variant, classifying corruption as non-retryable.
> - Updates `EncryptedConnection::validate` in [sqlcipher_connection.rs](https://github.com/xmtp/libxmtp/pull/4030/files#diff-9e990ba43940d106bb62ca5aee25623e90f2ac82a14f90927d8c0e709b0eb322) to inspect the PRAGMA/key validation error message; if it contains "malformed" or "corrupt" the error surfaces as `DatabaseCorrupt`, otherwise it remains `SqlCipherKeyIncorrect`.
> - Adds tests covering both the non-retryable classification and the corruption-vs-wrong-key distinction.
> - Behavioral Change: callers that previously saw `SqlCipherKeyIncorrect` for a corrupt database will now see `DatabaseCorrupt`; retry logic will no longer attempt retries on corruption errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9859ebb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->