### PR TITLE
insipx/db integrity 3 client method

### DIFF
--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -357,6 +357,23 @@ where
         Ok(())
     }
 
+    /// Run a read-only integrity check against this client's database. Uses
+    /// a dedicated short-lived read-only connection for persistent
+    /// databases, so it does not contend with this client's own
+    /// connection(s).
+    pub fn db_integrity_check(
+        &self,
+        level: IntegrityCheckLevel,
+    ) -> Result<IntegrityCheckResult, ClientError> {
+        // Match the closed-client behavior of `reconnect_db`: a closed
+        // client's methods error; post-close file checks belong to the
+        // standalone `check_database_integrity`.
+        if self.context.is_closed() {
+            return Err(ClientError::AlreadyClosed);
+        }
+        Ok(self.context.store().integrity_check(level)?)
+    }
+
     /// Cleanly shut down this client: cancel in-flight workers and streams,
     /// then release the DB connection. Idempotent — a second call is `Ok(())`.
     ///
@@ -1336,6 +1353,26 @@ pub(crate) mod tests {
             VerifierError::MalformedEipUrl,
         ));
         assert!(!non_retryable.is_retryable());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_db_integrity_check_errors_after_close() {
+        use crate::client::ClientError;
+        use xmtp_db::prelude::IntegrityCheckLevel;
+        tester!(alix);
+        alix.close().await?;
+        assert!(matches!(
+            alix.db_integrity_check(IntegrityCheckLevel::Quick),
+            Err(ClientError::AlreadyClosed)
+        ));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_db_integrity_check() {
+        use xmtp_db::prelude::{IntegrityCheckLevel, IntegrityCheckResult};
+        tester!(alix);
+        let result = alix.db_integrity_check(IntegrityCheckLevel::Full)?;
+        assert_eq!(result, IntegrityCheckResult::Ok);
     }
 
     #[xmtp_common::test]

--- a/crates/xmtp_mls/src/context.rs
+++ b/crates/xmtp_mls/src/context.rs
@@ -204,6 +204,10 @@ where
 
     fn context_ref(&self) -> &Self::ContextReference;
     fn db(&self) -> <Self::Db as XmtpDb>::DbQuery;
+    /// The database backing this context, at the [`XmtpDb`] level (for
+    /// database-lifecycle operations like integrity checks; use [`Self::db`]
+    /// for queries).
+    fn store(&self) -> &Self::Db;
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient>;
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>>;
 
@@ -290,6 +294,10 @@ where
 
     fn db(&self) -> <Self::Db as XmtpDb>::DbQuery {
         self.store.db()
+    }
+
+    fn store(&self) -> &Self::Db {
+        &self.store
     }
 
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient> {
@@ -389,6 +397,10 @@ where
 
     fn db(&self) -> <Self::Db as XmtpDb>::DbQuery {
         <T as XmtpSharedContext>::db(self)
+    }
+
+    fn store(&self) -> &Self::Db {
+        <T as XmtpSharedContext>::store(self)
     }
 
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient> {

--- a/crates/xmtp_mls/src/test/mock.rs
+++ b/crates/xmtp_mls/src/test/mock.rs
@@ -117,6 +117,10 @@ impl XmtpSharedContext for NewMockContext {
         self.store.db()
     }
 
+    fn store(&self) -> &Self::Db {
+        &self.store
+    }
+
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         &self.api_client
     }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `db_integrity_check` method to `Client` and `store` accessor to `XmtpSharedContext`
> - Adds `Client::db_integrity_check(level)` which runs a read-only integrity check on the client's database, returning `IntegrityCheckResult` or `ClientError::AlreadyClosed` when the client is closed.
> - Introduces a required `store(&self) -> &Self::Db` method on the `XmtpSharedContext` trait, implemented by `XmtpMlsLocalContext`, the generic delegating impl, and `NewMockContext`.
> - Adds tests covering the closed-client error path and the live-client `Full` check returning `Ok`.
> - Behavioral Change: `XmtpSharedContext` gains a new required trait method `store`, so all external implementations must add it to compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3adafff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->