### PR TITLE
feat(release): unified semver ordering for main-cut prereleases

### DIFF
--- a/.github/workflows/release-agent-sdk.yml
+++ b/.github/workflows/release-agent-sdk.yml
@@ -37,6 +37,10 @@ on:
         required: false
         type: string
         description: "Git ref to build from"
+      timestamp:
+        required: false
+        type: string
+        description: "Shared UTC YYYYMMDDHHMMSS stamp minted once per Release run"
       node-sdk-version:
         required: false
         type: string
@@ -81,11 +85,13 @@ jobs:
           RC_NUMBER: ${{ inputs.rc-number }}
           PENDING_VERSION: ${{ inputs.pending-version }}
           PENDING_KIND: ${{ inputs.pending-kind }}
+          REF: ${{ inputs.ref || github.ref }}
+          TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           if [ "$RELEASE_TYPE" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk agent-sdk --release-type rc --rc-number "$RC_NUMBER")
           elif [ "$RELEASE_TYPE" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk agent-sdk --release-type dev)
+            VERSION=$(xmtp-release compute-version --sdk agent-sdk --release-type dev --source-ref "$REF" --timestamp "$TIMESTAMP")
           elif [ "$RELEASE_TYPE" = "nightly" ]; then
             if [ -z "$PENDING_VERSION" ] || [ -z "$PENDING_KIND" ]; then
               echo "::error::nightly resolve called with empty pending version/kind"
@@ -93,6 +99,7 @@ jobs:
             fi
             VERSION=$(xmtp-release resolve-sdk-version \
               --sdk agent-sdk --release-type nightly \
+              --timestamp "$TIMESTAMP" \
               --pending-version "$PENDING_VERSION" \
               --pending-kind "$PENDING_KIND")
           else

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
         description: "Git ref to build from"
+      timestamp:
+        required: false
+        type: string
+        description: "Shared UTC YYYYMMDDHHMMSS stamp minted once per Release run"
       pending-version:
         required: false
         type: string
@@ -45,11 +49,14 @@ jobs:
 
       - name: Compute version
         id: version
+        env:
+          REF: ${{ inputs.ref }}
+          TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk android --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk android --release-type dev)
+            VERSION=$(xmtp-release compute-version --sdk android --release-type dev --source-ref "$REF" --timestamp "$TIMESTAMP")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             # Belt-and-suspenders: release.yml already skips this whole job when
             # the gate isn't green or there are no conventional commits
@@ -61,6 +68,7 @@ jobs:
             fi
             VERSION=$(xmtp-release resolve-sdk-version \
               --sdk android --release-type nightly \
+              --timestamp "$TIMESTAMP" \
               --pending-version "${{ inputs.pending-version }}" \
               --pending-kind "${{ inputs.pending-kind }}")
           else

--- a/.github/workflows/release-browser-sdk.yml
+++ b/.github/workflows/release-browser-sdk.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
         description: "Git ref to build from"
+      timestamp:
+        required: false
+        type: string
+        description: "Shared UTC YYYYMMDDHHMMSS stamp minted once per Release run"
       pending-version:
         required: false
         type: string
@@ -47,13 +51,38 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-release-tools
 
+      # This workflow versions TWO packages that pin each other: the browser-sdk
+      # here and `@xmtp/wasm-bindings` in the nested release-wasm.yml below. Each
+      # calls the version tools in its own job, and an EMPTY timestamp is not
+      # inert — it makes each job mint its own `now` fallback, so the published
+      # browser-sdk would pin a wasm-bindings whose `pre.<ts>.…` suffix differs
+      # from its own and from every other package in the run, breaking the
+      # whole-suffix lockstep the consumer bump PRs assert. release.yml mints one
+      # stamp per run and threads it in; empty on a stamped release type means
+      # that plumbing is broken, so fail here — `bindings` needs this job, so
+      # nothing has published yet. (rc/final carry no stamp and are unaffected;
+      # branch-cut devs ignore the stamp, but every caller mints one, so the
+      # guard stays on release-type alone rather than re-deriving `fromMain`.)
+      - name: Require the run-wide timestamp
+        if: inputs.release-type == 'dev' || inputs.release-type == 'nightly'
+        env:
+          TIMESTAMP: ${{ inputs.timestamp }}
+        run: |
+          if [ -z "$TIMESTAMP" ]; then
+            echo "::error::${{ inputs.release-type }} releases require the run-wide timestamp minted by release.yml; refusing to publish browser-sdk and wasm-bindings with independently minted stamps"
+            exit 1
+          fi
+
       - name: Compute version
         id: version
+        env:
+          REF: ${{ inputs.ref }}
+          TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk browser-sdk --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk browser-sdk --release-type dev)
+            VERSION=$(xmtp-release compute-version --sdk browser-sdk --release-type dev --source-ref "$REF" --timestamp "$TIMESTAMP")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
               echo "::error::nightly resolve called with empty pending version/kind"
@@ -61,6 +90,7 @@ jobs:
             fi
             VERSION=$(xmtp-release resolve-sdk-version \
               --sdk browser-sdk --release-type nightly \
+              --timestamp "$TIMESTAMP" \
               --pending-version "${{ inputs.pending-version }}" \
               --pending-kind "${{ inputs.pending-kind }}")
           else
@@ -76,6 +106,7 @@ jobs:
       release-type: ${{ inputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ inputs.ref }}
+      timestamp: ${{ inputs.timestamp }}
       pending-version: ${{ inputs.pending-version }}
       pending-kind: ${{ inputs.pending-kind }}
       dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -16,6 +16,10 @@ on:
         required: true
         type: string
         description: "Git ref to build from"
+      timestamp:
+        required: false
+        type: string
+        description: "Shared UTC YYYYMMDDHHMMSS stamp minted once per Release run"
       pending-version:
         required: false
         type: string
@@ -50,12 +54,15 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Compute version
         id: version
+        env:
+          REF: ${{ inputs.ref }}
+          TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           BASE=$(xmtp-release compute-version --sdk ios --release-type final)
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk ios --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk ios --release-type dev)
+            VERSION=$(xmtp-release compute-version --sdk ios --release-type dev --source-ref "$REF" --timestamp "$TIMESTAMP")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             # Belt-and-suspenders: release.yml already skips this whole job when
             # the gate isn't green or there are no conventional commits
@@ -67,6 +74,7 @@ jobs:
             fi
             VERSION=$(xmtp-release resolve-sdk-version \
               --sdk ios --release-type nightly \
+              --timestamp "$TIMESTAMP" \
               --pending-version "${{ inputs.pending-version }}" \
               --pending-kind "${{ inputs.pending-kind }}")
           else

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
         description: "Git ref to build from"
+      timestamp:
+        required: false
+        type: string
+        description: "Shared UTC YYYYMMDDHHMMSS stamp minted once per Release run"
       pending-version:
         required: false
         type: string
@@ -47,13 +51,34 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-release-tools
 
