### PR TITLE
fix(id): flip recovery id for normalized ECDSA signatures

### DIFF
--- a/crates/xmtp_id/src/associations/signature.rs
+++ b/crates/xmtp_id/src/associations/signature.rs
@@ -318,6 +318,26 @@ impl ValidatedLegacySignedPublicKey {
     }
 }
 
+fn flip_recovery_id_y_parity(recovery_id: u8) -> Result<u8, SignatureError> {
+    match recovery_id {
+        // Raw k256 recovery ids carry y parity in the low bit and may carry
+        // x-reduced state in the second bit.
+        0..=3 => Ok(recovery_id ^ 1),
+        // Ethereum legacy v values encode y parity as 27/28.
+        27 => Ok(28),
+        28 => Ok(27),
+        // EIP-155 values encode y parity as (v - 35) % 2.
+        35..=u8::MAX => {
+            if (recovery_id - 35) % 2 == 0 {
+                recovery_id.checked_add(1).ok_or(SignatureError::Invalid)
+            } else {
+                Ok(recovery_id - 1)
+            }
+        }
+        _ => Err(SignatureError::Invalid),
+    }
+}
+
 /// Converts a signature to use the lower-s value to prevent signature malleability
 pub fn to_lower_s(sig_bytes: &[u8]) -> Result<Vec<u8>, SignatureError> {
     // Check if we have a recovery id byte
@@ -331,9 +351,12 @@ pub fn to_lower_s(sig_bytes: &[u8]) -> Result<Vec<u8>, SignatureError> {
     let sig = K256Signature::try_from(sig_data)?;
 
     // If s is already normalized (lower-s), return the original bytes
-    let normalized = match sig.normalize_s() {
-        None => sig_data.to_vec(),
-        Some(normalized) => normalized.to_bytes().to_vec(),
+    let (normalized, recovery_id) = match sig.normalize_s() {
+        None => (sig_data.to_vec(), recovery_id),
+        Some(normalized) => (
+            normalized.to_bytes().to_vec(),
+            recovery_id.map(flip_recovery_id_y_parity).transpose()?,
+        ),
     };
 
     // Add back recovery id if it was present
@@ -421,6 +444,39 @@ mod tests {
         let recovered_sig = K256Signature::try_from(&normalized_high_s.as_slice()[..64]).unwrap();
         let is_high: bool = recovered_sig.s().is_high().into();
         assert!(!is_high, "Normalized signature should have low-s value");
+    }
+
+    #[xmtp_common::test]
+    fn test_to_lower_s_preserves_recoverable_ecdsa_signer() {
+        use crate::associations::verified_signature::VerifiedSignature;
+        use alloy::signers::k256::elliptic_curve::{Curve, bigint::Encoding};
+        use alloy::signers::k256::{Secp256k1, U256};
+
+        let signer = LocalSigner::random();
+        let message = "test message";
+        let signature = signer.sign_message_sync(message.as_bytes()).unwrap();
+        let low_s_sig: Vec<u8> = signature.into();
+
+        let s = U256::from_be_slice(&low_s_sig[32..64]);
+        let high_s = Secp256k1::ORDER.wrapping_sub(&s);
+        let high_s_bytes = high_s.to_be_bytes();
+
+        let mut high_s_sig = low_s_sig.clone();
+        high_s_sig[32..64].copy_from_slice(&high_s_bytes);
+        high_s_sig[64] = super::flip_recovery_id_y_parity(low_s_sig[64]).unwrap();
+
+        let normalized = to_lower_s(&high_s_sig).unwrap();
+        assert_eq!(
+            normalized[64], low_s_sig[64],
+            "normalizing s must flip the recovery id back to the original parity"
+        );
+
+        VerifiedSignature::from_recoverable_ecdsa_with_expected_address(
+            message,
+            &normalized,
+            signer.address().to_string().as_str(),
+        )
+        .expect("normalized high-s signature should recover the original signer");
     }
 
     #[wasm_bindgen_test(unsupported = test)]


### PR DESCRIPTION
## Summary

Fixes #4035

`to_lower_s()` normalized high-s ECDSA signatures to low-s form but kept the original recovery id byte unchanged.

For recoverable ECDSA signatures, changing `s` to its low-s equivalent also requires flipping the recovery id y-parity bit. Otherwise the normalized signature can recover a different Ethereum signer address.

---

## Changes

- Flip the recovery id y-parity when `normalize_s()` changes `s`.
- Handle raw k256 recovery ids, Ethereum legacy 27/28, and EIP-155-style values.
- Add a regression test that constructs a high-s equivalent signature and verifies normalization still recovers the original signer.

---

## How to Test

```bash
cargo fmt -p xmtp_id --check
cargo test -p xmtp_id test_to_lower_s_preserves_recoverable_ecdsa_signer
cargo test -p xmtp_id test_to_lower_s
cargo test -p xmtp_id associations::signature::tests
cargo check -p xmtp_id
git diff --check
```

**Note:** `cargo test -p xmtp_id` was also attempted. It passed 39 tests and failed 3 SCW verifier tests because no local RPC/anvil service was listening on `127.0.0.1:8545`. The failures appear unrelated to this signature normalization change.

---

## Checklist

- [x] Tests pass — targeted signature normalization tests green (unrelated SCW verifier failures due to missing local RPC service)
- [x] `cargo fmt` clean
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low-to-medium.** The fix only changes behavior for high-s signatures that require normalization — the recovery id flip is applied exactly when `normalize_s()` changes `s`, so low-s signatures are unaffected. The regression test verifies the normalized signature still recovers the original signer address.

**Type:** 🐛 Bug fix
**Fixes:** #4035

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `to_lower_s` to flip recovery id y-parity for normalized ECDSA signatures
> - When `to_lower_s` normalizes a high-s ECDSA signature to low-s, it now flips the appended recovery id using the new `flip_recovery_id_y_parity` helper so the correct signer can still be recovered.
> - The helper supports raw k256 ids (0..=3), Ethereum legacy v (27/28), and EIP-155 v (>=35), returning `SignatureError::Invalid` on invalid inputs or arithmetic overflow.
> - If no normalization is needed, the original bytes and recovery id are preserved as before.
> - Risk: for certain EIP-155 values near `u8::MAX`, `to_lower_s` may now return `SignatureError::Invalid` due to overflow where it previously succeeded with an unmodified recovery id.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72dbb7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->