### PR TITLE
build: scaffold and package the self-hosted backend

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -50,6 +50,7 @@ third-party = [
 [final-excludes]
 # Portable roots do not depend on the aggregate client feature graph.
 workspace-members = [
+  "xmtp_backend",
   "xmtp_common",
   "xmtp_cryptography",
   "xmtp_configuration",

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,5 @@
+# GitHub workflows
+
+Validate workflow edits with `just lint-config`.
+
+- `test-ios.yml` destroys its Fly backend during cleanup. Do not rerun only failed iOS test jobs after cleanup: they reuse the deleted backend URL. Rerun the deployment and dependent jobs, or the full workflow.

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -1,0 +1,70 @@
+name: Test self-hosted backend
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test-backend:
+    name: Test backend (native)
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 30
+    env:
+      NIX_DEVSHELL: rust
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-nix
+        with:
+          disk-key: rust
+          github-token: ${{ github.token }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          sccache: "false"
+      - uses: taiki-e/install-action@just
+      - name: Test backend
+        run: just test-backend
+
+  backend-image:
+    name: Backend image (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: blacksmith-16vcpu-ubuntu-2404
+            image: .#backend-image-x86_64-unknown-linux-musl
+            nix-disk: "true"
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            image: .#backend-image-aarch64-unknown-linux-musl
+            nix-disk: "false"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-nix
+        with:
+          disk-key: rust
+          nix-disk: ${{ matrix.nix-disk }}
+          github-token: ${{ github.token }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          sccache: "false"
+      - name: Build backend image
+        run: nix build "${{ matrix.image }}" --out-link backend-image-result
+      - name: Load backend image
+        run: docker load --input backend-image-result
+      - name: Check image architecture
+        env:
+          EXPECTED_ARCH: ${{ matrix.arch }}
+        run: |
+          actual_arch="$(docker image inspect ghcr.io/xmtp/backend:self-hosted --format '{{.Architecture}}')"
+          test "$actual_arch" = "$EXPECTED_ARCH"
+      - name: Run backend image
+        env:
+          PLATFORM: linux/${{ matrix.arch }}
+        run: |
+          output="$(docker run --rm --platform "$PLATFORM" ghcr.io/xmtp/backend:self-hosted)"
+          test "$output" = "Hello from the XMTP backend!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       devcontainer: ${{ steps.filter.outputs.devcontainer }}
       keepalive-probe: ${{ steps.filter.outputs.keepalive-probe }}
       validation: ${{ steps.filter.outputs.validation }}
+      backend: ${{ steps.filter.outputs.backend }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -154,11 +155,31 @@ jobs:
               - 'flake.lock'
               - '.github/workflows/test.yml'
               - '.github/workflows/test-validation.yml'
+            backend:
+              - 'apps/backend/**'
+              - 'crates/**'
+              - 'proto/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.cargo/**'
+              - 'rust-toolchain.toml'
+              - 'justfile'
+              - 'nix/**'
+              - 'flake.lock'
+              - '.github/actions/setup-nix/**'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/test-backend.yml'
 
   test-validation:
     needs: detect-changes
     if: needs.detect-changes.outputs.validation == 'true'
     uses: ./.github/workflows/test-validation.yml
+    secrets: inherit
+
+  test-backend:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend == 'true'
+    uses: ./.github/workflows/test-backend.yml
     secrets: inherit
 
   test-workspace:
@@ -244,6 +265,7 @@ jobs:
     if: always()
     needs:
       - test-validation
+      - test-backend
       - test-workspace
       - test-keepalive-probe
       - test-node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,6 +156,8 @@ jobs:
               - '.github/workflows/test.yml'
               - '.github/workflows/test-validation.yml'
             backend:
+              - 'flake.nix'
+              - 'dev/nix-shell'
               - 'apps/backend/**'
               - 'crates/**'
               - 'proto/**'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ Never run `cargo`, `yarn`, `./gradlew`, or `swift` bare. Use `just`, or `dev/nix
 ```bash
 just                    # list all recipes
 just backend up         # docker services. Most tests need them.
+just build-backend      # self-hosted hello-world binary through Nix.
+just test-backend       # the backend scaffold test.
 just check              # cargo check. default-members only.
 just test               # v3 + d14n tests. default-members only.
 just lint               # rust + config + markdown. Run before commit.
@@ -26,7 +28,7 @@ just lint-proto         # Buf checks the local proto/ schemas.
 just validation         # isolated shared validation checks and native/wasm tests.
 ```
 
-`default-members` = `apps/mls_validation_service`, `bindings/*`, `crates/*`. Other apps: see their `AGENTS.md`.
+`default-members` = `apps/backend`, `apps/mls_validation_service`, `bindings/*`, `crates/*`. Other apps: see their `AGENTS.md`.
 
 ## Rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11028,6 +11028,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmtp_backend"
+version = "1.12.0-dev"
+dependencies = [
+ "tokio",
+ "xmtp_common",
+]
+
+[[package]]
 name = "xmtp_common"
 version = "1.12.0-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ members = [
 
 exclude = ["apps/android"]
 
-# Default members must be part of workspace hack to maximize cache hits in CI/nix/crane
+# Default build and test members. Portable crates do not inherit the client workspace hack.
 default-members = [
+  "apps/backend",
   "apps/mls_validation_service",
   # Bindings
   "bindings/*",

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -7,9 +7,17 @@ Phase 1 hello-world binary for the self-hosted backend.
 ```bash
 dev/nix-shell 'cargo build --locked -p xmtp_backend'
 just check crate xmtp_backend
+just build-backend
+just test-backend
+just backend-image                     # amd64 image
+just backend-image aarch64             # arm64 image
 dev/nix-shell "cargo nextest run --locked -p xmtp_backend -E 'test(startup_message_is_written)'"
 just lint-rust
 dev/nix-shell 'cargo run --locked -p xmtp_backend'
 ```
 
 The binary prints one fixed startup message and exits. It has no server or storage.
+
+Nix outputs: `xmtp-backend`, `backend-image`, and
+`backend-image-aarch64-unknown-linux-musl`. Both images use the `xmtp-backend`
+entry point and the `ghcr.io/xmtp/backend:self-hosted` tag.

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -1,0 +1,15 @@
+# xmtp-backend
+
+Phase 1 hello-world binary for the self-hosted backend.
+
+## Commands
+
+```bash
+dev/nix-shell 'cargo build --locked -p xmtp_backend'
+just check crate xmtp_backend
+dev/nix-shell "cargo nextest run --locked -p xmtp_backend -E 'test(startup_message_is_written)'"
+just lint-rust
+dev/nix-shell 'cargo run --locked -p xmtp_backend'
+```
+
+The binary prints one fixed startup message and exits. It has no server or storage.

--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -12,6 +12,7 @@ name = "xmtp-backend"
 path = "src/main.rs"
 
 [dev-dependencies]
+tokio.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 
 [lints]

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "xmtp_backend"
+description = "XMTP self-hosted backend"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "xmtp-backend"
+path = "src/main.rs"
+
+[dev-dependencies]
+xmtp_common = { workspace = true, features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/apps/backend/src/main.rs
+++ b/apps/backend/src/main.rs
@@ -1,0 +1,22 @@
+use std::io::{self, Write};
+
+fn main() -> io::Result<()> {
+    write_greeting(io::stdout())
+}
+
+fn write_greeting(mut writer: impl Write) -> io::Result<()> {
+    writeln!(writer, "Hello from the XMTP backend!")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_greeting;
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn startup_message_is_written() {
+        let mut output = Vec::new();
+        write_greeting(&mut output)?;
+
+        assert_eq!(output, b"Hello from the XMTP backend!\n");
+    }
+}

--- a/crates/xmtp_mls_common/AGENTS.md
+++ b/crates/xmtp_mls_common/AGENTS.md
@@ -15,6 +15,5 @@ dev/nix-shell "cargo nextest run --profile ci -p xmtp_mls_common -E 'test(/app_d
 ## Gotchas
 
 - No Docker or client database dependency. All modules are available on native and wasm.
-- Never depend on `xmtp_db` for a shared type. Use `xmtp_proto::types`; SQL support is optional there.
 - General commit-log signing and decoding live in `commit_log`.
 - Types the backend also needs go here, not in `xmtp_mls`.

--- a/crates/xmtp_mls_validation/AGENTS.md
+++ b/crates/xmtp_mls_validation/AGENTS.md
@@ -4,7 +4,6 @@ Shared payload admission and stateless fixtures. No client database or transport
 
 General commit-log signing and decoding live in `xmtp_mls_common::commit_log`.
 Admission parsing and validation stay in this crate.
-Do not put general signing or encoding helpers here only because validation uses them.
 
 ```bash
 just check crate xmtp_mls_validation

--- a/justfile
+++ b/justfile
@@ -114,6 +114,16 @@ validation: check-validation test-validation
 
 # --- BACKEND ---
 
+# Build the Phase 1 self-hosted binary without starting the test services.
+build-backend:
+    nix build .#xmtp-backend
+
+test-backend:
+    cargo test --locked -p xmtp_backend
+
+backend-image arch="x86_64":
+    nix build .#backend-image-{{ arch }}-unknown-linux-musl
+
 # `just backend up`, `just backend down`
 [script("bash")]
 backend command="up":

--- a/nix/AGENTS.md
+++ b/nix/AGENTS.md
@@ -1,0 +1,9 @@
+# Nix
+
+Read `.claude/skills/working-with-nix/SKILL.md` before changing derivations.
+Check an affected output with `nix build --no-link .#<output>`; run `just lint-config`.
+
+## Build isolation
+
+- Cargo resolves every workspace member before applying package selection. Crane's `mkDummySrc` input needs each member's target sources, not just its manifest. Keep dependency-cache inputs narrow after dummy generation.
+- Local protobuf generation needs schemas and the real proto build script in both dependency-only and final sources, plus build-platform `protoc` when cross-compiling. After changing source filters, verify that a schema edit changes the dependency derivation and an unrelated Rust source edit does not.

--- a/nix/CLAUDE.md
+++ b/nix/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/nix/musl-docker.nix
+++ b/nix/musl-docker.nix
@@ -17,6 +17,16 @@
 
       crossPkgs = self.lib.mkCrossPkgs system targets;
       mkMlsValidationService = p: p.callPackage ./package/mls_validation_service.nix;
+      mkBackend = p: p.callPackage ./package/backend.nix;
+      backendImage =
+        target: architecture:
+        pkgs.dockerTools.buildLayeredImage {
+          name = "ghcr.io/xmtp/backend";
+          tag = "self-hosted";
+          inherit architecture;
+          contents = [ pkgs.cacert ];
+          config.Entrypoint = [ "${self'.packages.${"xmtp-backend-${target}"}}/bin/xmtp-backend" ];
+        };
 
       imageCommon = {
         name = "ghcr.io/xmtp/mls-validation-service"; # override ghcr images
@@ -26,6 +36,10 @@
     in
     {
       packages = {
+        xmtp-backend = pkgs.callPackage ./package/backend.nix { };
+        backend-image = backendImage "x86_64-unknown-linux-musl" "amd64";
+        backend-image-x86_64-unknown-linux-musl = self'.packages.backend-image;
+        backend-image-aarch64-unknown-linux-musl = backendImage "aarch64-unknown-linux-musl" "arm64";
         mls-validation-service = pkgs.callPackage ./package/mls_validation_service.nix { };
         # lib.recursiveUpdate lets imageCommon define other attributes in the `config` namesapce
         validation-service-image = pkgs.dockerTools.buildLayeredImage (
@@ -50,6 +64,10 @@
       // lib.mapAttrs' (target: crossPkgs: {
         name = "mls-validation-service-${target}";
         value = mkMlsValidationService crossPkgs { };
+      }) crossPkgs
+      // lib.mapAttrs' (target: crossPkgs: {
+        name = "xmtp-backend-${target}";
+        value = mkBackend crossPkgs { };
       }) crossPkgs;
     };
 }

--- a/nix/package/backend.nix
+++ b/nix/package/backend.nix
@@ -8,10 +8,26 @@ let
     p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ]
   );
   root = ./../..;
-  src = lib.fileset.toSource {
+  workspaceSource = lib.fileset.toSource {
     inherit root;
-    # Keep workspace targets present for locked Cargo resolution.
     fileset = xmtp.filesets.workspace;
+  };
+  backendSource = lib.fileset.toSource {
+    inherit root;
+    fileset = lib.fileset.unions [
+      (root + /Cargo.toml)
+      (rust.fileset.commonCargoSources (root + /apps/backend))
+    ];
+  };
+  # The scaffold uses only std. Keep other workspace targets as stubs for
+  # locked resolution; their Rust source does not affect the backend image.
+  # Add dependency sources here when the backend starts using shared crates.
+  src = rust.mkDummySrc {
+    src = workspaceSource;
+    extraDummyScript = ''
+      cp --remove-destination ${backendSource}/Cargo.toml $out/Cargo.toml
+      cp --recursive --remove-destination ${backendSource}/apps/backend/. $out/apps/backend/
+    '';
   };
   targetArgs = lib.optionalAttrs stdenv.hostPlatform.isMusl {
     RUSTFLAGS = "-C target-feature=+crt-static";

--- a/nix/package/backend.nix
+++ b/nix/package/backend.nix
@@ -1,0 +1,37 @@
+{
+  xmtp,
+  lib,
+  stdenv,
+}:
+let
+  rust = xmtp.craneLib.overrideToolchain (
+    p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ]
+  );
+  root = ./../..;
+  src = lib.fileset.toSource {
+    inherit root;
+    # Keep workspace targets present for locked Cargo resolution.
+    fileset = xmtp.filesets.workspace;
+  };
+  targetArgs = lib.optionalAttrs stdenv.hostPlatform.isMusl {
+    RUSTFLAGS = "-C target-feature=+crt-static";
+  };
+  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false (
+    targetArgs
+    // {
+      buildPhaseCargoCommand = "cargo build --locked --profile $CARGO_PROFILE -p xmtp_backend --bin xmtp-backend";
+    }
+  );
+in
+rust.buildPackage (
+  xmtp.base.commonArgs
+  // targetArgs
+  // {
+    inherit src cargoArtifacts;
+    pname = "xmtp-backend";
+    version = xmtp.mkVersion rust;
+    cargoExtraArgs = "--locked -p xmtp_backend --bin xmtp-backend";
+    doInstallCargoArtifacts = false;
+    doCheck = false;
+  }
+)

--- a/nix/package/mls_validation_service.nix
+++ b/nix/package/mls_validation_service.nix
@@ -46,6 +46,7 @@ let
       (commonCargoSources (root + /crates/xmtp_proto))
       (commonCargoSources (root + /crates/xmtp_macro))
       (commonCargoSources (root + /apps/mls_validation_service))
+      (commonCargoSources (root + /apps/backend))
     ];
   };
 

--- a/sdks/js/AGENTS.md
+++ b/sdks/js/AGENTS.md
@@ -27,5 +27,6 @@ NIX_DEVSHELL=js dev/nix-shell 'cd sdks/js/node-sdk && yarn vitest run -t "should
 
 - Needs `just backend up`. Run `just js install` and `just js bindings` once first for full local SDK work.
 - Node and agent CI uses `NIX_DEVSHELL=js-node`, `just js install-node-ci`, and `just js bindings-node`.
+- Verify dependency changes with the focused CI install. It omits root development tools; declare required tools in the selected workspace and run them with `yarn workspace <name> exec`.
 - `agent-sdk` reads types from `node-sdk/dist`. Build `node-sdk` first.
 - Formatting is treefmt prettier (`just lint-config`), not eslint.


### PR DESCRIPTION
Adds `apps/backend`, a hello-world `xmtp-backend` binary with one output test. Nix builds the native binary and Linux musl images for amd64 and arm64. CI checks both image architectures and runs each default entry point on a matching runner.

The backend is a default workspace member. Its build artifacts select only the backend package and remain separate from the aggregate client feature graph.

Validation: full `cargo build --locked` through `dev/nix-shell`; `just lint`; the single backend test; Nix native and both musl image builds; successful native, amd64, and arm64 greeting runs. Shared validation native/wasm tests and standalone dependency checks pass in the preceding PR.

Plan: https://plan.ref.tools/tuilwnPskCyECatA

Fourth and top PR in the Phase 1 stack, rooted at `self-hosted`. This binary does not yet serve requests; Phase 2 adds storage and the API.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scaffold and package the self-hosted `xmtp_backend` binary
> - Adds the `xmtp_backend` Cargo package with a `main` binary entry point that writes a startup greeting to stdout, plus a unit test verifying the exact output bytes in [main.rs](https://github.com/xmtp/libxmtp/pull/4068/files#diff-f77f34b7c2ee6a798faf605b6e2f80d17c1fc8474d96d6a94e105bba7192b34d)
> - Adds Nix derivations in [backend.nix](https://github.com/xmtp/libxmtp/pull/4068/files#diff-8cdfa38795ba7c98033e7316e8690355909cfebd9cf0d25d54b9149e8628084b) and [musl-docker.nix](https://github.com/xmtp/libxmtp/pull/4068/files#diff-4532091642057600d9511d47fc6c282ef03f1234c1e2bce79ccc9e23149e40a9) that build `xmtp-backend` for native, cross-compiled, and static musl targets, and produce self-hosted container images for amd64 and arm64
> - Adds a reusable CI workflow in [test-backend.yml](https://github.com/xmtp/libxmtp/pull/4068/files#diff-53ad70792419c0bd08b47cd2e73d793c7f0ea8173b37aec1126192c536ac7fbf) that runs native `just test-backend` and a matrix job that builds, loads, and verifies the container image for each architecture; [test.yml](https://github.com/xmtp/libxmtp/pull/4068/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) wires this into change detection and the aggregate test gate
> - Adds `just` recipes (`build-backend`, `test-backend`, `backend-image`) and registers `apps/backend` in workspace `default-members` and Hakari `final-excludes`
> - Risk: [mls_validation_service.nix](https://github.com/xmtp/libxmtp/pull/4068/files#diff-9a922ce2dc6f11757e441d0902a00c1e9263ea4cf17bc5bf9e8f63f8114cec02) now includes `apps/backend` sources in the validation-service Cargo source set; if backend sources change, the validation-service package rebuilds even when its own code is unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ffcbac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->