### PR TITLE
docs: document the Agent SDK and enable its API reference

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -93,6 +93,7 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: "true"
         run: just js build
       - run: just docs install
+      - run: just docs check-agent-docs
       - run: just docs build
       - uses: actions/upload-artifact@v7
         with:
@@ -159,6 +160,7 @@ jobs:
             'apps/docs/_site/terms/**/*.html'
             'apps/docs/_site/reference/browser-sdk/**/*.html'
             'apps/docs/_site/reference/node-sdk/**/*.html'
+            'apps/docs/_site/reference/agent-sdk/**/*.html'
             'apps/docs/_site/reference/error-glossary/**/*.html'
             'apps/docs/_site/reference/limits/**/*.html'
           fail: true

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -33,6 +33,7 @@ Do not keep one-time migration checks or copies of old page prose.
 - `check-search.mjs` and `search-config.mjs`: define search regression cases and ranking settings.
 - `check-ts-regions.mjs`, `example-config.mjs`, and `example-regions.mjs`: check SDK examples and render their source regions.
 - `typedoc-validation.mjs`: fail API reference builds on TypeDoc warnings or errors.
+- `agent-doc-coverage.mjs`: require TSDoc for reachable public Agent SDK declarations in CI.
 
 The files in `parity/` keep old URLs working and set Lighthouse score limits.
 They do not freeze page text or require access to the old site.

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -12,6 +12,7 @@ Commands run in the `docs` Nix shell through the root `justfile`.
 - `just docs dev`: start the local site.
 - `just docs build`: build the site.
 - `just docs check-examples`: check source examples against the built local SDKs.
+- `just docs check-agent-docs`: check all reachable public Agent SDK declarations for TSDoc.
 - `just docs lint`: lint the site code and Markdown.
 - `just docs format-check`: check formatting.
 - `just docs format`: format the site files.

--- a/apps/docs/api-references.mjs
+++ b/apps/docs/api-references.mjs
@@ -57,16 +57,10 @@ const references = [
       "ClientWorkerAction",
     ],
   }),
+  sdkReference("agent-sdk", "Agent SDK", "agent-sdk", {
+    exclude: [fileURLToPath(new URL("node-sdk/src/**", sdkRoot))],
+  }),
 ];