+      # Same hazard as release-browser-sdk.yml, and the one the consumer bump
+      # PRs actually assert on: this workflow versions the node-sdk here and
+      # `@xmtp/node-bindings` in the nested release-node.yml, in separate jobs.
+      # An empty timestamp makes each mint its own `now` fallback, so the two
+      # would ship different `pre.<ts>.…` suffixes and the convos-cli /
+      # convos-assistants manifests — which require the whole suffix to
+      # match — would reject the pair. Fail before `bindings` (which needs this
+      # job) starts. rc/final carry no stamp and are unaffected.
+      - name: Require the run-wide timestamp
+        if: inputs.release-type == 'dev' || inputs.release-type == 'nightly'
+        env:
+          TIMESTAMP: ${{ inputs.timestamp }}
+        run: |
+          if [ -z "$TIMESTAMP" ]; then
+            echo "::error::${{ inputs.release-type }} releases require the run-wide timestamp minted by release.yml; refusing to publish node-sdk and node-bindings with independently minted stamps"
+            exit 1
+          fi
+
       - name: Compute version
         id: version
+        env:
+          REF: ${{ inputs.ref }}
+          TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk node-sdk --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk node-sdk --release-type dev)
+            VERSION=$(xmtp-release compute-version --sdk node-sdk --release-type dev --source-ref "$REF" --timestamp "$TIMESTAMP")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             if [ -z "${{ inputs.pending-version }}" ] || [ -z "${{ inputs.pending-kind }}" ]; then
               echo "::error::nightly resolve called with empty pending version/kind"
@@ -61,6 +86,7 @@ jobs:
             fi
             VERSION=$(xmtp-release resolve-sdk-version \
               --sdk node-sdk --release-type nightly \
+              --timestamp "$TIMESTAMP" \
               --pending-version "${{ inputs.pending-version }}" \
               --pending-kind "${{ inputs.pending-kind }}")
           else
@@ -76,6 +102,7 @@ jobs:
       release-type: ${{ inputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ inputs.ref }}
+      timestamp: ${{ inputs.timestamp }}
       pending-version: ${{ inputs.pending-version }}
       pending-kind: ${{ inputs.pending-kind }}
       dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
         description: "Git ref to build from"
+      timestamp:
+        required: false
+        type: string
+        description: "Shared UTC YYYYMMDDHHMMSS stamp minted once per Release run"
       pending-version:
         required: false
         type: string
@@ -43,11 +47,14 @@ jobs:
 
       - name: Compute version
         id: version
+        env:
+          REF: ${{ inputs.ref }}
+          TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk node-bindings --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk node-bindings --release-type dev)
+            VERSION=$(xmtp-release compute-version --sdk node-bindings --release-type dev --source-ref "$REF" --timestamp "$TIMESTAMP")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             # Belt-and-suspenders: release.yml already skips this whole job when
             # the gate isn't green or there are no conventional commits
@@ -59,6 +66,7 @@ jobs:
             fi
             VERSION=$(xmtp-release resolve-sdk-version \
               --sdk node-bindings --release-type nightly \
+              --timestamp "$TIMESTAMP" \
               --pending-version "${{ inputs.pending-version }}" \
               --pending-kind "${{ inputs.pending-kind }}")
           else

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
         description: "Git ref to build from"
+      timestamp:
+        required: false
+        type: string
+        description: "Shared UTC YYYYMMDDHHMMSS stamp minted once per Release run"
       pending-version:
         required: false
         type: string
@@ -46,11 +50,14 @@ jobs:
 
       - name: Compute version
         id: version
+        env:
+          REF: ${{ inputs.ref }}
+          TIMESTAMP: ${{ inputs.timestamp }}
         run: |
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             VERSION=$(xmtp-release compute-version --sdk wasm-bindings --release-type rc --rc-number ${{ inputs.rc-number }})
           elif [ "${{ inputs.release-type }}" = "dev" ]; then
-            VERSION=$(xmtp-release compute-version --sdk wasm-bindings --release-type dev)
+            VERSION=$(xmtp-release compute-version --sdk wasm-bindings --release-type dev --source-ref "$REF" --timestamp "$TIMESTAMP")
           elif [ "${{ inputs.release-type }}" = "nightly" ]; then
             # Belt-and-suspenders: release.yml already skips this whole job when
             # the gate isn't green or there are no conventional commits
@@ -62,6 +69,7 @@ jobs:
             fi
             VERSION=$(xmtp-release resolve-sdk-version \
               --sdk wasm-bindings --release-type nightly \
+              --timestamp "$TIMESTAMP" \
               --pending-version "${{ inputs.pending-version }}" \
               --pending-kind "${{ inputs.pending-kind }}")
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
       release-type: ${{ steps.resolve.outputs.release-type }}
       ref: ${{ steps.resolve.outputs.ref }}
       branch: ${{ steps.branch.outputs.branch }}
+      timestamp: ${{ steps.timestamp.outputs.timestamp }}
       ios: ${{ steps.resolve.outputs.ios }}
       android: ${{ steps.resolve.outputs.android }}
       node-sdk: ${{ steps.resolve.outputs.node-sdk }}
@@ -116,6 +117,20 @@ jobs:
         env:
           REF: ${{ steps.resolve.outputs.ref }}
         run: echo "branch=${REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+      # ONE stamp for the whole run. Each SDK computes its version in its own
+      # job, minutes apart — if each called `date` itself, `@xmtp/node-sdk` and
+      # `@xmtp/node-bindings` from a single run would carry different
+      # `pre.<ts>.…` suffixes and break the consumers' same-suffix lockstep
+      # guards (they assert whole-suffix equality). Minted once here and
+      # threaded into every fan-out below.
+      #
+      # Second precision, not minute: the stamp is the semver ordering key, so
+      # two runs sharing one stamp fall through to comparing `dev` vs `nightly`
+      # (alphabetical — a newer dev would sort BELOW an older nightly) and then
+      # sha. Seconds keep separate runs on separate keys.
+      - name: Mint release timestamp
+        id: timestamp
+        run: echo "timestamp=$(date -u +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
       - name: Validate dev release
         if: steps.resolve.outputs.release-type == 'dev'
         env:
@@ -155,7 +170,7 @@ jobs:
           set -euo pipefail
           HEAD_SHA=$(gh api "repos/${REPO}/commits/${REF}" --jq '.sha[0:7]')
           LAST_TAG=$(gh api "repos/${REPO}/git/matching-refs/tags/ios-" \
-            --jq '[.[] | .ref | sub("refs/tags/"; "")] | map(select(test("-nightly\\."))) | sort | last // ""')
+            --jq '[.[] | .ref | sub("refs/tags/"; "")] | map(select(test("-pre\\..*\\.nightly\\."))) | sort | last // ""')
           if [ -n "$LAST_TAG" ]; then
             LAST_SHA=$(echo "$LAST_TAG" | grep -oE '[0-9a-f]{7}$' || true)
             if [ "$LAST_SHA" = "$HEAD_SHA" ]; then
@@ -194,6 +209,7 @@ jobs:
       release-type: ${{ needs.validate.outputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ needs.validate.outputs.ref }}
+      timestamp: ${{ needs.validate.outputs.timestamp }}
       pending-version: ${{ needs.plan.outputs.version }}
       pending-kind: ${{ needs.plan.outputs.kind }}
     secrets: inherit
