### PR TITLE
fix: clean leaked backend transactions on pool release

### DIFF
--- a/apps/backend/src/db.rs
+++ b/apps/backend/src/db.rs
@@ -5,7 +5,7 @@ mod read;
 pub(crate) mod stream;
 
 use crate::{config::Config, error::Error};
-use sqlx::{Connection, PgConnection, PgPool, postgres::PgPoolOptions};
+use sqlx::{Connection, PgConnection, PgPool, Row, postgres::PgPoolOptions};
 
 mod model;
 pub(crate) use model::*;
@@ -64,8 +64,27 @@ async fn connect_pool(url: &str, config: &Config) -> Result<PgPool, Error> {
             let timeout = timeout.clone();
             Box::pin(async move { configure(connection, &timeout).await })
         })
+        .after_release(|connection, _| Box::pin(release(connection)))
         .connect(url)
         .await?)
+}
+
+/// Roll back transactions that SQLx did not record before pool reuse.
+/// A cancelled `begin` can send BEGIN before SQLx increments its transaction
+/// depth, so its drop guard queues no rollback. The pool's ping only drains
+/// responses. Probe with one simple query: timestamps differ in an explicit
+/// transaction. A probe error makes SQLx close an aborted connection hard.
+async fn release(connection: &mut PgConnection) -> Result<bool, sqlx::Error> {
+    let in_transaction: bool =
+        sqlx::raw_sql("SELECT transaction_timestamp() <> statement_timestamp()")
+            .fetch_one(&mut *connection)
+            .await?
+            .try_get(0)?;
+    if in_transaction {
+        sqlx::raw_sql("ROLLBACK").execute(connection).await?;
+        tracing::warn!("rolled back an open transaction on pool release");
+    }
+    Ok(true)
 }
 
 /// Open the tailer's dedicated selected-read connection outside the request pool.

