### PR TITLE
feat(xmtp_mls): bound app-data change callback with a timeout

### DIFF
--- a/bindings/mobile/src/mls/change_callbacks.rs
+++ b/bindings/mobile/src/mls/change_callbacks.rs
@@ -67,6 +67,7 @@ impl From<FfiUnstableChangeCallbacks> for UnstableChangeCallbacks {
             app_data: callbacks
                 .app_data
                 .map(|cb| Arc::new(FfiAppDataChangeCallbackBridge::new(cb)) as _),
+            ..Default::default()
         }
     }
 }

--- a/bindings/node/src/client/change_callbacks.rs
+++ b/bindings/node/src/client/change_callbacks.rs
@@ -73,6 +73,7 @@ impl From<&UnstableChangeCallbacks> for RustUnstableChangeCallbacks {
       app_data: callbacks.app_data.clone().map(|cb| {
         Arc::new(AppDataChangeBridge { callback: cb }) as Arc<dyn RustAppDataChangeCallback>
       }),
+      ..Default::default()
     }
   }
 }

--- a/bindings/wasm/src/client/change_callbacks.rs
+++ b/bindings/wasm/src/client/change_callbacks.rs
@@ -110,6 +110,7 @@ impl From<UnstableChangeCallbacks> for RustUnstableChangeCallbacks {
         .app_data
         .take()
         .map(|cb| Arc::new(cb) as Arc<dyn RustAppDataChangeCallback>),
+      ..Default::default()
     }
   }
 }

--- a/crates/xmtp_mls/src/groups/change_callbacks.rs
+++ b/crates/xmtp_mls/src/groups/change_callbacks.rs
@@ -11,8 +11,8 @@
 //! registry is a struct rather than a bare callback argument so callbacks for
 //! the other mutable fields (name, description, image url, admin lists,
 //! permissions, disappearing settings) land as *additive* fields on a type the
-//! SDKs already construct — the same reason [`crate::groups::UpdateAppDataOptions`]
-//! and the FFI options records are structs.
+//! SDKs already construct — the same reason the bindings' `UpdateAppDataOptions`
+//! and the other FFI options records are structs.
 //!
 //! # Delivery contract
 //!
@@ -26,12 +26,46 @@
 //!
 //! Concretely, that means the sync path delivers a batch after the whole sync
 //! completes rather than between messages, and the stream path delivers each
-//! change as its message is processed. Changes are always awaited one at a
-//! time, in the order they were observed.
+//! change as its message is processed. Changes are dispatched one at a time, in
+//! the order they were observed — but see [Timeouts](#timeouts): that ordering
+//! holds only for callbacks that return within their budget.
 //!
 //! A callback observes the *net* change across one processed message, and fires
 //! for local commits as well as remote ones — an implementation that reacts by
 //! writing must make its merge idempotent, or it will chase its own echo.
+//!
+//! # Timeouts
+//!
+//! Each callback is given [`UnstableChangeCallbacks::app_data_timeout`] to
+//! return. A host that overruns it is abandoned: the expiry is logged and the
+//! rest of that batch is dropped, and neither the sync nor the stream fails,
+//! because the change being reported is already durably committed and the
+//! callback is advisory. Nothing is permanently lost — merges are idempotent,
+//! so the next change re-triggers one from current state.
+//!
+//! Abandoning is not cancelling. libxmtp drops the future and stops waiting;
+//! whether the host's own work stops is up to the binding. uniffi notifies the
+//! foreign side that the future was dropped, which its Kotlin and Swift
+//! bindings can wire to cancelling the task, whereas a JS promise behind napi
+//! or wasm-bindgen keeps running to completion — or never resolves — with
+//! nothing left listening.
+//!
+//! That has a consequence worth designing around: on a binding that cannot
+//! cancel, an abandoned callback may still publish *after* a later one already
+//! did, landing a merge derived from state that has since moved on. The budget
+//! bounds how long sync waits; it cannot unwind work the host has already
+//! started. **Pass the compare-and-swap guard** — `update_app_data(merged,
+//! Some(value_you_were_handed))` — so a late write is superseded at publish
+//! time instead of clobbering the newer one. Hosts that publish unguarded get
+//! last-writer-wins, and after a timeout "last" is not necessarily "latest".
+//!
+//! The budget also only bounds callbacks that *yield*. A handler that blocks
+//! its thread — synchronous FFI work, a blocking lock, `Thread.sleep` — stalls
+//! the task the timer lives on, so the timeout cannot fire and sync waits as
+//! long as the host does. This is inherent to async: a future that never
+//! returns from `poll` cannot be timed out from inside the same runtime.
+//! Callbacks must not block; do blocking work on the host's own executor and
+//! await its completion.
 //!
 //! # Stability
 //!
