### PR TITLE
feat(bindings/mobile): uniffi surface for Sentry telemetry

### DIFF
--- a/bindings/mobile/Cargo.toml
+++ b/bindings/mobile/Cargo.toml
@@ -34,7 +34,7 @@ xmtp_content_types.workspace = true
 xmtp_cryptography.workspace = true
 xmtp_db.workspace = true
 xmtp_id.workspace = true
-xmtp_logging.workspace = true
+xmtp_logging = { workspace = true, features = ["sentry"] }
 xmtp_mls.workspace = true
 xmtp_proto.workspace = true
 

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -193,18 +193,30 @@ pub fn set_native_log_level(log_level: FfiLogLevel) -> Result<(), FfiError> {
 /// stable id (MetricsStableIdEncoder derivation), never a raw inbox id.
 #[derive(uniffi::Record, Debug, Clone)]
 pub struct FfiSentryConfig {
+    /// The app's Sentry DSN.
     pub dsn: String,
+    /// Sentry environment name (e.g. "production", "staging").
     pub environment: Option<String>,
+    /// Release identifier reported to Sentry. Defaults to the libxmtp version
+    /// when `None`.
     pub release: Option<String>,
+    /// Fraction of transactions sampled for tracing. Valid range is
+    /// `[0.0, 1.0]`; `0.0` reports error events only, with no transactions.
     pub traces_sample_rate: f32,
+    /// Number of breadcrumbs kept in the rolling buffer before the oldest are
+    /// evicted; pass 100 to match the underlying crate default.
     pub max_breadcrumbs: u32,
+    /// The app-computed HKDF stable id, never a raw inbox id.
     pub user_stable_id: Option<String>,
+    /// Tags attached to every event. `component=libxmtp` is always added.
     pub tags: Vec<FfiSentryTag>,
 }
 
 #[derive(uniffi::Record, Debug, Clone)]
 pub struct FfiSentryTag {
+    /// Tag name.
     pub key: String,
+    /// Tag value.
     pub value: String,
 }
 
@@ -232,7 +244,8 @@ fn sentry_err(e: xmtp_logging::Error) -> FfiError {
 const NO_HANDLE: &str = "logging subscriber owned by host process";
 
 /// Enable Sentry error/trace export. Errors if logging is owned by the host
-/// process, the DSN is invalid, or OTLP telemetry is already active.
+/// process, the DSN is invalid, `traces_sample_rate` is outside `[0.0, 1.0]`,
+/// or OTLP telemetry is already active.
 #[uniffi::export]
 #[xmtp_common::err_span]
 pub fn enable_sentry_telemetry(config: FfiSentryConfig) -> Result<(), FfiError> {
@@ -240,7 +253,8 @@ pub fn enable_sentry_telemetry(config: FfiSentryConfig) -> Result<(), FfiError> 
     h.enable_sentry(config.into()).map_err(sentry_err)
 }
 
-/// Disable Sentry export, flushing pending envelopes first.
+/// Disable Sentry export: remove the layer, then, if this handle owns the
+/// installed client, flush and drop it. Clears the stamped user id.
 #[uniffi::export]
 #[xmtp_common::err_span]
 pub fn disable_sentry_telemetry() -> Result<(), FfiError> {

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -258,6 +258,10 @@ pub fn enable_sentry_telemetry(config: FfiSentryConfig) -> Result<(), FfiError> 
 #[uniffi::export]
 #[xmtp_common::err_span]
 pub fn disable_sentry_telemetry() -> Result<(), FfiError> {
+    // Clear the staged user id even when logging is host-owned and there is no
+    // handle to disable: the slot is ours regardless, and a stale id would
+    // attribute a later session's events.
+    xmtp_logging::sentry::set_user_stable_id(None);
     let h = handle().ok_or_else(|| FfiError::generic(NO_HANDLE))?;
     h.disable_sentry().map_err(sentry_err)
 }
@@ -272,7 +276,10 @@ pub fn set_sentry_user(stable_id: Option<String>) {
 /// Flush pending telemetry (file, OTLP, and Sentry). Call on app background.
 #[uniffi::export]
 pub fn flush_telemetry() {
-    if let Some(h) = handle() {
+    // Flush only an already-installed pipeline: `handle()` would lazily install
+    // our global subscriber, permanently claiming it from a host that flushes
+    // before configuring logging.
+    if let Some(h) = HANDLE.get().and_then(|h| h.as_ref()) {
         h.flush();
     }
 }
@@ -283,6 +290,17 @@ mod sentry_tests {
 
     #[test]
     fn ffi_config_maps_and_bad_dsn_errors() {
+        // Ordered first inside the one test fn: flush before any init must not
+        // lazily install the subscriber (the other calls below do install it).
+        flush_telemetry();
+        assert!(
+            HANDLE.get().is_none(),
+            "flush_telemetry must not install the logging pipeline"
+        );
+        // A user id staged with no handle/enable must not survive disable.
+        set_sentry_user(Some("staged".into()));
+        let _ = disable_sentry_telemetry();
+        assert!(!xmtp_logging::sentry::user_stable_id_is_set());
         let cfg = FfiSentryConfig {
             dsn: "not a dsn".into(),
             environment: Some("dev".into()),

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -189,6 +189,109 @@ pub fn set_native_log_level(log_level: FfiLogLevel) -> Result<(), FfiError> {
     Ok(())
 }
 
+/// Sentry telemetry configuration. `user_stable_id` is the app-computed HKDF
+/// stable id (MetricsStableIdEncoder derivation), never a raw inbox id.
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct FfiSentryConfig {
+    pub dsn: String,
+    pub environment: Option<String>,
+    pub release: Option<String>,
+    pub traces_sample_rate: f32,
+    pub max_breadcrumbs: u32,
+    pub user_stable_id: Option<String>,
+    pub tags: Vec<FfiSentryTag>,
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct FfiSentryTag {
+    pub key: String,
+    pub value: String,
+}
+
+impl From<FfiSentryConfig> for xmtp_logging::SentryConfig {
+    fn from(c: FfiSentryConfig) -> Self {
+        Self {
+            dsn: c.dsn,
+            environment: c.environment,
+            release: c.release,
+            traces_sample_rate: c.traces_sample_rate,
+            max_breadcrumbs: c.max_breadcrumbs as usize,
+            user_stable_id: c.user_stable_id,
+            tags: c.tags.into_iter().map(|t| (t.key, t.value)).collect(),
+        }
+    }
+}
+
+// Sentry setup errors carry the actionable reason (bad DSN, sample rate, OTLP
+// already active), so keep the message instead of the `Log` variant's fixed
+// "error initializing debug log file" text.
+fn sentry_err(e: xmtp_logging::Error) -> FfiError {
+    FfiError::generic(e.to_string())
+}
+
+const NO_HANDLE: &str = "logging subscriber owned by host process";
+
+/// Enable Sentry error/trace export. Errors if logging is owned by the host
+/// process, the DSN is invalid, or OTLP telemetry is already active.
+#[uniffi::export]
+#[xmtp_common::err_span]
+pub fn enable_sentry_telemetry(config: FfiSentryConfig) -> Result<(), FfiError> {
+    let h = handle().ok_or_else(|| FfiError::generic(NO_HANDLE))?;
+    h.enable_sentry(config.into()).map_err(sentry_err)
+}
+
+/// Disable Sentry export, flushing pending envelopes first.
+#[uniffi::export]
+#[xmtp_common::err_span]
+pub fn disable_sentry_telemetry() -> Result<(), FfiError> {
+    let h = handle().ok_or_else(|| FfiError::generic(NO_HANDLE))?;
+    h.disable_sentry().map_err(sentry_err)
+}
+
+/// Late identify: stamp (or clear) the pseudonymous user id on future events.
+/// Call at inbox-ready with the HKDF stable id.
+#[uniffi::export]
+pub fn set_sentry_user(stable_id: Option<String>) {
+    xmtp_logging::sentry::set_user_stable_id(stable_id);
+}
+
+/// Flush pending telemetry (file, OTLP, and Sentry). Call on app background.
+#[uniffi::export]
+pub fn flush_telemetry() {
+    if let Some(h) = handle() {
+        h.flush();
+    }
+}
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+
+    #[test]
+    fn ffi_config_maps_and_bad_dsn_errors() {
+        let cfg = FfiSentryConfig {
+            dsn: "not a dsn".into(),
+            environment: Some("dev".into()),
+            release: None,
+            traces_sample_rate: 0.0,
+            max_breadcrumbs: 50,
+            user_stable_id: None,
+            tags: vec![],
+        };
+        // Invalid DSN must surface as an error, not a silent no-op (unlike the
+        // log-level controls, which no-op without a handle). Which of the two
+        // error paths fires depends on whether this test binary won the
+        // subscriber install race, so accept either.
+        let err = enable_sentry_telemetry(cfg).unwrap_err().to_string();
+        assert!(
+            err.contains("invalid sentry dsn") || err.contains("owned by host process"),
+            "unexpected error: {err}"
+        );
+        set_sentry_user(None);
+        flush_telemetry();
+    }
+}
+
 #[cfg(test)]
 mod test_logger {
     use super::*;

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -290,17 +290,6 @@ mod sentry_tests {
 
     #[test]
     fn ffi_config_maps_and_bad_dsn_errors() {
-        // Ordered first inside the one test fn: flush before any init must not
-        // lazily install the subscriber (the other calls below do install it).
-        flush_telemetry();
-        assert!(
-            HANDLE.get().is_none(),
-            "flush_telemetry must not install the logging pipeline"
-        );
-        // A user id staged with no handle/enable must not survive disable.
-        set_sentry_user(Some("staged".into()));
-        let _ = disable_sentry_telemetry();
-        assert!(!xmtp_logging::sentry::user_stable_id_is_set());
         let cfg = FfiSentryConfig {
             dsn: "not a dsn".into(),
             environment: Some("dev".into()),

--- a/bindings/mobile/tests/telemetry_init.rs
+++ b/bindings/mobile/tests/telemetry_init.rs
@@ -1,0 +1,18 @@
+//! Global-initialization assertions that need a fresh process: unit tests in
+//! the lib target share one process and race the `HANDLE` OnceLock.
+#![cfg(not(target_arch = "wasm32"))]
+
+use xmtpv3::logger;
+
+#[test]
+fn flush_and_disable_before_init_touch_nothing() {
+    // Flush before any init must not lazily install the global subscriber.
+    logger::flush_telemetry();
+    // A user id staged with no handle/enable must not survive disable.
+    logger::set_sentry_user(Some("staged".into()));
+    let _ = logger::disable_sentry_telemetry();
+    assert!(!xmtp_logging::sentry::user_stable_id_is_set());
+    // Installing now must still succeed: flush/disable left the slot untouched
+    // (a lazy install by either would have claimed the subscriber already).
+    logger::init_logger();
+}


### PR DESCRIPTION
## Summary

PR 2 of 2, stacked on #4049 (core Sentry plumbing) — this layer's diff is only the mobile FFI surface (`bindings/mobile/Cargo.toml` + `src/logger.rs`, +118/−1):

- `FfiSentryConfig` / `FfiSentryTag` uniffi records (dsn, environment, release, `traces_sample_rate` [0.0–1.0], `max_breadcrumbs`, `user_stable_id` — the app-computed HKDF stable id, never a raw inbox id — and tags; `component=libxmtp` always added).
- `enable_sentry_telemetry(config)` — errors on invalid/empty DSN, out-of-range sample rate, host-owned subscriber, or while OTLP telemetry is active.
- `disable_sentry_telemetry()` — removes the layer, flushes and drops the owned client, clears the user id, restores any host client.
- `set_sentry_user(stable_id)` — late identify at inbox-ready; reaches already-bound worker hubs (global slot read at capture time).
- `flush_telemetry()` — file + OTLP + Sentry; call on app background.
- Errors surface as `FfiError::generic("telemetry: ...")` with the real cause preserved (deliberately bypasses `GenericError::Log`, whose Display discards its payload). A dedicated `GenericError::Telemetry` variant is an additive fast-follow (flat_error ⇒ no ABI break).

App-side wiring (Convos iOS/Android): pass the existing Sentry DSN, compute `user_stable_id` with `MetricsStableIdEncoder`, enable after app start, identify at inbox-ready, flush on background. Doc comments on the records/fns are written to be the generated Kotlin/Swift docs.

## Verification

- `cargo test -p xmtpv3 --lib logger::` — green (config-mapping + error-path test, red→green)
- `cargo check -p xmtpv3` on host and `aarch64-linux-android` (via nix devshell) — clean; Gradle half + uniffi-bindgen + iOS compile are CI's gates
- Workspace clippy `-Dwarnings` / fmt / hakari — clean

See #4049 for the PII posture and the four open decisions; they apply to this surface unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add uniffi Sentry telemetry surface to mobile bindings
> - Adds a `sentry` module to `xmtp_logging` with HKDF-based identity pseudonymization, event/span filtering, tag injection, and a `SentryConfig` struct; DSN validation and trace sample rate bounds are enforced at init
> - Exposes `enable_sentry_telemetry`, `disable_sentry_telemetry`, `set_sentry_user`, and `flush_telemetry` via uniffi in [logger.rs](https://github.com/xmtp/libxmtp/pull/4050/files#diff-9d8abec9a152321af4b2de4c3e41865e58cdcc8b6ac56aa49c772ba6321aad33), mapping `FfiSentryConfig` to the internal config
> - Introduces `bind_task_hub` in [telemetry.rs](https://github.com/xmtp/libxmtp/pull/4050/files#diff-7d3ea9720188a23d35327cc01a29d106bc3f980f62194f9ae8f93fee89d6d3df) so each spawned task runs under its own Sentry hub that tracks the process hub's client; the `err_span` macro now wraps async bodies in this hub and emits an ERROR event on failure
> - Sentry and OTLP telemetry are mutually exclusive; disabling Sentry restores the host app's previously-bound process hub client
> - `sentry.*` span fields are hidden from non-JSON log output (stdout, Android logcat) via `HideSentryFields` in [fmt.rs](https://github.com/xmtp/libxmtp/pull/4050/files#diff-57ed51d7d1e38ad7c46061f92d6de826b162021c7900e15e11da4e57cf54de55)
> - Risk: `LoggingHandle::enable_telemetry` now returns an error if Sentry is active; `err_span`-annotated async functions gain a per-call hub wrapper that changes where breadcrumbs and error events are captured, so any out-of-tree FFI consumers relying on the old span shape or hub behavior need updating
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34757ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->