### PR TITLE
feat: self-hosted backend static subscriptions and lifecycle

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -27,7 +27,7 @@ jobs:
         run: just backend-db-up
       - name: Check SQL cache
         run: just backend-sql-check
-      - name: Test backend
+      - name: Test backend, replica recovery, and HTTPS streaming
         run: just test-backend
       - name: Stop backend database
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,7 +1570,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1539,6 +1578,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-consensus-encoding"
@@ -2672,6 +2720,20 @@ checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid 0.10.2",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -6638,6 +6700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7545,7 +7616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
@@ -7826,6 +7897,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -8220,6 +8304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.28",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -11294,6 +11387,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "xdbg"
 version = "1.12.0-dev"
 dependencies = [
@@ -11638,6 +11749,7 @@ dependencies = [
  "clap",
  "const-hex",
  "futures",
+ "h2 0.4.19",
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
@@ -11646,13 +11758,16 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-types",
+ "rcgen",
  "reqwest 0.13.4",
+ "rustls",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "sqlx",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "toml 1.1.3+spec-1.1.0",
  "tonic",
@@ -12113,6 +12228,16 @@ name = "xxhash-rust"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/apps/backend/.sqlx/query-1e7d45b7b3e79b343ecddfb33b39c108e19d4d7146971175483c8548fe746756.json
+++ b/apps/backend/.sqlx/query-1e7d45b7b3e79b343ecddfb33b39c108e19d4d7146971175483c8548fe746756.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE datname = current_database()\n            AND wait_event_type = 'Lock' AND query LIKE 'SELECT COALESCE%'\n            AND clock_timestamp() - query_start > interval '50 milliseconds') AS \"waiting!\"",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "waiting!",
+        "type_info": "Bool",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "1e7d45b7b3e79b343ecddfb33b39c108e19d4d7146971175483c8548fe746756"
+}

--- a/apps/backend/.sqlx/query-7032a5741f1919efa30756d13ecfa13d9be2f5f2a46b07dfdb4d1a37b6d85ee3.json
+++ b/apps/backend/.sqlx/query-7032a5741f1919efa30756d13ecfa13d9be2f5f2a46b07dfdb4d1a37b6d85ee3.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND database = (SELECT oid FROM pg_database WHERE datname = current_database())",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "7032a5741f1919efa30756d13ecfa13d9be2f5f2a46b07dfdb4d1a37b6d85ee3"
+}

--- a/apps/backend/.sqlx/query-f547919c0e3816552a1113cde297c7acc78b3d20e5d8433a35f97e36bf639622.json
+++ b/apps/backend/.sqlx/query-f547919c0e3816552a1113cde297c7acc78b3d20e5d8433a35f97e36bf639622.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS (SELECT 1 FROM pg_locks WHERE database = (SELECT oid FROM pg_database WHERE datname = current_database())\n            AND locktype = 'relation' AND NOT granted) AS \"waiting!\"",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "waiting!",
+        "type_info": "Bool",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "f547919c0e3816552a1113cde297c7acc78b3d20e5d8433a35f97e36bf639622"
+}

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -14,6 +14,7 @@ just backend-sql-check                 # verify committed .sqlx
 just backend-schema                    # regenerate public config schema
 just test-backend
 just test-backend --lib config         # one module
+just test-backend --lib https_passthrough # HTTPS streaming ingress check
 just backend-image                     # amd64 image
 just backend-image aarch64             # arm64 image
 just lint-rust

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -50,11 +50,17 @@ xmtp_proto = { workspace = true, features = ["grpc_server_impls"] }
 [dev-dependencies]
 alloy-primitives.workspace = true
 async-trait.workspace = true
+h2 = "0.4"
 http.workspace = true
 http-body-util.workspace = true
 jsonschema = { version = "0.55", default-features = false }
+rcgen = { version = "0.14.10", default-features = false, features = ["ring"] }
 reqwest.workspace = true
+rustls.workspace = true
 tokio.workspace = true
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "ring",
+] }
 tonic-prost = "0.14"
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_id = { workspace = true, features = ["test-utils"] }