@@ -40,7 +74,18 @@
 //! surface.
 
 use std::sync::Arc;
-use xmtp_common::{MaybeSend, MaybeSync};
+use xmtp_common::{MaybeSend, MaybeSync, time::Duration};
+
+/// How long a single `app_data` callback may run before it is abandoned.
+///
+/// Sized against the round trip the callback exists to perform: merge, then
+/// publish the result with `update_app_data`, which commits, publishes, and
+/// waits for the intent to resolve — a few seconds on a poor mobile network.
+/// Ten leaves room for that while keeping the worst case a host can inflict on
+/// its own `sync()` call short enough to sit behind a spinner. Raising it buys
+/// slow networks more headroom at the cost of a longer visible stall; the
+/// balance is why this is a field rather than a hard-coded constant.
+pub const DEFAULT_APP_DATA_CALLBACK_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A change to a group's opaque `app_data` slot, observed after it was applied
 /// to local state.
@@ -60,6 +105,16 @@ pub struct AppDataChange {
 ///
 /// Async so an implementation can do the read-modify-write of a semantic merge
 /// — including publishing the merged result — before returning.
+///
+/// Two requirements on an implementation, both from
+/// [the module's timeout rules](self#timeouts):
+///
+/// - **Do not block the calling thread.** Await instead. A handler that blocks
+///   cannot be timed out, and stalls the group's sync for as long as it runs.
+/// - **Publish with the compare-and-swap guard** if it publishes at all —
+///   `update_app_data(merged, Some(change.new_value))`. A handler abandoned at
+///   the budget may still be running, and the guard is what stops its late
+///   write from overwriting a newer one.
 #[xmtp_common::async_trait]
 pub trait AppDataChangeCallback: MaybeSend + MaybeSync {
     async fn on_app_data_changed(&self, change: AppDataChange);
@@ -69,14 +124,35 @@ pub trait AppDataChangeCallback: MaybeSend + MaybeSync {
 ///
 /// Cloned into [`crate::context::XmtpMlsLocalContext`] at build time; an unset
 /// field costs a single `Option` check on the message-processing path.
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct UnstableChangeCallbacks {
     /// Fires when a processed message changed the group's `app_data`.
     pub app_data: Option<Arc<dyn AppDataChangeCallback>>,
+    /// How long [`Self::app_data`] may run before it is abandoned. Defaults to
+    /// [`DEFAULT_APP_DATA_CALLBACK_TIMEOUT`].
+    ///
+    /// Deliberately *not* mirrored on the FFI registries yet: no SDK caller has
+    /// asked to tune it, and exposing it costs a field on each of the uniffi,
+    /// napi, and wasm records plus the SDK surfaces above them. It lives here
+    /// so tests can shorten it, and so the knob is already additive the day
+    /// someone does ask.
+    pub app_data_timeout: Duration,
     // Future fields (name, description, image_url, admin_list, permissions,
     // disappearing_settings) go here. Each must default to `None`, and each
     // FFI mirror must carry a binding-level default, so adding one stays
     // non-breaking for compiled SDK callers.
+}
+
+impl Default for UnstableChangeCallbacks {
+    /// Hand-written rather than derived: the derive would default
+    /// `app_data_timeout` to [`Duration::ZERO`], which expires every callback
+    /// before it starts.
+    fn default() -> Self {
+        Self {
+            app_data: None,
+            app_data_timeout: DEFAULT_APP_DATA_CALLBACK_TIMEOUT,
+        }
+    }
 }
 
 impl UnstableChangeCallbacks {
@@ -91,6 +167,7 @@ impl std::fmt::Debug for UnstableChangeCallbacks {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UnstableChangeCallbacks")
             .field("app_data", &self.app_data.is_some())
+            .field("app_data_timeout", &self.app_data_timeout)
             .finish()
     }
 }

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2350,14 +2350,49 @@ where
     ///
     /// Awaited in order, one at a time: a merge decides what to write from the
     /// value it was handed, so overlapping or reordered dispatches would let a
-    /// host publish a merge derived from state that has already moved on.
+    /// host publish a merge derived from state that has already moved on. That
+    /// ordering requirement is why a slow callback cannot simply be spawned off
+    /// to the side.
+    ///
+    /// Each callback gets `app_data_timeout` to return. Expiry is logged and
+    /// never surfaced as an error: the change being reported is already durably
+    /// committed, so failing the sync would turn a badly behaved host callback
+    /// into a broken client.
+    ///
+    /// Abandoning at the budget is what *bounds* the stall, not what ends the
+    /// host's work — on a binding that cannot cancel, the abandoned handler may
+    /// still publish later, out of order. Restoring strict ordering would mean
+    /// holding the next dispatch until the previous one truly finished, which
+    /// is the unbounded wait the budget exists to prevent. The guard on
+    /// `update_app_data` is the intended remedy; see
+    /// [`crate::groups::change_callbacks`].
     pub(crate) async fn dispatch_app_data_changes(&self, changes: Vec<AppDataChange>) {
-        let Some(callback) = self.context.change_callbacks().app_data.clone() else {
+        let callbacks = self.context.change_callbacks();
+        let Some(callback) = callbacks.app_data.clone() else {
             return;
         };
+        let budget = callbacks.app_data_timeout;
+        let total = changes.len();
 
-        for change in changes {
-            callback.on_app_data_changed(change).await;
+        for (index, change) in changes.into_iter().enumerate() {
+            if xmtp_common::time::timeout(budget, callback.on_app_data_changed(change))
+                .await
+                .is_err()
+            {
+                // One expiry means wedged rather than slow — a host that is
+                // merely slow still returns. Dropping the rest of the batch
+                // holds the stall to a single budget instead of one per change;
+                // the next change re-triggers the merge from current state,
+                // which an idempotent merge handles by construction.
+                tracing::warn!(
+                    group_id = %self.group_id,
+                    "app_data change callback did not return within {:?}; dropping the \
+                     remaining {} change(s) in this batch",
+                    budget,
+                    total - index - 1,
+                );
+                return;
+            }
         }
     }
 

--- a/crates/xmtp_mls/src/groups/tests/test_change_callbacks.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_change_callbacks.rs
@@ -9,6 +9,7 @@ use crate::groups::send_message_opts::SendMessageOpts;
 use crate::tester;
 use crate::utils::TestMlsGroup;
 use std::sync::{Arc, Mutex, OnceLock};
+use xmtp_common::time::Duration;
 use xmtp_db::group_intent::{IntentState, StoredGroupIntent};
 use xmtp_db::prelude::*;
 
@@ -36,6 +37,7 @@ fn recording() -> (Arc<RecordingCallback>, UnstableChangeCallbacks) {
     let callback = Arc::new(RecordingCallback::default());
     let callbacks = UnstableChangeCallbacks {
         app_data: Some(callback.clone() as Arc<dyn AppDataChangeCallback>),
+        ..Default::default()
     };
     (callback, callbacks)
 }
@@ -153,6 +155,7 @@ async fn test_callback_can_publish_back_into_the_same_group() {
     let callback = Arc::new(RepublishingCallback::default());
     let callbacks = UnstableChangeCallbacks {
         app_data: Some(callback.clone() as Arc<dyn AppDataChangeCallback>),
+        ..Default::default()
     };
 
     tester!(alix);
@@ -378,5 +381,154 @@ async fn test_superseded_intent_resolves_promptly_as_an_error() {
         group.app_data()?,
         "current",
         "the guarded write must not have been applied"
+    );
+}
+
+/// The value a [`WedgingCallback`] hangs on.
+const WEDGE: &str = "wedge";
+
+/// Hangs forever on any change carrying [`WEDGE`]. Logs entry and return
+/// separately so a test can tell "never dispatched" apart from "dispatched and
+/// abandoned" — without that distinction, a regression that stopped detecting
+/// changes at all would satisfy the same assertions. Models a host handler
+/// that is *stuck* — an unresolved promise, a lock it never acquires — rather
+/// than one that is merely slow.
+#[derive(Default)]
+struct WedgingCallback {
+    entered: Mutex<Vec<String>>,
+    returned: Mutex<Vec<String>>,
+}
+
+impl WedgingCallback {
+    fn entered(&self) -> Vec<String> {
+        self.entered.lock().expect("lock poisoned").clone()
+    }
+
+    fn returned(&self) -> Vec<String> {
+        self.returned.lock().expect("lock poisoned").clone()
+    }
+
+    /// Drop whatever arrived while the group was being set up, so the
+    /// assertions below speak only to the changes the test provoked.
+    fn forget(&self) {
+        self.entered.lock().expect("lock poisoned").clear();
+        self.returned.lock().expect("lock poisoned").clear();
+    }
+}
+
+#[xmtp_common::async_trait]
+impl AppDataChangeCallback for WedgingCallback {
+    async fn on_app_data_changed(&self, change: AppDataChange) {
+        let value = change.new_value.unwrap_or_default();
+        self.entered
+            .lock()
+            .expect("lock poisoned")
+            .push(value.clone());
+        if value == WEDGE {
+            futures::future::pending::<()>().await;
+        }
+        self.returned.lock().expect("lock poisoned").push(value);
+    }
+}
+
+fn wedging(timeout: Duration) -> (Arc<WedgingCallback>, UnstableChangeCallbacks) {
+    let callback = Arc::new(WedgingCallback::default());
+    let callbacks = UnstableChangeCallbacks {
+        app_data: Some(callback.clone() as Arc<dyn AppDataChangeCallback>),
+        app_data_timeout: timeout,
+    };
+    (callback, callbacks)
+}
+
+/// A host callback that never returns must not stall its group forever. The
+/// dispatch is abandoned once `app_data_timeout` expires, the sync completes,
+/// the already-committed change survives, and the client keeps delivering the
+/// changes that follow.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_wedged_callback_does_not_stall_sync_forever() {
+    let (callback, callbacks) = wedging(Duration::from_millis(500));
+    tester!(alix);
+    tester!(bo, change_callbacks: callbacks);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group.add_members(&[bo.inbox_id()]).await?;
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&alix_group.group_id)?;
+    bo_group.sync().await?;
+    callback.forget();
+
+    alix_group.update_app_data(WEDGE.to_string(), None).await?;
+
+    xmtp_common::time::timeout(Duration::from_secs(30), bo_group.sync())
+        .await
+        .expect("sync never returned: the wedged callback was not abandoned")?;
+
+    assert_eq!(
+        callback.entered(),
+        [WEDGE.to_string()],
+        "the change must actually have reached the callback"
+    );
+    assert!(
+        callback.returned().is_empty(),
+        "the callback is still wedged, so it cannot have completed"
+    );
+    assert_eq!(
+        bo_group.app_data()?,
+        WEDGE,
+        "abandoning the callback must not roll back the committed change"
+    );
+
+    alix_group
+        .update_app_data("after".to_string(), None)
+        .await?;
+    bo_group.sync().await?;
+    assert_eq!(
+        callback.returned(),
+        ["after".to_string()],
+        "one abandoned dispatch must not poison later ones"
+    );
+}
+
+/// The first expiry abandons the rest of the batch instead of paying the
+/// budget again per change. A host that blows the budget is stuck, not slow,
+/// and re-confirming that N times turns a bounded stall into an unbounded one.
+/// Dropping the tail is safe because merges are idempotent: the host reads
+/// current state on the next change it does receive.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_wedged_callback_drops_the_rest_of_its_batch() {
+    let (callback, callbacks) = wedging(Duration::from_millis(500));
+    tester!(alix);
+    tester!(bo, change_callbacks: callbacks);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group.add_members(&[bo.inbox_id()]).await?;
+    bo.sync_welcomes().await?;
+    let bo_group = bo.group(&alix_group.group_id)?;
+    bo_group.sync().await?;
+    callback.forget();
+
+    // Two commits before a single sync, so both changes are collected into one
+    // batch and dispatched together.
+    alix_group.update_app_data(WEDGE.to_string(), None).await?;
+    alix_group
+        .update_app_data("second".to_string(), None)
+        .await?;
+
+    xmtp_common::time::timeout(Duration::from_secs(30), bo_group.sync())
+        .await
+        .expect("sync never returned: the wedged callback was not abandoned")?;
+
+    // Exactly one entry, and it is the wedge: the batch reached the callback
+    // and then stopped there. Had it kept going, "second" would have been
+    // entered too; had detection broken, there would be no entries at all.
+    assert_eq!(
+        callback.entered(),
+        [WEDGE.to_string()],
+        "the change queued behind the wedged one must be dropped, not dispatched"
+    );
+    assert_eq!(
+        bo_group.app_data()?,
+        "second",
+        "both commits must still be applied to local state — only the callback was skipped"
     );
 }


### PR DESCRIPTION
Closes the last open gap on the unstable app-data change callback that wasn't a proto change: a host handler that never returned stalled that group's sync indefinitely. Three reviewers flagged it independently on the original stack.

## What changed

Each callback now gets a bounded budget to return. The deadlock fix already funnelled every dispatch — sync path and stream path — through a single `dispatch_app_data_changes`, so the timeout wraps exactly one call site.

On expiry we log and **return**, dropping the rest of that batch. One expiry means the host is wedged, not slow — a slow host still returns — so re-confirming that once per change would turn a bounded stall into an unbounded one. Nothing is permanently lost: merges are already required to be idempotent, so the next change re-triggers one from current state.

Expiry is never surfaced as an error. The change being reported is already durably committed by the time dispatch runs, and the callback is advisory; failing the sync would turn a badly behaved host handler into a broken client.

## Why 10 seconds

The floor is the round trip the callback exists to perform: merge, then publish the result with `update_app_data`, which commits, publishes, and waits for the intent to resolve. That's a few seconds on a poor mobile network. Ten leaves room for that while keeping the worst case a host can inflict on its own `sync()` call short enough to sit behind a spinner.

## Why the knob isn't in the FFI

`app_data_timeout` is a field on the core `UnstableChangeCallbacks` but is deliberately **not** mirrored on the uniffi, napi, or wasm registries. No SDK caller has asked to tune it, and exposing it costs a field on each of the three records plus the SDK surfaces above them. It lives in core so tests can shorten it, and so the knob is already additive the day someone does ask. The three FFI `From` impls just gained `..Default::default()`, which also means future fields won't need to touch them again.

`Default` is hand-written rather than derived — the derive would default `app_data_timeout` to `Duration::ZERO`, expiring every callback before it starts.

## Abandoning is not cancelling

libxmtp drops the future and stops waiting; whether the host's own work stops is up to the binding. uniffi notifies the foreign side that the future was dropped, which its Kotlin and Swift bindings can wire to cancelling the task. A JS promise behind napi or wasm-bindgen keeps running to completion — or never resolves — with nothing left listening. Documented on the module.

## Tests

Two new tests, both built so they can't pass vacuously. The callback records entry and return separately, so "never dispatched" is distinguishable from "dispatched and abandoned" — without that, a regression that stopped detecting changes at all would satisfy the same assertions.

- `test_wedged_callback_does_not_stall_sync_forever` — sync completes, the committed change survives, and the next change is still delivered, so one wedged dispatch doesn't poison the client.
- `test_wedged_callback_drops_the_rest_of_its_batch` — two commits, one sync. Exactly one entry and it's the wedge: kept going would be `["wedge", "second"]`, broken detection would be `[]`.

## Known edge

The stream path (`factory.rs`) passes batches of at most one, so batch-dropping is a no-op there and a permanently wedged host pays a full budget per streamed app_data change — bounded per event, unbounded over time. A circuit breaker would close it; that felt like more machinery than an unstable feature warrants, so flagging rather than building it.

## Verification

- `just test v3 test_change_callbacks` — 10/10
- 325/325 app-data tests
- `just lint-rust` — clippy `--all-features --all-targets -Dwarnings`, fmt, hakari all clean
- `cargo check` for `xmtpv3`, `bindings_node`, and `bindings_wasm` (wasm32, `--all-targets --features test-utils`)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound `dispatch_app_data_changes` callbacks with a 10s timeout
> - Adds `app_data_timeout: Duration` field to `UnstableChangeCallbacks` with a default of 10 seconds via `DEFAULT_APP_DATA_CALLBACK_TIMEOUT`
> - `MlsGroup::dispatch_app_data_changes` wraps each `on_app_data_changed` call in `time::timeout(budget, ...)`; on timeout it logs a warning, drops the remaining changes in that batch, and returns
> - Updates FFI conversions in mobile, node, and wasm bindings to spread `..Default::default()` so the new field is populated
> - Adds `WedgingCallback` test helper and two tests verifying sync completes despite a wedged callback and that remaining batch changes are dropped
> - Behavioral Change: a slow or wedged app-data callback causes the rest of that batch's changes to be silently dropped; the callback does not retry and sync continues without error
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6018433.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->