### PR TITLE
insipx/db integrity 9 android sdk

### DIFF
--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -350,6 +350,55 @@ class ClientTest : BaseInstrumentedTest() {
     }
 
     @Test
+    fun testDbIntegrityCheck() {
+        val key = SecureRandom().generateSeed(32)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val fakeWallet = PrivateKeyBuilder()
+        val client =
+            runBlocking {
+                Client.create(
+                    account = fakeWallet,
+                    options =
+                        ClientOptions(
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            appContext = context,
+                            dbEncryptionKey = key,
+                        ),
+                )
+            }
+
+        val outcome = runBlocking { client.dbIntegrityCheck() }
+        assertEquals("ok", outcome.outcome)
+        assertEquals(emptyList<String>(), outcome.findings)
+    }
+
+    @Test
+    fun testCheckDatabaseIntegrityStatic() {
+        val key = SecureRandom().generateSeed(32)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val fakeWallet = PrivateKeyBuilder()
+        val client =
+            runBlocking {
+                Client.create(
+                    account = fakeWallet,
+                    options =
+                        ClientOptions(
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            appContext = context,
+                            dbEncryptionKey = key,
+                        ),
+                )
+            }
+
+        // Release the pooled connection so the free function's dedicated
+        // read-only connection isn't opened against a live client.
+        runBlocking { client.dropLocalDatabaseConnection() }
+
+        val outcome = runBlocking { Client.checkDatabaseIntegrity(client.dbPath, key) }
+        assertEquals("ok", outcome.outcome)
+    }
+
+    @Test
     fun testCanGetAnInboxIdFromAddress() {
         val key = SecureRandom().generateSeed(32)
         val context = InstrumentationRegistry.getInstrumentation().targetContext

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -14,6 +14,8 @@ import org.xmtp.android.library.libxmtp.ArchiveOptions
 import org.xmtp.android.library.libxmtp.AvailableArchive
 import org.xmtp.android.library.libxmtp.IdentityKind
 import org.xmtp.android.library.libxmtp.InboxState
+import org.xmtp.android.library.libxmtp.IntegrityCheckLevel
+import org.xmtp.android.library.libxmtp.IntegrityCheckOutcome
 import org.xmtp.android.library.libxmtp.PublicIdentity
 import org.xmtp.android.library.libxmtp.SignatureRequest
 import org.xmtp.android.library.libxmtp.toFfi
@@ -44,6 +46,7 @@ import uniffi.xmtpv3.inboxStateFromInboxIds
 import uniffi.xmtpv3.isConnected
 import uniffi.xmtpv3.revokeInstallations
 import java.io.File
+import uniffi.xmtpv3.checkDatabaseIntegrity as ffiCheckDatabaseIntegrity
 import uniffi.xmtpv3.setNativeLogLevel as ffiSetNativeLogLevel
 
 typealias PreEventCallback = suspend () -> Unit
@@ -256,6 +259,20 @@ class Client(
 
             return deletedCount
         }
+
+        /**
+         * Read-only integrity check of a database file by path, without a
+         * client. For encrypted databases pass the same 32-byte encryption
+         * key used to create the client.
+         */
+        suspend fun checkDatabaseIntegrity(
+            dbPath: String,
+            encryptionKey: ByteArray? = null,
+            level: IntegrityCheckLevel = IntegrityCheckLevel.QUICK,
+        ): IntegrityCheckOutcome =
+            withContext(Dispatchers.IO) {
+                IntegrityCheckOutcome(ffiCheckDatabaseIntegrity(dbPath, encryptionKey, level.toFfi()))
+            }
 
         suspend fun connectToApiBackend(api: ClientOptions.Api): XmtpApiClient {
             val cacheKey = api.toCacheKey()
@@ -813,6 +830,16 @@ class Client(
         withContext(Dispatchers.IO) {
             if (isInMemory) return@withContext
             ffiClient.dbReconnect()
+        }
+
+    /**
+     * Read-only integrity check of this client's database. Uses a dedicated
+     * read-only connection on a blocking thread, so it blocks neither the
+     * async runtime nor this client's DB operations.
+     */
+    suspend fun dbIntegrityCheck(level: IntegrityCheckLevel = IntegrityCheckLevel.QUICK): IntegrityCheckOutcome =
+        withContext(Dispatchers.IO) {
+            IntegrityCheckOutcome(ffiClient.dbIntegrityCheck(level.toFfi()))
         }
 
     /**

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/libxmtp/IntegrityCheckLevel.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/libxmtp/IntegrityCheckLevel.kt
@@ -1,0 +1,32 @@
+package org.xmtp.android.library.libxmtp
+
+import uniffi.xmtpv3.FfiIntegrityCheckLevel
+
+/**
+ * How thorough a [org.xmtp.android.library.Client.dbIntegrityCheck] /
+ * [org.xmtp.android.library.Client.checkDatabaseIntegrity] run should be.
+ */
+enum class IntegrityCheckLevel {
+    /**
+     * Cheap structural checks (page/index consistency), safe to run
+     * frequently.
+     */
+    QUICK,
+
+    /**
+     * Exhaustive check of every row and index entry. Slower; reserve for
+     * diagnostics.
+     */
+    FULL,
+
+    ;
+
+    /**
+     * Converts this Kotlin enum to FFI IntegrityCheckLevel
+     */
+    fun toFfi(): FfiIntegrityCheckLevel =
+        when (this) {
+            QUICK -> FfiIntegrityCheckLevel.QUICK
+            FULL -> FfiIntegrityCheckLevel.FULL
+        }
+}

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/libxmtp/IntegrityCheckOutcome.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/libxmtp/IntegrityCheckOutcome.kt
@@ -1,0 +1,22 @@
+package org.xmtp.android.library.libxmtp
+
+import uniffi.xmtpv3.FfiIntegrityCheckOutcome
+
+/**
+ * Result of a [org.xmtp.android.library.Client.dbIntegrityCheck] /
+ * [org.xmtp.android.library.Client.checkDatabaseIntegrity] run.
+ *
+ * [outcome] is one of `"ok"`, `"corrupt"`, `"unreadable"`, `"saltMissing"`,
+ * `"locked"`, or `"failed"`. [findings] holds row-level findings for a
+ * `"corrupt"` outcome, or the error/reason string for other non-`"ok"`
+ * outcomes; it is empty when [outcome] is `"ok"`.
+ */
+data class IntegrityCheckOutcome(
+    val outcome: String,
+    val findings: List<String>,
+) {
+    internal constructor(ffi: FfiIntegrityCheckOutcome) : this(
+        outcome = ffi.outcome,
+        findings = ffi.findings,
+    )
+}


### PR DESCRIPTION
Stacked on #4040. Android SDK wrappers: `IntegrityCheckLevel` / `IntegrityCheckOutcome` Kotlin types, `suspend fun Client.dbIntegrityCheck(level)` and companion `Client.checkDatabaseIntegrity(dbPath, encryptionKey?, level)` over the regenerated uniffi bindings; instrumented tests in ClientTest.kt. Verified locally: bindings regenerated via nix `dev/bindings`, gradle `build` green, spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1AXHNsnQmHW174i5rRUEb

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add database integrity check APIs to Android `Client`
> - Adds `Client.dbIntegrityCheck(level)` instance method that runs an integrity check on the client's own database, defaulting to `QUICK` and running on `Dispatchers.IO`
> - Adds `Client.checkDatabaseIntegrity(dbPath, encryptionKey, level)` companion method for read-only integrity checks by file path, also on `Dispatchers.IO`
> - Introduces `IntegrityCheckLevel` enum (`QUICK`, `FULL`) with `toFfi()` mapping and `IntegrityCheckOutcome` data class wrapping the FFI result
> - Adds tests in [ClientTest.kt](https://github.com/xmtp/libxmtp/pull/4041/files#diff-9f5bfd66b89b172878cdbd01f3170353a8f69331f134b75ab8bded1392191f38) verifying both APIs return `outcome == "ok"` with empty findings on a fresh database
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b0210b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->