### PR TITLE
h2 0.4.16 -> 0.4.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4219,9 +4219,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4707,7 +4707,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.16",
+ "h2 0.4.19",
  "http 1.4.2",
  "http-body 1.1.0",
  "httparse",
@@ -7794,7 +7794,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7851,7 +7851,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8762,7 +8762,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9134,7 +9134,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.16",
+ "h2 0.4.19",
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
@@ -10724,7 +10724,7 @@ dependencies = [
  "futures",
  "futures-test",
  "getrandom 0.4.3",
- "h2 0.4.16",
+ "h2 0.4.19",
  "http 1.4.2",
  "http-body-util",
  "hyper 1.11.0",


### PR DESCRIPTION
## Why

herald-lite dev has thrown up to ~273k errors/day since Aug 22 — every one a client-side `GoAway(b"too_many_data_frames", ENHANCE_YOUR_CALM, Library)` that kills a whole gRPC connection and fails every in-flight RPC on it with `RESOURCE_EXHAUSTED` (surfacing from `xmtp_api_grpc::grpc_client::client`). Onset matches herald picking up the node-bindings nightly built from #4024, which brought in h2 0.4.16.

h2 0.4.16's RUSTSEC-2026-0258 mitigation budgets received DATA frames smaller than 256 B against a **fixed** 25,600-byte allowance — roughly 100 tiny buffered frames per connection. Herald's ~200/s welcome-sync polling returns mostly-empty responses, so one account's concurrent sync batch trips the budget whenever the runtime is briefly slow to drain frames. Upstream confirmed the false positive on exactly this shape (many concurrent requests, small responses, one connection): hyperium/h2#939.

## Why 0.4.19 specifically

- **0.4.19** auto-scales the budget to half the initial connection window (min 25,600 B). We already set `initial_connection_window_size((1 << 31) - 1)` in `xmtp_api_grpc::apply_channel_options`, so the effective budget becomes ~1 GiB — the mitigation can no longer misfire on this workload, with no code changes.
- 0.4.17's END_STREAM exemption doesn't cover gRPC unary responses (trailers close the stream, not the DATA frame).
- 0.4.18's `data_frame_budget()` builder knob isn't plumbed through hyper/tonic, so we can't reach it.

Lockfile-only. Note for rollout: prod heralds are still on a pre-0.4.16 build and should promote straight to a build containing this fix — 0.4.16–0.4.18 must not reach prod.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Update `h2` crate from 0.4.16 to 0.4.19 in `Cargo.lock`
Bumps the `h2` HTTP/2 crate to the latest 0.4.x patch release via the generated lockfile. No source code changes are included; the update is lockfile-only.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54fd486.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->
