### PR TITLE
fix(logging): caller-supplied component tag wins over the libxmtp default

### DIFF
--- a/crates/xmtp_logging/src/sentry.rs
+++ b/crates/xmtp_logging/src/sentry.rs
@@ -144,9 +144,17 @@ fn scrub_breadcrumb(mut b: sentry::Breadcrumb) -> Option<sentry::Breadcrumb> {
 /// transport wrapper (`tag_transactions`). Transactions are therefore also
 /// *unscrubbed* by explicit decision; the release span fields are designed to be
 /// identity-free, which is what keeps that safe.
+/// Caller tags come first: every consumer stamps with first-occurrence-wins
+/// (`entry().or_insert`), so a caller-supplied `component` overrides the
+/// `libxmtp` default rather than the other way around.
 fn event_tags(cfg: &SentryConfig) -> Vec<(String, String)> {
-    std::iter::once(("component".to_string(), "libxmtp".to_string()))
-        .chain(cfg.tags.iter().cloned())
+    cfg.tags
+        .iter()
+        .cloned()
+        .chain(std::iter::once((
+            "component".to_string(),
+            "libxmtp".to_string(),
+        )))
         .collect()
 }
 
@@ -662,6 +670,23 @@ mod layer_tests {
             overriding.tags["app"], "host-set",
             "a tag the transaction already set must win over the configured one"
         );
+    }
+
+    #[test]
+    fn caller_supplied_component_tag_wins_over_the_default() {
+        let cfg = SentryConfig {
+            tags: vec![("component".into(), "host-app".into())],
+            ..Default::default()
+        };
+        let tags = event_tags(&cfg);
+        // First occurrence wins in every stamping consumer.
+        let first = tags.iter().find(|(k, _)| k == "component").unwrap();
+        assert_eq!(first.1, "host-app");
+        let mut event = sentry::protocol::Event::default();
+        for (k, v) in &tags {
+            event.tags.entry(k.clone()).or_insert_with(|| v.clone());
+        }
+        assert_eq!(event.tags["component"], "host-app");
     }
 
     /// The wrapper rebuilds transaction envelopes, so prove the headers survive


### PR DESCRIPTION
## Summary

Follow-up to #4049, addressing a review discrepancy: `event_tags()` put the `component=libxmtp` default *first* while every stamping consumer (the `before_send` hook and the transaction transport wrapper) uses first-occurrence-wins `entry().or_insert` — so a caller-supplied `component` tag was silently ignored, contradicting the stated "caller-set keys win" behavior.

Fix: caller tags now come first and the `libxmtp` default is appended, making the documented precedence real on both the error-event and transaction paths. One reorder in `event_tags` plus a precedence test; the existing default-present assertions are unchanged (their configs supply no `component`).

Note: `FfiSentryConfig.tags`' doc line ("component=libxmtp is always added") stays accurate in the added-when-absent sense and lives in #4050's diff, so it's untouched here.

## Testing

- New `caller_supplied_component_tag_wins_over_the_default` (vec ordering + or_insert flow-through)
- Full `xmtp_logging --features sentry` suite green; clippy `-Dwarnings`, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `event_tags` so caller-supplied component tag wins over libxmtp default
> In [sentry.rs](https://github.com/xmtp/libxmtp/pull/4053/files#diff-4447b628a48f0926cf6ec7a095a97e6962bb07f61dce0a91734a6987c772d95e), `event_tags` now places caller-supplied `cfg.tags` before the default `("component","libxmtp")` tag. Because Sentry tagging uses first-occurrence-wins semantics, a host-provided `component` value is now preserved for both events and transactions. Adds a test covering this ordering and the `or_insert` stamping path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a279ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->