### PR TITLE
insipx/db integrity 8 mobile bindings

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -530,6 +530,73 @@ pub async fn create_client(
     }))
 }
 
+#[derive(uniffi::Enum, Debug, Clone, Copy)]
+pub enum FfiIntegrityCheckLevel {
+    Quick,
+    Full,
+}
+
+impl From<FfiIntegrityCheckLevel> for xmtp_db::prelude::IntegrityCheckLevel {
+    fn from(level: FfiIntegrityCheckLevel) -> Self {
+        match level {
+            FfiIntegrityCheckLevel::Quick => Self::Quick,
+            FfiIntegrityCheckLevel::Full => Self::Full,
+        }
+    }
+}
+
+#[derive(uniffi::Record)]
+pub struct FfiIntegrityCheckOutcome {
+    /// "ok" | "corrupt" | "unreadable" | "saltMissing" | "locked" | "failed"
+    pub outcome: String,
+    /// Row-level findings (corrupt) or the error/reason string (other
+    /// non-ok outcomes). Empty when ok.
+    pub findings: Vec<String>,
+}
+
+impl From<xmtp_db::prelude::IntegrityCheckResult> for FfiIntegrityCheckOutcome {
+    fn from(r: xmtp_db::prelude::IntegrityCheckResult) -> Self {
+        use xmtp_db::prelude::IntegrityCheckResult::*;
+        let (outcome, findings) = match r {
+            Ok => ("ok", vec![]),
+            Corrupt { findings } => ("corrupt", findings),
+            Unreadable { reason } => ("unreadable", vec![reason]),
+            SaltMissing => ("saltMissing", vec![]),
+            Locked => ("locked", vec![]),
+            Failed { error } => ("failed", vec![error]),
+        };
+        FfiIntegrityCheckOutcome {
+            outcome: outcome.into(),
+            findings,
+        }
+    }
+}
+
+/// Read-only integrity check of a database file by path, without a client.
+/// Runs on a blocking thread. For encrypted databases pass the same 32-byte
+/// encryption key used to create the client.
+#[uniffi::export(async_runtime = "tokio", default(encryption_key = None, level = None))]
+pub async fn check_database_integrity(
+    db_path: String,
+    encryption_key: Option<Vec<u8>>,
+    level: Option<FfiIntegrityCheckLevel>,
+) -> Result<FfiIntegrityCheckOutcome, FfiError> {
+    // Same 32-byte validation and error message as `create_client`'s key
+    // conversion.
+    let key = encryption_key
+        .map(|k| -> Result<EncryptionKey, String> {
+            k.try_into()
+                .map_err(|_| "Malformed 32 byte encryption key".to_string())
+        })
+        .transpose()?;
+    let level = level.map(Into::into).unwrap_or_default();
+    let result = tokio::task::spawn_blocking(move || {
+        xmtp_db::prelude::check_database_integrity(&db_path, key.as_ref(), level)
+    })
+    .await?;
+    Ok(result.into())
+}
+
 #[allow(unused)]
 #[uniffi::export(async_runtime = "tokio")]
 #[tracing::instrument(level = "debug", skip_all)]
