### PR TITLE
insipx/db integrity 4 node bindings

### DIFF
--- a/bindings/node/src/client/mod.rs
+++ b/bindings/node/src/client/mod.rs
@@ -101,6 +101,24 @@ impl Client {
     Ok(())
   }
 
+  /// Read-only integrity check of this client's database, run on a blocking
+  /// thread (never the JS event loop). Persistent databases are checked on a
+  /// dedicated read-only connection and don't contend with this client's DB
+  /// operations; ephemeral in-memory databases use the client's own connection.
+  #[napi]
+  pub async fn db_integrity_check(
+    &self,
+    level: Option<crate::integrity::IntegrityCheckLevel>,
+  ) -> Result<crate::integrity::IntegrityCheckOutcome> {
+    let client = self.inner_client.clone();
+    let level = level.map(Into::into).unwrap_or_default();
+    let result = tokio::task::spawn_blocking(move || client.db_integrity_check(level))
+      .await
+      .map_err(|e| Error::from_reason(e.to_string()))?
+      .map_err(ErrorWrapper::from)?;
+    Ok(result.into())
+  }
+
   /// Cleanly shut down this client: cancel in-flight workers and streams, then
   /// release the DB connection. Idempotent — a second call resolves to `Ok`.
   ///

--- a/bindings/node/src/integrity.rs
+++ b/bindings/node/src/integrity.rs
@@ -1,0 +1,73 @@
+use napi::bindgen_prelude::{Error, Result, Uint8Array};
+use napi_derive::napi;
+use std::ops::Deref;
+
+#[napi(string_enum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntegrityCheckLevel {
+  Quick,
+  Full,
+}
+
+impl From<IntegrityCheckLevel> for xmtp_db::prelude::IntegrityCheckLevel {
+  fn from(level: IntegrityCheckLevel) -> Self {
+    match level {
+      IntegrityCheckLevel::Quick => Self::Quick,
+      IntegrityCheckLevel::Full => Self::Full,
+    }
+  }
+}
+
+#[napi(object)]
+pub struct IntegrityCheckOutcome {
+  /// "ok" | "corrupt" | "unreadable" | "saltMissing" | "locked" | "failed"
+  pub outcome: String,
+  /// Row-level findings (corrupt) or the error/reason string (other
+  /// non-ok outcomes). Empty when ok.
+  pub findings: Vec<String>,
+}
+
+impl From<xmtp_db::prelude::IntegrityCheckResult> for IntegrityCheckOutcome {
+  fn from(r: xmtp_db::prelude::IntegrityCheckResult) -> Self {
+    use xmtp_db::prelude::IntegrityCheckResult::*;
+    let (outcome, findings) = match r {
+      Ok => ("ok", vec![]),
+      Corrupt { findings } => ("corrupt", findings),
+      Unreadable { reason } => ("unreadable", vec![reason]),
+      SaltMissing => ("saltMissing", vec![]),
+      Locked => ("locked", vec![]),
+      Failed { error } => ("failed", vec![error]),
+    };
+    IntegrityCheckOutcome {
+      outcome: outcome.into(),
+      findings,
+    }
+  }
+}
+
+/// Read-only integrity check of a database file by path, without a client.
+/// Runs off the JS event loop. For encrypted databases pass the same
+/// 32-byte encryption key used to create the client.
+#[napi]
+pub async fn check_database_integrity(
+  db_path: String,
+  encryption_key: Option<Uint8Array>,
+  level: Option<IntegrityCheckLevel>,
+) -> Result<IntegrityCheckOutcome> {
+  // Same 32-byte validation and error message as
+  // `client::create_client::build_store`'s key conversion.
+  let key = encryption_key
+    .map(|k| -> Result<xmtp_db::EncryptionKey> {
+      k.deref()
+        .try_into()
+        .map_err(|_| Error::from_reason("Malformed 32 byte encryption key"))
+    })
+    .transpose()?;
+  let level = level.map(Into::into).unwrap_or_default();
+  let result = tokio::task::spawn_blocking(move || {
+    xmtp_db::prelude::check_database_integrity(&db_path, key.as_ref(), level)
+  })
+  .await
+  .map_err(|e| Error::from_reason(e.to_string()))?;
+  Ok(result.into())
+}

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -15,6 +15,7 @@ pub mod hmac_key;
 mod identity;
 pub mod inbox_id;
 mod inbox_state;