-
-// Enable this reference after the Agent SDK public API has documentation comments.
-if (process.env.XMTP_DOCS_INCLUDE_AGENT_REFERENCE === "true") {
-  references.push(
-    sdkReference("agent-sdk", "Agent SDK", "agent-sdk", {
-      exclude: [fileURLToPath(new URL("node-sdk/src/**", sdkRoot))],
-    }),
-  );
-}
 
 export const referencePlugins = references.flatMap(({ validator, plugin }) => [
   validator,

--- a/apps/docs/docs.just
+++ b/apps/docs/docs.just
@@ -17,6 +17,9 @@ build:
 check-examples:
     npm run check:examples
 
+check-agent-docs:
+    npm run check:agent-docs
+
 lint:
     npm run lint
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,6 +10,7 @@
     "dev": "astro dev --host 127.0.0.1",
     "build": "npm run check:examples && astro build",
     "check:examples": "node scripts/check-ts-regions.mjs && node --test tests/sdk-examples.integration.mjs",
+    "check:agent-docs": "node scripts/agent-doc-coverage.mjs",
     "preview": "astro preview --host 127.0.0.1",
     "lint": "eslint . && markdownlint '**/*.md' '**/*.mdx' --ignore node_modules --ignore dist --ignore .astro --ignore generated --ignore '_site/**' --ignore 'src/content/docs/reference/*-sdk/**' --ignore CLAUDE.md",
     "format": "prettier --write .",

--- a/apps/docs/parity/redirects.json
+++ b/apps/docs/parity/redirects.json
@@ -1,5 +1,6 @@
 {
   "/reference/node-sdk": "/reference/node-sdk/readme/",
+  "/reference/agent-sdk": "/reference/agent-sdk/readme/",
   "/reference/browser-sdk": "/reference/browser-sdk/readme/",
   "/agents/build-agents/create-a-client": "/sdk/client/",
   "/agents/build-agents/create-conversations": "/sdk/conversations/",

--- a/apps/docs/scripts/agent-doc-coverage.mjs
+++ b/apps/docs/scripts/agent-doc-coverage.mjs
@@ -1,0 +1,255 @@
+import ts from "typescript";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const sourceRoot = fileURLToPath(
+  new URL("../../../sdks/js/agent-sdk/src/", import.meta.url),
+);
+const options = {
+  noEmit: true,
+  skipLibCheck: true,
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+};
+
+function hasDoc(node) {
+  return ts.getJSDocCommentsAndTags(node).some((doc) => {
+    if (!ts.isJSDoc(doc)) return false;
+    const comment =
+      typeof doc.comment === "string"
+        ? doc.comment
+        : doc.comment?.map((part) => part.text ?? "").join("");
+    return Boolean(comment?.trim());
+  });
+}
+
+function isPrivate(node) {
+  return (
+    (node.name && ts.isPrivateIdentifier(node.name)) ||
+    node.modifiers?.some(
+      (modifier) =>
+        modifier.kind === ts.SyntaxKind.PrivateKeyword ||
+        modifier.kind === ts.SyntaxKind.ProtectedKeyword,
+    )
+  );
+}
+
+export function checkProgram(program, rootPath, ownerRoot) {
+  const checker = program.getTypeChecker();
+  const root = program.getSourceFile(rootPath);
+  if (!root) throw new Error(`API entry point is missing: ${rootPath}`);
+  const module = checker.getSymbolAtLocation(root);
+  if (!module) throw new Error(`API entry point is not a module: ${rootPath}`);
+  const missing = [];
+  const seen = new Set();
+  const seenTypes = new Set();
+  const owned = (node) =>
+    node.getSourceFile().fileName.startsWith(`${resolve(ownerRoot)}/`);
+
+  function requireDoc(node) {
+    if (hasDoc(node)) return;
+    const source = node.getSourceFile();
+    const line = source.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+    missing.push(
+      `${source.fileName}:${line}: missing TSDoc for ${node.name?.getText() ?? ts.SyntaxKind[node.kind]}`,
+    );
+  }
+
+  function followSymbol(symbol) {
+    if (!symbol) return;
+    if (symbol.flags & ts.SymbolFlags.Alias)
+      symbol = checker.getAliasedSymbol(symbol);
+    for (const declaration of symbol.declarations ?? []) {
+      if (owned(declaration)) visitDeclaration(declaration);
+    }
+  }
+
+  // Inferred return values and exported function variables are also public API.
+  function visitResolvedType(type) {
+    if (!type || seenTypes.has(type)) return;
+    seenTypes.add(type);
+    followSymbol(type.aliasSymbol);
+    if (
+      type.symbol?.declarations?.some(
+        (node) =>
+          owned(node) &&
+          (ts.isClassDeclaration(node) ||
+            ts.isInterfaceDeclaration(node) ||
+            ts.isEnumDeclaration(node)),
+      )
+    )
+      followSymbol(type.symbol);
+    for (const argument of type.aliasTypeArguments ?? [])
+      visitResolvedType(argument);
+    if (
+      type.flags & ts.TypeFlags.Object &&
+      type.objectFlags & ts.ObjectFlags.Reference
+    ) {
+      for (const argument of checker.getTypeArguments(type))
+        visitResolvedType(argument);
+    }
+    if (type.isUnionOrIntersection()) {
+      for (const part of type.types) visitResolvedType(part);
+    }
+    for (const kind of [ts.SignatureKind.Call, ts.SignatureKind.Construct]) {
+      for (const signature of checker.getSignaturesOfType(type, kind)) {
+        const declaration = signature.getDeclaration();
+        if (!declaration || !owned(declaration)) continue;
+        visitSignatureTypes(declaration);
+        visitResolvedType(checker.getTypePredicateOfSignature(signature)?.type);
+        for (const parameter of signature.getParameters()) {
+          const node = parameter.valueDeclaration ?? declaration;
+          visitResolvedType(checker.getTypeOfSymbolAtLocation(parameter, node));
+        }
+        visitResolvedType(checker.getReturnTypeOfSignature(signature));
+      }
+    }
+    for (const property of checker.getPropertiesOfType(type)) {
+      for (const declaration of property.declarations ?? []) {
+        if (owned(declaration) && !isPrivate(declaration))
+          visitDeclaration(declaration);
+      }
+    }
+  }
+
+  function visitSignatureTypes(node) {
+    visitType(node.type);
+    for (const parameter of node.parameters ?? []) visitType(parameter.type);
+    for (const parameter of node.typeParameters ?? []) {
+      visitType(parameter.constraint);
+      visitType(parameter.default);
+    }
+  }
+
+  // Follow public type syntax, not implementation bodies or private state.
+  function visitType(node) {
+    if (!node) return;
+    if (ts.isTypeLiteralNode(node)) {
+      for (const member of node.members) visitDeclaration(member);
+      return;
+    }
+    if (ts.isIdentifier(node)) {
+      const symbol = checker.getSymbolAtLocation(node);
+      const target =
+        symbol?.flags & ts.SymbolFlags.Alias
+          ? checker.getAliasedSymbol(symbol)
+          : symbol;
+      if (
+        target?.declarations?.some(
+          (declaration) =>
+            ts.isTypeAliasDeclaration(declaration) ||
+            ts.isInterfaceDeclaration(declaration) ||
+            ts.isClassDeclaration(declaration) ||
+            ts.isEnumDeclaration(declaration),
+        )
+      )
+        followSymbol(symbol);
+    }
+    ts.forEachChild(node, visitType);
+  }
+
+  function visitDeclaration(node) {
+    if (seen.has(node) || !owned(node) || isPrivate(node)) return;
+    seen.add(node);
+    requireDoc(node);
+    visitResolvedType(checker.getTypeAtLocation(node));
+    if (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) {
+      for (const member of node.members) {
+        if (!ts.isClassStaticBlockDeclaration(member)) visitDeclaration(member);
+      }
+      for (const clause of node.heritageClauses ?? []) visitType(clause);
+    }
+    if (ts.isEnumDeclaration(node)) {
+      for (const member of node.members) visitDeclaration(member);
+    }
+    visitSignatureTypes(node);
+    for (const parameter of node.parameters ?? []) {
+      if (
+        ts.isParameterPropertyDeclaration(parameter, node) &&
+        !isPrivate(parameter)
+      )
+        requireDoc(parameter);
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      for (const member of node.initializer.properties)
+        visitDeclaration(member);
+    }
+    if (ts.isShorthandPropertyAssignment(node)) {
+      const value =
+        checker.getShorthandAssignmentValueSymbol(node)?.valueDeclaration;
+      if (value?.initializer && ts.isArrowFunction(value.initializer)) {
+        visitType(value.initializer.type);
+        for (const parameter of value.initializer.parameters)
+          visitType(parameter.type);
+      }
+    }
+  }
+
+  const exports = checker.getExportsOfModule(module);
+  if (!exports.length)
+    throw new Error(`API entry point has no resolved exports: ${rootPath}`);
+  for (const symbol of exports) followSymbol(symbol);
+  return [...new Set(missing)];
+}
+
+export function checkSources(sources) {
+  const input = [...sources.keys()];
+  const defaults = ts.createCompilerHost(options);
+  const host = {
+    ...defaults,
+    directoryExists: (path) =>
+      input.some((file) => file.startsWith(`${path}/`)) ||
+      defaults.directoryExists(path),
+    fileExists: (file) => sources.has(file) || defaults.fileExists(file),
+    readFile: (file) => sources.get(file) ?? defaults.readFile(file),
+    getSourceFile: (file, version) =>
+      sources.has(file)
+        ? ts.createSourceFile(file, sources.get(file), version, true)
+        : defaults.getSourceFile(file, version),
+  };
+  return checkProgram(
+    ts.createProgram(input, options, host),
+    "/fixture/index.ts",
+    "/fixture",
+  );
+}
+
+export async function findUndocumented() {
+  const configPath = join(sourceRoot, "../tsconfig.json");
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (config.error)
+    throw new Error(
+      ts.flattenDiagnosticMessageText(config.error.messageText, "\n"),
+    );
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    dirname(configPath),
+  );
+  if (parsed.errors.length)
+    throw new Error(
+      parsed.errors
+        .map((error) =>
+          ts.flattenDiagnosticMessageText(error.messageText, "\n"),
+        )
+        .join("\n"),
+    );
+  return checkProgram(
+    ts.createProgram(parsed.fileNames, { ...parsed.options, ...options }),
+    join(sourceRoot, "index.ts"),
+    sourceRoot,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const missing = await findUndocumented();
+  if (missing.length) {
+    console.error(missing.join("\n"));
+    process.exitCode = 1;
+  } else console.log("Agent SDK public declarations have TSDoc.");
+}

--- a/apps/docs/tests/agent-doc-coverage.test.mjs
+++ b/apps/docs/tests/agent-doc-coverage.test.mjs
@@ -1,0 +1,168 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  checkSources,
+  findUndocumented,
+} from "../scripts/agent-doc-coverage.mjs";
+
+test("Agent SDK public declarations have TSDoc", async () => {
+  assert.deepEqual(await findUndocumented(), []);
+});
+
+test("coverage detects undocumented exported declarations and members", () => {
+  const files = new Map([
+    [
+      "/fixture/index.ts",
+      "export class Public { public value = 1; private hidden = 2; method() {} }",
+    ],
+  ]);
+  assert.equal(checkSources(files).length, 3);
+});
+
+test("coverage accepts documented declarations and excludes private members", () => {
+  const files = new Map([
+    [
+      "/fixture/index.ts",
+      `/** Public API. */
+export class Public {
+  /** Value. */
+  public value = 1;
+  private hidden = 2;
+  /** Does work. */
+  method() {}
+}`,
+    ],
+  ]);
+  assert.deepEqual(checkSources(files), []);
+});
+
+test("coverage resolves cross-file re-exports with JavaScript extensions", () => {
+  const sources = new Map([
+    ["/fixture/index.ts", 'export { Foo } from "./foo.js";'],
+    ["/fixture/foo.ts", "export class Foo { missing() {} }"],
+  ]);
+  assert.equal(checkSources(sources).length, 2);
+});
+
+test("coverage resolves local named aliases", () => {
+  assert.equal(
+    checkSources(
+      new Map([
+        [
+          "/fixture/index.ts",
+          "const missing = 1; export { missing as value };",
+        ],
+      ]),
+    ).length,
+    1,
+  );
+});
+
+test("coverage follows public base types and parameter types", () => {
+  const source = `
+/** Event names. */
+type Events = { missingEvent: [number] };
+/** Base type. */
+class Base<T> {}
+/** Options. */
+interface Options { missingOption: boolean }
+/** API. */
+export class API extends Base<Events> {
+  /** Do work. */
+  method(options: Options): void {}
+}`;
+  const missing = checkSources(new Map([["/fixture/index.ts", source]]));
+  assert.equal(missing.length, 2);
+  assert.ok(missing.some((line) => line.includes("missingEvent")));
+  assert.ok(missing.some((line) => line.includes("missingOption")));
+});
+
+test("coverage rejects empty docs and public constructors", () => {
+  assert.equal(
+    checkSources(
+      new Map([
+        ["/fixture/index.ts", "/** */ export class API { constructor() {} }"],
+      ]),
+    ).length,
+    2,
+  );
+});
+
+test("coverage checks object members and accepts documented shorthand", () => {
+  const source = `const helper = () => true;
+/** Predicates. */
+export const filter = {
+  /** Check value. */
+  helper,
+  missing: () => false,
+};`;
+  const missing = checkSources(new Map([["/fixture/index.ts", source]]));
+  assert.equal(missing.length, 1);
+  assert.match(missing[0], /missing$/u);
+});
+
+test("coverage does not include private state or unexported declarations", () => {
+  const source = `type Internal = { missing: string };
+class Hidden { missing() {} }
+/** Public API. */
+export class API {
+  #state: Internal;
+  private privateValue: Internal;
+  protected protectedValue: Internal;
+  /** Do work. */
+  static async run(): Promise<void> {}
+}`;
+  assert.deepEqual(checkSources(new Map([["/fixture/index.ts", source]])), []);
+});
+
+test("coverage follows arrow signatures and inferred return types", () => {
+  const source = `
+/** Options. */
+interface Options { missing: string }
+/** Result. */
+class Result { undocumented = 1 }
+/** Run. */
+export const run = (options: Options) => new Result();`;
+  const missing = checkSources(new Map([["/fixture/index.ts", source]]));
+  assert.equal(missing.length, 2);
+  assert.ok(missing.some((line) => line.endsWith("missing")));
+  assert.ok(missing.some((line) => line.endsWith("undocumented")));
+});
+
+test("coverage checks nested objects and exported object aliases", () => {
+  const source = `
+const inner = { missing: 1 };
+/** API. */
+export const api = {
+  /** Nested API. */
+  nested: inner,
+};
+/** Alias. */
+export const alias = inner;`;
+  const missing = checkSources(new Map([["/fixture/index.ts", source]]));
+  assert.equal(missing.length, 1);
+  assert.match(missing[0], /missing$/u);
+});
+
+test("coverage follows arrow predicates and generic constraints and defaults", () => {
+  for (const declaration of [
+    "export const api = (value: unknown): value is Hidden => true;",
+    "export const api = (value: unknown) => value instanceof Hidden;",
+    "export const api = <T extends Hidden>() => null;",
+    "export const api = <T = Hidden>() => null;",
+    "export const api = {\n/** Factory. */\ncreate: <T extends Hidden>() => null };",
+    "export const api = function <T extends Hidden>() { return null; };",
+  ]) {
+    const source = `class Hidden { missing = 1 }\n/** API. */\n${declaration}`;
+    const missing = checkSources(new Map([["/fixture/index.ts", source]]));
+    assert.equal(missing.length, 2, declaration);
+    assert.ok(
+      missing.some((line) => line.endsWith("Hidden")),
+      declaration,
+    );
+    assert.ok(
+      missing.some((line) => line.endsWith("missing")),
+      declaration,
+    );
+  }
+});

--- a/apps/docs/tests/agent-reference.spec.mjs
+++ b/apps/docs/tests/agent-reference.spec.mjs
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+test("Agent API reference renders inside the site", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/reference/agent-sdk/classes/agent/");
+  await expect(page.locator("h1")).toHaveText("Agent");
+  await expect(
+    page.getByRole("heading", { name: "Methods", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("navigation", { name: "Sections" }),
+  ).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath("agent-reference.png") });
+});

--- a/sdks/js/agent-sdk/src/core/Agent.ts
+++ b/sdks/js/agent-sdk/src/core/Agent.ts
@@ -63,80 +63,123 @@ type MessageStream<ContentTypes> = Awaited<
   ReturnType<Client<ContentTypes>["conversations"]["streamAllMessages"]>
 >;
 
-type EventHandlerMap<ContentTypes> = {
+/** Event names and handler arguments emitted by an agent. */
+export type EventHandlerMap<ContentTypes> = {
+  /** Actions message event. */
   actions: [ctx: MessageContext<Actions, ContentTypes>];
+  /** Remote attachment message event. */
   attachment: [ctx: MessageContext<RemoteAttachment, ContentTypes>];
+  /** Any conversation event. */
   conversation: [ctx: ConversationContext<ContentTypes>];
+  /** Group update event. */
   "group-update": [ctx: MessageContext<GroupUpdated, ContentTypes>];
+  /** Direct-message conversation event. */
   dm: [ctx: ConversationContext<ContentTypes, Dm<ContentTypes>>];
+  /** Group conversation event. */
   group: [ctx: ConversationContext<ContentTypes, Group<ContentTypes>>];
+  /** Inline attachment event. */
   "inline-attachment": [ctx: MessageContext<Attachment, ContentTypes>];
+  /** Intent event. */
   intent: [ctx: MessageContext<Intent, ContentTypes>];
+  /** Leave request event. */
   "leave-request": [ctx: MessageContext<LeaveRequest, ContentTypes>];
+  /** Markdown message event. */
   markdown: [ctx: MessageContext<string, ContentTypes>];
+  /** Generic message event. */
   message: [ctx: MessageContext<unknown, ContentTypes>];
+  /** Multiple attachment event. */
   "multi-attachment": [
     ctx: MessageContext<MultiRemoteAttachment, ContentTypes>,
   ];
+  /** Reaction message event. */
   reaction: [ctx: MessageContext<Reaction, ContentTypes>];
+  /** Read receipt event. */
   "read-receipt": [ctx: MessageContext<ReadReceipt, ContentTypes>];
+  /** Reply event. */
   reply: [ctx: MessageContext<EnrichedReply, ContentTypes>];
+  /** Agent start event. */
   start: [ctx: ClientContext<ContentTypes>];
+  /** Agent stop event. */
   stop: [ctx: ClientContext<ContentTypes>];
+  /** Plain-text message event. */
   text: [ctx: MessageContext<string, ContentTypes>];
+  /** Transaction reference event. */
   "transaction-reference": [
     ctx: MessageContext<TransactionReference, ContentTypes>,
   ];
+  /** Error that was not handled by error middleware. */
   unhandledError: [error: Error];
+  /** Undecodable or unsupported message event. */
   unknownMessage: [ctx: MessageContext<unknown, ContentTypes>];
+  /** Wallet send calls event. */
   "wallet-send-calls": [ctx: MessageContext<WalletSendCalls, ContentTypes>];
 };
 
 type EventName<ContentTypes> = keyof EventHandlerMap<ContentTypes>;
 
+/** Ethereum address encoded as a prefixed hexadecimal string. */
 type EthAddress = HexString;
 
+/** Values available to a handler for the current message. */
 export type AgentBaseContext<ContentTypes = unknown> = {
+  /** The client that received the message. */
   client: Client<ContentTypes>;
+  /** The conversation that contains the message. */
   conversation: Conversation;
+  /** The decoded message being handled. */
   message: DecodedMessage;
 };
 
+/** Context passed to error middleware; message and conversation may be absent. */
 export type AgentErrorContext<ContentTypes = unknown> = Partial<
   AgentBaseContext<ContentTypes>
 > & {
+  /** The client associated with the error. */
   client: Client<ContentTypes>;
 };
 
+/** Inputs used to wrap an already-created XMTP client. */
 export type AgentOptions<ContentTypes> = {
+  /** Client to wrap. */
   client: Client<ContentTypes>;
 };
 
+/** Handles a decoded message in normal middleware or command routing. */
 export type AgentMessageHandler<ContentTypes = unknown> = (
   ctx: MessageContext<ContentTypes>,
 ) => Promise<void> | void;
 
+/** Processes a message and calls `next` to continue the middleware chain. */
 export type AgentMiddleware<ContentTypes = unknown> = (
   ctx: MessageContext<unknown, ContentTypes>,
   next: () => Promise<void> | void,
 ) => Promise<void>;
 
+/** Handles an error and calls `next` with no argument to resume processing. */
 export type AgentErrorMiddleware<ContentTypes = unknown> = (
   error: unknown,
   ctx: AgentErrorContext<ContentTypes>,
   next: (err?: unknown) => Promise<void> | void,
 ) => Promise<void> | void;
 
+/** Client options used by `Agent.create`; `appVersion` and device sync have defaults. */
 export type AgentCreateOptions<ContentCodecs extends ContentCodec[] = []> =
-  Omit<ClientOptions & NetworkOptions, "codecs"> & { codecs?: ContentCodecs };
+  Omit<ClientOptions & NetworkOptions, "codecs"> & {
+    /** Custom content codecs registered with the client. */
+    codecs?: ContentCodecs;
+  };
 
+/** Stream options passed to both the conversation and message streams. */
 export type AgentStreamingOptions = Omit<StreamOptions, "onValue" | "onError">;
 
+/** Message-stream options exposed for callers that need the Node SDK shape. */
 export type StreamAllMessagesOptions<ContentTypes> = Parameters<
   Client<ContentTypes>["conversations"]["streamAllMessages"]
 >[0];
 
+/** Registration API returned by `agent.errors`. */
 export type AgentErrorRegistrar<ContentTypes> = {
+  /** Append one or more error middleware functions to the error chain. */
   use(
     ...errorMiddleware: Array<
       AgentErrorMiddleware<ContentTypes> | AgentErrorMiddleware<ContentTypes>[]
@@ -149,6 +192,7 @@ type ErrorFlow =
   | { kind: "continue"; error: unknown } // next(err) or handler throws
   | { kind: "stopped" }; // handler returns without next()
 
+/** Event-driven XMTP agent that routes conversations and messages to middleware. */
 export class Agent<ContentTypes = unknown> extends EventEmitter<
   EventHandlerMap<ContentTypes>
 > {
@@ -192,11 +236,13 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
   #stopped: boolean = false;
   #streamOptions?: AgentStreamingOptions;
 
+  /** Wrap an existing client without starting streams. */
   constructor({ client }: AgentOptions<ContentTypes>) {
     super();
     this.#client = client;
   }
 
+  /** Create an agent and client. Device sync defaults to disabled for agents. */
   static async create<ContentCodecs extends ContentCodec[] = []>(
     signer: Parameters<typeof Client.create>[0],
     // Note: we need to omit this so that "Client.create" can correctly infer the codecs.
@@ -236,6 +282,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     return new Agent({ client });
   }
 
+  /** Create an agent from `XMTP_*` variables. `XMTP_BACKEND_URL` overrides `options.backendUrl`; one must be supplied. */
   static async createFromEnv<ContentCodecs extends ContentCodec[] = []>(
     // Note: we need to omit this so that "Client.create" can correctly infer the codecs.
     options?: Partial<AgentCreateOptions<ContentCodecs>>,
@@ -292,10 +339,12 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     });
   }
 
+  /** Return the libxmtp version used by the wrapped client. */
   get libxmtpVersion() {
     return this.#client.libxmtpVersion;
   }
 
+  /** Add message middleware. Middleware runs in registration order. */
   use(
     ...middleware: Array<
       AgentMiddleware<ContentTypes> | AgentMiddleware<ContentTypes>[]
@@ -494,6 +543,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     });
   }
 
+  /** Start conversation and message streams. Calling this while running is a no-op. */
   async start(options?: AgentStreamingOptions) {
     if (this.#isLocked || this.#conversationsStream || this.#messageStream)
       return;
@@ -645,14 +695,17 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     return false;
   }
 
+  /** Return the wrapped client for operations outside agent middleware. */
   get client() {
     return this.#client;
   }
 
+  /** Return the error-middleware registrar. */
   get errors() {
     return this.#errors;
   }
 
+  /** Stop both streams and emit the `stop` event. Calling this is safe repeatedly. */
   async stop() {
     this.#stopped = true;
     this.#isLocked = true;
@@ -664,6 +717,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     this.#isLocked = false;
   }
 
+  /** Create a DM with an Ethereum address. The address is converted to an identifier. */
   createDmWithAddress(address: EthAddress, options?: CreateDmOptions) {
     return this.#client.conversations.createDmWithIdentifier(
       {
@@ -674,6 +728,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     );
   }
 
+  /** Create a group from Ethereum addresses. */
   createGroupWithAddresses(
     addresses: EthAddress[],
     options?: CreateGroupOptions,
@@ -690,6 +745,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     );
   }
 
+  /** Add Ethereum addresses to an existing group. */
   addMembersWithAddresses<ContentTypes>(
     group: Group<ContentTypes>,
     addresses: EthAddress[],
@@ -704,6 +760,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     return group.addMembersByIdentifiers(identifiers);
   }
 
+  /** Resolve a conversation context, or return `undefined` when it is not local. */
   async getConversationContext(conversationId: string) {
     const conversation =
       await this.client.conversations.getConversationById(conversationId);
@@ -716,6 +773,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     }
   }
 
