### PR TITLE
insipx/db integrity 10 ios sdk

### DIFF
--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -801,6 +801,27 @@ public final class Client {
 		)
 	}
 
+	/// Read-only integrity check of a database file by path, without a
+	/// client. For encrypted databases pass the same ``Data``
+	/// ``encryptionKey`` used to create the client.
+	public static func checkDatabaseIntegrity(
+		dbPath: String,
+		encryptionKey: Data? = nil,
+		level: IntegrityCheckLevel = .quick
+	) async throws -> IntegrityCheckOutcome {
+		let result: FfiIntegrityCheckOutcome
+		#if canImport(XMTPiOS)
+			result = try await XMTPiOS.checkDatabaseIntegrity(
+				dbPath: dbPath, encryptionKey: encryptionKey, level: level.toFfi()
+			)
+		#else
+			result = try await XMTP.checkDatabaseIntegrity(
+				dbPath: dbPath, encryptionKey: encryptionKey, level: level.toFfi()
+			)
+		#endif
+		return IntegrityCheckOutcome(result)
+	}
+
 	init(
 		ffiClient: FfiXmtpClient, dbPath: String,
 		installationID: String, inboxID: InboxId, environment: XMTPEnvironment,
@@ -979,6 +1000,17 @@ public final class Client {
 	{
 		try await CatchUpSummary(
 			ffiClient.catchUpToLive(opts: FfiCatchUpOptions(timeoutMs: timeoutMs))
+		)
+	}
+
+	/// Read-only integrity check of this client's local database. Runs on a
+	/// dedicated read-only connection, so it blocks neither this client's DB
+	/// operations nor the caller.
+	public func dbIntegrityCheck(level: IntegrityCheckLevel = .quick) async throws
+		-> IntegrityCheckOutcome
+	{
+		try await IntegrityCheckOutcome(
+			ffiClient.dbIntegrityCheck(level: level.toFfi())
 		)
 	}
 

--- a/sdks/ios/Sources/XMTPiOS/IntegrityCheck.swift
+++ b/sdks/ios/Sources/XMTPiOS/IntegrityCheck.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// How thorough a ``Client/dbIntegrityCheck(level:)`` /
+/// ``Client/checkDatabaseIntegrity(dbPath:encryptionKey:level:)`` run should
+/// be.
+public enum IntegrityCheckLevel: Sendable {
+	/// Cheap structural checks (page/index consistency), safe to run
+	/// frequently.
+	case quick
+	/// Exhaustive check of every row and index entry. Slower; reserve for
+	/// diagnostics.
+	case full
+
+	func toFfi() -> FfiIntegrityCheckLevel {
+		switch self {
+		case .quick:
+			.quick
+		case .full:
+			.full
+		}
+	}
+}
+
+/// Result of a ``Client/dbIntegrityCheck(level:)`` /
+/// ``Client/checkDatabaseIntegrity(dbPath:encryptionKey:level:)`` run.
+///
+/// ``outcome`` is one of `"ok"`, `"corrupt"`, `"unreadable"`,
+/// `"saltMissing"`, `"locked"`, or `"failed"`. ``findings`` holds row-level
+/// findings for a `"corrupt"` outcome, or the error/reason string for other
+/// non-`"ok"` outcomes; it is empty when ``outcome`` is `"ok"`.
+public struct IntegrityCheckOutcome: Sendable {
+	public let outcome: String
+	public let findings: [String]
+
+	init(_ ffi: FfiIntegrityCheckOutcome) {
+		outcome = ffi.outcome
+		findings = ffi.findings
+	}
+}

--- a/sdks/ios/Tests/XMTPTests/ClientTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ClientTests.swift
@@ -173,6 +173,34 @@ class ClientTests: XCTestCase {
 		try boClient.deleteLocalDatabase()
 	}
 
+	func testDbIntegrityCheck() async throws {
+		let key = try Crypto.secureRandomBytes(count: 32)
+		let bo = try PrivateKey.generate()
+		let boClient = try await Client.create(
+			account: bo,
+			options: .init(
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				dbEncryptionKey: key
+			)
+		)
+
+		let outcome = try await boClient.dbIntegrityCheck()
+		XCTAssertEqual(outcome.outcome, "ok")
+		XCTAssertEqual(outcome.findings, [])
+
+		// Release the pooled connection so the static function's dedicated
+		// read-only connection isn't opened against a live client.
+		try boClient.dropLocalDatabaseConnection()
+
+		let staticOutcome = try await Client.checkDatabaseIntegrity(
+			dbPath: boClient.dbPath, encryptionKey: key
+		)
+		XCTAssertEqual(staticOutcome.outcome, "ok")
+
+		try await boClient.reconnectLocalDatabase()
+		try boClient.deleteLocalDatabase()
+	}
+
 	func testCanMessage() async throws {
 		let fixtures = try await fixtures()
 		let notOnNetwork = try PrivateKey.generate()


### PR DESCRIPTION
Stacked on #4041 (top). iOS SDK wrappers: `IntegrityCheckLevel` / `IntegrityCheckOutcome` Swift types, `Client.dbIntegrityCheck(level:)` and static `Client.checkDatabaseIntegrity(dbPath:encryptionKey:level:)`; XCTest coverage in ClientTests. Authored on Linux against verified uniffi naming conventions — compile verification is CI's `test-ios`/`lint-ios` (the generated `xmtpv3.swift` is regenerated by `dev/bindings` there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1AXHNsnQmHW174i5rRUEb

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add database integrity check APIs to iOS SDK `Client`
> - Adds static `Client.checkDatabaseIntegrity(dbPath:encryptionKey:level:)` to run a read-only integrity check on an arbitrary database file path, including encrypted databases
> - Adds instance `Client.dbIntegrityCheck(level:)` to run a read-only integrity check on an existing client's local database via a dedicated read-only FFI connection
> - Introduces `IntegrityCheckLevel` enum (`.quick` default, `.full`) and `IntegrityCheckOutcome` struct (outcome + findings) to wrap FFI results
> - Adds `ClientTests.testDbIntegrityCheck` covering both APIs under encrypted DB conditions
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfc910d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->