--- a/apps/backend/src/db/stream.rs
+++ b/apps/backend/src/db/stream.rs
@@ -59,8 +59,9 @@ impl Drop for HistoryConnection {
             let slot = self.slot.take();
             tokio::spawn(async move {
                 // A pending statement error precedes ReadyForQuery. A second
-                // ping drains that response and the queued transaction rollback;
-                // it does not retry the statement. Never loop on a broken socket.
+                // ping drains the remaining responses without retrying the
+                // statement. The pool release hook handles untracked transactions.
+                // Never loop on a broken socket.
                 let mut result = connection.ping().await;
                 if matches!(result, Err(sqlx::Error::Database(_))) {
                     result = connection.ping().await;

--- a/apps/backend/src/db/tests.rs
+++ b/apps/backend/src/db/tests.rs
@@ -3,7 +3,83 @@ use crate::{
     db::Store,
     test_support::{TestDatabase, TestServer},
 };
+use sqlx::Connection;
 use xmtp_mls_validation::test_utils::inline_welcome_envelope;
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn cancelled_begin_returns_a_clean_connection() {
+    let database = TestDatabase::new()?;
+    let mut config: Config = toml::from_str(&format!("[database]\nurl = {:?}", database.url()))?;
+    config.database.max_connections = 1;
+    let store = Store::connect(&config).await?;
+    let mut connection = store.primary.acquire().await?;
+    let pid = sqlx::query_scalar::<_, i32>("SELECT pg_backend_pid()")
+        .fetch_one(&mut *connection)
+        .await?;
+    {
+        let mut begin = std::pin::pin!(
+            connection.begin_with("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        );
+        assert!(futures::poll!(&mut begin).is_pending());
+    }
+    drop(connection);
+
+    let mut connection = store.primary.acquire().await?;
+    assert_eq!(
+        sqlx::query_scalar::<_, i32>("SELECT pg_backend_pid()")
+            .fetch_one(&mut *connection)
+            .await?,
+        pid,
+        "an open transaction must be rolled back without replacing the connection"
+    );
+    let mut tx = connection
+        .begin_with("BEGIN ISOLATION LEVEL READ COMMITTED")
+        .await?;
+    let sequence = sqlx::query_scalar::<_, i64>("SELECT nextval('envelope_sequence')")
+        .fetch_one(&mut *tx)
+        .await?;
+    assert!(sequence > 0);
+    tx.rollback().await?;
+    drop(connection);
+    store.primary.close().await;
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn aborted_transaction_is_replaced_before_pool_reuse() {
+    let database = TestDatabase::new()?;
+    let mut config: Config = toml::from_str(&format!("[database]\nurl = {:?}", database.url()))?;
+    config.database.max_connections = 1;
+    let store = Store::connect(&config).await?;
+    let mut connection = store.primary.acquire().await?;
+    let pid = sqlx::query_scalar::<_, i32>("SELECT pg_backend_pid()")
+        .fetch_one(&mut *connection)
+        .await?;
+    sqlx::query("BEGIN").execute(&mut *connection).await?;
+    let error = sqlx::query("SELECT 1 / 0")
+        .execute(&mut *connection)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, sqlx::Error::Database(error) if error.code().as_deref() == Some("22012"))
+    );
+    drop(connection);
+
+    let mut connection = store.primary.acquire().await?;
+    let replacement_pid = sqlx::query_scalar::<_, i32>("SELECT pg_backend_pid()")
+        .fetch_one(&mut *connection)
+        .await?;
+    assert_ne!(replacement_pid, pid);
+    let mut tx = connection
+        .begin_with("BEGIN ISOLATION LEVEL READ COMMITTED")
+        .await?;
+    let sequence = sqlx::query_scalar::<_, i64>("SELECT nextval('envelope_sequence')")
+        .fetch_one(&mut *tx)
+        .await?;
+    assert!(sequence > 0);
+    tx.rollback().await?;
+    drop(connection);
+    store.primary.close().await;
+}
 
 #[xmtp_common::test(unwrap_try = true)]
 async fn startup_rejects_retention_that_overflows_the_database_clock() {

--- a/apps/backend/src/stream/tests/session.rs
+++ b/apps/backend/src/stream/tests/session.rs
@@ -178,6 +178,55 @@ async fn removal_acknowledgement_separates_old_and_new_registrations() {
 }
 
 #[xmtp_common::test(unwrap_try = true)]
+async fn cancelled_history_allows_publish_with_one_shared_connection() {
+    let server = TestServer::new(|config| {
+        config.database.max_connections = 1;
+        config.database.replica_url = None;
+    })
+    .await?;
+    let observer = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect_with((*server.backend.store.primary.connect_options()).clone())
+        .await?;
+    let meta = server.publish(vec![envelope(96, 1)]).await?.remove(0);
+    let topic = meta.topic.unwrap();
+    let mut stream = Native::open(&server).await?;
+    let mut blocker = observer.begin().await?;
+    sqlx::query("LOCK TABLE envelopes IN ACCESS EXCLUSIVE MODE")
+        .execute(&mut *blocker)
+        .await?;
+    stream
+        .update(1, vec![support::query_topic(topic.clone(), 0)], vec![])
+        .await?;
+    assert!(matches!(stream.next().await?, Frame::Applied(_)));
+    // The first history query is the earliest database wait controlled by
+    // the session tests. The snapshot's BEGIN has completed at this point.
+    xmtp_common::wait_for_eq(
+        || async {
+            sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE datname = current_database()
+                AND wait_event_type = 'Lock' AND query LIKE 'SELECT wanted.ordinal%')",
+            )
+            .fetch_one(&observer)
+            .await
+            .unwrap()
+        },
+        true,
+    )
+    .await?;
+    stream.update(2, vec![], vec![topic]).await?;
+    assert!(matches!(stream.next().await?, Frame::Applied(applied) if applied.id == 2));
+    blocker.rollback().await?;
+
+    let published = server.publish(vec![envelope(96, 2)]).await?;
+    assert_eq!(published.len(), 1);
+    assert!(published[0].cursor.as_ref().unwrap().sequence_id > 0);
+    drop(stream);
+    observer.close().await;
+    server.stop().await?;
+}
+
+#[xmtp_common::test(unwrap_try = true)]
 async fn removal_restarts_a_mixed_history_turn_without_losing_surviving_topics() {
     let server = TestServer::new(|config| config.streams.poll_interval_ms = 10).await?;
     let metas = server

--- a/docs/specs/002_backend_architecture.md
+++ b/docs/specs/002_backend_architecture.md
@@ -91,7 +91,7 @@ Replicas are supported from day one. Each configured replica URL names one physi
 | GetInboxIds | Replica, or primary when none is configured |
 | VerifySmartContractWalletSignatures | Configured chain RPC |
 
-- ARC-060: Use one pool when there is no replica. With a replica, express endpoint routing once. After a replica connection loss, restart stream recovery; do not retain unproved tailer state across a database replacement.
+- ARC-060: Use one pool when there is no replica. With a replica, express endpoint routing once. A pool release hook must roll back open transactions and discard connections with aborted transactions before reuse. After a replica connection loss, restart stream recovery; do not retain unproved tailer state across a database replacement.
 - ARC-061: Query uses bounded per-topic index probes, with a per-topic `limit + 1` only for internal candidate selection and a final total `limit + 1` cut. The configured Query limit bounds the whole response. Compute `has_more` from the same snapshot and choose candidate IDs before loading payloads. Worst-case candidate work is topics times `limit + 1`; no fixed latency is promised without measurement.
 - ARC-062: A nonempty successful page advances at least one requested topic cursor. Leave other cursors unchanged. Coalesce duplicate inputs as spec 001 requires. The loop drains a finite result set; continuous publication need not terminate a paging loop.
 - ARC-063: Newest reads join watermarks and envelopes in one statement. Metadata-only results select all metadata but not the payload. Full results add the payload. Do not omit an existing topic to fit a successful response into the byte limit.


### PR DESCRIPTION
## Problem

Client test suites against the Docker backend fail intermittently. The PostgreSQL log from one run shows, on single backend connections: `WARNING: there is already a transaction in progress` on a `BEGIN ISOLATION LEVEL READ COMMITTED`, then `ERROR: SET TRANSACTION ISOLATION LEVEL must be called before any query`, then thousands of `ERROR: current transaction is aborted, commands ignored until end of transaction block`, plus one `ERROR: cannot execute nextval() in a read-only transaction` on a publish.

A pooled connection is returned to the pool inside an open transaction. Once a later `BEGIN` fails inside it, the connection is poisoned for the rest of its life because the pool keeps handing it out.

## Root cause

sqlx 0.9 `PgTransactionManager::begin` queues the `BEGIN` statement, awaits `wait_until_ready`, and increments `transaction_depth` only afterwards. When the awaiting future is dropped (a cancelled gRPC request in the publish path, or a cancelled stream fetch while `HistoryConnection::snapshot` awaits `BEGIN ... REPEATABLE READ READ ONLY`), the drop guard calls `start_rollback`, which does nothing because the depth is still 0. The server has already opened the transaction. `PoolConnection::return_to_pool` only pings, so the connection goes back to the pool inside an open transaction. Without a replica the read pool is the primary pool, so a leaked read-only transaction also breaks publishes.

## Fix

- `apps/backend/src/db.rs`: an `after_release` hook probes `SELECT transaction_timestamp() <> statement_timestamp()`. Inside an explicit transaction block it issues `ROLLBACK` and logs one warning. In an aborted transaction the probe errors, and sqlx closes that connection instead of reusing it.
- `apps/backend/src/db/stream.rs`: the `HistoryConnection` drop comment no longer claims that its drain pings roll back the transaction.
- `docs/specs/002_backend_architecture.md`: one sentence on the release hook.

## Tests

- `db::tests::cancelled_begin_returns_a_clean_connection`: polls a real `begin_with` future once so `BEGIN` is flushed, drops it, and proves the same connection is reused clean (a write succeeds). Red without the hook (`25001`, then `25P02`), green with it.
- `db::tests::aborted_transaction_is_replaced_before_pool_reuse`: a raw aborted transaction released without rollback is closed, and the next acquire gets a different backend PID.
- `stream::tests::session::cancelled_history_allows_publish_with_one_shared_connection`: one shared connection, no replica, a cancelled history fetch, then a successful publish. This one cancels at the first history query rather than inside `BEGIN`, so it guards the path but does not reproduce the bug on its own.

`just test-backend`: 114 passed. `just backend-sql-check`, clippy with `-D warnings`, `cargo fmt --check`, `just lint-rust` clean.

## Cost

One extra round trip per pool release. If publish latency regresses under load, this hook is the first place to look. The hook stays harmless if a future sqlx release closes the cancellation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clean leaked backend transactions on pool release via `db.release`
> - Registers a release hook in `db.connect_pool` that runs before a pooled connection is reused, rolling back any open transaction it detects
> - The `db.release` callback probes transaction state by comparing transaction and statement timestamps; if rollback or the probe itself fails, the connection is rejected from the pool
> - Adds regression tests in [db/tests.rs](https://github.com/xmtp/libxmtp/pull/4073/files#diff-36e5dee95b4887e79f740e01148651af1b5b630222845bf42fc3898030b5adef) and [stream/tests/session.rs](https://github.com/xmtp/libxmtp/pull/4073/files#diff-2113bd818d85b29c5fba55262eb68a0d05cd6122247225418c12e94a615de0ff) covering cancelled `BEGIN`, aborted transactions, and single-connection pools
> - Updates the pooling architecture decision in [002_backend_architecture.md](https://github.com/xmtp/libxmtp/pull/4073/files#diff-33059fb89fb4e8831fe8d790ca1a7db076e8eff94de982c6b76a8656d790475d) to require the release hook
> - Behavioral Change: connections with aborted transactions are now replaced before pool reuse, changing backend process IDs; probe/rollback failures now cause the release hook to return an error instead of silently accepting the connection
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b325b04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->