@@ -211,6 +227,7 @@ jobs:
       release-type: ${{ needs.validate.outputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ needs.validate.outputs.ref }}
+      timestamp: ${{ needs.validate.outputs.timestamp }}
       pending-version: ${{ needs.plan.outputs.version }}
       pending-kind: ${{ needs.plan.outputs.kind }}
     secrets: inherit
@@ -227,6 +244,7 @@ jobs:
       release-type: ${{ needs.validate.outputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ needs.validate.outputs.ref }}
+      timestamp: ${{ needs.validate.outputs.timestamp }}
       pending-version: ${{ needs.plan.outputs.version }}
       pending-kind: ${{ needs.plan.outputs.kind }}
       dry-run: ${{ needs.validate.outputs.dry-run == 'true' }}
@@ -244,6 +262,7 @@ jobs:
       release-type: ${{ needs.validate.outputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ needs.validate.outputs.ref }}
+      timestamp: ${{ needs.validate.outputs.timestamp }}
       pending-version: ${{ needs.plan.outputs.version }}
       pending-kind: ${{ needs.plan.outputs.kind }}
       dry-run: ${{ needs.validate.outputs.dry-run == 'true' }}
@@ -264,6 +283,7 @@ jobs:
       release-type: ${{ needs.validate.outputs.release-type }}
       rc-number: ${{ inputs.rc-number }}
       ref: ${{ needs.validate.outputs.ref }}
+      timestamp: ${{ needs.validate.outputs.timestamp }}
       node-sdk-version: ${{ needs.release-node-sdk.outputs.version }}
       pending-version: ${{ needs.plan.outputs.version }}
       pending-kind: ${{ needs.plan.outputs.kind }}
@@ -440,10 +460,13 @@ jobs:
       - name: Compute libxmtp hub version
         id: hubver
         if: steps.guard.outputs.should-release == 'true'
+        env:
+          TIMESTAMP: ${{ needs.validate.outputs.timestamp }}
         run: |
           set -euo pipefail
           VERSION=$(xmtp-release resolve-sdk-version \
             --sdk libxmtp --release-type nightly \
+            --timestamp "$TIMESTAMP" \
             --pending-version "${{ needs.plan.outputs.version }}" \
             --pending-kind "${{ needs.plan.outputs.kind }}")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -456,14 +479,17 @@ jobs:
           git cliff --version
       # Per-nightly changelog: the delta since the PREVIOUS nightly tag (not
       # since the last stable). Computed BEFORE tagging this run, so the newest
-      # existing v*-nightly.* tag is genuinely the prior nightly. First-ever
-      # nightly (no prior nightly tag) falls back to since-last-stable.
+      # existing nightly tag is genuinely the prior nightly. Both eras are
+      # globbed — legacy `v*-nightly.<date>.<sha>` and unified
+      # `v*-pre.<ts>.nightly.<sha>` — so the range stays correct across the
+      # transition. First-ever nightly (no prior nightly tag) falls back to
+      # since-last-stable.
       - name: Compute per-nightly changelog
         id: nightly_changelog
         if: steps.guard.outputs.should-release == 'true'
         run: |
           set -euo pipefail
-          PREV_NIGHTLY=$(git tag -l 'v*-nightly.*' --sort=-creatordate | head -1 || true)
+          PREV_NIGHTLY=$(git tag -l 'v*-nightly.*' 'v*-pre.*.nightly.*' --sort=-creatordate | head -1 || true)
           if [ -n "$PREV_NIGHTLY" ]; then
             echo "::notice::Changelog range ${PREV_NIGHTLY}..HEAD"
             git cliff --config cliff.toml "${PREV_NIGHTLY}..HEAD" --strip header > /tmp/nightly-changelog.md 2>/dev/null || true

--- a/dev/drivers/xdbg_driver_lib/xdbg_driver_lib_py/__init__.py
+++ b/dev/drivers/xdbg_driver_lib/xdbg_driver_lib_py/__init__.py
@@ -35,10 +35,30 @@ def _console_width() -> int | None:
 
 _stderr_console = Console(stderr=True, highlight=False, width=_console_width())
 
+# Nightly tags span two eras and the matrix samples across the transition:
+#   legacy  <sdk>-<ver>-nightly.<YYYYMMDD>.<sha7>
+#   unified <sdk>-<ver>-pre.<YYYYMMDDHHMMSS>.nightly.<sha7>
+# One pattern covers both, with each era's parts COUPLED: the channel literal,
+# the stamp width and the trailing `.nightly` travel together in one arm, so
+# the cross products no release ever emits — `-pre.<YYYYMMDD>.<sha7>` (unified
+# channel, legacy stamp, no `.nightly`) and `-nightly.<YYYYMMDDHHMMSS>.nightly`
+# — are rejected instead of being sampled as if they were real nightlies. Dev
+# channels never match either: `-dev.<sha7>` and `-pre.<ts>.dev.<sha7>` both
+# fail the required `nightly` literal.
+#
+# Whichever arm hits, the day is `date8` and the commit is `sha`, so this ONE
+# pattern both filters (which remote tags bootstrap_fetch pulls) and parses
+# (which local tags nightly_candidates samples) — the set fetched is exactly the
+# set sampled, and the SDK prefixes are enforced on both sides. That matters
+# locally, where the tag namespace also holds `v<ver>-pre.…` hub tags and
+# whatever else a working copy has fetched; without the prefix those would
+# occupy sample slots that belong to real per-SDK nightlies.
 NIGHTLY_TAG_RE = re.compile(
-    r"^(?:node-bindings|wasm-bindings|android|ios)-.*-nightly\.\d{8}\.[0-9a-f]{7}$"
+    r"^(?:node-bindings|wasm-bindings|android|ios)-.*"
+    r"-(?:nightly\.(?P<legacy_date>\d{8})"
+    r"|pre\.(?P<unified_date>\d{8})\d{6}\.nightly)"
+    r"\.(?P<sha>[0-9a-f]{7})$"
 )
