### PR TITLE
fix(agent-sdk): normalize remote attachment scheme

### DIFF
--- a/sdks/js/agent-sdk/src/util/AttachmentUtil.scheme.test.ts
+++ b/sdks/js/agent-sdk/src/util/AttachmentUtil.scheme.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@xmtp/node-sdk", () => ({
+  decryptAttachment: vi.fn(),
+  encryptAttachment: vi.fn(),
+}));
+
+import { createRemoteAttachment } from "@/util/AttachmentUtil";
+
+describe("createRemoteAttachment", () => {
+  it("stores URL scheme without a trailing colon", () => {
+    const remoteAttachment = createRemoteAttachment(
+      {
+        contentDigest: new Uint8Array([1, 2, 3]),
+        filename: "hello.txt",
+        nonce: new Uint8Array([4, 5, 6]),
+        payload: new Uint8Array([7, 8, 9]),
+        salt: new Uint8Array([10, 11, 12]),
+        secret: new Uint8Array([13, 14, 15]),
+      },
+      "https://localhost/test_file",
+    );
+
+    expect(remoteAttachment.scheme).toBe("https");
+  });
+});

--- a/sdks/js/agent-sdk/src/util/AttachmentUtil.ts
+++ b/sdks/js/agent-sdk/src/util/AttachmentUtil.ts
@@ -49,7 +49,7 @@ export function createRemoteAttachment(
     filename: encryptedAttachment.filename,
     nonce: encryptedAttachment.nonce,
     salt: encryptedAttachment.salt,
-    scheme: url.protocol,
+    scheme: url.protocol.replace(/:$/, ""),
     secret: encryptedAttachment.secret,
     url: url.toString(),
   };


### PR DESCRIPTION
## Summary

Fixes #4034

`createRemoteAttachment()` used `new URL(fileUrl).protocol` directly as the remote attachment scheme.

In JavaScript, `URL.protocol` includes the trailing colon, so an HTTPS URL produced `scheme: "https:"`. The remote attachment metadata used elsewhere in libxmtp expects the scheme without the colon, e.g. `scheme: "https"`.

---

## Changes

- Normalize the URL protocol before storing it as `scheme`.
- Add a focused regression test that verifies `createRemoteAttachment(..., "https://localhost/test_file").scheme` is `"https"`.

---

## How to Test

```bash
corepack yarn install --immutable
corepack yarn workspace @xmtp/agent-sdk vitest run src/util/AttachmentUtil.scheme.test.ts
git diff --check
```

I also temporarily restored the old behavior and confirmed the new regression test fails with:

Expected: "https"
Received: "https:"


**Notes:**
- `corepack yarn workspace @xmtp/node-sdk build` completed with warnings about unresolved `@xmtp/node-bindings`, but produced `dist`.
- `corepack yarn workspace @xmtp/agent-sdk typecheck` was attempted and failed on existing unrelated ActionWizard TypeScript errors, not this change.

---

## Checklist

- [x] Tests pass — new regression test green, confirmed failing against old behavior
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** Single normalization change in `createRemoteAttachment()` — only the stored `scheme` string format changes (trailing colon stripped). No other fields, encryption logic, or URL handling are affected.

**Type:** 🐛 Bug fix
**Fixes:** #4034

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `createRemoteAttachment` to strip trailing colon from `RemoteAttachment.scheme`
> Changes `createRemoteAttachment` in [AttachmentUtil.ts](https://github.com/xmtp/libxmtp/pull/4037/files#diff-f2aeeabd747c16dc29a937ac4a8b20c70ef148f0851f18480f3f2d8c946beddc) to strip the trailing colon from `url.protocol` via regex, so the returned `scheme` is `'https'` rather than `'https:'`. Adds a Vitest suite in [AttachmentUtil.scheme.test.ts](https://github.com/xmtp/libxmtp/pull/4037/files#diff-8307451d4262e753f0ff6568de4d796c3cb7e9da3031cfee48f799f3221be657) that mocks `@xmtp/node-sdk` and asserts the scheme for `https://localhost/test_file`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dd35ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->