### PR TITLE
chore(logging): normalize tracing attribute keys across the workspace

### DIFF
--- a/apps/keepalive-probe/src/main.rs
+++ b/apps/keepalive-probe/src/main.rs
@@ -329,7 +329,7 @@ async fn subscribe_once(
                     };
                     tracing::info!(
                         id,
-                        msg_id = mid,
+                        message_id = mid,
                         total = received,
                         "payload received (dropped)"
                     );

--- a/apps/xmtp_debug/src/app/generate/identity.rs
+++ b/apps/xmtp_debug/src/app/generate/identity.rs
@@ -248,7 +248,7 @@ impl GenerateIdentity {
             tracing::error!("{} errors during identity generation", errs.len());
             tracing::error!("{} unique errors during identity generation", unique.len());
             for err in unique.into_iter() {
-                error!(err);
+                error!(error = err);
             }
             bail!("Error generation failed");
         }

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -208,7 +208,7 @@ impl GenerateMessages {
         owner_group
             .add_members(&[hex::encode(not_in_group)])
             .await
-            .inspect_err(|e| error!(%group, "{}", e))?;
+            .inspect_err(|e| error!(group_id = %group, "{}", e))?;
         // make sure to update the group metadata
         let mut new_group = group.clone();
         new_group.members.push(*not_in_group);
@@ -249,7 +249,7 @@ impl GenerateMessages {
             mls_group
                 .update_group_description(words)
                 .await
-                .inspect_err(|e| error!(%group, "{}", e))?;
+                .inspect_err(|e| error!(group_id = %group, "{}", e))?;
             Ok(())
         } else {
             Err(MessageSendError::NoGroup.into())
@@ -334,7 +334,7 @@ impl GenerateMessages {
         let stored_group = group_store
             .random(rng)?
             .ok_or(eyre!("no group in local store"))?;
-        info!(time = ?Instant::now(), group = %stored_group.id(), "sending message");
+        info!(time = ?Instant::now(), group_id = %stored_group.id(), "sending message");
         let Some(sender_inbox_id) = stored_group.members.choose(rng).copied() else {
             return Err(MessageSendError::NoGroup);
         };

--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -505,7 +505,7 @@ impl HealthContext {
             if let Err(e) = c.sync_welcomes().await {
                 tracing::warn!(
                     target: "healthcheck",
-                    inbox = c.inbox_id(),
+                    inbox_id = c.inbox_id(),
                     error = %e,
                     label,
                     "sync_welcomes fanout failed",
@@ -529,7 +529,7 @@ impl HealthContext {
             if let Err(e) = c.sync_welcomes().await {
                 tracing::warn!(
                     target: "healthcheck",
-                    inbox = c.inbox_id(),
+                    inbox_id = c.inbox_id(),
                     error = %e,
                     label,
                     "sync_welcomes fanout failed",

--- a/apps/xmtp_debug/src/app/health/ops/add_members.rs
+++ b/apps/xmtp_debug/src/app/health/ops/add_members.rs
@@ -24,7 +24,7 @@ impl HealthOp for AddMembersToNewGroup {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "AddMembersToNewGroup")
+        fields(operation = "AddMembersToNewGroup")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let primary_bytes = ctx.primary.inbox_id_bytes();
@@ -74,7 +74,7 @@ impl HealthOp for AddPrimaryToExistingGroups {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "AddPrimaryToExistingGroups")
+        fields(operation = "AddPrimaryToExistingGroups")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let primary_inbox = ctx.primary.inbox_id_hex();

--- a/apps/xmtp_debug/src/app/health/ops/bootstrap.rs
+++ b/apps/xmtp_debug/src/app/health/ops/bootstrap.rs
@@ -28,7 +28,7 @@ impl HealthOp for BootstrapIdentities {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "BootstrapIdentities")
+        fields(operation = "BootstrapIdentities")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let start = Instant::now();

--- a/apps/xmtp_debug/src/app/health/ops/create_dm.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_dm.rs
@@ -17,7 +17,7 @@ impl HealthOp for CreateDm {
         "CreateDm"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "CreateDm"))]
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(operation = "CreateDm"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_existing_client(|ctx, peer_hc| {
             async move {

--- a/apps/xmtp_debug/src/app/health/ops/create_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_group.rs
@@ -19,7 +19,7 @@ impl HealthOp for CreateGroup {
         "CreateGroup"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "CreateGroup"))]
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(operation = "CreateGroup"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let start = Instant::now();
         let outcome: color_eyre::eyre::Result<(GroupId, InboxId)> = (|| {

--- a/apps/xmtp_debug/src/app/health/ops/create_identity.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_identity.rs
@@ -35,7 +35,11 @@ impl HealthOp for CreateIdentity {
         "CreateIdentity"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "CreateIdentity"))]
+    #[tracing::instrument(
+        target = "healthcheck.op",
+        skip_all,
+        fields(operation = "CreateIdentity")
+    )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let start = Instant::now();
         let outcome: Result<Identity> = async {

--- a/apps/xmtp_debug/src/app/health/ops/ensure_per_version_membership.rs
+++ b/apps/xmtp_debug/src/app/health/ops/ensure_per_version_membership.rs
@@ -33,7 +33,7 @@ impl HealthOp for EnsurePerVersionMembership {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "EnsurePerVersionMembership")
+        fields(operation = "EnsurePerVersionMembership")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let Some(new_group_id) = ctx.new_groups.first().cloned() else {
@@ -103,7 +103,7 @@ impl HealthOp for EnsurePerVersionMembership {
                 let hex_to_add: Vec<String> = to_add.iter().map(hex::encode).collect();
                 tracing::info!(
                     target: "healthcheck",
-                    group = %new_group_id,
+                    group_id = %new_group_id,
                     adding = ?hex_to_add,
                     "adding representative members for missing versions",
                 );

--- a/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
+++ b/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
@@ -14,7 +14,11 @@ impl HealthOp for GetMutableMetadata {
         "GetMutableMetadata"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "GetMutableMetadata"))]
+    #[tracing::instrument(
+        target = "healthcheck.op",
+        skip_all,
+        fields(operation = "GetMutableMetadata")
+    )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {
             primary.group(&gid)?.mutable_metadata()?;

--- a/apps/xmtp_debug/src/app/health/ops/leave_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/leave_group.rs
@@ -21,7 +21,7 @@ impl HealthOp for LeaveGroup {
         "LeaveGroup"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "LeaveGroup"))]
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(operation = "LeaveGroup"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let Some(gid) = ctx.new_groups.first().cloned() else {
             return vec![OpResult::fail(

--- a/apps/xmtp_debug/src/app/health/ops/remove_member.rs
+++ b/apps/xmtp_debug/src/app/health/ops/remove_member.rs
@@ -22,7 +22,11 @@ impl HealthOp for RemoveMember {
         "RemoveMember"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "RemoveMember"))]
+    #[tracing::instrument(
+        target = "healthcheck.op",
+        skip_all,
+        fields(operation = "RemoveMember")
+    )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let Some(gid) = ctx.new_groups.first().cloned() else {
             return vec![OpResult::fail(

--- a/apps/xmtp_debug/src/app/health/ops/send_message.rs
+++ b/apps/xmtp_debug/src/app/health/ops/send_message.rs
@@ -19,7 +19,7 @@ impl HealthOp for SendMessage {
         "SendMessage"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "SendMessage"))]
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(operation = "SendMessage"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let ctx_ref = &*ctx;
         ctx_ref

--- a/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
@@ -15,7 +15,11 @@ impl HealthOp for UpdateAdminList {
         "UpdateAdminList"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateAdminList"))]
+    #[tracing::instrument(
+        target = "healthcheck.op",
+        skip_all,
+        fields(operation = "UpdateAdminList")
+    )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {
             let inbox = primary.inbox_id().to_string();

--- a/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
@@ -13,7 +13,11 @@ impl HealthOp for UpdateAppData {
         "UpdateAppData"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateAppData"))]
+    #[tracing::instrument(
+        target = "healthcheck.op",
+        skip_all,
+        fields(operation = "UpdateAppData")
+    )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {
             primary

--- a/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
@@ -17,7 +17,7 @@ impl HealthOp for UpdateCommitLogSigner {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "UpdateCommitLogSigner")
+        fields(operation = "UpdateCommitLogSigner")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {

--- a/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
@@ -17,7 +17,11 @@ impl HealthOp for UpdateConsentState {
         "UpdateConsentState"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateConsentState"))]
+    #[tracing::instrument(
+        target = "healthcheck.op",
+        skip_all,
+        fields(operation = "UpdateConsentState")
+    )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {
             primary
@@ -40,7 +44,7 @@ impl HealthOp for UpdateConsentStateQuiet {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "UpdateConsentStateQuiet")
+        fields(operation = "UpdateConsentStateQuiet")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {

--- a/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
@@ -16,7 +16,7 @@ impl HealthOp for UpdateGroupDescription {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "UpdateGroupDescription")
+        fields(operation = "UpdateGroupDescription")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {

--- a/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
@@ -16,7 +16,7 @@ impl HealthOp for UpdateGroupImageUrlSquare {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "UpdateGroupImageUrlSquare")
+        fields(operation = "UpdateGroupImageUrlSquare")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {

--- a/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
@@ -13,7 +13,11 @@ impl HealthOp for UpdateGroupName {
         "UpdateGroupName"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateGroupName"))]
+    #[tracing::instrument(
+        target = "healthcheck.op",
+        skip_all,
+        fields(operation = "UpdateGroupName")
+    )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {
             primary

--- a/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
@@ -17,7 +17,7 @@ impl HealthOp for UpdateMessageDisappearing {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "UpdateMessageDisappearing")
+        fields(operation = "UpdateMessageDisappearing")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {
@@ -44,7 +44,7 @@ impl HealthOp for RemoveMessageDisappearing {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "RemoveMessageDisappearing")
+        fields(operation = "RemoveMessageDisappearing")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {

--- a/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
@@ -17,7 +17,7 @@ impl HealthOp for UpdatePermissionPolicy {
     #[tracing::instrument(
         target = "healthcheck.op",
         skip_all,
-        fields(op = "UpdatePermissionPolicy")
+        fields(operation = "UpdatePermissionPolicy")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_group(self.name(), |primary, gid| async move {

--- a/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
+++ b/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
@@ -16,7 +16,11 @@ impl HealthOp for UploadKeyPackage {
         "UploadKeyPackage"
     }
 
-    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UploadKeyPackage"))]
+    #[tracing::instrument(
+        target = "healthcheck.op",
+        skip_all,
+        fields(operation = "UploadKeyPackage")
+    )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         ctx.for_each_client(self.name(), |client| async move {
             client

--- a/apps/xmtp_debug/src/app/health/result.rs
+++ b/apps/xmtp_debug/src/app/health/result.rs
@@ -162,7 +162,7 @@ impl OpResult {
         match self.status {
             Status::Pass => tracing::info!(
                 target: "healthcheck",
-                op = self.op_name,
+                operation = self.op_name,
                 status = "pass",
                 target = %self.target.as_deref().unwrap_or(""),
                 duration_ms,
@@ -170,7 +170,7 @@ impl OpResult {
             ),
             Status::Fail => tracing::error!(
                 target: "healthcheck",
-                op = self.op_name,
+                operation = self.op_name,
                 status = "fail",
                 target = %self.target.as_deref().unwrap_or(""),
                 duration_ms,
@@ -179,7 +179,7 @@ impl OpResult {
             ),
             Status::Skipped(missing) => tracing::info!(
                 target: "healthcheck",
-                op = self.op_name,
+                operation = self.op_name,
                 status = "skipped",
                 target = %self.target.as_deref().unwrap_or(""),
                 missing = ?missing,

--- a/apps/xmtp_debug/src/app/health/validators/no_forks.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_forks.rs
@@ -24,7 +24,7 @@ impl Validator for NoForkedGroups {
     #[tracing::instrument(
         target = "healthcheck.validator",
         skip_all,
-        fields(op = "NoForkedGroups")
+        fields(operation = "NoForkedGroups")
     )]
     async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let clients = match ctx.all_clients() {

--- a/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
@@ -22,7 +22,7 @@ impl Validator for NoMissingMessages {
     #[tracing::instrument(
         target = "healthcheck.validator",
         skip_all,
-        fields(op = "NoMissingMessages")
+        fields(operation = "NoMissingMessages")
     )]
     async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let mut out = Vec::new();
@@ -74,8 +74,8 @@ impl Validator for NoMissingMessages {
                 if let Err(e) = mls_group.sync_with_conn().await {
                     tracing::debug!(
                         target: "healthcheck",
-                        inbox = client.inbox_id(),
-                        group = %group_id,
+                        inbox_id = client.inbox_id(),
+                        group_id = %group_id,
                         error = %e,
                         "sync_with_conn before NoMissingMessages check failed",
                     );
@@ -95,8 +95,8 @@ impl Validator for NoMissingMessages {
                 Ok(None) => {
                     tracing::debug!(
                         target: "healthcheck",
-                        inbox = client.inbox_id(),
-                        group = %group_id,
+                        inbox_id = client.inbox_id(),
+                        group_id = %group_id,
                         "skipping NoMissingMessages: client has no local group row",
                     );
                     continue;
@@ -104,8 +104,8 @@ impl Validator for NoMissingMessages {
                 Err(e) => {
                     tracing::warn!(
                         target: "healthcheck",
-                        inbox = client.inbox_id(),
-                        group = %group_id,
+                        inbox_id = client.inbox_id(),
+                        group_id = %group_id,
                         error = %e,
                         "find_group failed; skipping client/group",
                     );
@@ -126,8 +126,8 @@ impl Validator for NoMissingMessages {
                         missing += 1;
                         tracing::warn!(
                             target: "healthcheck",
-                            inbox = client.inbox_id(),
-                            group = %group_id,
+                            inbox_id = client.inbox_id(),
+                            group_id = %group_id,
                             message_id = %hex::encode(msg.id),
                             sender = %hex::encode(msg.sender_inbox_id),
                             sent_at_ns = msg.sent_at_ns,
@@ -138,8 +138,8 @@ impl Validator for NoMissingMessages {
                     Err(e) => {
                         tracing::warn!(
                             target: "healthcheck",
-                            inbox = client.inbox_id(),
-                            group = %group_id,
+                            inbox_id = client.inbox_id(),
+                            group_id = %group_id,
                             error = %e,
                             message_id = %hex::encode(msg.id),
                             "get_group_message error; counting as missing",

--- a/apps/xmtp_debug/src/app/info.rs
+++ b/apps/xmtp_debug/src/app/info.rs
@@ -47,9 +47,9 @@ impl Info {
         let sqlite_stores = crate::app::App::db_directory()?;
         let db_dir_size = fs_extra::dir::get_size(&sqlite_stores)? / 1_000 / 1_000;
         info!(
-            metadata.identities,
-            metadata.groups,
-            metadata.messages,
+            identities = metadata.identities,
+            groups = metadata.groups,
+            messages = metadata.messages,
             project = crate::app::App::data_directory()?.as_value(),
             sqlite = sqlite_stores.as_value(),
             sqlite_size = %format!("{db_dir_size}MB"),

--- a/apps/xmtp_debug/src/app/inspect.rs
+++ b/apps/xmtp_debug/src/app/inspect.rs
@@ -72,7 +72,11 @@ impl Inspect {
                     })
                     .collect::<Vec<PrintableGroup>>();
                 for group in groups.iter() {
-                    info!(group.group_id, group.created_at_ns, "group");
+                    info!(
+                        group_id = group.group_id,
+                        created_at_ns = group.created_at_ns,
+                        "group"
+                    );
                 }
             }
         }

--- a/apps/xmtp_debug/src/app/modify.rs
+++ b/apps/xmtp_debug/src/app/modify.rs
@@ -199,7 +199,7 @@ async fn add_members_from_redb(
             {
                 tracing::warn!(
                     target: "xdbg.modify",
-                    inbox = %inbox,
+                    inbox_id = %inbox,
                     error = %e,
                     "failed to promote inbox to super-admin"
                 );
@@ -211,7 +211,7 @@ async fn add_members_from_redb(
         target: "xdbg.modify",
         added = inbox_ids.len(),
         promoted = promote_super_admin,
-        group = %hex::encode(local_group.id()),
+        group_id = %hex::encode(local_group.id()),
         "add-from-redb completed"
     );
 

--- a/apps/xmtp_debug/src/app/sync.rs
+++ b/apps/xmtp_debug/src/app/sync.rs
@@ -116,15 +116,15 @@ impl Sync {
                     stats.new_dms += 1;
                     tracing::info!(
                         target: "xdbg.sync",
-                        id = %dm_id,
+                        dm_id = %dm_id,
                         "imported new dm into DmStore"
                     );
                 }
                 Some(_existing) => {
                     tracing::info!(
                         target: "xdbg.sync",
-                        id = %dm_id,
-                        group = %gid,
+                        dm_id = %dm_id,
+                        group_id = %gid,
                         "dm already persisted; skipping"
                     );
                 }
@@ -151,8 +151,8 @@ impl Sync {
                     stats.new_groups += 1;
                     tracing::info!(
                         target: "xdbg.sync",
-                        group = %gid,
-                        members = member_count,
+                        group_id = %gid,
+                        member_count = member_count,
                         "imported new group into GroupStore"
                     );
                 }
@@ -166,8 +166,8 @@ impl Sync {
                     stats.updated_groups += 1;
                     tracing::info!(
                         target: "xdbg.sync",
-                        group = %gid,
-                        members = member_count,
+                        group_id = %gid,
+                        member_count = member_count,
                         "updated GroupStore membership"
                     );
                 }
@@ -199,8 +199,8 @@ impl Sync {
                     stats.orphan_messages += 1;
                     tracing::warn!(
                         target: "xdbg.sync",
-                        inbox = client.inbox_id(),
-                        group = %gid,
+                        inbox_id = client.inbox_id(),
+                        group_id = %gid,
                         message_id = %hex::encode(message_id),
                         "recorded orphan message via sync — sender did not record it"
                     );

--- a/apps/xmtp_debug/src/app/test.rs
+++ b/apps/xmtp_debug/src/app/test.rs
@@ -502,7 +502,7 @@ impl Test {
 
         info!(
             iterations,
-            msg_count,
+            message_count = msg_count,
             timeout_secs,
             v3_backend = ?self.network.backend,
             v4_node = %v4_node_url,
@@ -581,7 +581,7 @@ impl Test {
         info!(group_baseline, "group topic baseline");
 
         // Step 4: Send N tagged messages
-        info!(msg_count, "sending tagged messages on V3");
+        info!(message_count = msg_count, "sending tagged messages on V3");
         let send_start = Instant::now();
         for i in 0..msg_count {
             let payload = format!(
@@ -1049,7 +1049,7 @@ impl Test {
 
         info!(
             iterations,
-            msg_count,
+            message_count = msg_count,
             timeout_secs,
             v3_backend = ?self.network.backend,
             v4_node = %v4_node_url,
@@ -1110,7 +1110,7 @@ impl Test {
         info!(group_baseline, "group topic baseline captured");
 
         // Step 3: Send N tagged messages
-        info!(msg_count, "sending tagged messages on V3");
+        info!(message_count = msg_count, "sending tagged messages on V3");
         for i in 0..msg_count {
             let payload = format!(
                 "{}{}_{}_{}",

--- a/crates/xmtp_common/src/event_logging.rs
+++ b/crates/xmtp_common/src/event_logging.rs
@@ -39,7 +39,14 @@ pub enum Event {
 
     // ===================== MLS Operations =====================
     /// Received staged commit. Merging and clearing any pending commits.
-    #[context(group_id, sender_installation_id, msg_epoch, epoch, hash, icon = "❗")]
+    #[context(
+        group_id,
+        sender_installation_id,
+        message_epoch,
+        epoch,
+        hash,
+        icon = "❗"
+    )]
     MLSReceivedStagedCommit,
     /// Processed staged commit.
     #[context(
@@ -52,12 +59,12 @@ pub enum Event {
         left_inboxes,
         metadata_changes,
         cursor,
-        originator,
+        originator_id,
         icon = "😮‍💨"
     )]
     MLSProcessedStagedCommit,
     /// Received application message.
-    #[context(group_id, epoch, msg_epoch, sender_inbox_id)]
+    #[context(group_id, epoch, message_epoch, sender_inbox_id)]
     MLSReceivedApplicationMessage,
 
     // ===================== Network =====================
@@ -90,7 +97,7 @@ pub enum Event {
     #[context(group_id, intent_id, intent_kind, icon = "⚠️")]
     GroupSyncIntentErrored,
     /// Attempt to publish intent failed.
-    #[context(group_id, intent_id, intent_kind, err, icon = "❌")]
+    #[context(group_id, intent_id, intent_kind, error, icon = "❌")]
     GroupSyncPublishFailed,
     /// Application message published successfully.
     #[context(group_id, intent_id, icon = "📤")]
@@ -102,7 +109,7 @@ pub enum Event {
     #[context(group_id, hash, icon = "🛑")]
     GroupSyncStagedCommitPresent,
     /// Updating group cursor.
-    #[context(group_id, cursor, originator, icon = "📍")]
+    #[context(group_id, cursor, originator_id, icon = "📍")]
     GroupCursorUpdate,
 
     // ===================== Group Membership =====================
@@ -124,13 +131,13 @@ pub enum Event {
     #[context(group_id)]
     DeviceSyncSentSyncRequest,
     /// Processing new sync message.
-    #[context(msg_type, external, msg_id, group_id)]
+    #[context(msg_type, external, message_id, group_id)]
     DeviceSyncProcessingMessages,
     /// Failed to process device sync message.
-    #[context(msg_id, err)]
+    #[context(message_id, error)]
     DeviceSyncMessageProcessingError,
     /// Processing sync archive.
-    #[context(msg_id, group_id)]
+    #[context(message_id, group_id)]
     DeviceSyncArchiveProcessingStart,
     /// Received a V1 sync payload. V1 is no longer supported. Ignoring.
     DeviceSyncV1Archive,
@@ -139,14 +146,14 @@ pub enum Event {
     /// Downloading sync archive.
     DeviceSyncArchiveDownloading,
     /// Sync archive download failure.
-    #[context(status, err)]
+    #[context(status, error)]
     DeviceSyncPayloadDownloadFailure,
     /// Beginning archive import.
     DeviceSyncArchiveImportStart,
     /// Finished sync archive import.
     DeviceSyncArchiveImportSuccess,
     /// Archive import failed.
-    #[context(err)]
+    #[context(error)]
     DeviceSyncArchiveImportFailure,
     /// Attempted to acknowledge a sync request, but it was already acknowledged
     /// by another installation.
@@ -162,7 +169,7 @@ pub enum Event {
     #[context(group_id, server_url)]
     DeviceSyncArchiveUploadStart,
     /// Failed to send sync archive.
-    #[context(group_id, pin, err)]
+    #[context(group_id, pin, error)]
     DeviceSyncArchiveUploadFailure,
     /// Archive upload complete.
     #[context(group_id)]

--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -810,7 +810,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
 
         if groups.len() > 1 {
             tracing::warn!(
-                cursor.sequence_id,
+                welcome_id = cursor.sequence_id,
                 "More than one group found for welcome_id {}",
                 cursor.sequence_id
             );

--- a/crates/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_intent.rs
@@ -439,7 +439,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
 
     // Set the intent with the given ID to `Published` and set the payload hash. Optionally add
     // `post_commit_data`
-    #[tracing::instrument(level = "debug", skip(self, payload_hash), fields(id = intent_id, payload_hash = hex::encode(payload_hash)))]
+    #[tracing::instrument(level = "debug", skip(self, payload_hash), fields(intent_id = intent_id, payload_hash = hex::encode(payload_hash)))]
     fn set_group_intent_published(
         &self,
         intent_id: ID,
@@ -691,7 +691,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(id = %intent.id, kind = %intent.kind, group_id = %intent.group_id))]
+    #[tracing::instrument(level = "debug", skip_all, fields(intent_id = %intent.id, intent_kind = %intent.kind, group_id = %intent.group_id))]
     fn set_group_intent_error_and_fail_msg(
         &self,
         intent: &StoredGroupIntent,

--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -1234,7 +1234,7 @@ where
                             label = %String::from_utf8_lossy(label),
                             type_name = std::any::type_name::<T>(),
                             bytes_len = bytes.len(),
-                            err = %_orig_err,
+                            error = %_orig_err,
                             "bincode deserialize failed (no path captured)",
                         );
                     }
@@ -1247,7 +1247,7 @@ where
                             path = %path,
                             type_name = std::any::type_name::<T>(),
                             bytes_len = bytes.len(),
-                            err = %inner,
+                            error = %inner,
                             "bincode deserialize failed",
                         );
                     }

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -708,7 +708,7 @@ where
         Ok(group)
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(who = self.context.inbox_id(), size = inbox_ids.len()))]
+    #[tracing::instrument(level = "debug", skip_all, fields(inbox_id = self.context.inbox_id(), size = inbox_ids.len()))]
     pub async fn create_group_with_members(
         &self,
         inbox_ids: &[impl AsIdRef],
@@ -724,7 +724,7 @@ where
     }
 
     /// Create a new Direct Message with the default settings
-    #[tracing::instrument(level = "debug", skip_all, fields(who = self.context.inbox_id(), with = target_inbox_id))]
+    #[tracing::instrument(level = "debug", skip_all, fields(inbox_id = self.context.inbox_id(), with = target_inbox_id))]
     async fn create_dm_by_inbox_id(
         &self,
         target_inbox_id: InboxId,

--- a/crates/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
@@ -49,7 +49,7 @@ impl DecryptedWelcome {
             data,
             welcome_metadata,
         } = welcome_v1;
-        tracing::debug!(id = %welcome.cursor, "Trying to decrypt welcome");
+        tracing::debug!(welcome_id = %welcome.cursor, "Trying to decrypt welcome");
         let wrapper_ciphersuite = WrapperAlgorithm::try_from(*wrapper_algorithm)?;
         let hash_ref = find_key_package_hash_ref(provider, hpke_public_key)?;
         let private_key = find_private_key(provider, &hash_ref, &wrapper_ciphersuite)?;
@@ -69,7 +69,7 @@ impl DecryptedWelcome {
         } else {
             deserialize_welcome_metadata(&welcome_metadata_bytes)
                 .map_err(|e| {
-                    tracing::debug!(?e, "Failed to deserialize welcome metadata; ignoring.")
+                    tracing::debug!(error = ?e, "Failed to deserialize welcome metadata; ignoring.")
                 })
                 .ok()
         };

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -532,7 +532,7 @@ where
     /// Sync from the network with the 'conn' (local database).
     /// must return a summary of all messages synced, whether they were
     /// successful or not.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(err, fields(who = %self.context.inbox_id(), operation = "sync_with_conn")))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(err, fields(inbox_id = %self.context.inbox_id(), operation = "sync_with_conn")))]
     #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub async fn sync_with_conn(&self) -> Result<SyncSummary, SyncSummary> {
         // App-data changes observed while processing are collected here and
@@ -609,7 +609,7 @@ where
         }
     }
 
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip_all))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip_all))]
     #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub(crate) async fn sync_until_last_intent_resolved(&self) -> Result<SyncSummary, GroupError> {
         // Filter to kinds this build understands: after a downgrade,
@@ -635,7 +635,7 @@ where
      *
      * This method will retry up to `xmtp_configuration::MAX_GROUP_SYNC_RETRIES` times.
      */
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(err, level = "info", fields(who = %self.context.inbox_id(), operation = "intent"), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(err, level = "info", fields(inbox_id = %self.context.inbox_id(), operation = "intent"), skip(self)))]
     #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub(crate) async fn sync_until_intent_resolved(
         &self,
@@ -666,7 +666,7 @@ where
         result
     }
 
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -883,8 +883,8 @@ where
                             installation_id = %self.context.installation_id(),
                             group_id = %self.group_id,
                             cursor = %cursor,
-                            intent.id,
-                            intent.kind = %intent.kind,
+                            intent_id = intent.id,
+                            intent_kind = %intent.kind,
                             "Intent for msg = [{cursor}] was published in epoch {} with local save intent epoch of {} but group is currently in epoch {}",
                             message_epoch,
                             published_in_epoch,
@@ -925,7 +925,7 @@ where
                                 group_id = %self.group_id,
                                 cursor = %cursor,
                                 intent_id = intent.id,
-                                intent.kind = %intent.kind,
+                                intent_kind = %intent.kind,
                                 "Error decoding staged commit for intent, now may be forked: {err:?}",
                             );
                             IntentResolutionError {
@@ -960,8 +960,8 @@ where
                                 installation_id = %self.context.installation_id(),
                                 group_id = %self.group_id,
                                 cursor = %cursor,
-                                intent.id,
-                                intent.kind = %intent.kind,
+                                intent_id = intent.id,
+                                intent_kind = %intent.kind,
                                 "Error validating commit for own message. Intent ID [{}]: {err:?}",
                                 intent.id,
                             );
@@ -1057,8 +1057,8 @@ where
             installation_id = %self.context.installation_id(),
             group_id = %self.group_id,
             cursor = %cursor,
-            intent.id,
-            intent.kind = %intent.kind,
+            intent_id = intent.id,
+            intent_kind = %intent.kind,
             "[{}]-[{}] processing own message for intent {} / {}, message_epoch: {}",
             self.context.inbox_id(),
             hex::encode(self.group_id),
@@ -1138,7 +1138,7 @@ where
                     left_inboxes = $payload.left_inboxes,
                     metadata_changes = $payload.metadata_field_changes,
                     cursor = cursor.sequence_id,
-                    originator = cursor.originator_id
+                    originator_id = cursor.originator_id
                 );
             }
 
@@ -1253,8 +1253,8 @@ where
             installation_id = %self.context.installation_id(),sender_inbox_id = sender_inbox_id,
             sender_installation_id = hex::encode(&sender_installation_id),
             group_id = %self.group_id,
-            current_epoch = mls_group.epoch().as_u64(),
-            msg_epoch = processed_message.epoch().as_u64(),
+            group_epoch = mls_group.epoch().as_u64(),
+            message_epoch = processed_message.epoch().as_u64(),
             msg_group_id = hex::encode(processed_message.group_id().as_slice()),
             cursor = %cursor,
             "[{}] extracted sender inbox id: {}",
@@ -1460,8 +1460,8 @@ where
                 inbox_id = self.context.inbox_id(),
                 installation_id = %self.context.installation_id(),
                 group_id = %self.group_id,
-                current_epoch = mls_group.epoch().as_u64(),
-                msg_epoch = processed_message.epoch().as_u64(),
+                group_epoch = mls_group.epoch().as_u64(),
+                message_epoch = processed_message.epoch().as_u64(),
                 cursor = ?cursor,
                 "[{}] processing message in transaction epoch = {}, cursor = {:?}",
                 self.context.inbox_id(),
@@ -1548,7 +1548,7 @@ where
                     sender_installation_id,
                     group_id = self.group_id,
                     epoch = mls_group.epoch().as_u64(),
-                    msg_epoch,
+                    message_epoch = msg_epoch,
                     msg_group_id,
                     cursor = %cursor,
                 );
@@ -1704,7 +1704,7 @@ where
                     sender_installation_id,
                     group_id = self.group_id,
                     epoch = mls_group.epoch().as_u64(),
-                    msg_epoch,
+                    message_epoch = msg_epoch,
                     msg_group_id,
                     cursor = %cursor,
                     hash = #message_envelope.payload_hash
@@ -1760,7 +1760,7 @@ where
                         left_inboxes = $payload.left_inboxes,
                         metadata_changes = $payload.metadata_field_changes,
                         cursor = cursor.sequence_id,
-                        originator = cursor.originator_id
+                        originator_id = cursor.originator_id
                     );
                 }
 
@@ -2464,7 +2464,7 @@ where
                     group_id = %self.group_id,
                     cursor = %envelope.cursor,
                     intent_id,
-                    intent.kind = %intent.kind,
+                    intent_kind = %intent.kind,
                     "client [{}] is about to process own envelope [{}] for intent [{}] [{}]",
                     self.context.inbox_id(),
                     envelope.cursor,
@@ -2799,7 +2799,7 @@ where
 
     #[cfg_attr(
         any(test, feature = "test-utils"),
-        tracing::instrument(level = "info", skip_all, fields(who = %self.context.inbox_id()))
+        tracing::instrument(level = "info", skip_all, fields(inbox_id = %self.context.inbox_id()))
     )]
     // Returns a bare ProcessSummary, so the canonical `#[mls_span]` (which
     // records `err`) cannot apply; keep the same span shape by hand.
@@ -2892,7 +2892,7 @@ where
                 self.context.installation_id(),
                 group_id = message.group_id.as_slice(),
                 cursor = message.cursor.sequence_id,
-                originator = message.cursor.originator_id
+                originator_id = message.cursor.originator_id
             );
         } else {
             tracing::debug!("no cursor update required");
@@ -3094,8 +3094,8 @@ where
                         tracing::error!(error = %err, "error getting publish intent data {:?}", err);
                         if (intent.publish_attempts + 1) as usize >= MAX_INTENT_PUBLISH_ATTEMPTS {
                             tracing::error!(
-                                intent.id,
-                                intent.kind = %intent.kind,
+                                intent_id = intent.id,
+                                intent_kind = %intent.kind,
                                 inbox_id = self.context.inbox_id(),
                                 installation_id = %self.context.installation_id(),group_id = %self.group_id,
                                 "intent {} has reached max publish attempts", intent.id);
@@ -3141,8 +3141,8 @@ where
                         tracing::debug!(
                             inbox_id = self.context.inbox_id(),
                             installation_id = %self.context.installation_id(),
-                            intent.id,
-                            intent.kind = %intent.kind,
+                            intent_id = intent.id,
+                            intent_kind = %intent.kind,
                             group_id = %self.group_id,
                             "[{}] set stored intent [{}] with hash [{}] to state `published`",
                             self.context.inbox_id(),
@@ -3177,7 +3177,7 @@ where
                                     group_id = intent.group_id,
                                     intent_id = intent.id,
                                     intent_kind = ?kind,
-                                    err = ?err
+                                    error = ?err
                                 );
 
                                 handle_published_intent_send_failure(&db, &intent)?;
@@ -3316,7 +3316,7 @@ where
                     {
                         tracing::info!(
                             group_id = %self.group_id,
-                            intent.id,
+                            intent_id = intent.id,
                             field = %metadata_intent.field_name,
                             "abandoning guarded metadata update: committed value no longer matches"
                         );
@@ -4249,8 +4249,8 @@ where
                 tracing::debug!(
                     inbox_id = self.context.inbox_id(),
                     installation_id = %self.context.installation_id(),
-                    intent.id,
-                    intent.kind = %intent.kind, "taking post commit action"
+                    intent_id = intent.id,
+                    intent_kind = %intent.kind, "taking post commit action"
                 );
 
                 let post_commit_action = PostCommitAction::from_bytes(post_commit_data.as_slice())?;
@@ -4300,7 +4300,7 @@ where
      * This is designed to handle cases where existing members have added a new installation to their inbox or revoked an installation
      * and the group has not been updated to include it.
      */
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip_all))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip_all))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip_all)
@@ -4429,7 +4429,7 @@ where
      *
      * Internally, this breaks the request into chunks to avoid exceeding the GRPC max message size limits
      */
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(who = %self.context.inbox_id())))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(inbox_id = %self.context.inbox_id())))]
     #[cfg_attr(not(any(test, feature = "test-utils")), tracing::instrument(skip_all))]
     pub(super) async fn send_welcomes(
         &self,
@@ -4973,8 +4973,8 @@ fn handle_published_intent_send_failure<Db: QueryGroupIntent>(
 ) -> Result<(), GroupError> {
     if (intent.publish_attempts + 1) as usize >= MAX_INTENT_PUBLISH_ATTEMPTS {
         tracing::error!(
-            intent.id,
-            intent.kind = %intent.kind,
+            intent_id = intent.id,
+            intent_kind = %intent.kind,
             "intent {} has reached max publish attempts",
             intent.id
         );

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -38,7 +38,7 @@ pub(crate) fn inbox_ids_from_new_key_packages(
             let credential = match BasicCredential::try_from(kp.leaf_node().credential().clone()) {
                 Ok(credential) => credential,
                 Err(e) => {
-                    tracing::warn!(?e, "failed to decode key package leaf credential");
+                    tracing::warn!(error = ?e, "failed to decode key package leaf credential");
                     return None;
                 }
             };
@@ -46,7 +46,7 @@ pub(crate) fn inbox_ids_from_new_key_packages(
                 Ok(inbox_id) => Some(inbox_id),
                 Err(e) => {
                     tracing::warn!(
-                        ?e,
+                        error = ?e,
                         "failed to parse inbox id from key package credential; \
                          skipping inbox for phantom-member verification"
                     );

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -1492,7 +1492,7 @@ where
 
     /// Publish all unpublished messages. This happens by calling `sync_until_last_intent_resolved`
     /// which publishes all pending intents and reads them back from the network.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = self.context.inbox_id()), skip(self)))]
     #[cfg_attr(not(any(test, feature = "test-utils")), xmtp_common::mls_span)]
     pub async fn publish_messages(&self) -> Result<(), GroupError> {
         self.ensure_not_paused().await?;
@@ -1894,7 +1894,7 @@ where
             .await
     }
 
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(who = %self.context.inbox_id(), inbox_ids = ?inbox_ids.as_ref().iter().map(|i| i.as_ref()).collect::<Vec<_>>())))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(inbox_id = %self.context.inbox_id(), inbox_ids = ?inbox_ids.as_ref().iter().map(|i| i.as_ref()).collect::<Vec<_>>())))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip_all)
@@ -1978,7 +1978,7 @@ where
     ///
     /// # Returns
     /// A `Result` indicating success or failure of the operation.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(who = %self.context.inbox_id(), inbox_ids = ?inbox_ids)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(inbox_id = %self.context.inbox_id(), inbox_ids = ?inbox_ids)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip_all)
@@ -2135,7 +2135,7 @@ where
             Err(e) => {
                 tracing::error!(
                     group_id = %self.group_id,
-                    members = ?valid_removals,
+                    removed_members = ?valid_removals,
                     error = %e,
                     "Failed to remove pending members from group"
                 );
@@ -2278,7 +2278,7 @@ where
 
     /// Updates the name of the group. Will error if the user does not have the appropriate permissions
     /// to perform these updates.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -2315,7 +2315,7 @@ where
     ///
     /// `None` keeps the historical last-writer-wins behavior: whatever landed
     /// in the meantime is overwritten.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -2400,7 +2400,7 @@ where
     /// - Setting the min version to pre-release versions may not behave as expected
     /// - When the version is not explicitly specified, unexpected behavior may arise,
     ///   for example if the code is left in across multiple version bumps.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -2536,7 +2536,7 @@ where
     }
 
     /// Updates the permission policy of the group. This requires super admin permissions.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -2590,7 +2590,7 @@ where
     }
 
     /// Updates the description of the group.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -2630,7 +2630,7 @@ where
     }
 
     /// Updates the image URL (square) of the group.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -2693,7 +2693,7 @@ where
         .await
     }
 
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -2716,7 +2716,7 @@ where
         Ok(())
     }
 
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -2925,7 +2925,7 @@ where
     }
 
     /// Updates the admin list of the group and syncs the changes to the network.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))
@@ -3083,7 +3083,7 @@ where
     }
 
     /// Update this installation's leaf key in the group by creating a key update commit
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = %self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -128,7 +128,7 @@ where
 
                 if matches!(err, GroupError::Storage(Duplicate(WelcomeId(_)))) {
                     tracing::warn!(
-                        welcome_cursor = %welcome.cursor,
+                        welcome_id = %welcome.cursor,
                         "Welcome ID already stored: {}",
                         err
                     );
@@ -143,7 +143,7 @@ where
                     // welcome skipped), so log at warn rather than error to avoid
                     // marking the span as status:error and inflating the error rate.
                     tracing::warn!(
-                        welcome_cursor = %welcome.cursor,
+                        welcome_id = %welcome.cursor,
                         "welcome already processed, skipping: {}",
                         err
                     );
@@ -190,14 +190,14 @@ where
                 Ok(None) => {}
                 Err(err) if err.is_retryable() => {
                     tracing::warn!(
-                        welcome_cursor = %welcome_cursor,
+                        welcome_id = %welcome_cursor,
                         "stopping welcome sync after retryable failure: {err}"
                     );
                     break;
                 }
                 Err(err) => {
                     tracing::warn!(
-                        welcome_cursor = %welcome_cursor,
+                        welcome_id = %welcome_cursor,
                         "skipping welcome after non-retryable failure: {err}"
                     );
                 }
@@ -409,11 +409,11 @@ where
         // group re-evaluation in `handle_group_paused` wouldn't fire
         // for a quiet paused group).
         if let Err(err) = self.unstick_paused_groups().await {
-            tracing::debug!(?err, "unstick_paused_groups failed, continuing with sync");
+            tracing::debug!(error = ?err, "unstick_paused_groups failed, continuing with sync");
         }
 
         if let Err(err) = self.sync_welcomes().await {
-            tracing::debug!(?err, "sync_welcomes failed, continuing with group sync");
+            tracing::debug!(error = ?err, "sync_welcomes failed, continuing with group sync");
         }
         let query_args = GroupQueryArgs {
             consent_states,
@@ -474,13 +474,13 @@ where
                     match is_active_res {
                         Ok(is_active) if is_active => {
                             if let Err(err) = group.sync_with_conn().await {
-                                tracing::warn!(?err, "sync_with_conn failed");
+                                tracing::warn!(error = ?err, "sync_with_conn failed");
                                 failed_group_count.fetch_add(1, Ordering::SeqCst);
                                 return;
                             }
 
                             if let Err(err) = group.maybe_update_installations(None).await {
-                                tracing::warn!(?err, "maybe_update_installations failed");
+                                tracing::warn!(error = ?err, "maybe_update_installations failed");
                                 failed_group_count.fetch_add(1, Ordering::SeqCst);
                                 return;
                             }
@@ -489,7 +489,7 @@ where
                         }
                         Ok(_) => { /* group inactive, skip */ }
                         Err(err) => {
-                            tracing::warn!(?err, "load_mls_group_with_lock_async failed");
+                            tracing::warn!(error = ?err, "load_mls_group_with_lock_async failed");
                             failed_group_count.fetch_add(1, Ordering::SeqCst);
                         }
                     }

--- a/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -156,7 +156,7 @@ where
                 tracing::warn!(
                     inbox_id = self.0.inbox_id(),
                     group_id = %msg.group_id,
-                    cursor_id = %msg.cursor,
+                    cursor = %msg.cursor,
                     "recovery sync triggered by streamed message failed",
                 );
                 tracing::warn!("{summary}");
@@ -305,8 +305,8 @@ where
                 // But still exists defensively
                 tracing::error!(
                     group_id = %msg.group_id,
-                    cursor_id = %msg.cursor,
-                    err = e.to_string(),
+                    cursor = %msg.cursor,
+                    error = e.to_string(),
                     "process stream entry {:?}",
                     e
                 );
@@ -314,7 +314,7 @@ where
             }
             Ok(processed_msg) => {
                 tracing::trace!(
-                    cursor_id = %msg.cursor,
+                    cursor = %msg.cursor,
                     group_id = %msg.group_id,
                     "message process in stream success, synced single msg @cursor={},group_id={}",
                     processed_msg.cursor,

--- a/crates/xmtp_mls/src/worker/device_sync/mod.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/mod.rs
@@ -283,7 +283,7 @@ where
     /// Sends a device sync message.
     /// If the `group_id` is `None`, the message will be sent
     /// to the primary sync group ID.
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(inbox_id = self.context.inbox_id()), skip(self)))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip(self))

--- a/crates/xmtp_mls/src/worker/device_sync/worker.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/worker.rs
@@ -324,7 +324,7 @@ where
                 self.context.installation_id(),
                 msg_type,
                 external = is_external,
-                msg_id = #msg.id,
+                message_id = #msg.id,
                 group_id = msg.group_id
             );
 
@@ -337,8 +337,8 @@ where
                 log_event!(
                     Event::DeviceSyncMessageProcessingError,
                     self.context.installation_id(),
-                    err = %err,
-                    msg_id = #msg.id
+                    error = %err,
+                    message_id = #msg.id
                 );
                 self.context
                     .db()
@@ -406,7 +406,7 @@ where
 
                 if self.is_reply_requested_by_installation(&reply).await? {
                     self.process_archive(msg, reply).await.inspect_err(
-                                        |err| log_event!(Event::DeviceSyncArchiveImportFailure, self.context.installation_id(), err = %err),
+                                        |err| log_event!(Event::DeviceSyncArchiveImportFailure, self.context.installation_id(), error = %err),
                                     )?;
                 } else {
                     log_event!(
@@ -666,7 +666,7 @@ where
         log_event!(
             Event::DeviceSyncArchiveProcessingStart,
             self.context.installation_id(),
-            msg_id = #msg.id,
+            message_id = #msg.id,
             group_id = msg.group_id
         );
         if reply.kind() != BackupElementSelectionProto::Unspecified {
@@ -688,7 +688,7 @@ where
                 Event::DeviceSyncPayloadDownloadFailure,
                 self.context.installation_id(),
                 status = %response.status(),
-                err = %err
+                error = %err
             );
             return Err(DeviceSyncError::Reqwest(err));
         }

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -386,7 +386,7 @@ where
                             context.installation_id(),
                             group_id = send_sync_archive.sync_group_id,
                             pin = send_sync_archive.pin(),
-                            err = %e
+                            error = %e
                         )
                     })?;
             }


### PR DESCRIPTION
## Summary

Mechanical normalization of structured tracing field keys so the same concept always uses the same attribute name across `crates/`, `bindings/`, and `apps/`. No behavior changes — only log/span field keys (and formatting re-wraps from `cargo fmt`).

159 field-key sites renamed onto a canonical vocabulary; groundwork for span/trace export where attribute consistency determines queryability.

### Canonical vocabulary

| Concept | Canonical key | Replaces |
|---|---|---|
| inbox id | `inbox_id` | `who` (23), `inbox` (9) |
| group id | `group_id` | `group` (14) — `conversation_id` never occurred as a key |
| operation | `operation` | `op` (28, xmtp_debug health ops) |
| error | `error` | `err` (9), `e` (3) |
| intent | `intent_id`, `intent_kind` | `intent.id` (8), `intent.kind` (9), bare `id`/`kind` (3) |
| message id | `message_id` | `msg_id` (7) |
| welcome | `welcome_id` | `welcome_cursor` (4), dotted variants |
| cursor | `cursor` | `cursor_id` (3) |
| epochs | `group_epoch` / `message_epoch` | `current_epoch` (2), `msg_epoch` (6) |
| counts | `message_count`, `member_count`, `removed_members` | `msg_count` (4), `members` (3) |

Also renames the `log_event!` `#[context(...)]` schema keys in `xmtp_common::event_logging` (`err`→`error`, `originator`→`originator_id`, `msg_id`→`message_id`, `msg_epoch`→`message_epoch`, 25 sites incl. call sites) since those are real tracing field keys. The id-in-message-string design of `log_event!` is untouched.

Deliberately not changed: role-qualified variants (`sender_inbox_id`, `actor_installation_id`, …) stay distinct; `op = %change.op` in `validated_commit.rs` is a different concept (MLS membership op); `%` Display vs `?` Debug on `error` values left as-is (content change, sometimes intentional); span-name-vs-`operation` gap on four streaming spans left for the telemetry work.

## Testing

- `cargo check --workspace --all-targets` — clean
- `just lint-rust` (clippy, fmt --check, hakari) — clean
- Rename-only diff on log attribute keys; no functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize tracing and structured logging field keys across workspace
> - Renames tracing span fields and structured log keys to consistent names across `apps/xmtp_debug`, `crates/xmtp_mls`, `crates/xmtp_db`, `crates/xmtp_common`, and `apps/keepalive-probe`
> - Key renames: `op`→`operation`, `who`→`inbox_id`, `err`→`error`, `group`→`group_id`, `inbox`→`inbox_id`, `msg_id`→`message_id`, `msg_epoch`→`message_epoch`, `originator`→`originator_id`, `intent.id`→`intent_id`, `intent.kind`→`intent_kind`, `welcome_cursor`/`id`→`welcome_id`, `msg_count`→`message_count`, `members`→`member_count`, `cursor_id`→`cursor`
> - Converts implicit/positional error captures (e.g. `error!(err)`) to explicit named fields (e.g. `error!(error = err)`)
> - Behavioral Change: all consumers of tracing spans or structured logs (dashboards, alerting queries, log pipelines) that filter or group on the old field names will stop matching; update downstream queries to use the new key names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40334fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->