--- a/apps/backend/src/server.rs
+++ b/apps/backend/src/server.rs
@@ -11,7 +11,7 @@ use crate::{
 use std::{collections::HashMap, num::NonZeroUsize};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
-use tonic::transport::Server;
+use tonic::{server::NamedService, transport::Server};
 use tonic_web::GrpcWebLayer;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
 use xmtp_id::scw_verifier::{
@@ -77,19 +77,7 @@ pub async fn serve(
         .max_decoding_message_size(receive)
         .max_encoding_message_size(send);
     let (reporter, health) = tonic_health::server::health_reporter();
-    reporter.set_serving::<QueryServiceServer<Backend>>().await;
-    reporter
-        .set_serving::<PublishServiceServer<Backend>>()
-        .await;
-    reporter
-        .set_serving::<IdentityServiceServer<Backend>>()
-        .await;
-    reporter
-        .set_serving::<SubscriptionServiceServer<Backend>>()
-        .await;
-    reporter
-        .set_service_status("", tonic_health::ServingStatus::Serving)
-        .await;
+    report_health(&reporter, tonic_health::ServingStatus::Serving).await;
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods(Any)
@@ -132,7 +120,7 @@ pub async fn serve(
         result = &mut serving => result,
         _ = shutdown => {
             guard.stop();
-            reporter.set_service_status("", tonic_health::ServingStatus::NotServing).await;
+            report_health(&reporter, tonic_health::ServingStatus::NotServing).await;
             let _ = stop.send(());
             let drain = xmtp_common::time::Duration::from_millis(backend.config.server.max_drain_duration_ms);
             match xmtp_common::time::timeout(drain, &mut serving).await {
@@ -140,5 +128,22 @@ pub async fn serve(
                 Err(_) => { lifecycle.cancel(); Ok(()) },
             }
         }
+    }
+}
+
+/// Keep aggregate health and each advertised RPC service in the same lifecycle
+/// state. Named health watchers must see shutdown before connections drain.
+async fn report_health(
+    reporter: &tonic_health::server::HealthReporter,
+    status: tonic_health::ServingStatus,
+) {
+    for service in [
+        "",
+        QueryServiceServer::<Backend>::NAME,
+        PublishServiceServer::<Backend>::NAME,
+        IdentityServiceServer::<Backend>::NAME,
+        SubscriptionServiceServer::<Backend>::NAME,
+    ] {
+        reporter.set_service_status(service, status).await;
     }
 }

--- a/apps/backend/src/server.rs
+++ b/apps/backend/src/server.rs
@@ -18,6 +18,7 @@ use xmtp_id::scw_verifier::{
     CachedSmartContractSignatureVerifier, MultiSmartContractSignatureVerifier,
 };
 
+mod lifecycle;
 pub(crate) mod request_logger;
 #[cfg(test)]
 mod tests;
@@ -99,14 +100,17 @@ pub async fn serve(
             "grpc-status-details-bin".parse().expect("static header"),
             "x-request-id".parse().expect("static header"),
         ]);
-    let streams = backend.streams.clone();
-    let shutdown = async move {
-        shutdown.await;
-        if let Some(streams) = streams {
-            streams.stop();
-        }
+    use futures::StreamExt;
+    let lifecycle = lifecycle::Lifecycle::new();
+    let guard = lifecycle::ShutdownGuard {
+        lifecycle: lifecycle.clone(),
+        streams: backend.streams.clone(),
     };
-    Server::builder()
+    let incoming_lifecycle = lifecycle.clone();
+    let incoming = TcpListenerStream::new(listener)
+        .map(move |socket| socket.map(|socket| incoming_lifecycle.connection(socket)));
+    let (stop, stopped) = tokio::sync::oneshot::channel();
+    let serving = Server::builder()
         .accept_http1(true)
         .max_concurrent_streams(limits.max_http2_streams as u32)
         .layer(cors)
@@ -114,11 +118,27 @@ pub async fn serve(
             backend.config.server.request_logger,
         ))
         .layer(GrpcWebLayer::new())
+        .layer(lifecycle::AdmissionLayer(lifecycle.clone()))
         .add_service(health)
         .add_service(query)
         .add_service(publish)
         .add_service(identity)
         .add_service(subscription)
-        .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
-        .await
+        .serve_with_incoming_shutdown(incoming, async {
+            let _ = stopped.await;
+        });
+    tokio::pin!(serving);
+    tokio::select! {
+        result = &mut serving => result,
+        _ = shutdown => {
+            guard.stop();
+            reporter.set_service_status("", tonic_health::ServingStatus::NotServing).await;
+            let _ = stop.send(());
+            let drain = xmtp_common::time::Duration::from_millis(backend.config.server.max_drain_duration_ms);
+            match xmtp_common::time::timeout(drain, &mut serving).await {
+                Ok(result) => result,
+                Err(_) => { lifecycle.cancel(); Ok(()) },
+            }
+        }
+    }
 }

--- a/apps/backend/src/server/lifecycle.rs
+++ b/apps/backend/src/server/lifecycle.rs
@@ -1,0 +1,195 @@
+//! Admission and cancellation for one serving instance.
+
+use futures::{FutureExt, future::BoxFuture};
+use http::{Request, Response};
+use std::{
+    io,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::{Context, Poll},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::TcpStream,
+    sync::watch,
+};
+use tonic::{body::Body, transport::server::Connected};
+use tower::{Layer, Service};
+
+pub(super) struct Lifecycle {
+    stopping: AtomicBool,
+    canceled: watch::Sender<bool>,
+}
+
+impl Lifecycle {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            stopping: AtomicBool::new(false),
+            canceled: watch::channel(false).0,
+        })
+    }
+
+    /// Close admission before stopping listeners or failing existing streams.
+    pub fn stop(&self) {
+        self.stopping.store(true, Ordering::Release);
+    }
+
+    /// Cancel handlers and socket IO at the end of the unary drain budget.
+    pub fn cancel(&self) {
+        self.stop();
+        self.canceled.send_replace(true);
+    }
+
+    fn deadline(&self) -> BoxFuture<'static, ()> {
+        let mut canceled = self.canceled.subscribe();
+        async move {
+            loop {
+                if *canceled.borrow_and_update() {
+                    return;
+                }
+                if canceled.changed().await.is_err() {
+                    return;
+                }
+            }
+        }
+        .boxed()
+    }
+
+    /// Give each accepted connection a deadline wakeup, including idle sockets
+    /// and responses blocked by peer flow control. Tonic spawns connection tasks
+    /// separately, so dropping its listener future alone does not cancel them.
+    pub fn connection(&self, inner: TcpStream) -> DrainIo {
+        DrainIo {
+            inner,
+            deadline: self.deadline(),
+            canceled: false,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct AdmissionLayer(pub Arc<Lifecycle>);
+impl<S> Layer<S> for AdmissionLayer {
+    type Service = Admission<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        Admission {
+            inner,
+            lifecycle: self.0.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Admission<S> {
+    inner: S,
+    lifecycle: Arc<Lifecycle>,
+}
+impl<S> Service<Request<Body>> for Admission<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>>,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.lifecycle.stopping.load(Ordering::Acquire) {
+            Poll::Ready(Ok(()))
+        } else {
+            self.inner.poll_ready(cx)
+        }
+    }
+
+    /// Requests admitted before shutdown get the remaining drain budget. Later
+    /// requests fail without reaching payload validation or database code.
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        if self.lifecycle.stopping.load(Ordering::Acquire) {
+            return Box::pin(async { Ok(unavailable()) });
+        }
+        let future = self.inner.call(request);
+        let deadline = self.lifecycle.deadline();
+        Box::pin(async move {
+            tokio::select! { biased; _ = deadline => Ok(unavailable()), result = future => result }
+        })
+    }
+}
+
+fn unavailable() -> Response<Body> {
+    tonic::Status::unavailable("server is shutting down").into_http()
+}
+
+pub(super) struct DrainIo {
+    inner: TcpStream,
+    deadline: BoxFuture<'static, ()>,
+    canceled: bool,
+}
+impl DrainIo {
+    fn check(&mut self, cx: &mut Context<'_>) -> io::Result<()> {
+        if !self.canceled {
+            self.canceled = self.deadline.as_mut().poll(cx).is_ready();
+        }
+        if self.canceled {
+            Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "server drain deadline reached",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+impl Connected for DrainIo {
+    type ConnectInfo = <TcpStream as Connected>::ConnectInfo;
+    fn connect_info(&self) -> Self::ConnectInfo {
+        self.inner.connect_info()
+    }
+}
+impl AsyncRead for DrainIo {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.check(cx)?;
+        Pin::new(&mut self.inner).poll_read(cx, buffer)
+    }
+}
+impl AsyncWrite for DrainIo {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bytes: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.check(cx)?;
+        Pin::new(&mut self.inner).poll_write(cx, bytes)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.check(cx)?;
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+pub(super) struct ShutdownGuard {
+    pub lifecycle: Arc<Lifecycle>,
+    pub streams: Option<Arc<crate::stream::StreamHub>>,
+}
+impl ShutdownGuard {
+    pub fn stop(&self) {
+        self.lifecycle.stop();
+        if let Some(streams) = &self.streams {
+            streams.stop();
+        }
+    }
+}
+impl Drop for ShutdownGuard {
+    fn drop(&mut self) {
+        self.stop();
+        self.lifecycle.cancel();
+    }
+}

--- a/apps/backend/src/server/tests.rs
+++ b/apps/backend/src/server/tests.rs
@@ -1,1 +1,4 @@
+mod drain_io;
+mod grpc_web;
+mod lifecycle;
 mod transport;

--- a/apps/backend/src/server/tests/drain_io.rs
+++ b/apps/backend/src/server/tests/drain_io.rs
@@ -7,6 +7,7 @@ use bytes::Bytes;
 use xmtp_common::time::{Duration, timeout};
 use xmtp_proto::types::TopicKind;
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn shutdown_closes_a_connection_with_a_flow_control_blocked_subscription() {
     let mut server = TestServer::new(|config| config.server.max_drain_duration_ms = 100).await?;

--- a/apps/backend/src/server/tests/drain_io.rs
+++ b/apps/backend/src/server/tests/drain_io.rs
@@ -1,0 +1,55 @@
+use super::transport::encode_frame;
+use crate::{
+    api,
+    test_support::{TestServer, query_topic, topic},
+};
+use bytes::Bytes;
+use xmtp_common::time::{Duration, timeout};
+use xmtp_proto::types::TopicKind;
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn shutdown_closes_a_connection_with_a_flow_control_blocked_subscription() {
+    let mut server = TestServer::new(|config| config.server.max_drain_duration_ms = 100).await?;
+    let socket =
+        tokio::net::TcpStream::connect(server.url.strip_prefix("http://").unwrap()).await?;
+    let (mut client, connection) = h2::client::Builder::new()
+        .initial_window_size(0)
+        .handshake::<_, Bytes>(socket)
+        .await?;
+    let connection = tokio::spawn(connection);
+    let request = http::Request::post(format!(
+        "{}/xmtp.backend.v1.SubscriptionService/SubscribeStatic",
+        server.url
+    ))
+    .header("content-type", "application/grpc")
+    .body(())?;
+    let topics = (0_u64..10_000)
+        .map(|id| {
+            let mut identifier = [0; 32];
+            identifier[..8].copy_from_slice(&id.to_be_bytes());
+            query_topic(topic(TopicKind::WelcomeMessagesV1, &identifier), 0)
+        })
+        .collect();
+    let body = encode_frame(api::SubscribeStaticRequest { topics });
+    let (response, mut sender) = client.send_request(request, false)?;
+    sender.send_data(body.into(), true)?;
+    let mut response = timeout(Duration::from_secs(5), response)
+        .await??
+        .into_body();
+    assert!(
+        timeout(Duration::from_millis(100), response.data())
+            .await
+            .is_err(),
+        "the response must remain blocked by the zero receive window"
+    );
+    server.shutdown();
+    timeout(Duration::from_secs(1), server.wait_stopped()).await??;
+    // Keep both the stream and client alive. Dropping them would let the server
+    // finish even if shutdown left its spawned connection task running.
+    let ended = timeout(Duration::from_secs(1), connection).await?;
+    let _ = ended?;
+    drop(response);
+    drop(sender);
+    drop(client);
+    server.stop().await?;
+}

--- a/apps/backend/src/server/tests/grpc_web.rs
+++ b/apps/backend/src/server/tests/grpc_web.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use api::subscribe_static_response::Response as Frame;
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn direct_grpc_web_static_subscription_delivers_incrementally_with_cors_headers() {
     let server = TestServer::new(|config| config.streams.poll_interval_ms = 10).await?;

--- a/apps/backend/src/server/tests/grpc_web.rs
+++ b/apps/backend/src/server/tests/grpc_web.rs
@@ -1,0 +1,56 @@
+use crate::{
+    api,
+    test_support::{
+        self, TestServer,
+        grpc_web::{self, WebStream},
+        native::envelope,
+    },
+};
+use api::subscribe_static_response::Response as Frame;
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn direct_grpc_web_static_subscription_delivers_incrementally_with_cors_headers() {
+    let server = TestServer::new(|config| config.streams.poll_interval_ms = 10).await?;
+    let meta = server.publish(vec![envelope(97, 1)]).await?.remove(0);
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert("origin", "https://client.example".parse()?);
+    headers.insert("authorization", "test-token".parse()?);
+    headers.insert("x-client-version", "test-client".parse()?);
+    let client = xmtp_common::http::client_builder()
+        .default_headers(headers)
+        .build()?;
+    let mut web: WebStream<api::SubscribeStaticResponse> = grpc_web::open(
+        &client,
+        &server.url,
+        "/xmtp.backend.v1.SubscriptionService/SubscribeStatic",
+        api::SubscribeStaticRequest {
+            topics: vec![test_support::query_topic(meta.topic.clone().unwrap(), 0)],
+        },
+    )
+    .await?;
+    assert_eq!(web.headers["access-control-allow-origin"], "*");
+    assert!(
+        web.headers["access-control-expose-headers"]
+            .to_str()?
+            .contains("x-request-id")
+    );
+    uuid::Uuid::parse_str(web.headers["x-request-id"].to_str()?)?;
+    assert!(
+        matches!(web.stream.message().await?.unwrap().response, Some(Frame::Started(started)) if started.targets[0].through_sequence_id == 1)
+    );
+    assert!(
+        matches!(web.stream.message().await?.unwrap().response, Some(Frame::Messages(messages)) if messages.envelopes[0].meta == Some(meta))
+    );
+    let later = server.publish(vec![envelope(97, 2)]).await?.remove(0);
+    let frame = xmtp_common::time::timeout(
+        xmtp_common::time::Duration::from_secs(5),
+        web.stream.message(),
+    )
+    .await??
+    .unwrap();
+    assert!(
+        matches!(frame.response, Some(Frame::Messages(messages)) if messages.envelopes[0].meta == Some(later))
+    );
+    drop(web);
+    server.stop().await?;
+}

--- a/apps/backend/src/server/tests/https_ingress.rs
+++ b/apps/backend/src/server/tests/https_ingress.rs
@@ -90,6 +90,7 @@ async fn next_frame(
         .ok_or_else(|| "empty static response".into())
 }
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn https_passthrough_preserves_streaming_headers_and_status_details() {
     let server = TestServer::new(|_| {}).await?;

--- a/apps/backend/src/server/tests/https_ingress.rs
+++ b/apps/backend/src/server/tests/https_ingress.rs
@@ -1,0 +1,196 @@
+use super::{GrpcWebResponse, api, encode_frame, support};
+use api::subscribe_static_response::Response as Frame;
+use std::sync::Arc;
+use support::{TestResult, TestServer, grpc_web};
+use tokio::{net::TcpListener, task::JoinSet};
+use tokio_rustls::TlsAcceptor;
+use xmtp_common::time::{Duration, timeout};
+use xmtp_mls_validation::test_utils::inline_welcome_envelope;
+
+struct HttpsIngress {
+    url: String,
+    client: reqwest::Client,
+    task: tokio::task::JoinHandle<TestResult>,
+}
+
+impl HttpsIngress {
+    /// Terminate TLS and pass HTTP bytes unchanged to the backend.
+    /// No gRPC conversion or complete-response buffer exists at this boundary.
+    async fn start(backend: &str) -> TestResult<Self> {
+        xmtp_cryptography::install_crypto_provider();
+        let rcgen::CertifiedKey { cert, signing_key } =
+            rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
+        let client = xmtp_common::http::client_builder()
+            .add_root_certificate(reqwest::Certificate::from_der(cert.der())?)
+            .default_headers(
+                [
+                    ("origin", "https://app.example"),
+                    ("authorization", "Bearer test"),
+                    ("x-app-version", "https-test"),
+                    ("x-libxmtp-version", "https-test"),
+                ]
+                .into_iter()
+                .map(|(name, value)| Ok((name.parse()?, value.parse()?)))
+                .collect::<TestResult<reqwest::header::HeaderMap>>()?,
+            )
+            .http1_only()
+            .build()?;
+        let tls = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(
+                vec![cert.der().clone()],
+                rustls::pki_types::PrivatePkcs8KeyDer::from(signing_key.serialize_der()).into(),
+            )?;
+        let acceptor = TlsAcceptor::from(Arc::new(tls));
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let url = format!("https://localhost:{}", listener.local_addr()?.port());
+        let upstream = backend
+            .strip_prefix("http://")
+            .ok_or("expected HTTP backend")?
+            .to_owned();
+        let task = tokio::spawn(async move {
+            let mut connections = JoinSet::new();
+            loop {
+                tokio::select! {
+                    accepted = listener.accept() => {
+                        let (socket, _) = accepted?;
+                        let acceptor = acceptor.clone();
+                        let upstream = upstream.clone();
+                        connections.spawn(async move {
+                            let mut tls = acceptor.accept(socket).await?;
+                            let mut backend = tokio::net::TcpStream::connect(upstream).await?;
+                            tokio::io::copy_bidirectional(&mut tls, &mut backend).await?;
+                            Ok::<_, std::io::Error>(())
+                        });
+                    }
+                    result = connections.join_next(), if !connections.is_empty() => {
+                        let _ = result.ok_or("missing ingress task")??;
+                    }
+                }
+            }
+        });
+        Ok(Self { url, client, task })
+    }
+}
+
+impl Drop for HttpsIngress {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// Require a frame before the response ends, so buffering fails this check.
+async fn next_frame(
+    response: &mut grpc_web::WebStream<api::SubscribeStaticResponse>,
+) -> TestResult<Frame> {
+    timeout(Duration::from_secs(5), response.stream.message())
+        .await??
+        .ok_or("stream ended")?
+        .response
+        .ok_or_else(|| "empty static response".into())
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn https_passthrough_preserves_streaming_headers_and_status_details() {
+    let server = TestServer::new(|_| {}).await?;
+    let ingress = HttpsIngress::start(&server.url).await?;
+    let path = format!(
+        "{}/xmtp.backend.v1.SubscriptionService/SubscribeStatic",
+        ingress.url
+    );
+    let preflight = ingress
+        .client
+        .request(reqwest::Method::OPTIONS, &path)
+        .header("origin", "https://app.example")
+        .header("access-control-request-method", "POST")
+        .header(
+            "access-control-request-headers",
+            "authorization,content-type,x-app-version,x-libxmtp-version",
+        )
+        .send()
+        .await?;
+    assert!(preflight.status().is_success());
+    let allowed = preflight.headers()["access-control-allow-headers"].to_str()?;
+    for header in [
+        "authorization",
+        "content-type",
+        "x-app-version",
+        "x-libxmtp-version",
+    ] {
+        assert!(allowed.split(',').any(|value| value.trim() == header));
+    }
+    let envelope = inline_welcome_envelope([71; 32]);
+    let parsed = xmtp_mls_validation::parse_envelope(envelope.clone())?;
+    let topic = api::Topic {
+        topic: parsed.topic.to_vec(),
+    };
+    let mut response = grpc_web::open(
+        &ingress.client,
+        &ingress.url,
+        "/xmtp.backend.v1.SubscriptionService/SubscribeStatic",
+        api::SubscribeStaticRequest {
+            topics: vec![api::TopicQuery {
+                topic: Some(topic.clone()),
+                cursor: None,
+            }],
+        },
+    )
+    .await?;
+    assert_eq!(response.headers["access-control-allow-origin"], "*");
+    assert!(response.headers.contains_key("x-request-id"));
+    let exposed = response.headers["access-control-expose-headers"].to_str()?;
+    for header in [
+        "grpc-status",
+        "grpc-message",
+        "grpc-status-details-bin",
+        "x-request-id",
+    ] {
+        assert!(exposed.split(',').any(|value| value.trim() == header));
+    }
+    let Frame::Started(started) = next_frame(&mut response).await? else {
+        panic!("first frame must be Started");
+    };
+    assert_eq!(started.targets.len(), 1);
+    assert_eq!(started.targets[0].topic, Some(topic));
+    assert_eq!(started.targets[0].through_sequence_id, 0);
+    let meta = server.publish(vec![envelope.clone()]).await?.remove(0);
+    loop {
+        match next_frame(&mut response).await? {
+            Frame::Messages(messages) => {
+                assert_eq!(messages.envelopes.len(), 1);
+                assert_eq!(messages.envelopes[0].envelope, Some(envelope));
+                assert_eq!(messages.envelopes[0].meta, Some(meta));
+                break;
+            }
+            Frame::Keepalive(_) => {}
+            Frame::Started(_) => panic!("unexpected second Started"),
+        }
+    }
+    drop(response);
+    let response = ingress
+        .client
+        .post(format!(
+            "{}/xmtp.backend.v1.PublishService/Publish",
+            ingress.url
+        ))
+        .header("content-type", "application/grpc-web+proto")
+        .body(encode_frame(api::PublishRequest {
+            envelopes: vec![api::ClientEnvelope::default()],
+        }))
+        .send()
+        .await?;
+    let status = response.status();
+    let headers = response.headers().clone();
+    let response = GrpcWebResponse {
+        status,
+        headers,
+        body: response.bytes().await?.to_vec(),
+    };
+    assert_eq!(
+        response.grpc_status(),
+        Some(tonic::Code::InvalidArgument as i32)
+    );
+    assert!(response.has_grpc_status_details());
+    drop(ingress);
+    server.stop().await?;
+}

--- a/apps/backend/src/server/tests/lifecycle.rs
+++ b/apps/backend/src/server/tests/lifecycle.rs
@@ -7,6 +7,47 @@ use crate::{
 };
 use xmtp_common::time::{Duration, Instant, timeout};
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
+#[xmtp_common::test(unwrap_try = true)]
+async fn shutdown_marks_aggregate_and_named_health_services_not_serving() {
+    use tonic_health::pb::{
+        HealthCheckRequest, health_check_response::ServingStatus, health_client::HealthClient,
+    };
+    let mut server = TestServer::new(|config| config.server.max_drain_duration_ms = 2000).await?;
+    let mut client = HealthClient::new(server.channel.clone());
+    let mut watches = Vec::new();
+    for service in [
+        "",
+        "xmtp.backend.v1.QueryService",
+        "xmtp.backend.v1.PublishService",
+        "xmtp.backend.v1.IdentityService",
+        "xmtp.backend.v1.SubscriptionService",
+    ] {
+        let mut watch = client
+            .watch(HealthCheckRequest {
+                service: service.into(),
+            })
+            .await?
+            .into_inner();
+        assert_eq!(
+            watch.message().await?.unwrap().status(),
+            ServingStatus::Serving
+        );
+        watches.push(watch);
+    }
+    server.shutdown();
+    for mut watch in watches {
+        assert_eq!(
+            timeout(Duration::from_secs(1), watch.message())
+                .await??
+                .unwrap()
+                .status(),
+            ServingStatus::NotServing
+        );
+    }
+    server.stop().await?;
+}
+
 async fn blocked_publish(
     server: &TestServer,
 ) -> crate::test_support::TestResult<(

--- a/apps/backend/src/server/tests/lifecycle.rs
+++ b/apps/backend/src/server/tests/lifecycle.rs
@@ -32,6 +32,7 @@ async fn blocked_publish(
     Ok((blocker, publish))
 }
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn shutdown_fails_streams_immediately_and_drains_an_admitted_publish() {
     let mut server = TestServer::new(|config| config.server.max_drain_duration_ms = 2_000).await?;
@@ -45,13 +46,16 @@ async fn shutdown_fails_streams_immediately_and_drains_an_admitted_publish() {
             .code(),
         tonic::Code::Unavailable
     );
-    assert!(
+    // HTTP/2 can reject the new stream before it reaches the admission layer.
+    assert!(matches!(
         server
             .query()
             .get(api::GetRequest { sequence_id: 1 })
             .await
-            .is_err()
-    );
+            .unwrap_err()
+            .code(),
+        tonic::Code::Unavailable | tonic::Code::Cancelled
+    ));
     blocker.commit().await?;
     assert_eq!(publish.await??.into_inner().envelope_metas.len(), 1);
     timeout(Duration::from_secs(1), server.wait_stopped()).await??;
@@ -65,6 +69,7 @@ async fn shutdown_fails_streams_immediately_and_drains_an_admitted_publish() {
     server.stop().await?;
 }
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn shutdown_deadline_cancels_unfinished_unary_work_without_a_commit() {
     let mut server = TestServer::new(|config| config.server.max_drain_duration_ms = 100).await?;
@@ -88,6 +93,7 @@ async fn shutdown_deadline_cancels_unfinished_unary_work_without_a_commit() {
     server.stop().await?;
 }
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn shutdown_also_ends_a_static_subscription() {
     let mut server = TestServer::new(|_| {}).await?;

--- a/apps/backend/src/server/tests/lifecycle.rs
+++ b/apps/backend/src/server/tests/lifecycle.rs
@@ -1,0 +1,115 @@
+use crate::{
+    api,
+    test_support::{
+        TestServer,
+        native::{Native, envelope},
+    },
+};
+use xmtp_common::time::{Duration, Instant, timeout};
+
+async fn blocked_publish(
+    server: &TestServer,
+) -> crate::test_support::TestResult<(
+    sqlx::Transaction<'static, sqlx::Postgres>,
+    tokio::task::JoinHandle<Result<tonic::Response<api::PublishResponse>, tonic::Status>>,
+)> {
+    let mut blocker = server.backend.store.primary.begin().await?;
+    sqlx::query!("LOCK TABLE envelopes IN SHARE MODE")
+        .execute(&mut *blocker)
+        .await?;
+    let mut client = server.publisher();
+    let publish = tokio::spawn(async move {
+        client
+            .publish(api::PublishRequest {
+                envelopes: vec![envelope(98, 1)],
+            })
+            .await
+    });
+    xmtp_common::wait_for_eq(|| async {
+        sqlx::query_scalar!(r#"SELECT EXISTS (SELECT 1 FROM pg_locks WHERE database = (SELECT oid FROM pg_database WHERE datname = current_database())
+            AND locktype = 'relation' AND NOT granted) AS "waiting!""#).fetch_one(&server.backend.store.primary).await.unwrap()
+    }, true).await?;
+    Ok((blocker, publish))
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn shutdown_fails_streams_immediately_and_drains_an_admitted_publish() {
+    let mut server = TestServer::new(|config| config.server.max_drain_duration_ms = 2_000).await?;
+    let mut stream = Native::open(&server).await?;
+    let (blocker, publish) = blocked_publish(&server).await?;
+    server.shutdown();
+    assert_eq!(
+        timeout(Duration::from_millis(500), stream.output.message())
+            .await?
+            .unwrap_err()
+            .code(),
+        tonic::Code::Unavailable
+    );
+    assert!(
+        server
+            .query()
+            .get(api::GetRequest { sequence_id: 1 })
+            .await
+            .is_err()
+    );
+    blocker.commit().await?;
+    assert_eq!(publish.await??.into_inner().envelope_metas.len(), 1);
+    timeout(Duration::from_secs(1), server.wait_stopped()).await??;
+    assert_eq!(
+        sqlx::query_scalar!("SELECT count(*) FROM envelopes")
+            .fetch_one(&server.backend.store.primary)
+            .await?,
+        Some(1)
+    );
+    drop(stream);
+    server.stop().await?;
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn shutdown_deadline_cancels_unfinished_unary_work_without_a_commit() {
+    let mut server = TestServer::new(|config| config.server.max_drain_duration_ms = 100).await?;
+    let (blocker, publish) = blocked_publish(&server).await?;
+    let started = Instant::now();
+    server.shutdown();
+    timeout(Duration::from_secs(1), server.wait_stopped()).await??;
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert!(timeout(Duration::from_secs(1), publish).await??.is_err());
+    blocker.commit().await?;
+    xmtp_common::wait_for_eq(|| async {
+        sqlx::query_scalar!("SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND database = (SELECT oid FROM pg_database WHERE datname = current_database())")
+            .fetch_one(&server.backend.store.primary).await.unwrap()
+    }, Some(0)).await?;
+    assert_eq!(
+        sqlx::query_scalar!("SELECT count(*) FROM envelopes")
+            .fetch_one(&server.backend.store.primary)
+            .await?,
+        Some(0)
+    );
+    server.stop().await?;
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn shutdown_also_ends_a_static_subscription() {
+    let mut server = TestServer::new(|_| {}).await?;
+    let topic =
+        crate::test_support::topic(xmtp_proto::types::TopicKind::WelcomeMessagesV1, &[99; 32]);
+    let mut client =
+        api::subscription_service_client::SubscriptionServiceClient::new(server.channel.clone());
+    let mut stream = client
+        .subscribe_static(api::SubscribeStaticRequest {
+            topics: vec![crate::test_support::query_topic(topic, 0)],
+        })
+        .await?
+        .into_inner();
+    assert!(stream.message().await?.is_some());
+    server.shutdown();
+    assert_eq!(
+        timeout(Duration::from_secs(1), stream.message())
+            .await?
+            .unwrap_err()
+            .code(),
+        tonic::Code::Unavailable
+    );
+    drop(stream);
+    server.stop().await?;
+}

--- a/apps/backend/src/server/tests/transport.rs
+++ b/apps/backend/src/server/tests/transport.rs
@@ -8,6 +8,9 @@ use tonic::{Code, Request};
 use tonic_health::pb::{HealthCheckRequest, health_check_response, health_client::HealthClient};
 use xmtp_mls_validation::test_utils::inline_welcome_envelope;
 
+#[path = "https_ingress.rs"]
+mod https_ingress;
+
 struct GrpcWebResponse {
     status: reqwest::StatusCode,
     headers: HeaderMap,
@@ -50,7 +53,7 @@ impl GrpcWebResponse {
     }
 }
 
-fn encode_frame(message: impl Message) -> Vec<u8> {
+pub(super) fn encode_frame(message: impl Message) -> Vec<u8> {
     let bytes = message.encode_to_vec();
     let mut frame = Vec::with_capacity(5 + bytes.len());
     frame.push(0);

--- a/apps/backend/src/service/subscription.rs
+++ b/apps/backend/src/service/subscription.rs
@@ -38,12 +38,26 @@ impl api::subscription_service_server::SubscriptionService for Backend {
 
     /// Handle the static subscription endpoint.
     ///
-    /// Subscription delivery is not implemented in this backend build, so the
-    /// endpoint returns `UNIMPLEMENTED`.
+    /// Static sessions share native ordering and capacity rules. The initial
+    /// fixed targets precede data, and the request ending does not end delivery.
     async fn subscribe_static(
         &self,
-        _: Request<api::SubscribeStaticRequest>,
+        request: Request<api::SubscribeStaticRequest>,
     ) -> Result<Response<Self::SubscribeStaticStream>, Status> {
-        Err(Status::unimplemented("subscriptions are not available"))
+        let hub = self
+            .streams
+            .clone()
+            .ok_or_else(|| Status::unavailable("stream service unavailable"))?;
+        let request_id = request
+            .extensions()
+            .get::<crate::server::request_logger::RequestId>()
+            .map(|id| id.0)
+            .unwrap_or_else(uuid::Uuid::new_v4);
+        Ok(Response::new(Box::pin(crate::stream::static_subscription(
+            hub,
+            self.config.clone(),
+            request.into_inner().topics,
+            request_id,
+        )?)))
     }
 }

--- a/apps/backend/src/stream.rs
+++ b/apps/backend/src/stream.rs
@@ -9,7 +9,7 @@ mod tests;
 
 use crate::{config::Config, error::Error};
 pub(crate) use registry::Registry;
-pub(crate) use session::native;
+pub(crate) use session::{native, static_subscription};
 use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::{sync::Semaphore, task::JoinHandle};

--- a/apps/backend/src/stream/output.rs
+++ b/apps/backend/src/stream/output.rs
@@ -2,6 +2,7 @@ use super::OUTBOUND_FRAMES;
 use crate::{api, config::OUTBOUND_QUEUE_BYTES};
 use futures::{Stream, task::AtomicWaker};
 use parking_lot::Mutex;
+use prost::Message;
 use std::{
     pin::Pin,
     sync::{
@@ -94,20 +95,32 @@ impl Drop for Reservation {
     }
 }
 
+pub(super) enum WireResponse {
+    Native(api::SubscribeResponse),
+    Static(api::SubscribeStaticResponse),
+}
+impl WireResponse {
+    pub fn encoded_len(&self) -> usize {
+        match self {
+            Self::Native(value) => value.encoded_len(),
+            Self::Static(value) => value.encoded_len(),
+        }
+    }
+}
 pub(super) struct Frame {
-    pub value: api::SubscribeResponse,
+    pub value: WireResponse,
     pub reservation: Reservation,
     pub challenge: Option<tokio::sync::oneshot::Sender<xmtp_common::time::Instant>>,
 }
 
-pub(crate) struct NativeOutput {
+pub(super) struct SessionOutput {
     pub(super) receiver: mpsc::Receiver<Frame>,
     pub(super) terminal: Arc<Terminal>,
     ended: bool,
     task: tokio::task::JoinHandle<()>,
 }
 
-impl NativeOutput {
+impl SessionOutput {
     pub(super) fn new(
         receiver: mpsc::Receiver<Frame>,
         terminal: Arc<Terminal>,
@@ -122,8 +135,8 @@ impl NativeOutput {
     }
 }
 
-impl Stream for NativeOutput {
-    type Item = Result<api::SubscribeResponse, Status>;
+impl Stream for SessionOutput {
+    type Item = Result<WireResponse, Status>;
     /// Transport polling is the Ping handoff boundary. Release queue capacity
     /// here and start its response deadline, not when the owner queues the Ping.
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -158,7 +171,7 @@ impl Stream for NativeOutput {
         }
     }
 }
-impl Drop for NativeOutput {
+impl Drop for SessionOutput {
     fn drop(&mut self) {
         self.task.abort();
         self.terminal.closed.store(true, Ordering::Release);
@@ -180,11 +193,11 @@ mod tests {
         let reservation = budget.reserve(100).unwrap();
         sender
             .send(Frame {
-                value: api::SubscribeResponse {
+                value: WireResponse::Native(api::SubscribeResponse {
                     response: Some(api::subscribe_response::Response::Ping(api::Ping {
                         nonce: 1,
                     })),
-                },
+                }),
                 reservation,
                 challenge: Some(challenge),
             })
@@ -196,7 +209,7 @@ mod tests {
         ));
         assert_eq!(budget.available(), OUTBOUND_QUEUE_BYTES - 100);
         let task = tokio::spawn(std::future::pending());
-        let mut output = NativeOutput::new(receiver, terminal, task);
+        let mut output = SessionOutput::new(receiver, terminal, task);
         let before_poll = xmtp_common::time::Instant::now();
         assert!(output.next().await.unwrap().is_ok());
         assert!(handed.await? >= before_poll);

--- a/apps/backend/src/stream/session.rs
+++ b/apps/backend/src/stream/session.rs
@@ -1,7 +1,7 @@
 use super::{
     ENVELOPE_OVERHEAD, FETCH_TOPICS, OUTBOUND_FRAMES, StreamHub, fetch,
     keepalive::{Bucket, Challenge},
-    output::{Frame, NativeOutput, Reservation},
+    output::{Frame, Reservation, SessionOutput, WireResponse},
     registry::{LiveBatch, Mailbox},
 };
 use crate::{
@@ -13,6 +13,7 @@ use crate::{
 use futures::{
     FutureExt, StreamExt,
     future::{BoxFuture, pending},
+    stream::BoxStream,
 };
 use prost::Message;
 use std::{
@@ -44,6 +45,7 @@ struct PendingFetch {
     page: BoxFuture<'static, Result<fetch::ResultPage, Status>>,
 }
 struct Session {
+    static_subscription: bool,
     request_id: uuid::Uuid,
     hub: Arc<StreamHub>,
     id: u64,
@@ -77,14 +79,59 @@ pub(crate) fn native(
     config: Arc<Config>,
     input: Streaming<api::SubscribeRequest>,
     request_id: uuid::Uuid,
-) -> Result<NativeOutput, Status> {
+) -> Result<impl futures::Stream<Item = Result<api::SubscribeResponse, Status>> + Send, Status> {
+    Ok(
+        start(hub, config, Box::pin(input), request_id, None)?.map(|result| {
+            result.and_then(|value| match value {
+                WireResponse::Native(value) => Ok(value),
+                _ => Err(Status::internal("native response mismatch")),
+            })
+        }),
+    )
+}
+
+/// Use the same ordered delivery owner with a fixed interest set. The unary
+/// request's end is not connected to the native half-close signal.
+pub(crate) fn static_subscription(
+    hub: Arc<StreamHub>,
+    config: Arc<Config>,
+    topics: Vec<api::TopicQuery>,
+    request_id: uuid::Uuid,
+) -> Result<impl futures::Stream<Item = Result<api::SubscribeStaticResponse, Status>> + Send, Status>
+{
+    if topics.is_empty() || topics.len() > config.limits.max_static_topics {
+        return Err(Status::invalid_argument("invalid static topic count"));
+    }
+    Ok(start(
+        hub,
+        config,
+        Box::pin(futures::stream::pending()),
+        request_id,
+        Some(topics),
+    )?
+    .map(|result| {
+        result.and_then(|value| match value {
+            WireResponse::Static(value) => Ok(value),
+            _ => Err(Status::internal("static response mismatch")),
+        })
+    }))
+}
+
+fn start(
+    hub: Arc<StreamHub>,
+    config: Arc<Config>,
+    input: BoxStream<'static, Result<api::SubscribeRequest, Status>>,
+    request_id: uuid::Uuid,
+    initial: Option<Vec<api::TopicQuery>>,
+) -> Result<SessionOutput, Status> {
     let mailbox = Arc::new(Mailbox {
         frame_bytes: DELIVERY_FRAME_BYTES.min(config.limits.max_response_bytes.saturating_add(5)),
         ..Default::default()
     });
     let id = hub.registry.connect(mailbox.clone())?;
     let (output, receiver) = mpsc::channel(OUTBOUND_FRAMES);
-    let session = Session {
+    let mut session = Session {
+        static_subscription: initial.is_some(),
         hub,
         id,
         request_id,
@@ -110,6 +157,13 @@ pub(crate) fn native(
         challenge: None,
         nonce: 0,
     };
+    if let Some(topics) = initial {
+        session.update(api::subscribe_request::Update {
+            id: 1,
+            adds: topics,
+            removes: Vec::new(),
+        })?;
+    }
     let terminal = mailbox.terminal.clone();
     let span = tracing::Span::current();
     let dispatch = tracing::dispatcher::get_default(Clone::clone);
@@ -122,18 +176,23 @@ pub(crate) fn native(
         .instrument(span)
         .with_subscriber(dispatch),
     );
-    Ok(NativeOutput::new(receiver, terminal, task))
+    Ok(SessionOutput::new(receiver, terminal, task))
 }
 
 impl Session {
     /// Serialize control, targets, history, live data, and timers in one owner.
     /// Target reads and history remain cancellable while input is processed.
-    async fn run(mut self, mut input: Streaming<api::SubscribeRequest>) -> Result<(), Status> {
-        self.control(api::subscribe_response::Response::Started(
-            api::subscribe_response::Started {
-                keepalive_interval_ms: self.config.streams.keepalive_interval_ms as u32,
-            },
-        ))?;
+    async fn run(
+        mut self,
+        mut input: BoxStream<'static, Result<api::SubscribeRequest, Status>>,
+    ) -> Result<(), Status> {
+        if !self.static_subscription {
+            self.control(api::subscribe_response::Response::Started(
+                api::subscribe_response::Started {
+                    keepalive_interval_ms: self.config.streams.keepalive_interval_ms as u32,
+                },
+            ))?;
+        }
         let mut pending_input = VecDeque::new();
         loop {
             if self.mailbox.terminal.closed() {
@@ -207,6 +266,9 @@ impl Session {
     }
 
     fn timer(&self) -> BoxFuture<'static, ()> {
+        if self.static_subscription && self.pending_update.is_some() {
+            return pending().boxed();
+        }
         let deadline = match &self.challenge {
             Some(challenge) => challenge.deadline,
             None => Some(
@@ -223,9 +285,16 @@ impl Session {
     /// Other frames remain ordered for later processing; inbound traffic is not activity.
     fn on_timer(
         &mut self,
-        input: &mut Streaming<api::SubscribeRequest>,
+        input: &mut BoxStream<'static, Result<api::SubscribeRequest, Status>>,
         pending_input: &mut VecDeque<api::SubscribeRequest>,
     ) -> Result<(), Status> {
+        if self.static_subscription {
+            return self.wire_control(WireResponse::Static(api::SubscribeStaticResponse {
+                response: Some(api::subscribe_static_response::Response::Keepalive(
+                    api::subscribe_static_response::Keepalive {},
+                )),
+            }));
+        }
         if self.challenge.is_some() {
             let mut bytes = 0;
             while let Some(frame) = input.next().now_or_never() {
@@ -262,7 +331,7 @@ impl Session {
             .budget
             .reserve(frame.encoded_len() + 5)
             .ok_or_else(capacity)?;
-        self.admit(frame, reservation, Some(sent))?;
+        self.admit(WireResponse::Native(frame), reservation, Some(sent))?;
         self.challenge = Some(Challenge {
             nonce: self.nonce,
             handed,
@@ -396,9 +465,12 @@ impl Session {
                 added_targets: targets,
             },
         ))?;
-        tracing::info!(request_id = %self.request_id, update_id = update.id,
-            added_topics = update.topics.len(), removed_topics = update.removed_topics,
-            "subscription interests updated");
+        if self.static_subscription {
+            tracing::info!(request_id = %self.request_id, added_topics = update.topics.len(), "static subscription started");
+        } else {
+            tracing::info!(request_id = %self.request_id, update_id = update.id,
+                added_topics = update.topics.len(), removed_topics = update.removed_topics, "subscription interests updated");
+        }
         for (topic, head) in update.topics.into_iter().zip(heads) {
             if let Some(registration) = self.topics.get_mut(&topic) {
                 registration.needed = registration.needed.max(head);
@@ -416,7 +488,12 @@ impl Session {
         let limits = &self.config.limits;
         if update.id == 0
             || update.id <= self.update_id
-            || update.adds.len() > limits.max_update_adds
+            || update.adds.len()
+                > if self.static_subscription {
+                    limits.max_static_topics
+                } else {
+                    limits.max_update_adds
+                }
             || update.removes.len() > limits.max_update_removes
         {
             return Err(Status::invalid_argument("invalid update id or item count"));
@@ -445,7 +522,13 @@ impl Session {
             }
             total -= usize::from(self.topics.contains_key(&topic.topic));
         }
-        if total > limits.max_stream_topics {
+        if total
+            > if self.static_subscription {
+                limits.max_static_topics
+            } else {
+                limits.max_stream_topics
+            }
+        {
             return Err(Status::invalid_argument("stream topic limit exceeded"));
         }
         Ok(adds)
@@ -641,10 +724,18 @@ impl Session {
         envelopes: Vec<api::ServerEnvelope>,
         reservation: Reservation,
     ) -> Result<(), Status> {
-        let value = api::SubscribeResponse {
-            response: Some(api::subscribe_response::Response::Messages(
-                api::subscribe_response::Messages { envelopes },
-            )),
+        let value = if self.static_subscription {
+            WireResponse::Static(api::SubscribeStaticResponse {
+                response: Some(api::subscribe_static_response::Response::Messages(
+                    api::subscribe_static_response::Messages { envelopes },
+                )),
+            })
+        } else {
+            WireResponse::Native(api::SubscribeResponse {
+                response: Some(api::subscribe_response::Response::Messages(
+                    api::subscribe_response::Messages { envelopes },
+                )),
+            })
         };
         if value.encoded_len() + 5 > self.mailbox.frame_bytes {
             return Err(capacity());
@@ -653,9 +744,27 @@ impl Session {
     }
 
     fn control(&mut self, response: api::subscribe_response::Response) -> Result<(), Status> {
-        let value = api::SubscribeResponse {
-            response: Some(response),
+        let value = if self.static_subscription {
+            let api::subscribe_response::Response::Applied(applied) = response else {
+                return Err(Status::internal("static control mismatch"));
+            };
+            WireResponse::Static(api::SubscribeStaticResponse {
+                response: Some(api::subscribe_static_response::Response::Started(
+                    api::subscribe_static_response::Started {
+                        keepalive_interval_ms: self.config.streams.keepalive_interval_ms as u32,
+                        targets: applied.added_targets,
+                    },
+                )),
+            })
+        } else {
+            WireResponse::Native(api::SubscribeResponse {
+                response: Some(response),
+            })
         };
+        self.wire_control(value)
+    }
+
+    fn wire_control(&mut self, value: WireResponse) -> Result<(), Status> {
         let bytes = value.encoded_len() + 5;
         if value.encoded_len() > self.config.limits.max_response_bytes {
             return Err(capacity());
@@ -668,7 +777,7 @@ impl Session {
     /// frame while allowing the caller to advance its delivery floor.
     fn admit(
         &mut self,
-        value: api::SubscribeResponse,
+        value: WireResponse,
         mut reservation: Reservation,
         challenge: Option<tokio::sync::oneshot::Sender<Instant>>,
     ) -> Result<(), Status> {

--- a/apps/backend/src/stream/session.rs
+++ b/apps/backend/src/stream/session.rs
@@ -466,7 +466,8 @@ impl Session {
             },
         ))?;
         if self.static_subscription {
-            tracing::info!(request_id = %self.request_id, added_topics = update.topics.len(), "static subscription started");
+            tracing::info!(request_id = %self.request_id, added_topics = update.topics.len(),
+                removed_topics = update.removed_topics, "static subscription started");
         } else {
             tracing::info!(request_id = %self.request_id, update_id = update.id,
                 added_topics = update.topics.len(), removed_topics = update.removed_topics, "subscription interests updated");

--- a/apps/backend/src/stream/tests.rs
+++ b/apps/backend/src/stream/tests.rs
@@ -1,2 +1,4 @@
+mod recovery;
 mod replica;
 mod session;
+mod r#static;

--- a/apps/backend/src/stream/tests/recovery.rs
+++ b/apps/backend/src/stream/tests/recovery.rs
@@ -1,0 +1,72 @@
+use crate::{
+    api,
+    test_support::{
+        self, RunningServer, TestServer,
+        native::{Native, envelope},
+    },
+};
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn reconnect_to_independent_instance_replays_received_but_unprocessed_rows() {
+    let mut first = TestServer::new(|config| config.streams.poll_interval_ms = 10).await?;
+    let metas = first
+        .publish((1..=4).map(|value| envelope(96, value)).collect())
+        .await?;
+    let topic = metas[0].topic.clone().unwrap();
+    let mut original = Native::open(&first).await?;
+    original
+        .update(1, vec![test_support::query_topic(topic.clone(), 0)], vec![])
+        .await?;
+    assert!(matches!(
+        original.next().await?,
+        api::subscribe_response::Response::Applied(_)
+    ));
+    assert_eq!(original.messages(4).await?.len(), 4);
+    drop(original);
+    first.shutdown();
+    first.wait_stopped().await?;
+    let mut second = RunningServer::new((*first.backend.config).clone()).await?;
+    let mut native = Native::open(&second).await?;
+    native
+        .update(1, vec![test_support::query_topic(topic.clone(), 2)], vec![])
+        .await?;
+    assert!(
+        matches!(native.next().await?, api::subscribe_response::Response::Applied(applied) if applied.added_targets[0].through_sequence_id == 4)
+    );
+    let rows = native.messages(2).await?;
+    assert_eq!(
+        rows.iter()
+            .map(|row| row
+                .meta
+                .as_ref()
+                .unwrap()
+                .cursor
+                .as_ref()
+                .unwrap()
+                .sequence_id)
+            .collect::<Vec<_>>(),
+        vec![3, 4]
+    );
+    let mut client =
+        api::subscription_service_client::SubscriptionServiceClient::new(second.channel.clone());
+    let mut static_stream = client
+        .subscribe_static(api::SubscribeStaticRequest {
+            topics: vec![test_support::query_topic(topic, 2)],
+        })
+        .await?
+        .into_inner();
+    assert!(matches!(
+        static_stream.message().await?.unwrap().response,
+        Some(api::subscribe_static_response::Response::Started(_))
+    ));
+    let Some(api::subscribe_static_response::Response::Messages(messages)) =
+        static_stream.message().await?.unwrap().response
+    else {
+        panic!("expected static replay");
+    };
+    assert_eq!(messages.envelopes, rows);
+    drop(native);
+    drop(static_stream);
+    second.stop().await?;
+    first.stop().await?;
+}

--- a/apps/backend/src/stream/tests/recovery.rs
+++ b/apps/backend/src/stream/tests/recovery.rs
@@ -6,6 +6,7 @@ use crate::{
     },
 };
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn reconnect_to_independent_instance_replays_received_but_unprocessed_rows() {
     let mut first = TestServer::new(|config| config.streams.poll_interval_ms = 10).await?;

--- a/apps/backend/src/stream/tests/static.rs
+++ b/apps/backend/src/stream/tests/static.rs
@@ -1,0 +1,230 @@
+use crate::{
+    api,
+    test_support::{self, TestServer, native::envelope},
+};
+use api::subscribe_static_response::Response as Frame;
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn static_targets_precede_ordered_history_and_live_delivery() {
+    let server = TestServer::new(|config| config.streams.poll_interval_ms = 10).await?;
+    let metas = server
+        .publish(vec![envelope(91, 1), envelope(91, 2)])
+        .await?;
+    let topic = metas[0].topic.clone().unwrap();
+    let empty = test_support::topic(xmtp_proto::types::TopicKind::WelcomeMessagesV1, &[92; 32]);
+    let mut client =
+        api::subscription_service_client::SubscriptionServiceClient::new(server.channel.clone());
+    let mut stream = client
+        .subscribe_static(api::SubscribeStaticRequest {
+            topics: vec![
+                test_support::query_topic(empty.clone(), 0),
+                test_support::query_topic(topic.clone(), 0),
+            ],
+        })
+        .await?
+        .into_inner();
+    let Some(Frame::Started(started)) = stream.message().await?.unwrap().response else {
+        panic!("expected targets first");
+    };
+    assert_eq!(
+        started.targets,
+        vec![
+            api::CatchupTarget {
+                topic: Some(empty),
+                through_sequence_id: 0
+            },
+            api::CatchupTarget {
+                topic: Some(topic),
+                through_sequence_id: 2
+            }
+        ]
+    );
+    let Some(Frame::Messages(history)) = stream.message().await?.unwrap().response else {
+        panic!("expected history");
+    };
+    assert_eq!(
+        history
+            .envelopes
+            .iter()
+            .map(|row| row
+                .meta
+                .as_ref()
+                .unwrap()
+                .cursor
+                .as_ref()
+                .unwrap()
+                .sequence_id)
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+    let later = server.publish(vec![envelope(91, 3)]).await?.remove(0);
+    let Some(Frame::Messages(live)) = stream.message().await?.unwrap().response else {
+        panic!("expected live delivery after unary request completion");
+    };
+    assert_eq!(live.envelopes[0].meta, Some(later));
+    drop(stream);
+    server.stop().await?;
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn static_keepalives_are_one_way_and_do_not_expire_waiting_for_pong() {
+    let server = TestServer::new(|config| {
+        config.streams.keepalive_interval_ms = 10;
+        config.streams.max_pong_wait_ms = 20;
+    })
+    .await?;
+    let topic = test_support::topic(xmtp_proto::types::TopicKind::WelcomeMessagesV1, &[93; 32]);
+    let mut client =
+        api::subscription_service_client::SubscriptionServiceClient::new(server.channel.clone());
+    let mut stream = client
+        .subscribe_static(api::SubscribeStaticRequest {
+            topics: vec![test_support::query_topic(topic, 0)],
+        })
+        .await?
+        .into_inner();
+    assert!(matches!(
+        stream.message().await?.unwrap().response,
+        Some(Frame::Started(_))
+    ));
+    for _ in 0..4 {
+        assert!(matches!(
+            stream.message().await?.unwrap().response,
+            Some(Frame::Keepalive(_))
+        ));
+    }
+    drop(stream);
+    server.stop().await?;
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn static_request_validates_its_own_limits_and_unique_topics() {
+    let server = TestServer::new(|config| {
+        config.limits.max_stream_topics = 1;
+        config.limits.max_update_adds = 1;
+        config.limits.max_static_topics = 2;
+    })
+    .await?;
+    let a = test_support::topic(xmtp_proto::types::TopicKind::WelcomeMessagesV1, &[94; 32]);
+    let b = test_support::topic(xmtp_proto::types::TopicKind::WelcomeMessagesV1, &[95; 32]);
+    let mut client =
+        api::subscription_service_client::SubscriptionServiceClient::new(server.channel.clone());
+    for topics in [
+        vec![],
+        vec![test_support::query_topic(a.clone(), 0); 2],
+        vec![test_support::query_topic(a.clone(), 0); 3],
+        vec![test_support::query_topic(a.clone(), u64::MAX)],
+        vec![api::TopicQuery::default()],
+    ] {
+        assert_eq!(
+            client
+                .subscribe_static(api::SubscribeStaticRequest { topics })
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::InvalidArgument
+        );
+    }
+    let mut stream = client
+        .subscribe_static(api::SubscribeStaticRequest {
+            topics: vec![
+                test_support::query_topic(a, 0),
+                test_support::query_topic(b, 0),
+            ],
+        })
+        .await?
+        .into_inner();
+    assert!(
+        matches!(stream.message().await?.unwrap().response, Some(Frame::Started(started)) if started.targets.len() == 2)
+    );
+    drop(stream);
+    server.stop().await?;
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn static_initial_log_and_completion_share_request_id_and_body_counts() {
+    use prost::Message;
+    use tower::Layer;
+    use tracing::instrument::WithSubscriber;
+    use xmtp_logging::{Level, test_logging::LogCapture};
+    let server = TestServer::new(|_| {}).await?;
+    let topic = test_support::topic(xmtp_proto::types::TopicKind::WelcomeMessagesV1, &[101; 32]);
+    let request = api::SubscribeStaticRequest {
+        topics: vec![test_support::query_topic(topic, 0)],
+    };
+    let bytes = request.encoded_len() + 5;
+    let inner =
+        api::subscription_service_server::SubscriptionServiceServer::new(server.backend.clone());
+    let layer = crate::server::request_logger::RequestLoggerLayer(true).layer(inner);
+    let mut client = tonic::client::Grpc::new(layer);
+    let capture = LogCapture::new(Level::Info);
+    let response = client.server_streaming(tonic::Request::new(request), "/xmtp.backend.v1.SubscriptionService/SubscribeStatic".parse()?,
+        tonic_prost::ProstCodec::<api::SubscribeStaticRequest, api::SubscribeStaticResponse>::default()).with_subscriber(capture.dispatch()).await?;
+    let request_id = response
+        .metadata()
+        .get("x-request-id")
+        .unwrap()
+        .to_str()?
+        .to_owned();
+    let mut stream = response.into_inner();
+    assert!(matches!(
+        stream.message().await?.unwrap().response,
+        Some(Frame::Started(_))
+    ));
+    drop(stream);
+    let logs: Vec<serde_json::Value> = capture
+        .output()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(logs.len(), 2);
+    assert_eq!(logs[0]["message"], "static subscription started");
+    assert_eq!(logs[0]["added_topics"], 1);
+    assert_eq!(logs[0]["request_id"], request_id);
+    assert_eq!(logs[1]["request_id"], request_id);
+    assert_eq!(logs[1]["request_size_bytes"], bytes);
+    assert!(logs[1]["response_size_bytes"].as_u64().unwrap() > 0);
+    server.stop().await?;
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn static_started_waits_for_target_capture_before_sending_keepalives() {
+    let server = TestServer::new(|config| {
+        config.streams.keepalive_interval_ms = 10;
+        config.streams.max_pong_wait_ms = 20;
+    })
+    .await?;
+    let mut blocker = server.backend.store.primary.begin().await?;
+    sqlx::query!("LOCK TABLE topic_watermark IN ACCESS EXCLUSIVE MODE")
+        .execute(&mut *blocker)
+        .await?;
+    let topic = test_support::topic(xmtp_proto::types::TopicKind::WelcomeMessagesV1, &[102; 32]);
+    let mut client =
+        api::subscription_service_client::SubscriptionServiceClient::new(server.channel.clone());
+    let mut stream = client
+        .subscribe_static(api::SubscribeStaticRequest {
+            topics: vec![test_support::query_topic(topic, 0)],
+        })
+        .await?
+        .into_inner();
+    xmtp_common::wait_for_eq(
+        || async {
+            sqlx::query_scalar!(
+                r#"SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE datname = current_database()
+            AND wait_event_type = 'Lock' AND query LIKE 'SELECT COALESCE%'
+            AND clock_timestamp() - query_start > interval '50 milliseconds') AS "waiting!""#
+            )
+            .fetch_one(&server.backend.store.primary)
+            .await
+            .unwrap()
+        },
+        true,
+    )
+    .await?;
+    blocker.commit().await?;
+    assert!(matches!(
+        stream.message().await?.unwrap().response,
+        Some(Frame::Started(_))
+    ));
+    drop(stream);
+    server.stop().await?;
+}

--- a/apps/backend/src/stream/tests/static.rs
+++ b/apps/backend/src/stream/tests/static.rs
@@ -4,6 +4,37 @@ use crate::{
 };
 use api::subscribe_static_response::Response as Frame;
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
+#[xmtp_common::test(unwrap_try = true)]
+async fn oversized_static_targets_fail_without_a_partial_started_frame() {
+    let server = TestServer::new(|config| {
+        config.limits.max_envelope_bytes = 1024;
+        config.limits.max_response_bytes = 66_560;
+    })
+    .await?;
+    let topics = (0_u64..2000)
+        .map(|id| {
+            let mut identifier = [0; 32];
+            identifier[..8].copy_from_slice(&id.to_be_bytes());
+            let topic =
+                test_support::topic(xmtp_proto::types::TopicKind::WelcomeMessagesV1, &identifier);
+            test_support::query_topic(topic, 0)
+        })
+        .collect();
+    let mut client =
+        api::subscription_service_client::SubscriptionServiceClient::new(server.channel.clone());
+    let error = match client
+        .subscribe_static(api::SubscribeStaticRequest { topics })
+        .await
+    {
+        Err(error) => error,
+        Ok(response) => response.into_inner().message().await.unwrap_err(),
+    };
+    assert_eq!(error.code(), tonic::Code::ResourceExhausted);
+    server.stop().await?;
+}
+
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn static_targets_precede_ordered_history_and_live_delivery() {
     let server = TestServer::new(|config| config.streams.poll_interval_ms = 10).await?;
@@ -66,6 +97,7 @@ async fn static_targets_precede_ordered_history_and_live_delivery() {
     server.stop().await?;
 }
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn static_keepalives_are_one_way_and_do_not_expire_waiting_for_pong() {
     let server = TestServer::new(|config| {
@@ -96,6 +128,7 @@ async fn static_keepalives_are_one_way_and_do_not_expire_waiting_for_pong() {
     server.stop().await?;
 }
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn static_request_validates_its_own_limits_and_unique_topics() {
     let server = TestServer::new(|config| {
@@ -140,6 +173,7 @@ async fn static_request_validates_its_own_limits_and_unique_topics() {
     server.stop().await?;
 }
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn static_initial_log_and_completion_share_request_id_and_body_counts() {
     use prost::Message;
@@ -179,6 +213,7 @@ async fn static_initial_log_and_completion_share_request_id_and_body_counts() {
     assert_eq!(logs.len(), 2);
     assert_eq!(logs[0]["message"], "static subscription started");
     assert_eq!(logs[0]["added_topics"], 1);
+    assert_eq!(logs[0]["removed_topics"], 0);
     assert_eq!(logs[0]["request_id"], request_id);
     assert_eq!(logs[1]["request_id"], request_id);
     assert_eq!(logs[1]["request_size_bytes"], bytes);
@@ -186,6 +221,7 @@ async fn static_initial_log_and_completion_share_request_id_and_body_counts() {
     server.stop().await?;
 }
 
+#[xmtp_common::timeout(std::time::Duration::from_secs(20))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn static_started_waits_for_target_capture_before_sending_keepalives() {
     let server = TestServer::new(|config| {

--- a/apps/backend/src/test_support.rs
+++ b/apps/backend/src/test_support.rs
@@ -63,10 +63,7 @@ impl TestServer {
             )?);
         }
         let running = RunningServer::from_backend(backend).await?;
-        Ok(Self {
-            running,
-            database,
-        })
+        Ok(Self { running, database })
     }
 
     pub async fn stop(mut self) -> TestResult {

--- a/apps/backend/src/test_support.rs
+++ b/apps/backend/src/test_support.rs
@@ -1,6 +1,7 @@
 use crate::{Backend, api, config::Config, server};
 mod database;
 pub use database::TestDatabase;
+pub(crate) mod grpc_web;
 pub(crate) mod native;
 pub(crate) mod replica;
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
@@ -10,12 +11,27 @@ use xmtp_id::scw_verifier::{CachedSmartContractSignatureVerifier, SmartContractS
 pub type TestResult<T = ()> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 pub struct TestServer {
+    running: RunningServer,
+    database: TestDatabase,
+}
+impl std::ops::Deref for TestServer {
+    type Target = RunningServer;
+    fn deref(&self) -> &RunningServer {
+        &self.running
+    }
+}
+impl std::ops::DerefMut for TestServer {
+    fn deref_mut(&mut self) -> &mut RunningServer {
+        &mut self.running
+    }
+}
+
+pub struct RunningServer {
     pub backend: Backend,
     pub channel: Channel,
     pub url: String,
-    database: TestDatabase,
     stop: Option<oneshot::Sender<()>>,
-    task: JoinHandle<Result<(), tonic::transport::Error>>,
+    task: Option<JoinHandle<Result<(), tonic::transport::Error>>>,
 }
 
 impl TestServer {
@@ -46,6 +62,40 @@ impl TestServer {
                     .unwrap(),
             )?);
         }
+        let running = RunningServer::from_backend(backend).await?;
+        Ok(Self {
+            running,
+            database,
+        })
+    }
+
+    pub async fn stop(mut self) -> TestResult {
+        self.running.stop().await?;
+        self.database.remove()?;
+        Ok(())
+    }
+}
+
+pub fn query_topic(topic: api::Topic, sequence_id: u64) -> api::TopicQuery {
+    api::TopicQuery {
+        topic: Some(topic),
+        cursor: Some(api::Cursor { sequence_id }),
+    }
+}
+
+pub fn topic(kind: xmtp_proto::types::TopicKind, identifier: &[u8]) -> api::Topic {
+    api::Topic {
+        topic: kind.create(identifier).to_vec(),
+    }
+}
+
+impl RunningServer {
+    /// Start an independent backend instance against an existing test database.
+    pub async fn new(config: Config) -> TestResult<Self> {
+        Self::from_backend(server::initialize(config).await?).await
+    }
+
+    async fn from_backend(backend: Backend) -> TestResult<Self> {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let url = format!("http://{}", listener.local_addr()?);
         let (stop, stopped) = oneshot::channel();
@@ -57,9 +107,8 @@ impl TestServer {
             backend,
             channel,
             url,
-            database,
             stop: Some(stop),
-            task,
+            task: Some(task),
         })
     }
 
@@ -87,34 +136,35 @@ impl TestServer {
             .envelope_metas)
     }
 
-    pub async fn stop(mut self) -> TestResult {
-        self.stop.take().expect("one stop sender").send(()).ok();
-        (&mut self.task).await??;
-        self.backend.store.primary.close().await;
-        self.backend.store.read.close().await;
-        self.database.remove()?;
-        Ok(())
-    }
-}
-
-pub fn query_topic(topic: api::Topic, sequence_id: u64) -> api::TopicQuery {
-    api::TopicQuery {
-        topic: Some(topic),
-        cursor: Some(api::Cursor { sequence_id }),
-    }
-}
-
-pub fn topic(kind: xmtp_proto::types::TopicKind, identifier: &[u8]) -> api::Topic {
-    api::Topic {
-        topic: kind.create(identifier).to_vec(),
-    }
-}
-
-impl Drop for TestServer {
-    fn drop(&mut self) {
+    pub fn shutdown(&mut self) {
         if let Some(stop) = self.stop.take() {
             let _ = stop.send(());
         }
-        self.task.abort();
+    }
+
+    /// Wait for service work without closing pools needed by database assertions.
+    pub async fn wait_stopped(&mut self) -> TestResult {
+        if let Some(task) = &mut self.task {
+            let result = task.await;
+            self.task = None;
+            result??;
+        }
+        Ok(())
+    }
+
+    pub async fn stop(&mut self) -> TestResult {
+        self.shutdown();
+        self.wait_stopped().await?;
+        self.backend.store.primary.close().await;
+        self.backend.store.read.close().await;
+        Ok(())
+    }
+}
+impl Drop for RunningServer {
+    fn drop(&mut self) {
+        self.shutdown();
+        if let Some(task) = &self.task {
+            task.abort();
+        }
     }
 }

--- a/apps/backend/src/test_support/grpc_web.rs
+++ b/apps/backend/src/test_support/grpc_web.rs
@@ -1,0 +1,69 @@
+use super::TestResult;
+use futures::StreamExt;
+use http_body_util::{BodyExt, StreamBody};
+use prost::Message;
+use tonic::body::Body;
+use tower::{Layer, service_fn};
+
+pub struct WebStream<T> {
+    pub headers: reqwest::header::HeaderMap,
+    pub stream: tonic::Streaming<T>,
+}
+
+/// Use Tonic's public gRPC-Web client layer over real HTTP/1.1. Only the finite
+/// request is collected; response frames and trailers remain streamed. The
+/// supplied client's default headers and TLS configuration are preserved.
+pub async fn open<Q, R>(
+    client: &reqwest::Client,
+    url: &str,
+    method: &str,
+    request: Q,
+) -> TestResult<WebStream<R>>
+where
+    Q: Message + Send + 'static,
+    R: Message + Default + Send + 'static,
+{
+    let client = client.clone();
+    let transport = service_fn(
+        move |request: http::Request<tonic_web::GrpcWebCall<Body>>| {
+            let client = client.clone();
+            async move {
+                let (parts, body) = request.into_parts();
+                let body = BodyExt::collect(body).await?.to_bytes();
+                let response = client
+                    .request(parts.method, parts.uri.to_string())
+                    .version(parts.version)
+                    .headers(parts.headers)
+                    .body(body)
+                    .send()
+                    .await?;
+                let status = response.status();
+                let headers = response.headers().clone();
+                let body = StreamBody::new(
+                    response
+                        .bytes_stream()
+                        .map(|bytes| bytes.map(http_body::Frame::data)),
+                );
+                let mut response = http::Response::new(Body::new(body));
+                *response.status_mut() = status;
+                *response.headers_mut() = headers;
+                Ok::<_, Box<dyn std::error::Error + Send + Sync>>(response)
+            }
+        },
+    );
+    let transport = tonic_web::GrpcWebClientLayer::new().layer(transport);
+    let mut grpc = tonic::client::Grpc::with_origin(transport, url.parse()?);
+    grpc.ready().await?;
+    let response = grpc
+        .server_streaming(
+            tonic::Request::new(request),
+            method.parse()?,
+            tonic_prost::ProstCodec::<Q, R>::default(),
+        )
+        .await?;
+    let headers = response.metadata().clone().into_headers();
+    Ok(WebStream {
+        headers,
+        stream: response.into_inner(),
+    })
+}

--- a/apps/backend/src/test_support/native.rs
+++ b/apps/backend/src/test_support/native.rs
@@ -1,7 +1,7 @@
 use crate::api::{
     self, subscribe_request::Request as Input, subscribe_response::Response as Frame,
 };
-use crate::test_support::{TestResult, TestServer};
+use crate::test_support::{RunningServer, TestResult};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Status, Streaming};
@@ -12,7 +12,7 @@ pub struct Native {
     pub output: Streaming<api::SubscribeResponse>,
 }
 impl Native {
-    pub async fn open(server: &TestServer) -> TestResult<Self> {
+    pub async fn open(server: &RunningServer) -> TestResult<Self> {
         let (input, receiver) = mpsc::channel(128);
         let output = api::subscription_service_client::SubscriptionServiceClient::new(
             server.channel.clone(),

--- a/docs/self-hosted/backend-operations.md
+++ b/docs/self-hosted/backend-operations.md
@@ -117,6 +117,18 @@ conversion. Preserve CORS preflight, authorization and version headers, gRPC
 trailers, and incremental response frames. Do not buffer streaming responses.
 The plaintext backend listener is not a public endpoint.
 
+The backend test suite includes an HTTPS ingress check. A test-only TLS terminator
+passes HTTP bytes to the service without gRPC conversion. The check requires a
+Started frame before publication, then requires the published envelope while the
+same response stays open. It also checks CORS, request headers, and error details.
+Run this check with `just test-backend --lib https_passthrough`.
+
+Shutdown stops request admission and ends active subscriptions. Unary requests
+already admitted can finish within `server.max_drain_duration_ms`. At the end of
+that budget, the service cancels remaining handlers and connection IO. Clients
+must reconnect to another instance with their safe topic cursors. A dropped
+response does not establish whether a publish committed.
+
 Caller authentication and caller quotas are not implemented until Phase 6.
 Do not expose this unauthenticated service to untrusted traffic.
 

--- a/docs/self-hosted/backend-operations.md
+++ b/docs/self-hosted/backend-operations.md
@@ -128,6 +128,7 @@ already admitted can finish within `server.max_drain_duration_ms`. At the end of
 that budget, the service cancels remaining handlers and connection IO. Clients
 must reconnect to another instance with their safe topic cursors. A dropped
 response does not establish whether a publish committed.
+Shutdown marks both aggregate health and every named RPC service `NOT_SERVING`.
 
 Caller authentication and caller quotas are not implemented until Phase 6.
 Do not expose this unauthenticated service to untrusted traffic.

--- a/docs/self-hosted/tests/existing-requirements.md
+++ b/docs/self-hosted/tests/existing-requirements.md
@@ -49,6 +49,10 @@ Requirement IDs stay in documentation, not in Rust names or comments.
 | Physical replica lag, late gaps, startup visibility, and connection loss | `apps/backend/src/stream/tests/replica.rs` |
 | Coalesced boundary maintenance | `apps/backend/src/stream/tailer/tests.rs` |
 | Shared live payloads, catch-up notices, outbound reservations, and Ping handoff | Module-local tests in `apps/backend/src/stream/registry.rs` and `apps/backend/src/stream/output.rs` |
+| Static targets, static-only limits, one-way keepalive, and request-log correlation | `apps/backend/src/stream/tests/static.rs` |
+| Reconnect to an independent instance with safe cursors | `apps/backend/src/stream/tests/recovery.rs` |
+| Direct gRPC-Web streaming and HTTPS ingress | `apps/backend/src/server/tests/grpc_web.rs` and `apps/backend/src/server/tests/https_ingress.rs` |
+| Shutdown admission, unary drain, and flow-controlled connection termination | `apps/backend/src/server/tests/lifecycle.rs` and `apps/backend/src/server/tests/drain_io.rs` |
 
 The dedicated backend CI job runs these tests against PostgreSQL 18. The legacy
 SDK Nix test jobs exclude this package; they do not provide its test database.


### PR DESCRIPTION
## Summary

Third of three Phase 2 PRs, based on #4070. Completes static subscriptions, bounded shutdown, and cross-instance recovery checks. Tonic serves gRPC-Web directly on the native listener.

[Plan](https://plan.ref.tools/0gFOWk3q9WKw0brL). This phase does not connect SDKs to the new backend or add caller authentication, pruning, or full telemetry.

## Reviewer guide

- Review `stream/session.rs`, `stream/output.rs`, and `service/subscription.rs` together. Static subscriptions share the native history/live engine. Check that ordered fixed targets precede messages, static limits do not inherit native Update limits, and one-way keepalives never wait for Pong.
- Review `server/lifecycle.rs` with `server.rs`. Admission stops before drain begins. Active subscriptions fail promptly; admitted unary requests get the configured drain budget. Tonic spawns connection tasks, so cancellation must also reach socket IO when peer flow control blocks a response.
- Review `server/tests/drain_io.rs` for the shutdown resource boundary. The client holds a zero receive window and keeps its stream and connection alive. A returned server future alone is not sufficient evidence of connection cleanup.
- Review module-local static, recovery, and transport tests. A replacement instance must replay from the supplied safe cursor, including rows received but not processed on the old instance. Test fixtures do not use a client database.
- Review `server/tests/https_ingress.rs` and the shared gRPC-Web test helper. The test-only TLS terminator passes bytes unchanged. Tonic owns framing; responses remain incremental. Check CORS, auth/version headers, request IDs, and structured status details.

## Plan deviations and owner decisions

- The HTTPS smoke test uses an in-process TLS terminator instead of a separately deployed proxy. It performs no gRPC conversion and requires no external ingress service. TLS and HTTP/2 test dependencies are development-only.
- Shutdown includes a deadline-aware socket wrapper. Dropping Tonic's listener future does not by itself bound spawned connection tasks.
- Tests remain beside their owning modules. Shared test fixtures and codecs live in test support; important cancellation and ordering functions have RustDoc.

## Validation

- The complete stack passes 111 backend tests, including HTTPS incremental delivery, static delivery, cross-instance recovery, and shutdown. The flow-control shutdown regression fails when socket cancellation is removed and passes when restored.
- Full `just lint`, SQL cache verification, and offline default-member workspace build pass locally.
- CI passed before this review pass; CI must rerun for the updated heads. Independent verification passed the approved static, transport, lifecycle, and reconnect requirements. The owner-requested retry-policy amendment is not implemented while its scope is pending.
- Named health watchers now receive NOT_SERVING at shutdown, as does aggregate health. The regression fails on the previous implementation.
- An independent gated-publication probe disproved the reported static Started ordering race. Registration remains early to prevent message loss; delivery stays gated until Started is admitted.

Latest review pass: static/lifecycle SQLx metadata moved into `apps/backend/.sqlx`, completing the relocation across the stack. There are no new static behavior changes. Full lint, all 111 backend tests, cache verification, and the offline workspace build pass after the restack.