+  /** Return the agent account address, when the client has one. */
   get address() {
     return this.#client.accountIdentifier?.identifier;
   }

--- a/sdks/js/agent-sdk/src/core/AgentError.ts
+++ b/sdks/js/agent-sdk/src/core/AgentError.ts
@@ -1,14 +1,18 @@
+/** Error with a numeric Agent SDK code and optional original cause. */
 export class AgentError extends Error {
   #code: number;
 
+  /** Create an error with a stable code for middleware and logs. */
   constructor(code: number, message: string, cause?: unknown) {
     super(message, { cause });
     this.#code = code;
   }
 
+  /** Return the numeric error code. */
   get code() {
     return this.#code;
   }
 }
 
+/** Error raised when an Agent SDK stream fails. */
 export class AgentStreamingError extends AgentError {}

--- a/sdks/js/agent-sdk/src/core/ClientContext.ts
+++ b/sdks/js/agent-sdk/src/core/ClientContext.ts
@@ -1,16 +1,25 @@
 import type { Client } from "@xmtp/node-sdk";
 
+/** Context emitted for agent lifecycle events and supplied to error handlers. */
 export class ClientContext<ContentTypes = unknown> {
   #client: Client<ContentTypes>;
 
-  constructor({ client }: { client: Client<ContentTypes> }) {
+  /** Create a context for a client. */
+  constructor({
+    client,
+  }: {
+    /** The client that emitted the event. */
+    client: Client<ContentTypes>;
+  }) {
     this.#client = client;
   }
 
+  /** Return the account identifier used by the client, when available. */
   getClientAddress() {
     return this.#client.accountIdentifier?.identifier;
   }
 
+  /** Return the wrapped XMTP client. */
   get client() {
     return this.#client;
   }

--- a/sdks/js/agent-sdk/src/core/ConversationContext.ts
+++ b/sdks/js/agent-sdk/src/core/ConversationContext.ts
@@ -12,31 +12,38 @@ import {
 } from "@/util/AttachmentUtil";
 import { ClientContext } from "./ClientContext";
 
+/** Context for a conversation event and its client. */
 export class ConversationContext<
   ContentTypes = unknown,
   ConversationType extends Conversation = Conversation,
 > extends ClientContext<ContentTypes> {
   #conversation: ConversationType;
 
+  /** Create a context for a conversation. */
   constructor({
     conversation,
     client,
   }: {
+    /** The conversation that emitted the event. */
     conversation: ConversationType;
+    /** The client that owns the conversation. */
     client: Client<ContentTypes>;
   }) {
     super({ client });
     this.#conversation = conversation;
   }
 
+  /** Narrow this context to a direct-message conversation. */
   isDm(): this is ConversationContext<ContentTypes, Dm<ContentTypes>> {
     return filter.isDM(this.#conversation);
   }
 
+  /** Narrow this context to a group conversation. */
   isGroup(): this is ConversationContext<ContentTypes, Group<ContentTypes>> {
     return filter.isGroup(this.#conversation);
   }
 
+  /** Encrypt and send a remote attachment through the supplied upload callback. */
   async sendRemoteAttachment(
     unencryptedFile: File,
     uploadCallback: AttachmentUploadCallback,
@@ -48,18 +55,22 @@ export class ConversationContext<
     await this.#conversation.sendRemoteAttachment(remoteAttachment);
   }
 
+  /** Return the conversation that triggered this context. */
   get conversation() {
     return this.#conversation;
   }
 
+  /** Whether the conversation consent state is `allowed`. */
   get isAllowed() {
     return this.#conversation.consentState() === ConsentState.Allowed;
   }
 
+  /** Whether the conversation consent state is `denied`. */
   get isDenied() {
     return this.#conversation.consentState() === ConsentState.Denied;
   }
 
+  /** Whether the conversation consent state is `unknown`. */
   get isUnknown() {
     return this.#conversation.consentState() === ConsentState.Unknown;
   }

--- a/sdks/js/agent-sdk/src/core/MessageContext.ts
+++ b/sdks/js/agent-sdk/src/core/MessageContext.ts
@@ -26,19 +26,23 @@ import { filter, type DecodedMessageWithContent } from "@/core/filter";
 import type { AgentBaseContext } from "./Agent";
 import { ConversationContext } from "./ConversationContext";
 
+/** Constructor values for a message context. */
 export type MessageContextParams<
   MessageContentType = unknown,
   ContentTypes = unknown,
 > = Omit<AgentBaseContext<ContentTypes>, "message"> & {
+  /** The decoded message that emitted the event. */
   message: DecodedMessageWithContent<MessageContentType>;
 };
 
+/** Context for a decoded message delivered to agent middleware. */
 export class MessageContext<
   MessageContentType = unknown,
   ContentTypes = unknown,
 > extends ConversationContext<ContentTypes> {
   #message: DecodedMessageWithContent<MessageContentType>;
 
+  /** Create a context from a decoded message and its conversation. */
   constructor({
     message,
     conversation,
@@ -48,44 +52,54 @@ export class MessageContext<
     this.#message = message;
   }
 
+  /** Narrow the message when its encoded type id matches the supplied codec. */
   usesCodec<T extends ContentCodec>(
     codecClass: new () => T,
   ): this is MessageContext<ReturnType<T["decode"]>> {
     return filter.usesCodec(this.#message, codecClass);
   }
 
+  /** Narrow the message to Markdown content. */
   isMarkdown(): this is MessageContext<string> {
     return isMarkdown(this.#message);
   }
 
+  /** Narrow the message to plain text content. */
   isText(): this is MessageContext<string> {
     return isText(this.#message);
   }
 
+  /** Narrow the message to a reply. */
   isReply(): this is MessageContext<Reply> {
     return isReply(this.#message);
   }
 
+  /** Narrow the message to a reaction. */
   isReaction(): this is MessageContext<Reaction> {
     return isReaction(this.#message);
   }
 
+  /** Narrow the message to a read receipt. */
   isReadReceipt(): this is MessageContext<ReadReceipt> {
     return isReadReceipt(this.#message);
   }
 
+  /** Narrow the message to a remote attachment. */
   isRemoteAttachment(): this is MessageContext<RemoteAttachment> {
     return isRemoteAttachment(this.#message);
   }
 
+  /** Narrow the message to a transaction reference. */
   isTransactionReference(): this is MessageContext<TransactionReference> {
     return isTransactionReference(this.#message);
   }
 
+  /** Narrow the message to wallet send calls. */
   isWalletSendCalls(): this is MessageContext<WalletSendCalls> {
     return isWalletSendCalls(this.#message);
   }
 
+  /** Send an `added` reaction that references this message. */
   async sendReaction(
     content: string,
     schema: Reaction["schema"] = ReactionSchema.Unicode,
@@ -108,14 +122,17 @@ export class MessageContext<
     });
   }
 
+  /** Reply to this message with Markdown content. */
   async sendMarkdownReply(markdown: string) {
     await this.#sendReply(encodeMarkdown(markdown));
   }
 
+  /** Reply to this message with plain text content. */
   async sendTextReply(text: string) {
     await this.#sendReply(encodeText(text));
   }
 
+  /** Resolve the sender's first identifier from the local inbox state. */
   async getSenderAddress() {
     const inboxState = await this.client.preferences.getInboxStates([
       this.#message.senderInboxId,
@@ -123,6 +140,7 @@ export class MessageContext<
     return inboxState[0]?.identifiers[0]?.identifier;
   }
 
+  /** Return the decoded message. */
   get message() {
     return this.#message;
   }

--- a/sdks/js/agent-sdk/src/core/filter.ts
+++ b/sdks/js/agent-sdk/src/core/filter.ts
@@ -10,8 +10,10 @@ import {
   type DecodedMessage,
 } from "@xmtp/node-sdk";
 
+/** A decoded message whose content is known to be present. */
 export type DecodedMessageWithContent<ContentTypes = unknown> =
   DecodedMessage<ContentTypes> & {
+    /** The decoded content after the presence check. */
     content: ContentTypes;
   };
 
@@ -63,14 +65,23 @@ const usesCodec = <T extends ContentCodec>(
   );
 };
 
+/** Type guards used by Agent middleware to classify messages and conversations. */
 export const filter = {
+  /** Return true when a message was sent by the supplied client. */
   fromSelf,
+  /** Return true when a message contains decoded content. */
   hasContent,
+  /** Return true when a conversation is a direct message. */
   isDM,
+  /** Return true when a conversation is a group. */
   isGroup,
+  /** Return true when the message sender is a group admin. */
   isGroupAdmin,
+  /** Return true when the message sender is a group super admin. */
   isGroupSuperAdmin,
+  /** Return true when a message uses the supplied codec. */
   usesCodec,
 };
 
+/** Short alias for {@link filter}. */
 export const f = filter;

--- a/sdks/js/agent-sdk/src/debug/log.ts
+++ b/sdks/js/agent-sdk/src/debug/log.ts
@@ -14,10 +14,12 @@ const isLogLevel = (level: string): level is LogLevel => {
   return validLogLevels.includes(level as LogLevel);
 };
 
+/** Return the log levels accepted by the Agent SDK. */
 export const getValidLogLevels = (): LogLevel[] => {
   return [...validLogLevels];
 };
 
+/** Parse a case-insensitive log level, returning `null` for invalid input. */
 export const parseLogLevel = (rawLevel: string) => {
   const normalizedLevel =
     rawLevel.charAt(0).toUpperCase() + rawLevel.slice(1).toLowerCase();
@@ -29,6 +31,7 @@ export const parseLogLevel = (rawLevel: string) => {
   return null;
 };
 
+/** Log client, installation, and key-package details for operational debugging. */
 export const logDetails = async <ContentTypes>(agent: Agent<ContentTypes>) => {
   const xmtp = `\x1b[38;2;252;76;52m
     ██╗  ██╗███╗   ███╗████████╗██████╗
@@ -87,13 +90,19 @@ export const getTestUrl = <ContentTypes>(client: Client<ContentTypes>) => {
   return `http://xmtp.chat/dm/${address}`;
 };
 
-type InstallationInfo = {
+/** Registration details for the client's inbox and installation. */
+export type InstallationInfo = {
+  /** Number of registered installations in the inbox. */
   totalInstallations: number;
+  /** This client's installation ID. */
   installationId: string;
+  /** ID of the newest registered installation, or null if none is found. */
   mostRecentInstallationId: null | string;
+  /** Whether this client is the newest registered installation. */
   isMostRecent: boolean;
 };
 
+/** Read installation count and determine whether this client is newest. */
 export const getInstallationInfo = async <ContentTypes>(
   client: Client<ContentTypes>,
 ): Promise<InstallationInfo> => {

--- a/sdks/js/agent-sdk/src/middleware/ActionWizard.ts
+++ b/sdks/js/agent-sdk/src/middleware/ActionWizard.ts
@@ -36,20 +36,24 @@ type ActionWizardSession = {
   conversation: Conversation;
 };
 
-type ActionWizardCompleteHandler<ContentTypes> = (
+/** Callback after a user supplies an answer to every wizard step. */
+export type ActionWizardCompleteHandler<ContentTypes> = (
   answers: Record<string, string>,
   ctx: MessageContext<unknown, ContentTypes>,
 ) => Promise<void> | void;
 
-type ActionWizardCancelHandler<ContentTypes> = (
+/** Callback when a user cancels or restarts a wizard session. */
+export type ActionWizardCancelHandler<ContentTypes> = (
   ctx: MessageContext<unknown, ContentTypes>,
 ) => Promise<void> | void;
 
+/** Options for the cancel action added to select steps. */
 export type ActionWizardCancelOptions = {
   /** Custom label for the cancel button (default: "Cancel") */
   label?: string;
 };
 
+/** Configuration for an interactive action wizard. */
 export type ActionWizardOptions = {
   /**
    * When true, the wizard sends all steps via DM to the user.
@@ -80,6 +84,7 @@ export class ActionWizard<ContentTypes = unknown> {
   #completeHandler?: ActionWizardCompleteHandler<ContentTypes>;
   #cancelHandler?: ActionWizardCancelHandler<ContentTypes>;
 
+  /** Create a wizard identified by the slash command `id`. */
   constructor(id: string, options?: ActionWizardOptions) {
     this.#id = id;
     this.#dm = options?.dm ?? false;
@@ -91,17 +96,25 @@ export class ActionWizard<ContentTypes = unknown> {
     }
   }
 
+  /** Build the key used to isolate one sender's session in one conversation. */
   static sessionKey(conversationId: string, senderInboxId: string): string {
     return `${conversationId}:${senderInboxId}`;
   }
 
+  /** Build the action id used for a wizard step. */
   static stepKey(wizardId: string, stepId: string): string {
     return `${wizardId}:${stepId}`;
   }
 
+  /** Add a button-selection step. */
   select(
     id: string,
-    options: { description: string; actions: Action[] },
+    options: {
+      /** Prompt shown with the action buttons. */
+      description: string;
+      /** Action buttons offered for this step. */
+      actions: Action[];
+    },
   ): this {
     this.#steps.push({
       type: "select",
@@ -112,9 +125,15 @@ export class ActionWizard<ContentTypes = unknown> {
     return this;
   }
 
+  /** Add a free-text step. */
   text(
     id: string,
-    options: { description: string; isMarkdown?: boolean },
+    options: {
+      /** Prompt shown before the user enters text. */
+      description: string;
+      /** Send the prompt as Markdown when true. */
+      isMarkdown?: boolean;
+    },
   ): this {
     this.#steps.push({
       type: "text",
@@ -125,16 +144,19 @@ export class ActionWizard<ContentTypes = unknown> {
     return this;
   }
 
+  /** Register the callback invoked after the final answer. */
   onComplete(handler: ActionWizardCompleteHandler<ContentTypes>): this {
     this.#completeHandler = handler;
     return this;
   }
 
+  /** Register the callback invoked when a session is cancelled or restarted. */
   onCancel(handler: ActionWizardCancelHandler<ContentTypes>): this {
     this.#cancelHandler = handler;
     return this;
   }
 
+  /** Start or replace the session for the message sender. */
   async start(ctx: MessageContext<unknown, ContentTypes>): Promise<void> {
     const { senderInboxId } = ctx.message;
     const conversation = this.#dm
@@ -150,6 +172,7 @@ export class ActionWizard<ContentTypes = unknown> {
     await this.#sendCurrentStep(key);
   }
 
+  /** Return whether this sender has an active session in the conversation. */
   isActive(conversationId: string, senderInboxId: string): boolean {
     return this.#sessions.has(
       ActionWizard.sessionKey(conversationId, senderInboxId),
@@ -207,6 +230,7 @@ export class ActionWizard<ContentTypes = unknown> {
     }
   }
 
+  /** Return middleware that starts and advances wizard sessions. */
   middleware(): AgentMiddleware<ContentTypes> {
     return async (ctx, next) => {
       const key = ActionWizard.sessionKey(

--- a/sdks/js/agent-sdk/src/middleware/CommandRouter.ts
+++ b/sdks/js/agent-sdk/src/middleware/CommandRouter.ts
@@ -9,15 +9,18 @@ interface CommandEntry {
   description?: string;
 }
 
+/** Optional behavior for a command router. */
 export interface CommandRouterConfig {
   /** Command string to trigger help output (e.g., "/help") */
   helpCommand?: `/${string}`;
 }
 
+/** Routes slash commands and unmatched text to agent handlers. */
 export class CommandRouter<ContentTypes = unknown> {
   #commandMap = new Map<string, CommandEntry>();
   #defaultHandler: AgentMessageHandler<SupportedType> | null = null;
 
+  /** Create a router. A help command is registered when configured. */
   constructor(config: CommandRouterConfig = {}) {
     if (config.helpCommand) {
       this.#registerHelpCommand(config.helpCommand);
@@ -46,16 +49,20 @@ export class CommandRouter<ContentTypes = unknown> {
     this.command(command, "Show available commands", helpHandler);
   }
 
+  /** Return registered commands in insertion order. */
   get commandList(): string[] {
     return Array.from(this.#commandMap.keys());
   }
 
+  /** Register a slash command. Commands are matched case-insensitively. */
   command(command: string, handler: AgentMessageHandler<SupportedType>): this;
+  /** Register a command with a description shown by the help command. */
   command(
     command: string,
     description: string,
     handler: AgentMessageHandler<SupportedType>,
   ): this;
+  /** Register the command using the normalized handler arguments. */
   command(
     command: string,
     handlerOrDescription: AgentMessageHandler<SupportedType> | string,
@@ -87,11 +94,13 @@ export class CommandRouter<ContentTypes = unknown> {
     return this;
   }
 
+  /** Register the handler for text that does not match a command. */
   default(handler: AgentMessageHandler<SupportedType>): this {
     this.#defaultHandler = handler;
     return this;
   }
 
+  /** Handle one text context and return whether a handler ran. */
   async handle(ctx: MessageContext<SupportedType>): Promise<boolean> {
     const messageText = ctx.message.content;
     const parts = messageText.split(" ");
@@ -122,6 +131,7 @@ export class CommandRouter<ContentTypes = unknown> {
     return false;
   }
 
+  /** Return middleware that routes text messages to registered handlers. */
   middleware(): AgentMiddleware<ContentTypes> {
     return async (ctx, next) => {
       if (ctx.isText()) {

--- a/sdks/js/agent-sdk/src/middleware/PerformanceMonitor.ts
+++ b/sdks/js/agent-sdk/src/middleware/PerformanceMonitor.ts
@@ -2,15 +2,23 @@ import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import v8 from "node:v8";
 import type { AgentMiddleware } from "@/core/Agent";
 
+/** CPU, event-loop, and memory measurements for one report interval. */
 export interface HealthReport {
+  /** CPU use during the reporting interval, as a percentage. */
   cpuPercent: number;
+  /** Mean event-loop delay during the interval, in milliseconds. Defaults to 0 when no samples exist. */
   eventLoopDelayMs: number;
+  /** Used V8 heap, in megabytes. */
   heapMB: number;
+  /** Used V8 heap as a percentage of the heap limit. */
   heapPercent: number;
+  /** V8 heap limit, in megabytes. */
   heapLimitMB: number;
+  /** Resident process memory, in megabytes. */
   totalMB: number;
 }
 
+/** Reporting intervals and callbacks for {@link PerformanceMonitor}. */
 export interface PerformanceMonitorConfig {
   /** Interval in ms between health reports (default: 60000). Set to 0 to disable. */
   healthReportInterval?: number;
@@ -46,6 +54,7 @@ export class PerformanceMonitor<ContentTypes = unknown> {
   #onShutdown: () => void;
   #eventLoopHistogram: ReturnType<typeof monitorEventLoopDelay>;
 
+  /** Start monitoring immediately using the configured reporting interval. */
   constructor(config: PerformanceMonitorConfig = {}) {
     const {
       healthReportInterval = 60_000,
@@ -130,6 +139,7 @@ export class PerformanceMonitor<ContentTypes = unknown> {
     });
   }
 
+  /** Stop timers and event-loop sampling. Repeated calls are safe. */
   shutdown() {
     if (this.#isShutdown) {
       return;
@@ -141,6 +151,7 @@ export class PerformanceMonitor<ContentTypes = unknown> {
     this.#onShutdown();
   }
 
+  /** Return middleware that measures each message handler duration. */
   middleware(): AgentMiddleware<ContentTypes> {
     return async (_, next) => {
       const start = performance.now();

--- a/sdks/js/agent-sdk/src/user/NameResolver.ts
+++ b/sdks/js/agent-sdk/src/user/NameResolver.ts
@@ -59,6 +59,7 @@ const resolveName = async (
   return address;
 };
 
+/** Create a resolver for Ethereum addresses and Web3.bio names. */
 export const createNameResolver = (apiKey?: string) => {
   return (name: string) => resolveName(name, apiKey);
 };

--- a/sdks/js/agent-sdk/src/user/User.ts
+++ b/sdks/js/agent-sdk/src/user/User.ts
@@ -16,12 +16,17 @@ import {
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 
+/** Local EOA material used to construct an Agent signer. */
 export type User = {
+  /** Private key used by the wallet. */
   key: Hex;
+  /** viem account derived from {@link key}. */
   account: PrivateKeyAccount;
+  /** viem wallet client used to sign messages. */
   wallet: WalletClient;
 };
 
+/** Create a viem wallet, generating a private key when one is not supplied. */
 export const createUser = (key?: HexString, chain: Chain = sepolia): User => {
   const accountKey = key ?? generatePrivateKey();
   const account = privateKeyToAccount(accountKey);
@@ -36,11 +41,13 @@ export const createUser = (key?: HexString, chain: Chain = sepolia): User => {
   };
 };
 
+/** Convert a user wallet address to the XMTP identifier shape. */
 export const createIdentifier = (user: User): Identifier => ({
   identifier: user.account.address.toLowerCase(),
   identifierKind: IdentifierKind.Ethereum,
 });
 
+/** Adapt a viem wallet to the byte-returning XMTP signer interface. */
 export const createSigner = (user: User): Signer => {
   const identifier = createIdentifier(user);
   return {

--- a/sdks/js/agent-sdk/src/util/AttachmentUtil.ts
+++ b/sdks/js/agent-sdk/src/util/AttachmentUtil.ts
@@ -6,6 +6,7 @@ import {
   type RemoteAttachment,
 } from "@xmtp/node-sdk";
 
+/** Uploads encrypted attachment bytes and returns their public URL. */
 export type AttachmentUploadCallback = (
   attachment: EncryptedAttachment,
 ) => Promise<string>;
@@ -14,7 +15,6 @@ export type AttachmentUploadCallback = (
  * Downloads and decrypts a remote attachment.
  *
  * @param remoteAttachment - The remote attachment metadata containing the downloadd URL and encryption keys
- * @param agent - The agent instance used to lookup the necessary decoding codec
  * @returns A promise that resolves with the decrypted attachment
  */
 export async function downloadRemoteAttachment(

--- a/sdks/js/agent-sdk/src/util/LimitedMap.ts
+++ b/sdks/js/agent-sdk/src/util/LimitedMap.ts
@@ -1,11 +1,14 @@
+/** Map that evicts the oldest key when its size limit is reached. */
 export class LimitedMap<K, V> {
   #map = new Map<K, V>();
   #limit: number;
 
+  /** Create a map with a fixed maximum number of entries. */
   constructor(limit: number) {
     this.#limit = limit;
   }
 
+  /** Store a value, evicting the oldest entry when full. */
   set(key: K, value: V) {
     if (this.#map.size >= this.#limit) {
       const it = this.#map.keys().next();
@@ -16,6 +19,7 @@ export class LimitedMap<K, V> {
     this.#map.set(key, value);
   }
 
+  /** Return a value or `undefined` when the key is absent. */
   get(key: K) {
     return this.#map.get(key);
   }

--- a/sdks/js/agent-sdk/src/util/TransactionUtil.ts
+++ b/sdks/js/agent-sdk/src/util/TransactionUtil.ts
@@ -17,31 +17,85 @@ import {
  */
 export const erc20Abi = [
   {
+    /** ABI entry kind. */
     type: "function",
+    /** ERC-20 function name. */
     name: "transfer",
+    /** Recipient and amount parameters. */
     inputs: [
-      { name: "to", type: "address" },
-      { name: "amount", type: "uint256" },
+      {
+        /** Recipient parameter name. */
+        name: "to",
+        /** Solidity address type. */
+        type: "address",
+      },
+      {
+        /** Token amount parameter name. */
+        name: "amount",
+        /** Unsigned 256-bit integer type. */
+        type: "uint256",
+      },
     ],
-    outputs: [{ name: "", type: "bool" }],
+    /** Transfer success result. */
+    outputs: [
+      {
+        /** The ABI does not name this return value. */
+        name: "",
+        /** Boolean result type. */
+        type: "bool",
+      },
+    ],
+    /** This function does not accept native tokens. */
     stateMutability: "nonpayable",
   },
   {
+    /** ABI entry kind. */
     type: "function",
+    /** ERC-20 balance lookup function name. */
     name: "balanceOf",
-    inputs: [{ name: "account", type: "address" }],
-    outputs: [{ name: "", type: "uint256" }],
+    /** Account whose balance is requested. */
+    inputs: [
+      {
+        /** Account parameter name. */
+        name: "account",
+        /** Solidity address type. */
+        type: "address",
+      },
+    ],
+    /** Balance in the token's base units. */
+    outputs: [
+      {
+        /** The ABI does not name this return value. */
+        name: "",
+        /** Unsigned 256-bit integer type. */
+        type: "uint256",
+      },
+    ],
+    /** This function does not change contract state. */
     stateMutability: "view",
   },
   {
+    /** ABI entry kind. */
     type: "function",
+    /** ERC-20 decimal precision function name. */
     name: "decimals",
+    /** This function has no parameters. */
     inputs: [],
-    outputs: [{ name: "", type: "uint8" }],
+    /** Number of decimal places used by the token. */
+    outputs: [
+      {
+        /** The ABI does not name this return value. */
+        name: "",
+        /** Unsigned 8-bit integer type. */
+        type: "uint8",
+      },
+    ],
+    /** This function does not change contract state. */
     stateMutability: "view",
   },
 ] as const;
 
+/** Parameters for creating an ERC-20 transfer call payload. */
 export type CreateERC20TransferCallsOptions = {
   /** The viem Chain object (e.g., baseSepolia from "viem/chains"). */
   chain: Chain;
@@ -57,11 +111,13 @@ export type CreateERC20TransferCallsOptions = {
   description: string;
 };
 
+/** Parameters for creating a native-token transfer call payload. */
 export type CreateNativeTransferCallsOptions = Omit<
   CreateERC20TransferCallsOptions,
   "tokenAddress"
 >;
 
+/** Parameters for reading an ERC-20 balance. */
 export type GetERC20BalanceOptions = {
   /** The viem Chain object. */
   chain: Chain;
@@ -73,6 +129,7 @@ export type GetERC20BalanceOptions = {
   transport?: Transport;
 };
 
+/** Parameters for reading ERC-20 token decimals. */
 export type GetERC20DecimalsOptions = {
   /** The viem Chain object. */
   chain: Chain;


### PR DESCRIPTION
## Summary

Completes the Agent SDK reference portion of the approved [docs site plan](https://plan.ref.tools/FMcz3rCEVN69MOug).

- Documents public Agent SDK declarations, members, events, options, and reachable local types.
- Exports the existing public event, callback, and installation-info types for generated documentation.
- Enables the Agent SDK TypeDoc reference in the site.
- Adds a TypeScript compiler-based documentation coverage check and negative regression tests.

This PR builds on `nm/docs-site`. It does not change Agent runtime behavior, deploy the site, or change DNS.

## Validation

- Agent SDK build and lint.
- Public documentation coverage and negative regression tests.
- Strict TypeDoc validation.
- Full site build and composed-artifact validation.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document the Agent SDK and enable its API reference in docs site
> - Adds a TypeScript coverage checker at [agent-doc-coverage.mjs](https://github.com/xmtp/libxmtp/pull/4083/files#diff-96b63fa8f07796c764cd06e31b34ce4675ede012b7cf0528192ab4a953424281) that traverses the Agent SDK's public exports and reports reachable declarations missing non-empty TSDoc comments; private and protected members are excluded.
> - Adds TSDoc to all public Agent SDK declarations across `core`, `middleware`, `user`, `util`, and `debug` modules so the coverage check passes.
> - Enables the Agent SDK reference in the docs configuration unconditionally, adds a redirect from `/reference/agent-sdk` to its README page, and adds a Playwright browser test validating the generated reference page renders.
> - Registers `check:agent-docs` as an npm script and a `docs.just` recipe, and adds a CI step in [deploy-docs.yml](https://github.com/xmtp/libxmtp/pull/4083/files#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6) that runs the coverage check before the site build and validates the Agent SDK reference HTML directory exists.
> - Behavioral Change: CI documentation builds now fail when reachable public Agent SDK declarations lack TSDoc, and the Agent SDK reference is always included in the composed site.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9e27757. 21 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->