### PR TITLE
fix: recover rejoin messages and repair CI streaming checks

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -50,10 +50,16 @@ jobs:
           github-token: ${{ github.token }}
       - uses: taiki-e/install-action@just
       - run: just ios docs apps/docs/generated/reference/swift
+      - name: Archive Swift reference
+        # DocC symbol filenames contain colons, which upload-artifact rejects.
+        env:
+          # Keep macOS metadata files out of the published reference.
+          COPYFILE_DISABLE: "1"
+        run: tar -cf "${RUNNER_TEMP}/docs-swift.tar" -C apps/docs/generated/reference/swift .
       - uses: actions/upload-artifact@v7
         with:
           name: docs-swift
-          path: apps/docs/generated/reference/swift
+          path: ${{ runner.temp }}/docs-swift.tar
           if-no-files-found: error
 
   kotlin:
@@ -127,7 +133,11 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: docs-swift
-          path: apps/docs/generated/reference/swift
+          path: ${{ runner.temp }}/docs-swift
+      - name: Extract Swift reference
+        run: |
+          mkdir -p apps/docs/generated/reference/swift
+          tar -xf "${RUNNER_TEMP}/docs-swift/docs-swift.tar" -C apps/docs/generated/reference/swift
       - uses: actions/download-artifact@v8
         with:
           name: docs-kotlin

