### PR TITLE
fix(agent-sdk): strip trailing colon from URL scheme in createRemoteAttachment

### DIFF
--- a/sdks/js/agent-sdk/src/util/AttachmentUtil.test.ts
+++ b/sdks/js/agent-sdk/src/util/AttachmentUtil.test.ts
@@ -78,6 +78,10 @@ describe("AttachmentUtil", () => {
 
       expect(remoteAttachment.url).toBe(testUrl);
       expect(remoteAttachment.filename).toBe(fileName);
+      // Issue #4034: scheme must not carry the trailing colon that
+      // URL.protocol includes (e.g. "https", not "https:"), matching the
+      // format used elsewhere in libxmtp's remote attachment tests/examples.
+      expect(remoteAttachment.scheme).toBe("https");
 
       const receivedAttachment =
         await downloadRemoteAttachment(remoteAttachment);
@@ -95,6 +99,32 @@ describe("AttachmentUtil", () => {
         receivedAttachment.content,
       );
       expect(decryptedContent).toBe(fileContent);
+    });
+  });
+
+  describe("createRemoteAttachment scheme normalization", () => {
+    it("strips the trailing colon from URL.protocol (issue #4034)", async () => {
+      const fileContent = "scheme normalization test";
+      const unencryptedFile = new File([fileContent], "hello.txt", {
+        type: "text/plain",
+      });
+      const arrayBuffer = await unencryptedFile.arrayBuffer();
+      const encryptedAttachment = encryptAttachment({
+        filename: unencryptedFile.name,
+        content: new Uint8Array(arrayBuffer),
+        mimeType: unencryptedFile.type,
+      });
+
+      for (const [fileUrl, expectedScheme] of [
+        ["https://localhost/test_file", "https"],
+        ["http://localhost/test_file", "http"],
+      ] as const) {
+        const remoteAttachment = createRemoteAttachment(
+          encryptedAttachment,
+          fileUrl,
+        );
+        expect(remoteAttachment.scheme).toBe(expectedScheme);
+      }
     });
   });
 });

--- a/sdks/js/agent-sdk/src/util/AttachmentUtil.ts
+++ b/sdks/js/agent-sdk/src/util/AttachmentUtil.ts
@@ -49,7 +49,7 @@ export function createRemoteAttachment(
     filename: encryptedAttachment.filename,
     nonce: encryptedAttachment.nonce,
     salt: encryptedAttachment.salt,
-    scheme: url.protocol,
+    scheme: url.protocol.replace(/:$/, ""),
     secret: encryptedAttachment.secret,
     url: url.toString(),
   };


### PR DESCRIPTION
Fixes #4034

`createRemoteAttachment()` stored `url.protocol` directly as the remote attachment scheme. `URL.protocol` includes the trailing colon (e.g. `"https:"`), but the rest of libxmtp's remote attachment tests and content type examples consistently use the scheme without it (e.g. `"https"`) - `bindings/node/test/RemoteAttachmentEncryption.test.ts`, `bindings/wasm/test/RemoteAttachmentEncryption.test.ts`, `bindings/wasm/test/EnrichedMessage.test.ts`, and `crates/xmtp_content_types/src/remote_attachment.rs`.

**Fix:** strip the trailing colon with `url.protocol.replace(/:$/, "")`, matching the suggested fix in the issue.

**Tests:** added a regression test asserting the scheme for both `https` and `http` URLs. Verified it fails against the pre-fix code (`expected 'https:' to be 'https'`) and passes against the fix, via a full native build (`cargo build` for `bindings/node`, then `yarn build` for `node-sdk`, since `agent-sdk`'s test suite imports `encryptAttachment` from `@xmtp/node-sdk`, which requires the compiled native binding).

Verified locally: `vitest run src/util/AttachmentUtil.test.ts` - 3/3 passing, `typecheck`, `eslint`, and `prettier` clean on both changed files.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip trailing colon from URL scheme in `createRemoteAttachment`
> `URL.protocol` returns a trailing colon (e.g. `https:`), which was being stored as the attachment scheme. The fix removes that colon so schemes like `https` and `http` are stored cleanly. Tests now assert scheme normalization for both HTTPS and HTTP URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd9db85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->