@@ -768,6 +835,21 @@ impl FfiXmtpClient {
     #[tracing::instrument(skip_all)]
     pub async fn db_reconnect(&self) -> Result<(), FfiError> {
         Ok(self.inner_client.reconnect_db()?)
+    }
+
+    /// Read-only integrity check of this client's database. Uses a
+    /// dedicated read-only connection on a blocking thread, so it blocks
+    /// neither the async runtime nor this client's DB operations.
+    #[tracing::instrument(skip_all)]
+    pub async fn db_integrity_check(
+        &self,
+        level: Option<FfiIntegrityCheckLevel>,
+    ) -> Result<FfiIntegrityCheckOutcome, FfiError> {
+        let client = self.inner_client.clone();
+        let level = level.map(Into::into).unwrap_or_default();
+        let result =
+            tokio::task::spawn_blocking(move || client.db_integrity_check(level)).await??;
+        Ok(result.into())
     }
 
     /// Cleanly shut down this client: cancel in-flight workers and detached

--- a/bindings/mobile/src/mls/tests/integrity.rs
+++ b/bindings/mobile/src/mls/tests/integrity.rs
@@ -1,0 +1,86 @@
+//! Tests for the read-only database integrity check: the client method
+//! (`FfiXmtpClient::db_integrity_check`) and the free function
+//! (`check_database_integrity`).
+
+use crate::{DbOptions, check_database_integrity};
+use xmtp_db::EncryptedMessageStore;
+
+use super::*;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_db_integrity_check_ok() {
+    let client = new_test_client().await;
+    let outcome = client.db_integrity_check(None).await.unwrap();
+    assert_eq!(outcome.outcome, "ok");
+    assert!(outcome.findings.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_check_database_integrity_free_fn_ok() {
+    let ffi_inbox_owner = FfiWalletInboxOwner::new();
+    let ident = ffi_inbox_owner.identifier();
+    let nonce = 1;
+    let inbox_id = ident.inbox_id(nonce).unwrap();
+    let db_path = tmp_path();
+    let key: Vec<u8> = EncryptedMessageStore::<()>::generate_enc_key().into();
+
+    let client = create_client(
+        connect_to_backend_test().await,
+        DbOptions::new(Some(db_path.clone()), Some(key.clone()), None, None, None),
+        &inbox_id,
+        ident,
+        nonce,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    register_client_with_wallet(&ffi_inbox_owner, &client).await;
+    // Release the DB connection before checking the file out from under a
+    // still-open client.
+    client.shutdown().await.unwrap();
+
+    let outcome = check_database_integrity(db_path, Some(key), None)
+        .await
+        .unwrap();
+    assert_eq!(outcome.outcome, "ok");
+    assert!(outcome.findings.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_check_database_integrity_free_fn_wrong_key_is_unreadable() {
+    let ffi_inbox_owner = FfiWalletInboxOwner::new();
+    let ident = ffi_inbox_owner.identifier();
+    let nonce = 1;
+    let inbox_id = ident.inbox_id(nonce).unwrap();
+    let db_path = tmp_path();
+    let key: Vec<u8> = EncryptedMessageStore::<()>::generate_enc_key().into();
+
+    let client = create_client(
+        connect_to_backend_test().await,
+        DbOptions::new(Some(db_path.clone()), Some(key), None, None, None),
+        &inbox_id,
+        ident,
+        nonce,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    register_client_with_wallet(&ffi_inbox_owner, &client).await;
+    client.shutdown().await.unwrap();
+
+    let wrong_key: Vec<u8> = EncryptedMessageStore::<()>::generate_enc_key().into();
+    let outcome = check_database_integrity(db_path, Some(wrong_key), None)
+        .await
+        .unwrap();
+    assert_eq!(outcome.outcome, "unreadable");
+}

--- a/bindings/mobile/src/mls/tests/mod.rs
+++ b/bindings/mobile/src/mls/tests/mod.rs
@@ -90,6 +90,7 @@ mod content_types;
 mod dms;
 mod group_management;
 mod identity;
+mod integrity;
 mod lifecycle;
 mod networking;
 mod static_methods;


### PR DESCRIPTION
Stacked on #4039. uniffi mobile bindings: `FfiIntegrityCheckLevel`, `FfiIntegrityCheckOutcome`, `FfiXmtpClient.db_integrity_check(level?)` and free `check_database_integrity(db_path, encryption_key?, level?)` — both async via `spawn_blocking` around the sync Rust calls; key conversion mirrors `create_client` ("Malformed 32 byte encryption key"). 3 backend-connected tests (ok / by-path ok on encrypted DB / wrong-key unreadable). clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1AXHNsnQmHW174i5rRUEb

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mobile FFI bindings for database integrity checks
> - Adds `FfiIntegrityCheckLevel` enum and `FfiIntegrityCheckOutcome` record with conversions to `xmtp_db` types
> - Adds `check_database_integrity` free function for read-only path-based checks, validating optional 32-byte encryption keys
> - Adds `FfiXmtpClient.db_integrity_check` method to run checks against the client's database
> - Both APIs offload work to `tokio::task::spawn_blocking` and return structured outcomes with standardized strings (`ok`, `corrupt`, `unreadable`, `saltMissing`, `locked`, `failed`)
> - Adds tests in [integrity.rs](https://github.com/xmtp/libxmtp/pull/4040/files#diff-9bce070821664d88fdbfc160abab2d440ee2da515a7d81300982a5bdd99a2b59) covering the client method and the free function with correct and wrong keys
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc5b3d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->