--- a/bindings/mobile/src/mls/tests/streaming.rs
+++ b/bindings/mobile/src/mls/tests/streaming.rs
@@ -223,36 +223,30 @@ async fn test_message_streaming() {
     stream_closer.end_and_wait().await.unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+#[xmtp_common::test(unwrap_try = true, flavor = "multi_thread", worker_threads = 5)]
 async fn test_message_streaming_when_removed_then_added() {
+    async fn wait_for_message(callback: &RustStreamCallback, content: &[u8]) {
+        wait_for_eq(
+            || async { callback.message_contents().iter().any(|m| m == content) },
+            true,
+        )
+        .await
+        .unwrap();
+    }
+
     let amal = new_test_client().await;
     let bola = new_test_client().await;
-    tracing::info!(
-        "Created Inbox IDs {} and {}",
-        amal.inbox_id(),
-        bola.inbox_id()
-    );
-
     let amal_group = amal
         .conversations()
         .create_group_by_identity(
             vec![bola.account_identifier.clone()],
             FfiCreateGroupOptions::default(),
         )
-        .await
-        .unwrap();
-    tracing::warn!("Created group");
+        .await?;
 
-    // Sync both clients to drain the add-member transcript message
-    // before starting streams, so it doesn't flake the message counts.
-    amal.conversations()
-        .sync_all_conversations(None)
-        .await
-        .unwrap();
-    bola.conversations()
-        .sync_all_conversations(None)
-        .await
-        .unwrap();
+    // Drain the initial membership transcript before starting the streams.
+    amal.conversations().sync_all_conversations(None).await?;
+    bola.conversations().sync_all_conversations(None).await?;
 
     let bola_stream_callback = Arc::new(RustStreamCallback::default());
     let bola_stream_closer = bola
@@ -264,85 +258,60 @@ async fn test_message_streaming_when_removed_then_added() {
         .conversations()
         .stream_all_messages(amal_stream_callback.clone(), None)
         .await;
-    tracing::warn!("waiting for ready");
     bola_stream_closer.wait_for_ready().await;
     amal_stream_closer.wait_for_ready().await;
-    tracing::warn!("ready");
 
-    amal_group
-        .send(b"hello1".to_vec(), FfiSendMessageOpts::default())
-        .await
-        .unwrap();
-    tracing::warn!("sent hello1");
-    bola_stream_callback.wait_for_delivery(None).await.unwrap();
-    amal_stream_callback.wait_for_delivery(None).await.unwrap();
-    amal_group
-        .send(b"hello2".to_vec(), FfiSendMessageOpts::default())
-        .await
-        .unwrap();
-    tracing::warn!("sent hello2");
-    bola_stream_callback.wait_for_delivery(None).await.unwrap();
-    amal_stream_callback.wait_for_delivery(None).await.unwrap();
+    for content in [b"hello1", b"hello2"] {
+        amal_group
+            .send(content.to_vec(), FfiSendMessageOpts::default())
+            .await?;
+        wait_for_message(&bola_stream_callback, content).await;
+        wait_for_message(&amal_stream_callback, content).await;
+    }
     assert_eq!(bola_stream_callback.message_count(), 2);
     assert_eq!(amal_stream_callback.message_count(), 2);
-    assert!(!bola_stream_closer.is_closed());
-    assert!(!amal_stream_closer.is_closed());
 
-    tracing::warn!("removing members");
     amal_group
         .remove_members(vec![bola.inbox_id().clone()])
-        .await
-        .unwrap();
-    tracing::warn!("removed members");
-    bola_stream_callback.wait_for_delivery(None).await.unwrap();
-    amal_stream_callback.wait_for_delivery(None).await.unwrap();
-    tracing::warn!("received delivery");
-    assert_eq!(bola_stream_callback.message_count(), 3); // Member removal transcript message
-    assert_eq!(amal_stream_callback.message_count(), 3);
-    //
-    tracing::warn!("sending hello3");
+        .await?;
+    wait_for_eq(|| async { bola_stream_callback.message_count() }, 3).await?;
+    wait_for_eq(|| async { amal_stream_callback.message_count() }, 3).await?;
+
     amal_group
         .send(b"hello3".to_vec(), FfiSendMessageOpts::default())
-        .await
-        .unwrap();
-    amal_stream_callback.wait_for_delivery(None).await.unwrap();
-    tracing::warn!("received delivery");
-    //TODO: could verify with a log message
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    assert_eq!(bola_stream_callback.message_count(), 3); // Don't receive messages while removed
-    assert_eq!(amal_stream_callback.message_count(), 4);
-    assert!(!bola_stream_closer.is_closed());
-    assert!(!amal_stream_closer.is_closed());
+        .await?;
+    wait_for_message(&amal_stream_callback, b"hello3").await;
 
-    tracing::warn!("adding members");
     amal_group
         .add_members_by_identity(vec![bola.account_identifier.clone()])
-        .await
-        .unwrap();
-    tracing::warn!("Added members");
-
-    // Amal observes its own commit for the re-add. Wait for that instead of a
-    // fixed delay: on a loaded machine the commit can take longer than a sleep,
-    // and Bola's stream cannot resume until the re-add is delivered.
-    xmtp_common::wait_for_eq(|| async { amal_stream_callback.message_count() }, 5)
-        .await
-        .unwrap();
-    assert_eq!(bola_stream_callback.message_count(), 3); // Don't receive transcript messages while removed
-
+        .await?;
+    // Send immediately: Bola must recover even if its welcome is still pending.
     amal_group
-        .send("hello4".as_bytes().to_vec(), FfiSendMessageOpts::default())
-        .await
-        .unwrap();
-    amal_stream_callback.wait_for_delivery(None).await.unwrap();
-    // fails here
-    bola_stream_callback.wait_for_delivery(None).await.unwrap();
-    assert_eq!(bola_stream_callback.message_count(), 4); // Receiving messages again
-    assert_eq!(amal_stream_callback.message_count(), 6);
+        .send(b"hello4".to_vec(), FfiSendMessageOpts::default())
+        .await?;
+    wait_for_message(&bola_stream_callback, b"hello4").await;
+    wait_for_message(&amal_stream_callback, b"hello4").await;
+
+    // Checking the full sequence after recovery also proves that hello3 was
+    // excluded. A delay while Bola is removed cannot establish that outcome.
+    let bola_messages: Vec<_> = bola_stream_callback
+        .messages
+        .lock()
+        .iter()
+        .filter(|m| m.kind == FfiConversationMessageKind::Application)
+        .map(|m| m.content.clone())
+        .collect();
+    assert_eq!(
+        bola_messages,
+        vec![b"hello1".to_vec(), b"hello2".to_vec(), b"hello4".to_vec()]
+    );
+    assert_eq!(bola_stream_callback.message_count(), 4);
+    wait_for_eq(|| async { amal_stream_callback.message_count() }, 6).await?;
     assert!(!bola_stream_closer.is_closed());
     assert!(!amal_stream_closer.is_closed());
 
-    bola_stream_closer.end_and_wait().await.unwrap();
-    amal_stream_closer.end_and_wait().await.unwrap();
+    bola_stream_closer.end_and_wait().await?;
+    amal_stream_closer.end_and_wait().await?;
     assert!(bola_stream_closer.is_closed());
     assert!(amal_stream_closer.is_closed());
 }

--- a/crates/xmtp_mls/src/subscriptions/process_message.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message.rs
@@ -216,6 +216,44 @@ mod tests {
     use rstest_reuse::{self, *};
     use xmtp_proto::types::GroupId;
 
+    /// A group envelope can arrive before the rejoin welcome is processed.
+    /// Drive the shared stream processor without a welcome consumer to fix that order.
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn streamed_message_recovers_pending_rejoin_welcome() {
+        use crate::{tester, utils::MlsGroupExt};
+
+        tester!(alix, disable_workers);
+        tester!(bo, disable_workers);
+        let group = alix.create_group(None, None)?;
+        group.invite(&bo).await?;
+        bo.sync_welcomes().await?;
+        let bo_group = bo.group(&group.group_id)?;
+        bo_group.sync().await?;
+        let factory = ProcessMessageFuture::new(bo.context.clone());
+
+        group.remove_members(&[bo.inbox_id()]).await?;
+        let removal = group.test_get_last_message_from_network().await?;
+        process_one(&factory, removal).await?;
+        assert!(!bo_group.is_active()?);
+
+        group.send_msg(b"while removed").await;
+        let excluded = group.test_get_last_message_from_network().await?;
+        assert!(process_one(&factory, excluded).await?.message.is_none());
+
+        group.invite(&bo).await?;
+        group.send_msg(b"after rejoin").await;
+        let message = group.test_get_last_message_from_network().await?;
+        assert!(!bo_group.is_active()?);
+
+        let delivered = process_one(&factory, message).await?.message;
+        assert_eq!(
+            delivered.map(|message| message.decrypted_message_bytes),
+            Some(b"after rejoin".to_vec()),
+            "the stream must recover the welcome before consuming the message"
+        );
+        assert!(bo_group.is_active()?);
+    }
+
     #[template]
     #[rstest]
     #[case(vec![55, 60], vec![70, 80], 60)]

--- a/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -6,6 +6,7 @@ use crate::groups::{
     MlsGroup,
     mls_sync::GroupMessageProcessingError,
     summary::{MessageIdentifier, SyncSummary},
+    welcome_sync::WelcomeService,
 };
 use crate::subscriptions::SubscribeError;
 use crate::subscriptions::process_message::MessageIdentifierBuilder;
@@ -139,7 +140,21 @@ where
             ConversationType::Group,
             msg.timestamp(),
         );
-        match group.sync_with_conn().await {
+        let recovery = async {
+            // Group messages and welcomes have no cross-topic order. A rejoin
+            // welcome can still be pending when its first group message arrives.
+            // Recover it before group sync rejects the inactive group and the
+            // stream consumes the envelope without delivering its message.
+            if !group.is_active().map_err(SyncSummary::other)? {
+                WelcomeService::new(self.0.clone())
+                    .sync_welcomes()
+                    .await
+                    .map_err(SyncSummary::other)?;
+            }
+            group.sync_with_conn().await
+        }
+        .await;
+        match recovery {
             Ok(summary) => {
                 let epoch = group.epoch().await.unwrap_or(0);
                 tracing::debug!(

--- a/sdks/js/agent-sdk/src/core/Agent.reconnect.test.ts
+++ b/sdks/js/agent-sdk/src/core/Agent.reconnect.test.ts
@@ -9,6 +9,11 @@ const PROXY_NAME = "backend";
 const TOXIPROXY_API = "http://localhost:8474";
 const TOXIPROXY_PORT = "6010";
 
+const DELIVERY_WAIT = { timeout: 30_000, interval: 100 };
+// The transport can wait 30 seconds plus up to 30 seconds of jitter before
+// its next reconnect attempt. Leave time for that attempt and catch-up.
+const RECOVERY_WAIT = { timeout: 75_000, interval: 100 };
+
 // Set transport deadlines before the first client reads them.
 process.env.XMTP_GRPC_KEEPALIVE_INTERVAL_SECS = "10";
 process.env.XMTP_GRPC_KEEPALIVE_TIMEOUT_SECS = "10";
@@ -77,7 +82,7 @@ describe("Agent reconnect", () => {
       try {
         await agent.start();
         const first = await createConversation();
-        await expect.poll(() => received).toEqual([first.id]);
+        await expect.poll(() => received, DELIVERY_WAIT).toEqual([first.id]);
 
         if (fault === "black hole") await blackHole(true);
         else await enableBackend(false);
@@ -94,11 +99,11 @@ describe("Agent reconnect", () => {
         else await enableBackend(true);
         faultActive = false;
         await expect
-          .poll(() => received, { timeout: 15_000 })
+          .poll(() => received, RECOVERY_WAIT)
           .toEqual([first.id, missed.id]);
         const after = await createConversation();
         await expect
-          .poll(() => received)
+          .poll(() => received, DELIVERY_WAIT)
           .toEqual([first.id, missed.id, after.id]);
         expect(onStart).toHaveBeenCalledTimes(1);
         expect(onStop).not.toHaveBeenCalled();

--- a/sdks/js/browser-sdk/test/Dm.test.ts
+++ b/sdks/js/browser-sdk/test/Dm.test.ts
@@ -171,24 +171,27 @@ describe("Dm", () => {
       },
     });
 
-    await dm.sendText("gm");
-    await dm.sendText("gm2");
+    const consumedMessages: unknown[] = [];
+    const consumed = (async () => {
+      for await (const message of stream) {
+        consumedMessages.push(message.content);
+      }
+    })();
 
-    // End the stream once both messages have arrived. A fixed delay races a
-    // loaded machine, where the second message lands after the timer fires.
-    void vi
-      .waitFor(() => {
-        expect(streamedMessages.length).toBe(2);
-      }, WAIT)
-      .then(() => stream.end());
+    try {
+      await dm.sendText("gm");
+      await dm.sendText("gm2");
 
-    let count = 0;
-    for await (const message of stream) {
-      count++;
-      expect(message).toBeDefined();
+      // Callback delivery can precede iterator consumption. Closing the stream
+      // clears its queue, so wait for both consumers before closing it.
+      await vi.waitFor(() => {
+        expect(streamedMessages).toEqual(["gm", "gm2"]);
+        expect(consumedMessages).toEqual(["gm", "gm2"]);
+      }, WAIT);
+    } finally {
+      await stream.end();
+      await consumed;
     }
-    expect(count).toBe(2);
-    expect(streamedMessages).toEqual(["gm", "gm2"]);
   });
 
   it("should manage consent state", async () => {


### PR DESCRIPTION
A group message can arrive before its rejoin welcome is processed. The stream recovery path then rejects the inactive group and returns no message. This PR recovers pending welcomes before group sync, fixes two asynchronous test waits, and transfers Swift DocC output as a tar archive.

Approved plan: https://plan.ref.tools/0cvhQTv4Hzrraz0a

## 1. Mobile remove/re-add: confirmed product bug

`MessageConsumer` processes group envelopes independently of welcome tasks. `Syncer::recover` previously called group sync directly. An inactive group rejected that sync, so `MessageProcessor` returned `message: None`. The later welcome did not request replay because `add_group` already tracked the topic. A longer callback timeout cannot restore a consumed message.

The fix checks for a pending welcome when recovery finds an inactive group, then synchronizes the group. It does not change the transport cursor rules or increase the mobile timeout. The mobile test now checks message content, sends immediately after re-add, and checks the complete application-message sequence to prove exclusion during removal. It no longer mixes count polling with stale notification permits.

A new regression uses real clients and network envelopes. It processes removal, checks that a message sent during removal is excluded, leaves the rejoin welcome pending, and passes the first post-rejoin envelope through the shared stream processor. The regression was added and run **before** the product change. Only the recovery implementation changed between its failing and passing runs.

### Before the fix

Command (with `XDG_CACHE_HOME=/tmp/xmtp-flakes-cache`, `XMTP_BACKEND_URL=http://127.0.0.1:5050`, and `NIX_DEVSHELL=rust`):

```sh
dev/nix-shell "cargo nextest run --profile ci -p xmtp_mls -E 'test(streamed_message_recovers_pending_rejoin_welcome)' --retries 0"
```

Real output excerpt:

```text
        FAIL [   0.286s] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
    Group is inactive
    processed 0 total messages, 
    assertion `left == right` failed: the stream must recover the welcome before consuming the message
      left: None
     right: Some([97, 102, 116, 101, 114, 32, 114, 101, 106, 111, 105, 110])
```

### After the fix

The same command and regression:

```text
PASS [   0.316s] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
Summary [   0.318s] 1 test run: 1 passed, 714 skipped
```

The original CI failure was at `streaming.rs:338` after 60.97 seconds. Its available CI excerpt did not show the event order. The deterministic local regression confirms the product defect independently.

## 2. Agent reconnect: recovery deadline

The test already polled, but allowed only 15 seconds for recovery. The transport permits a 30-second retry delay plus up to 30 seconds of jitter. The recovery poll now allows 75 seconds; ordinary delivery polls explicitly allow 30 seconds. Ordered conversation IDs, no-error checks, and start/stop counts remain. Fault-duration sleeps remain because they define the disconnect and black-hole windows.

The deadline mismatch is verified in code. The original CI run did not retain enough transport timing data to prove which delay caused that specific timeout. No separate agent delivery defect was reproduced. The local repeat evidence below is not a claim that the original CI timing was reproduced.

## 3. Browser DM: callback/iterator closure race

The test previously closed the stream when `onValue` had seen both messages. The iterator could still have a queued message; `AsyncStream.done()` clears that queue. The test now consumes in the background and awaits convergence of both exact content arrays before closing. Cleanup and consumer completion are awaited. This follows the background-consumer pattern in `81206c67d`; no stream implementation behavior is changed.

## 4. Swift DocC: deterministic artifact rejection

The CI log confirms `actions/upload-artifact@v7` rejected `data/documentation/xmtpios/apistats/init(apistats:).json` because its filename contains a colon. The macOS producer and Linux composer still need artifact transfer. The producer now uploads one `docs-swift.tar`; the composer extracts it into the original Swift reference directory. `COPYFILE_DISABLE=1` prevents macOS tar from adding AppleDouble files to the Linux output. Symbol paths are preserved.

An actual macOS tar → ZIP artifact → Linux tar extraction round trip used the failing filename, an HTML link, hidden metadata, and a symlink. The Linux output matched the source directory exactly:

```text
PASS: macOS tar -> ZIP artifact -> Linux tar extraction
PASS: all 8 source paths match, including bytes, hidden metadata, and symlink target
PASS: no extra AppleDouble files in the Linux output
PASS: data/documentation/xmtpios/apistats/init(apistats:).json
```

This was a fixture round trip using Linux tar in a temporary Docker container. A full Swift DocC build and hosted artifact upload were not run locally; the PR workflow must verify those steps.

## 5. iOS DNS: stale rerun URL; left unchanged

Run https://github.com/xmtp/libxmtp/actions/runs/34409582463 provides a specific cause:

- Attempt 1 deployed at 22:00:44 UTC, then cleanup logged `Destroyed app libxmtp-ios-test-34409582463-1` at 22:31:08 UTC.
- Attempt 2 started the iOS tests at 22:31:52 UTC and still set `XMTP_BACKEND_URL=https://libxmtp-ios-test-34409582463-1.fly.dev`.
- Those tests failed hostname lookup against the deleted app.

`wait-backend` checks image publication. The separate deployment job probes the service, and cleanup later destroys it. This is a rerun/deployment-lifecycle failure, not evidence of a client DNS bug. Rerun deployment with its dependent tests, or the full workflow. The existing workflows AGENTS.md already records this rule. No iOS client or Fly configuration change is needed for the observed failure.

## Validation

The existing `libxmtp` backend stack was reused without restart or teardown. No changes were made to `phase45/metrics`.

- `dev/nix-shell 'just lint'` passed: Clippy, Rust formatting, hakari checks, configuration formatting, Markdown, and protobuf lint.
- Both changed JS SDKs passed type checking and focused ESLint.
- The shared message-processing suite passed: `Summary [0.609s] 19 tests run: 19 passed, 696 skipped`.
- The following repeated checks used retries disabled. Filtered tests are reported as skipped by the runners; no test was disabled.

### Rust repeat runs

The two commands used `--profile ci --retries 0 --stress-count 10`, with package/test filters for the new regression and the mobile remove/re-add test. Real output:

```text
        PASS [   0.194s] [ 1/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
        PASS [   0.202s] [ 2/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
        PASS [   0.156s] [ 3/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
        PASS [   0.139s] [ 4/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
        PASS [   0.172s] [ 5/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
        PASS [   0.178s] [ 6/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
        PASS [   0.160s] [ 7/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
        PASS [   0.163s] [ 8/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
        PASS [   0.174s] [ 9/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
        PASS [   0.147s] [10/10] (1/1) xmtp_mls subscriptions::process_message::tests::streamed_message_recovers_pending_rejoin_welcome
     Summary [   1.693s] 10/10 stress run iterations: 10 passed
        PASS [   0.674s] [ 1/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
        PASS [   0.624s] [ 2/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
        PASS [   0.629s] [ 3/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
        PASS [   0.625s] [ 4/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
        PASS [   0.629s] [ 5/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
        PASS [   0.618s] [ 6/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
        PASS [   0.620s] [ 7/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
        PASS [   0.617s] [ 8/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
        PASS [   0.618s] [ 9/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
        PASS [   0.623s] [10/10] (1/1) xmtpv3 mls::tests::streaming::test_message_streaming_when_removed_then_added
     Summary [   6.283s] 10/10 stress run iterations: 10 passed
```

### JavaScript repeat runs

Each loop ran 10 times and stopped on the first nonzero exit. Agent validation ran the full three-test reconnect file on each iteration (30 passes total), using `--retry 0`:

```sh
NIX_DEVSHELL=js dev/nix-shell 'cd sdks/js && for iteration in $(seq 1 10); do echo "Agent reconnect iteration ${iteration}/10"; yarn workspace @xmtp/agent-sdk exec vitest run src/core/Agent.reconnect.test.ts --retry 0 --reporter=verbose || exit; done'
```

Real output excerpt:

```text
Agent reconnect iteration 1/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 8527ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30639ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 6368ms
Agent reconnect iteration 2/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 8835ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30861ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 5069ms
Agent reconnect iteration 3/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 8452ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30654ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 5034ms
Agent reconnect iteration 4/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 11028ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30662ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 5069ms
Agent reconnect iteration 5/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 9727ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30871ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 5085ms
Agent reconnect iteration 6/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 8430ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30646ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 5041ms
Agent reconnect iteration 7/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 10842ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30728ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 5059ms
Agent reconnect iteration 8/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 7911ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30770ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 5043ms
Agent reconnect iteration 9/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 7627ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30878ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 5041ms
Agent reconnect iteration 10/10
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a disconnect without closing or errors 6000ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect and resume in order after a black hole without closing or errors 30853ms
 ✓ src/core/Agent.reconnect.test.ts > Agent reconnect > should reconnect when start() fails initially 5053ms
```

The native macOS browser could not open its test session: Chromium logged `bootstrap_check_in ... Permission denied (1100)`, and Vitest reported no tests. The successful browser runs used **Linux Chromium in a local Playwright 1.61.1 Docker container**, with the host Vite runner, the generated WASM bindings, and the existing backend. An ignored temporary config imported the repository config and changed only the Playwright provider to:

```ts
playwright({
  connectOptions: {
    wsEndpoint: "ws://127.0.0.1:3337/",
    exposeNetwork: "<loopback>",
  },
});
```

The browser server command was:

```sh
docker run --detach --rm --init --name xmtp-flakes-playwright --publish 127.0.0.1:3337:3337 mcr.microsoft.com/playwright:v1.61.1-noble npx --yes playwright@1.61.1 run-server --host 0.0.0.0 --port 3337
```

The repeat command was:

```sh
NIX_DEVSHELL=js dev/nix-shell 'cd sdks/js/browser-sdk && for iteration in $(seq 1 10); do echo "Browser DM iteration ${iteration}/10"; yarn exec vitest run test/Dm.test.ts --config ../../../target/ci-flakes-browser.config.mts --retry 0 --reporter=verbose -t "should stream messages$" || exit; done'
```

Both JS loops set `XMTP_BACKEND_URL=http://127.0.0.1:5050`, `XDG_CACHE_HOME=/tmp/xmtp-flakes-cache`, and `YARN_ENABLE_GLOBAL_CACHE=false`. The temporary browser container was stopped after validation; the shared backend stack was left running.

Real output excerpt:

```text
Browser DM iteration 1/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3418ms
Browser DM iteration 2/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3459ms
Browser DM iteration 3/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3485ms
Browser DM iteration 4/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3428ms
Browser DM iteration 5/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3398ms
Browser DM iteration 6/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3476ms
Browser DM iteration 7/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3495ms
Browser DM iteration 8/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3458ms
Browser DM iteration 9/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3416ms
Browser DM iteration 10/10
 ✓ |chromium| test/Dm.test.ts > Dm > should stream messages 3405ms
```




<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix rejoin message recovery in `ProcessMessageFuture.recover` and repair CI Swift artifact checks
> - Streamed-message recovery now checks whether the target group is inactive and, if so, synchronizes pending rejoin welcomes before the normal group sync in [factory.rs](https://github.com/xmtp/libxmtp/pull/4085/files#diff-a0753b0ead0db388d6b83a9eb6825168e078a4c73f2fe28c70dd141c25e16b5d). This lets a group envelope that arrives before its rejoin welcome be processed after the group is reactivated.
> - The Swift documentation CI job in [deploy-docs.yml](https://github.com/xmtp/libxmtp/pull/4085/files#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6) now tars the generated Swift reference before upload and extracts it on the assembly side, so symbol files with colons in their names survive artifact storage.
> - Streaming and reconnect tests across mobile bindings and the JS agent SDK switch from fixed sleeps to content- and count-based polling, and new regression tests cover the rejoin-before-welcome ordering.
> - Risk: `recover` now depends on the welcome synchronization service; if that service fails for an inactive group, recovery returns the existing error summary type rather than processing the pending envelope.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1049f37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
