### PR TITLE
ci(android): raise integration test timeouts (#4044)

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -30,7 +30,8 @@ jobs:
   integration-tests:
     name: Integration Tests (Android)
     runs-on: blacksmith-16vcpu-ubuntu-2404
-    timeout-minutes: 30
+    # Job budget leaves headroom for setup/backend before the suite step (#4044).
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
@@ -50,8 +51,9 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      # Suite runs ~18–20m with 0 failures; 20m step budget killed healthy runs (#4044).
       - name: Run integration tests
-        timeout-minutes: 20
+        timeout-minutes: 30
         env:
           NIX_DEVSHELL: android
           NIX_ANDROID_EMULATOR_FLAGS: "-no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -memory 4096 -partition-size 8192"


### PR DESCRIPTION
## Summary
- Raise Android integration step timeout from 20m → 30m
- Raise job timeout from 30m → 45m so setup/backend still fit under the job budget

## Why
The connectedCheck suite now runs ~18–20 minutes and often completes 198–202/202 tests with **0 failures**, then gets killed by the 20-minute step timeout. This flake is independent of PR content (seen on main and on PRs with no Android changes).

Fixes #4044

## Test plan
- [x] Verified workflow values locally: step=30, job=45, job > step headroom
- [x] CI `test-android / Integration Tests` completes without the step timeout

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise Android integration test timeouts in `test-android.yml`
> Increases the Integration Tests (Android) job timeout from 30 to 45 minutes and the 'Run integration tests' step timeout from 20 to 30 minutes in [test-android.yml](https://github.com/xmtp/libxmtp/pull/4054/files#diff-3b81be755592f3336798d751e9b23577d4622e81571545a2a9d382c45fd86665). Explanatory comments are added next to each changed value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fbc14c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->