+pub mod integrity;
 mod messages;
 mod permissions;
 mod signatures;

--- a/bindings/node/test/Integrity.test.ts
+++ b/bindings/node/test/Integrity.test.ts
@@ -1,0 +1,75 @@
+import { randomBytes } from 'node:crypto'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  createLocalBackend,
+  createRegisteredClient,
+  createUser,
+  type User,
+} from '@test/helpers'
+import {
+  checkDatabaseIntegrity,
+  createClientWithBackend,
+  generateInboxId,
+  IdentifierKind,
+  IntegrityCheckLevel,
+  LogLevel,
+  SyncWorkerMode,
+} from '../dist'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Mirrors `helpers.ts`'s internal `dbPath` computation (`createClient` does
+// not expose it) so `checkDatabaseIntegrity` can be pointed at the same file
+// after a client using that path has been closed.
+const dbPathFor = (user: User) => join(__dirname, `${user.uuid}.db3`)
+
+// `helpers.ts`'s `createClient` doesn't thread an `encryptionKey` through
+// `DbOptions`, so the wrong-key scenario builds a client directly. Identity
+// registration is skipped: the assertion is about decrypting the file, not
+// about what is stored in it.
+const createEncryptedClient = async (user: User, encryptionKey: Uint8Array) => {
+  const identifier = {
+    identifier: user.account.address,
+    identifierKind: IdentifierKind.Ethereum,
+  }
+  return createClientWithBackend(
+    await createLocalBackend(),
+    { dbPath: dbPathFor(user), encryptionKey },
+    generateInboxId(identifier),
+    identifier,
+    SyncWorkerMode.Disabled,
+    { level: LogLevel.Error },
+    undefined
+  )
+}
+
+describe('integrity', () => {
+  it('reports ok for a healthy client db, live and by path', async () => {
+    const user = createUser()
+    const client = await createRegisteredClient(user)
+
+    const live = await client.dbIntegrityCheck(IntegrityCheckLevel.Full)
+    expect(live.outcome).toBe('ok')
+    expect(live.findings).toEqual([])
+
+    await client.close()
+    const byPath = await checkDatabaseIntegrity(
+      dbPathFor(user),
+      undefined,
+      IntegrityCheckLevel.Quick
+    )
+    expect(byPath.outcome).toBe('ok')
+  })
+
+  it('reports unreadable for a wrong key', async () => {
+    const user = createUser()
+    const encryptionKey = new Uint8Array(randomBytes(32))
+    const client = await createEncryptedClient(user, encryptionKey)
+    await client.close()
+    const wrongKey = new Uint8Array(32).fill(7)
+    const res = await checkDatabaseIntegrity(dbPathFor(user), wrongKey)
+    expect(res.outcome).toBe('unreadable')
+  })
+})


### PR DESCRIPTION
Stacked on #4031. Node napi surface: async `checkDatabaseIntegrity(dbPath, encryptionKey?, level?)` and `client.dbIntegrityCheck(level?)`, both running the Rust work off the JS event loop via `spawn_blocking`, returning `{ outcome, findings }` with outcome ∈ `ok|corrupt|unreadable|saltMissing|locked|failed`. Key conversion mirrors `create_client`. Vitest coverage: live + by-path ok on real DBs; wrong-key `unreadable` against a genuinely SQLCipher-encrypted DB. Full node suite 118/118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1AXHNsnQmHW174i5rRUEb

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Node bindings for database integrity check APIs
> - Exposes `dbIntegrityCheck(level?)` on `client.Client` and a standalone `check_database_integrity(path, key?, level?)` function to run read-only integrity checks off the JS event loop
> - Introduces `IntegrityCheckLevel` enum (`Quick`/`Full`) and `IntegrityCheckOutcome` struct (`outcome` + `findings`) for Node-facing types
> - Standalone path-based check validates the optional 32-byte encryption key and returns a specific error on malformed input
> - Risk: `check_database_integrity` requires a 32-byte key; wrong-length keys return a `napi::Error` rather than being silently handled
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b43082b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->