-NIGHTLY_PARSE_RE = re.compile(r".*-nightly\.(\d{8})\.([0-9a-f]{7})$")
 
 STATUS_PLAIN = {
     "PASS": "✓ PASS",
@@ -295,10 +315,11 @@ def nightly_candidates() -> list[tuple[str, str]]:
     seen = set()
     out = []
     for t in git_tags_by_creator_date():
-        m = NIGHTLY_PARSE_RE.match(t)
+        m = NIGHTLY_TAG_RE.match(t)
         if not m:
             continue
-        key = (m.group(1), m.group(2))
+        # Exactly one date arm participates per match; the other is None.
+        key = (m["legacy_date"] or m["unified_date"], m["sha"])
         if key not in seen:
             seen.add(key)
             out.append(key)

--- a/dev/release-tools/src/commands/compute-version.ts
+++ b/dev/release-tools/src/commands/compute-version.ts
@@ -3,7 +3,8 @@ import type { GlobalArgs, ReleaseType } from "../types";
 import { getSdkConfig } from "../lib/sdk-config";
 import {
   computeVersion as computeVersionFn,
-  getNightlyDate,
+  getTimestamp,
+  validateTimestamp,
 } from "../lib/version";
 import { getShortSha } from "../lib/git";
 
@@ -26,28 +27,57 @@ export function builder(yargs: Argv<GlobalArgs>) {
     .option("rcNumber", {
       type: "number",
       describe: "RC number (required for rc releases)",
+    })
+    .option("sourceRef", {
+      type: "string",
+      describe:
+        "Git ref the release is cut from (e.g. refs/heads/main); main-cut builds get the ordered pre.* format",
+    })
+    .option("timestamp", {
+      type: "string",
+      describe:
+        "Shared UTC YYYYMMDDHHMMSS stamp for this release run (defaults to now)",
     });
 }
 
 export function handler(
   argv: ArgumentsCamelCase<
-    GlobalArgs & { sdk: string; releaseType: ReleaseType; rcNumber?: number }
+    GlobalArgs & {
+      sdk: string;
+      releaseType: ReleaseType;
+      rcNumber?: number;
+      sourceRef?: string;
+      timestamp?: string;
+    }
   >,
 ) {
   if (argv.releaseType === "rc" && argv.rcNumber == null) {
     throw new Error("--rc-number is required when --release-type is 'rc'");
   }
+  // Validated up front, before the release type decides whether the stamp is
+  // even used: a malformed one always means broken plumbing.
+  const runTimestamp = validateTimestamp(argv.timestamp);
 
   const config = getSdkConfig(argv.sdk);
   const baseVersion = config.manifest.readVersion(argv.repoRoot);
   const needsSha = argv.releaseType === "dev" || argv.releaseType === "nightly";
   const shortSha = needsSha ? getShortSha(argv.repoRoot) : undefined;
-  const nightlyDate =
-    argv.releaseType === "nightly" ? getNightlyDate() : undefined;
+  const fromMain =
+    (argv.sourceRef ?? "").replace(/^refs\/heads\//, "") === "main";
+  // Nightlies are schedule-cut from main by construction, so they always take
+  // the ordered pre.* timeline; devs only when the ref says they came off main.
+  const needsTimestamp =
+    argv.releaseType === "nightly" || (argv.releaseType === "dev" && fromMain);
+  // The run-wide stamp when the Release workflow threaded one in; otherwise a
+  // fresh one, for standalone/manual invocations.
+  const timestamp = needsTimestamp
+    ? (runTimestamp ?? getTimestamp())
+    : undefined;
   const version = computeVersionFn(baseVersion, argv.releaseType, {
     rcNumber: argv.rcNumber,
     shortSha,
-    nightlyDate,
+    timestamp,
+    fromMain,
   });
   console.log(version);
 }

--- a/dev/release-tools/src/commands/resolve-sdk-version.ts
+++ b/dev/release-tools/src/commands/resolve-sdk-version.ts
@@ -2,7 +2,7 @@ import type { ArgumentsCamelCase, Argv } from "yargs";
 import type { GlobalArgs, ReleaseType } from "../types";
 import { getSdkConfig } from "../lib/sdk-config";
 import { resolveSdkVersion } from "../lib/sdk-version";
-import { getNightlyDate } from "../lib/version";
+import { getTimestamp, validateTimestamp } from "../lib/version";
 import { getShortSha } from "../lib/git";
 
 export const command = "resolve-sdk-version";
@@ -17,10 +17,13 @@ export function builder(yargs: Argv<GlobalArgs>) {
         demandOption: true,
         describe: "SDK name",
       })
+      // No "dev": this command is the track-aware path, only ever reached for
+      // rc/final/nightly. A dev here would silently emit the legacy shape from
+      // a pending version nothing has published yet.
       .option("releaseType", {
         type: "string",
         demandOption: true,
-        choices: ["dev", "rc", "final", "nightly"] as const,
+        choices: ["rc", "final", "nightly"] as const,
       })
       // pending-* are only meaningful for the nightly/track-aware path. They are
       // optional at the CLI layer and validated in the handler so the signature
@@ -35,6 +38,11 @@ export function builder(yargs: Argv<GlobalArgs>) {
         describe: "Pending libxmtp bump kind — required",
       })
       .option("rcNumber", { type: "number" })
+      .option("timestamp", {
+        type: "string",
+        describe:
+          "Shared UTC YYYYMMDDHHMMSS stamp for this release run (defaults to now)",
+      })
   );
 }
 
@@ -46,9 +54,11 @@ export function handler(
       pendingVersion?: string;
       pendingKind?: "major" | "minor" | "patch";
       rcNumber?: number;
+      timestamp?: string;
     }
   >,
 ) {
+  const runTimestamp = validateTimestamp(argv.timestamp);
   if (!argv.pendingVersion || !argv.pendingKind) {
     throw new Error(
       "resolve-sdk-version requires --pending-version and --pending-kind " +
@@ -58,10 +68,11 @@ export function handler(
 
   const config = getSdkConfig(argv.sdk);
   const base = config.manifest.readVersion(argv.repoRoot);
-  const needsSha = argv.releaseType === "dev" || argv.releaseType === "nightly";
-  const shortSha = needsSha ? getShortSha(argv.repoRoot) : undefined;
-  const nightlyDate =
-    argv.releaseType === "nightly" ? getNightlyDate() : undefined;
+  const isNightly = argv.releaseType === "nightly";
+  const shortSha = isNightly ? getShortSha(argv.repoRoot) : undefined;
+  // Every SDK in one nightly run must land on the SAME pre.<ts> suffix, so use
+  // the run stamp threaded in by release.yml; mint one only when standalone.
+  const timestamp = isNightly ? (runTimestamp ?? getTimestamp()) : undefined;
 
   const version = resolveSdkVersion({
     track: config.versionTrack,
@@ -69,7 +80,7 @@ export function handler(
     pending: { version: argv.pendingVersion, kind: argv.pendingKind },
     releaseType: argv.releaseType,
     rcNumber: argv.rcNumber,
-    nightlyDate,
+    timestamp,
     shortSha,
   });
   console.log(version);

--- a/dev/release-tools/src/lib/sdk-version.ts
+++ b/dev/release-tools/src/lib/sdk-version.ts
@@ -60,7 +60,8 @@ export interface ResolveSdkVersionArgs {
   pending: PendingRelease;
   releaseType: ReleaseType;
   rcNumber?: number;
-  nightlyDate?: string;
+  /** UTC YYYYMMDDHHMMSS stamp for the unified pre.* timeline (main-cut builds). */
+  timestamp?: string;
   shortSha?: string;
 }
 
@@ -90,7 +91,7 @@ export function resolveSdkVersion(args: ResolveSdkVersionArgs): string {
 
   return computeVersion(target, args.releaseType, {
     rcNumber: args.rcNumber,
-    nightlyDate: args.nightlyDate,
+    timestamp: args.timestamp,
     shortSha: args.shortSha,
   });
 }

--- a/dev/release-tools/src/lib/version.ts
+++ b/dev/release-tools/src/lib/version.ts
@@ -47,7 +47,10 @@ export function filterAndSortTags(
 export interface ComputeVersionOptions {
   rcNumber?: number;
   shortSha?: string;
-  nightlyDate?: string;
+  /** UTC YYYYMMDDHHMMSS stamp for the unified pre.* timeline (main-cut builds) */
+  timestamp?: string;
+  /** True when the release is cut from main; gates the ordered pre.* format */
+  fromMain?: boolean;
 }
 
 /**
@@ -72,21 +75,107 @@ export function computeVersion(
       if (!options.shortSha) {
         throw new Error("shortSha is required for dev releases");
       }
+      if (options.fromMain) {
+        if (!options.timestamp) {
+          throw new Error("timestamp is required for main-cut dev releases");
+        }
+        return `${normalized}-pre.${options.timestamp}.dev.${options.shortSha}`;
+      }
+      // Branch-cut devs keep the legacy, unordered shape: below every pre.*
+      // under semver and invisible to consumer renovate configs — delivered
+      // only through the bot bump PRs.
       return `${normalized}-dev.${options.shortSha}`;
     }
     case "nightly": {
-      if (!options.nightlyDate) {
-        throw new Error("nightlyDate is required for nightly releases");
+      if (!options.timestamp) {
+        throw new Error("timestamp is required for nightly releases");
       }
       if (!options.shortSha) {
         throw new Error("shortSha is required for nightly releases");
       }
-      return `${normalized}-nightly.${options.nightlyDate}.${options.shortSha}`;
+      return `${normalized}-pre.${options.timestamp}.nightly.${options.shortSha}`;
     }
   }
 }
 
-/** Today's date as a compact `YYYYMMDD` stamp for nightly version strings. */
-export function getNightlyDate(): string {
-  return new Date().toISOString().slice(0, 10).replace(/-/g, "");
+/**
+ * Now as a compact UTC `YYYYMMDDHHMMSS` stamp for the pre.* timeline.
+ *
+ * The stamp IS the ordering key: semver compares it as a numeric identifier
+ * before it ever looks at the channel or the sha. Two runs that share a stamp
+ * therefore fall through to comparing `dev` vs `nightly` (alphabetical, so a
+ * newer dev sorts BELOW an older nightly) and then sha (arbitrary) — a
+ * backwards "upgrade" for anything resolving latest. Second precision keeps
+ * distinct runs on distinct keys; minute precision did not.
+ */
+export function getTimestamp(): string {
+  return formatTimestamp(new Date());
+}
+
+/** `YYYYMMDDHHMMSS` for an instant, UTC, truncated (never rounded). */
+function formatTimestamp(date: Date): string {
+  return date.toISOString().slice(0, 19).replace(/[-T:]/g, "");
+}
+
+/**
+ * True when the 14 digits name an instant that actually exists.
+ *
+ * Checked by round trip: every out-of-range component ROLLS OVER through
+ * `Date.UTC` (month 13 -> next January, day 32 -> next month, hour 24 -> next
+ * day, 30 February -> March), so re-formatting the resulting instant yields
+ * different digits than went in. Years below 1000 are rejected up front for two
+ * reasons: the stamp is a semver NUMERIC identifier, which must not carry a
+ * leading zero (`0…` makes the whole version unparseable), and `Date.UTC` maps
+ * years 0-99 onto 1900-1999 rather than the literal year, so the round trip
+ * alone would not be trustworthy there.
+ */
+function isRealUtcStamp(stamp: string): boolean {
+  const [year, month, day, hour, minute, second] = [
+    stamp.slice(0, 4),
+    stamp.slice(4, 6),
+    stamp.slice(6, 8),
+    stamp.slice(8, 10),
+    stamp.slice(10, 12),
+    stamp.slice(12, 14),
+  ].map(Number);
+  if (year < 1000) return false;
+  const instant = new Date(
+    Date.UTC(year, month - 1, day, hour, minute, second),
+  );
+  return formatTimestamp(instant) === stamp;
+}
+
+/**
+ * Validate a caller-supplied `--timestamp`. Every version computed within one
+ * Release run must carry the SAME stamp (the consumer bump PRs assert
+ * whole-suffix equality across `@xmtp/node-sdk` and `@xmtp/node-bindings`), so
+ * the run mints one stamp and threads it into every job.
+ *
+ * Absent/empty means "no run stamp was threaded" — the caller falls back to
+ * `getTimestamp()`, which is correct for standalone invocations. A non-empty
+ * but malformed value means the workflow plumbing is broken, so throw rather
+ * than fall back and silently desynchronize the run.
+ *
+ * "Malformed" is more than the wrong digit count. The stamp lands verbatim in a
+ * semver prerelease identifier and is the ordering key, so it must also name a
+ * real UTC instant: `00000000000000` passes a digits-only test yet yields
+ * `X.Y.Z-pre.00000000000000.<channel>.<sha>`, which semver refuses to parse at
+ * all (numeric identifiers may not have a leading zero), and `20261301…` parses
+ * happily while sorting nowhere near where its digits claim. The emitted format
+ * is unchanged — `date -u +%Y%m%d%H%M%S` and `getTimestamp()` only ever produce
+ * stamps that pass — this only rejects values no minting path can produce.
+ */
+export function validateTimestamp(supplied?: string): string | undefined {
+  if (!supplied) return undefined;
+  if (!/^\d{14}$/.test(supplied)) {
+    throw new Error(
+      `--timestamp must be a UTC YYYYMMDDHHMMSS stamp (14 digits), got: ${supplied}`,
+    );
+  }
+  if (!isRealUtcStamp(supplied)) {
+    throw new Error(
+      `--timestamp must be a real UTC YYYYMMDDHHMMSS instant, got: ${supplied}`,
+    );
+  }
+  return supplied;
 }

--- a/dev/release-tools/tests/commands/compute-version.test.ts
+++ b/dev/release-tools/tests/commands/compute-version.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { handler } from "../../src/commands/compute-version";
+
+// The handler resolves the short sha through git, so exercise it against a
+// real throwaway repo — same approach as the other command tests.
+describe("compute-version --source-ref / --timestamp", () => {
+  let tmpDir: string;
+  let shortSha: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-tools-compute-"));
+    fs.mkdirSync(path.join(tmpDir, "sdks/js/node-sdk"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "sdks/js/node-sdk/package.json"),
+      `${JSON.stringify({ name: "@xmtp/node-sdk", version: "6.2.0" }, null, 2)}\n`,
+    );
+    execSync("git init", { cwd: tmpDir });
+    execSync("git config user.email test@test.com", { cwd: tmpDir });
+    execSync("git config user.name Test", { cwd: tmpDir });
+    execSync("git config commit.gpgSign false", { cwd: tmpDir });
+    execSync("git add -A", { cwd: tmpDir });
+    execSync('git commit -m "init"', { cwd: tmpDir });
+    shortSha = execSync("git rev-parse --short=7 HEAD", { cwd: tmpDir })
+      .toString()
+      .trim();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function run(sourceRef?: string, timestamp?: string): string {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      handler({
+        _: [],
+        $0: "",
+        repoRoot: tmpDir,
+        sdk: "node-sdk",
+        releaseType: "dev",
+        sourceRef,
+        timestamp,
+      } as Parameters<typeof handler>[0]);
+      return String(spy.mock.calls.at(-1)?.[0]);
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it("emits the ordered pre.* shape for a main-cut dev", () => {
+    const version = run("refs/heads/main");
+    expect(version).toMatch(
+      new RegExp(`^6\\.2\\.0-pre\\.\\d{14}\\.dev\\.${shortSha}$`),
+    );
+  });
+
+  it("emits the legacy shape without --source-ref", () => {
+    expect(run()).toBe(`6.2.0-dev.${shortSha}`);
+  });
+
+  it("treats a branch-cut ref as legacy", () => {
+    expect(run("refs/heads/release/1.10")).toBe(`6.2.0-dev.${shortSha}`);
+  });
+
+  it("accepts a bare 'main' as well as refs/heads/main", () => {
+    expect(run("main")).toMatch(/^6\.2\.0-pre\.\d{14}\.dev\.[0-9a-f]{7}$/);
+  });
+
+  // The run-wide stamp release.yml mints must reach the version verbatim —
+  // that identity is what makes every SDK of one run share a pre.* suffix.
+  it("uses the supplied --timestamp verbatim", () => {
+    expect(run("refs/heads/main", "20260102030405")).toBe(
+      `6.2.0-pre.20260102030405.dev.${shortSha}`,
+    );
+  });
+
+  it("rejects a malformed --timestamp", () => {
+    expect(() => run("refs/heads/main", "2026")).toThrow(/timestamp/);
+  });
+
+  // A 12-digit stamp is the old minute-precision shape. Accepting it would let
+  // a stale caller reintroduce same-minute ordering ties, so it must fail loud
+  // rather than pass through.
+  it("rejects a minute-precision (12-digit) --timestamp", () => {
+    expect(() => run("refs/heads/main", "202601020304")).toThrow(/14 digits/);
+  });
+
+  // 14 digits that name no instant would still be interpolated verbatim into
+  // the published version, where they either sort by fiction (month 13) or
+  // make the version unparseable (leading zero). Neither reaches npm.
+  it.each(["20261301000000", "20260230120000", "00000000000000"])(
+    "rejects the impossible calendar stamp %s",
+    (stamp) => {
+      expect(() => run("refs/heads/main", stamp)).toThrow(/real UTC/);
+    },
+  );
+});

--- a/dev/release-tools/tests/sdk-version.test.ts
+++ b/dev/release-tools/tests/sdk-version.test.ts
@@ -62,10 +62,10 @@ describe("resolveSdkVersion", () => {
         base: "1.10.0",
         pending,
         releaseType: "nightly",
-        nightlyDate: "20260603",
+        timestamp: "20260603060000",
         shortSha: "abc1234",
       }),
-    ).toBe("1.11.0-nightly.20260603.abc1234");
+    ).toBe("1.11.0-pre.20260603060000.nightly.abc1234");
   });
 
   it("independent nightly previews the next number on its own base", () => {
@@ -75,13 +75,13 @@ describe("resolveSdkVersion", () => {
         base: "4.10.0",
         pending,
         releaseType: "nightly",
-        nightlyDate: "20260603",
+        timestamp: "20260603060000",
         shortSha: "abc1234",
       }),
-    ).toBe("4.11.0-nightly.20260603.abc1234");
+    ).toBe("4.11.0-pre.20260603060000.nightly.abc1234");
   });
 
-  it("nightly requires date and sha", () => {
+  it("nightly requires timestamp and sha", () => {
     expect(() =>
       resolveSdkVersion({
         track: "independent",

--- a/dev/release-tools/tests/version.test.ts
+++ b/dev/release-tools/tests/version.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import semver from "semver";
 import {
   computeVersion,
   filterAndSortTags,
+  getTimestamp,
   normalizeVersion,
+  validateTimestamp,
 } from "../src/lib/version";
 
 describe("filterAndSortTags", () => {
@@ -84,57 +86,271 @@ describe("computeVersion", () => {
     expect(() => computeVersion("4.10.0", "dev")).toThrow();
   });
 
-  it("appends nightly suffix with date and short sha", () => {
+  it("appends nightly suffix with timestamp and short sha", () => {
     expect(
       computeVersion("4.10.0", "nightly", {
-        nightlyDate: "20260428",
+        timestamp: "20260428060000",
         shortSha: "cc66682",
       }),
-    ).toBe("4.10.0-nightly.20260428.cc66682");
+    ).toBe("4.10.0-pre.20260428060000.nightly.cc66682");
   });
 
-  it("throws if nightly release has no nightlyDate", () => {
+  it("throws if nightly release has no timestamp", () => {
     expect(() =>
       computeVersion("4.10.0", "nightly", { shortSha: "cc66682" }),
-    ).toThrow(/nightlyDate/);
+    ).toThrow(/timestamp/);
   });
 
   it("throws if nightly release has no shortSha", () => {
     expect(() =>
-      computeVersion("4.10.0", "nightly", { nightlyDate: "20260428" }),
+      computeVersion("4.10.0", "nightly", { timestamp: "20260428060000" }),
     ).toThrow(/shortSha/);
   });
 
-  it("nightly versions sort lexicographically by date", () => {
+  it("nightly versions sort lexicographically by timestamp", () => {
     const versions = [
       computeVersion("4.10.0", "nightly", {
-        nightlyDate: "20260429",
+        timestamp: "20260429060000",
         shortSha: "bbbbbbb",
       }),
       computeVersion("4.10.0", "nightly", {
-        nightlyDate: "20260427",
+        timestamp: "20260427060000",
         shortSha: "aaaaaaa",
       }),
       computeVersion("4.10.0", "nightly", {
-        nightlyDate: "20260428",
+        timestamp: "20260428060000",
         shortSha: "ccccccc",
       }),
     ];
     const lexSorted = [...versions].sort();
     const semverSorted = [...versions].sort(semver.compare);
     expect(lexSorted).toEqual([
-      "4.10.0-nightly.20260427.aaaaaaa",
-      "4.10.0-nightly.20260428.ccccccc",
-      "4.10.0-nightly.20260429.bbbbbbb",
+      "4.10.0-pre.20260427060000.nightly.aaaaaaa",
+      "4.10.0-pre.20260428060000.nightly.ccccccc",
+      "4.10.0-pre.20260429060000.nightly.bbbbbbb",
     ]);
     expect(lexSorted).toEqual(semverSorted);
   });
 
   it("nightly is a valid semver prerelease", () => {
     const v = computeVersion("4.10.0", "nightly", {
-      nightlyDate: "20260428",
+      timestamp: "20260428060000",
       shortSha: "cc66682",
     });
     expect(semver.parse(v)).not.toBeNull();
+  });
+});
+
+describe("unified pre.* prerelease ordering", () => {
+  it("formats main-cut nightly as pre.<ts>.nightly.<sha>", () => {
+    expect(
+      computeVersion("4.9.0", "nightly", {
+        timestamp: "20260825060000",
+        shortSha: "a53a97e",
+      }),
+    ).toBe("4.9.0-pre.20260825060000.nightly.a53a97e");
+  });
+
+  it("formats main-cut dev as pre.<ts>.dev.<sha>", () => {
+    expect(
+      computeVersion("4.9.0", "dev", {
+        timestamp: "20260825153000",
+        shortSha: "999b077",
+        fromMain: true,
+      }),
+    ).toBe("4.9.0-pre.20260825153000.dev.999b077");
+  });
+
+  it("keeps branch-cut dev on the legacy shape", () => {
+    expect(computeVersion("4.9.0", "dev", { shortSha: "999b077" })).toBe(
+      "4.9.0-dev.999b077",
+    );
+  });
+
+  it("orders the unified timeline by timestamp across channels", () => {
+    const nightly = computeVersion("4.9.0", "nightly", {
+      timestamp: "20260825060000",
+      shortSha: "a53a97e",
+    });
+    const dev = computeVersion("4.9.0", "dev", {
+      timestamp: "20260825153000",
+      shortSha: "999b077",
+      fromMain: true,
+    });
+    expect(semver.gt(dev, nightly)).toBe(true); // later dev beats earlier nightly
+  });
+
+  it("orders a later nightly above an earlier dev", () => {
+    const dev = computeVersion("4.9.0", "dev", {
+      timestamp: "20260825060000",
+      shortSha: "999b077",
+      fromMain: true,
+    });
+    const nightly = computeVersion("4.9.0", "nightly", {
+      timestamp: "20260825153000",
+      shortSha: "a53a97e",
+    });
+    expect(semver.gt(nightly, dev)).toBe(true);
+  });
+
+  it("ignores the timestamp for a branch-cut dev", () => {
+    expect(
+      computeVersion("4.9.0", "dev", {
+        shortSha: "a",
+        timestamp: "20260825153000",
+      }),
+    ).toBe("4.9.0-dev.a");
+  });
+
+  it("sorts legacy shapes below all pre.* and rc above", () => {
+    const pre = "4.9.0-pre.20260825060000.nightly.a53a97e";
+    expect(semver.gt(pre, "4.9.0-nightly.20260826.fffffff")).toBe(true);
+    expect(semver.gt(pre, "4.9.0-dev.999b077")).toBe(true);
+    expect(semver.gt("4.9.0-rc1", pre)).toBe(true);
+  });
+
+  it("getTimestamp returns UTC YYYYMMDDHHMMSS", () => {
+    // Pinned to a fixed instant: the stamp must be UTC regardless of the
+    // runner's local zone, must carry seconds, and must truncate sub-second
+    // precision rather than round.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-25T15:30:45.987Z"));
+    try {
+      expect(getTimestamp()).toBe("20260825153045");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Regression: with minute precision, two runs starting in the same UTC
+  // minute shared an ordering key, so semver fell through to the channel
+  // identifier ("dev" < "nightly" alphabetically) and then the sha. A dev cut
+  // seconds AFTER a nightly therefore sorted BELOW it — a silent backwards
+  // upgrade for anything resolving latest. Second precision separates them.
+  it("orders same-minute runs by seconds, not by channel name", () => {
+    const nightly = computeVersion("4.9.0", "nightly", {
+      timestamp: "20260825060000",
+      shortSha: "a53a97e",
+    });
+    const dev = computeVersion("4.9.0", "dev", {
+      timestamp: "20260825060030",
+      shortSha: "999b077",
+      fromMain: true,
+    });
+    expect(semver.gt(dev, nightly)).toBe(true);
+    // ...and the reverse ordering within the same minute holds too.
+    const laterNightly = computeVersion("4.9.0", "nightly", {
+      timestamp: "20260825060059",
+      shortSha: "ccccccc",
+    });
+    expect(semver.gt(laterNightly, dev)).toBe(true);
+  });
+
+  it("keeps the widened stamp a numeric semver identifier", () => {
+    const parsed = semver.parse(
+      computeVersion("4.9.0", "nightly", {
+        timestamp: "20260825060000",
+        shortSha: "a53a97e",
+      }),
+    );
+    // Numeric (not string) => semver compares stamps arithmetically, and the
+    // value stays inside Number.MAX_SAFE_INTEGER at 14 digits.
+    expect(parsed?.prerelease[1]).toBe(20260825060000);
+    expect(Number.isSafeInteger(parsed?.prerelease[1])).toBe(true);
+  });
+
+  it("requires timestamp for main-cut builds", () => {
+    expect(() =>
+      computeVersion("4.9.0", "nightly", { shortSha: "a53a97e" }),
+    ).toThrow(/timestamp/);
+    expect(() =>
+      computeVersion("4.9.0", "dev", { shortSha: "a", fromMain: true }),
+    ).toThrow(/timestamp/);
+  });
+});
+
+describe("validateTimestamp", () => {
+  it("passes an absent stamp through as the now-fallback signal", () => {
+    expect(validateTimestamp()).toBeUndefined();
+    expect(validateTimestamp("")).toBeUndefined();
+  });
+
+  it.each([
+    ["20260825153045", "a plain instant"],
+    ["20240229120000", "a real leap day"],
+    ["20261231235959", "the last second of a year"],
+    ["20260101000000", "midnight"],
+  ])("accepts %s (%s)", (stamp) => {
+    expect(validateTimestamp(stamp)).toBe(stamp);
+  });
+
+  it.each(["2026", "202601020304", "2026010203040506", "2026082515304a", "  "])(
+    "rejects the wrong shape: %s",
+    (stamp) => {
+      expect(() => validateTimestamp(stamp)).toThrow(/14 digits/);
+    },
+  );
+
+  // The digit count alone let impossible calendar values through, and those
+  // sort by their literal digits — a stamp claiming month 13 lands after every
+  // real December and before the following January.
+  it.each([
+    ["20261301000000", "month 13"],
+    ["20260032000000", "month 00"],
+    ["20260832000000", "day 32"],
+    ["20260800000000", "day 00"],
+    ["20260230120000", "30 February"],
+    ["20250229120000", "29 February in a non-leap year"],
+    ["20260825240000", "hour 24"],
+    ["20260825236000", "minute 60"],
+    ["20260825235960", "second 60"],
+  ])("rejects %s (%s)", (stamp) => {
+    expect(() => validateTimestamp(stamp)).toThrow(/real UTC/);
+  });
+
+  // The reported case. It is not merely nonsensical: a leading-zero numeric
+  // identifier is illegal SemVer, so the version it produces cannot be parsed
+  // at all — proven below rather than asserted.
+  it("rejects an all-zero stamp, which would emit unparseable semver", () => {
+    expect(() => validateTimestamp("00000000000000")).toThrow(/real UTC/);
+    expect(semver.parse("4.9.0-pre.00000000000000.dev.999b077")).toBeNull();
+  });
+
+  it.each(["09990825153045", "00010101000000"])(
+    "rejects the leading-zero stamp %s",
+    (stamp) => {
+      expect(() => validateTimestamp(stamp)).toThrow(/real UTC/);
+    },
+  );
+
+  // The mint path (`date -u +%Y%m%d%H%M%S` in release.yml, `getTimestamp()`
+  // for standalone runs) must never trip the tightened check.
+  it("accepts every stamp getTimestamp mints", () => {
+    vi.useFakeTimers();
+    try {
+      for (const instant of [
+        "2026-01-01T00:00:00.000Z",
+        "2026-03-01T00:00:00.000Z",
+        "2024-02-29T12:00:00.000Z", // leap day
+        "2026-12-31T23:59:59.000Z",
+        "2026-08-25T15:30:45.987Z",
+      ]) {
+        vi.setSystemTime(new Date(instant));
+        const stamp = getTimestamp();
+        expect(validateTimestamp(stamp)).toBe(stamp);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps every accepted stamp a valid semver numeric identifier", () => {
+    const stamp = validateTimestamp("20260825153045");
+    const version = computeVersion("4.9.0", "dev", {
+      timestamp: stamp,
+      shortSha: "999b077",
+      fromMain: true,
+    });
+    expect(semver.parse(version)?.prerelease[1]).toBe(20260825153045);
   });
 });

--- a/dev/updatecli/convos-assistants.yaml
+++ b/dev/updatecli/convos-assistants.yaml
@@ -59,7 +59,7 @@ targets:
     disablesourceinput: true
     spec:
       file: package.json
-      matchpattern: '("@xmtp/node-bindings"\s*:\s*")\d+\.\d+\.\d+-(?:dev|nightly)\.[^"]+(")'
+      matchpattern: '("@xmtp/node-bindings"\s*:\s*")\d+\.\d+\.\d+-(?:dev|nightly|pre)\.[^"]+(")'
       replacepattern: '${1}{{ requiredEnv "BINDING_VERSION" }}${2}'
   pnpm-lockfile:
     name: refresh pnpm-lock.yaml

--- a/dev/updatecli/convos-cli.yaml
+++ b/dev/updatecli/convos-cli.yaml
@@ -50,7 +50,7 @@ targets:
     disablesourceinput: true
     spec:
       file: package.json
-      matchpattern: '("@xmtp/node-sdk"\s*:\s*")\d+\.\d+\.\d+-(?:dev|nightly)\.[^"]+(")'
+      matchpattern: '("@xmtp/node-sdk"\s*:\s*")\d+\.\d+\.\d+-(?:dev|nightly|pre)\.[^"]+(")'
       replacepattern: '${1}{{ requiredEnv "VERSION" }}${2}'
   node-bindings-pin:
     name: 'pin @xmtp/node-bindings {{ requiredEnv "BINDING_VERSION" }}'
@@ -59,7 +59,7 @@ targets:
     disablesourceinput: true
     spec:
       file: package.json
-      matchpattern: '("@xmtp/node-bindings"\s*:\s*")\d+\.\d+\.\d+-(?:dev|nightly)\.[^"]+(")'
+      matchpattern: '("@xmtp/node-bindings"\s*:\s*")\d+\.\d+\.\d+-(?:dev|nightly|pre)\.[^"]+(")'
       replacepattern: '${1}{{ requiredEnv "BINDING_VERSION" }}${2}'
   pnpm-lockfile:
     name: refresh pnpm-lock.yaml


### PR DESCRIPTION
## Summary

Main-cut dev and nightly releases now share one semver-ordered prerelease format:

```
X.Y.Z-pre.<YYYYMMDDHHMMSS>.<channel>.<shortSha>     channel ∈ {dev, nightly}
```

The numeric timestamp decides order; the channel is inert metadata after it. Dev releases cut from any other ref keep the legacy `X.Y.Z-dev.<shortSha>` shape — which sorts below every `pre.*` and matches no consumer renovate config, so feature-branch builds stay renovate-invisible and flow only through the automated consumer bump PRs. `rc<N>`/finals are untouched (they already outrank `pre.*` under semver).

## Why

Dev and nightly could never be ordered against each other — semver compares the channel word before any date — so consumers used channel-specific renovate machinery with no ordering semantics (`followTag: nightly` on npm). That bit on 2026-08-25: renovate automerged a move from a fresh `dev.999b077` (Aug 25 main) *backwards* to `nightly.20260822`, because that's where the dist-tag pointed. Under the unified timeline, backwards moves are structurally impossible and consumer configs reduce to plain "sort for latest" (follow-up config PRs in the consumer repos).

## Key mechanics

- **One timestamp per release run**, minted in `validate` and threaded through every reusable workflow (including the nested node/wasm workflows and the hub's version resolution) — so all SDK versions from one run share an identical suffix and the consumers' same-suffix lockstep guards keep working.
- `compute-version --source-ref` derives main-cut-ness in tested TS; `--timestamp` carries the shared stamp (validated `\d{12}`, falls back to now for ad-hoc use).
- Nightly skip-check and changelog tag lookups cover both tag eras; the xdbg cross-version driver parses both nightly shapes (transition spans old tags).
- updatecli consumer-bump manifests widened to match all pin shapes.

## Testing

188 release-tools tests incl. a cross-channel `semver.gt` ordering matrix, UTC pin via fake timers, CLI passthrough/rejection cases; read-only `updatecli pipeline diff` against the real consumer repos proving old-shape pins are matched and new-shape values injected; pyyaml on all touched workflows.

## Rollout (staged-safe)

This PR is safe alone: npm consumers keep flowing (legacy nightlies remain internally semver-ordered), git-tag/gradle consumers stall harmlessly until their config PRs land (following separately). Normal releases then re-pin the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify semver prerelease ordering for main-cut dev and nightly releases
> - Main-cut dev versions now emit `pre.<timestamp>.dev.<sha>` and nightly versions emit `pre.<timestamp>.nightly.<sha>`, replacing legacy `-dev.<sha>` and `-nightly.<YYYYMMDD>.<sha>` formats; branch-cut devs keep the legacy shape
> - [release.yml](https://github.com/xmtp/libxmtp/pull/4048/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) mints a single run-wide UTC `YYYYMMDDHHMMSS` timestamp and threads it into all SDK release subworkflows and the hub nightly computation
> - [compute-version.ts](https://github.com/xmtp/libxmtp/pull/4048/files#diff-ef25609f0c30717028e1aaa37f61bb5393e9101e0a5d61a90e8818ec1a1a206e) and [resolve-sdk-version.ts](https://github.com/xmtp/libxmtp/pull/4048/files#diff-5f362ce8ee6983902dc6e38b59d94936c9ac350c3380b9073b3fd62df6e72a48) gain `--source-ref` and `--timestamp` options; [version.ts](https://github.com/xmtp/libxmtp/pull/4048/files#diff-94cfe60c34c4b752034ccf50ddf80546b0be541bfe3e9e015037e38e520c11d8) adds `getTimestamp` and `validateTimestamp` helpers
> - Nightly tag recognition in [xdbg_driver_lib_py/__init__.py](https://github.com/xmtp/libxmtp/pull/4048/files#diff-ff400178609e2854f91476cad94afc7b2d274a3f52a1dfd3e707ae5be131c84b) and updatecli manifests is broadened to match both legacy and unified tag formats
> - Behavioral Change: prerelease version strings change shape across all SDKs for main-cut dev and nightly; browser-sdk and node-sdk workflows now fail early if `timestamp` input is empty for dev/nightly runs; `resolve-sdk-version` no longer accepts `dev` as a release type; invalid timestamps throw instead of falling back
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c96879e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
