### PR TITLE
chore(dev): add opt-in sccache shared build cache

### DIFF
--- a/dev/sccache-env
+++ b/dev/sccache-env
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Opt-in shared Rust compilation cache for local development.
+#
+# Source this (do not execute it) in a shell before running cargo:
+#
+#   source dev/sccache-env
+#   cargo build
+#
+# Why: every git worktree keeps its own target/ directory, so N worktrees
+# rebuild the same dependencies N times. sccache gives them one shared cache
+# while each worktree keeps its own cargo lock, so parallel builds in
+# different worktrees still run at full width.
+#
+# Trade-off: sccache cannot cache incremental compilation, so this turns
+# incremental off. That is the right default for fresh worktrees, where
+# incremental has nothing to reuse. When you are hand-iterating on one crate
+# in one worktree, prefer incremental instead: re-export CARGO_INCREMENTAL=1
+# and unset RUSTC_WRAPPER.
+#
+# This file is never sourced automatically. CI and Nix package builds must not
+# use it: `nix build` runs in a sandbox where the cache is unreachable, and CI
+# sets its own sccache through .github/actions/setup-nix.
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  echo "dev/sccache-env must be sourced, not executed:" >&2
+  echo "  source dev/sccache-env" >&2
+  exit 1
+fi
+
+if ! command -v sccache >/dev/null 2>&1; then
+  echo "sccache not found. Enter the dev shell first (nix develop, or direnv)." >&2
+  return 1
+fi
+
+# Bounded, self-evicting cache (LRU). Unlike target/, this has a real ceiling.
+export SCCACHE_DIR="${SCCACHE_DIR:-${HOME}/.cache/sccache}"
+export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-60G}"
+RUSTC_WRAPPER="$(command -v sccache)"
+export RUSTC_WRAPPER
+# Required: sccache cannot cache incremental artifacts.
+export CARGO_INCREMENTAL=0
+
+echo "sccache enabled: dir=${SCCACHE_DIR} max=${SCCACHE_CACHE_SIZE}"
+echo "  stats: sccache --show-stats | disable: unset RUSTC_WRAPPER CARGO_INCREMENTAL"

--- a/docs/nix-setup.md
+++ b/docs/nix-setup.md
@@ -130,3 +130,57 @@ nix flake show
   CI and local builds skip redundant work
 - **Omnix for CI orchestration** — the `.envrc` integrates with
   [omnix](https://omnix.page) for CI workflow management
+
+## Shared Build Cache (sccache)
+
+Each git worktree keeps its own `target/` directory. Without a shared cache, N
+worktrees compile the same dependencies N times, and `target/` grows to tens of
+gigabytes per worktree.
+
+`sccache` is in the `rust` and `default` dev shells. It is **off by default**.
+Turn it on per shell:
+
+```bash
+source dev/sccache-env
+cargo build
+```
+
+Every worktree keeps its own cargo lock, so builds in different worktrees still
+run in parallel at full width. They share one compilation cache, so work that
+one worktree already did is copied instead of recompiled.
+
+### Trade-off: incremental compilation
+
+sccache cannot cache incremental compilation, so `dev/sccache-env` sets
+`CARGO_INCREMENTAL=0`. Choose per task:
+
+- **Many worktrees, fresh branches, agent-driven work** — use sccache.
+  Incremental has nothing to reuse in a fresh worktree.
+- **Hand-iterating on one crate in one worktree** — prefer incremental.
+  Do not source the script, or run:
+
+  ```bash
+  unset RUSTC_WRAPPER
+  export CARGO_INCREMENTAL=1
+  ```
+
+### Cache size
+
+The cache is bounded and evicts least-recently-used entries. Default is 60 GiB;
+override with `SCCACHE_CACHE_SIZE` before sourcing.
+
+```bash
+just cache-stats            # hit rates and current size
+just clean-incremental      # delete incremental/ dirs unused 14+ days
+just clean-incremental 30   # ...or a different age
+```
+
+### CI and releases
+
+`dev/sccache-env` is never sourced automatically and is for local use only.
+
+- **Nix builds** (`nix build`, releases, `.#validation`, `.#nextest`) run in a
+  sandbox and never see `RUSTC_WRAPPER`. They are unaffected.
+- **CI** sets its own sccache through the `sccache` input of
+  `.github/actions/setup-nix`, backed by the GitHub Actions cache. Workflows
+  that build inside `nix build` set `sccache: "false"` on purpose.

--- a/justfile
+++ b/justfile
@@ -103,3 +103,25 @@ test-validation:
     dev/check-validation test
 
 validation: check-validation test-validation
+
+# --- DISK ---
+
+# Show sccache hit rates and cache size.
+cache-stats:
+    sccache --show-stats
+
+# Delete stale incremental/ dirs across all worktrees (default: unused 14+ days).
+[script("bash")]
+clean-incremental days="14":
+    set -euo pipefail
+    roots=$(git worktree list --porcelain | awk '/^worktree /{print $2}')
+    total=0
+    for root in $roots; do
+      for dir in $(find "$root/target" -maxdepth 2 -type d -name incremental -atime +{{ days }} 2>/dev/null); do
+        size=$(du -sk "$dir" | cut -f1)
+        total=$((total + size))
+        echo "removing $dir ($((size / 1024)) MB)"
+        rm -rf "$dir"
+      done
+    done
+    echo "reclaimed $((total / 1024)) MB"

--- a/nix/lib/shell-common.nix
+++ b/nix/lib/shell-common.nix
@@ -15,6 +15,7 @@
   cargo-deny,
   cargo-machete,
   cargo-hakari,
+  sccache,
   sqlx-cli,
   grpc-health-probe,
   lcov,
@@ -122,6 +123,9 @@ in
     cargo-hakari
     sqlx-cli
     grpc-health-probe
+    # Shared compilation cache across worktrees. Inert until RUSTC_WRAPPER is
+    # set; see dev/sccache-env and docs/nix-setup.md.
+    sccache
   ];
 
   # CI-only cargo tools (coverage — Linux only)


### PR DESCRIPTION
## Problem

Each git worktree keeps its own `target/` directory, so N worktrees recompile
the same dependencies N times. In practice this reached 321 GB in `/tmp`, with
a single `target/` dir holding 52 GB of `deps/` and 32 GB of `incremental/`.

The obvious fix — a shared `CARGO_TARGET_DIR` — is the wrong one here. Cargo
takes an exclusive lock per target dir, so concurrent builds across worktrees
would serialize. That trades away parallelism, which matters when several
agents build at once.

## Approach

Share the *compilation cache*, not the *target dir*. Every worktree keeps its
own `target/` and its own cargo lock, so parallel builds still run at full
width; they consult one shared sccache, so dependency work done in one worktree
is reused in the rest.

Unlike `target/`, the cache is bounded and evicts LRU (60 GiB default), which
is the self-limiting behaviour stable Cargo's target dir does not have
(`-Zgc` remains nightly-only on our 1.97.1 toolchain).

## Measured

Building `xmtp_common` in two different worktrees:

| | wall | user CPU | cache |
|---|---|---|---|
| Worktree A, cold | 43.6s | 2m40s | 0 hits / 324 misses |
| Worktree B, warm | 22.8s | 17s | 85 hits |

## Changes

- `nix/lib/shell-common.nix` — add `sccache` to `cargoTools`, so the `rust` and
  `default` shells both have it.
- `dev/sccache-env` — sourced by hand to enable it. Refuses to run if executed
  rather than sourced.
- `justfile` — `just cache-stats`, `just clean-incremental [days]`.
- `docs/nix-setup.md` — setup, the incremental trade-off, and CI boundaries.

## Trade-off

sccache cannot cache incremental compilation, so `dev/sccache-env` sets
`CARGO_INCREMENTAL=0`. That suits fresh worktrees and agent-driven work, where
incremental has nothing to reuse. For hand-iterating on a single crate,
incremental is still faster — the docs say so and give the opt-out.

## CI and releases are unaffected

This was the main risk, and it is handled structurally rather than by
convention:

- **Off by default.** `dev/sccache-env` is never sourced automatically.
  Verified: `RUSTC_WRAPPER` and `CARGO_INCREMENTAL` are both empty on entering
  the shell.
- **Nix builds are sandboxed.** Nothing under `nix/` sets `RUSTC_WRAPPER`, so
  `nix build`, releases, `.#validation` and `.#nextest` cannot see it.
- **CI keeps its own path.** `.github/actions/setup-nix` still configures
  sccache via its `sccache` input against the GHA cache. Jobs that build inside
  `nix build` set `sccache: "false"` on purpose; that is untouched.

**No CI or release file is modified** — the diff is 4 files, additive only.

## Verification

- `sccache` present in the `rust` shell; both env vars empty by default.
- Sourcing sets the wrapper; executing directly exits 1.
- Cross-worktree cache hits confirmed (table above).
- `nix build --no-link .#cargo-clippy.aarch64-darwin.keepalive-probe` succeeds.
- `just lint-config` clean (nixfmt 0 changed, shellcheck clean after fixing SC2155).
- `just lint-markdown` clean.
- Both `devShells.rust` and `devShells.default` still evaluate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in `sccache` shared build cache for Rust development
> - Adds `dev/sccache-env`, a Bash script developers source to enable sccache for Rust compilation. It sets a default 60 GiB cache under the user's cache directory, points `RUSTC_WRAPPER` at the sccache binary, and disables Cargo incremental compilation (which conflicts with sccache).
> - Adds two justfile recipes: `cache-stats` to display sccache hit rates and cache size, and `clean-incremental` to remove stale incremental directories older than a configurable threshold (default 14 days) across Git worktrees.
> - Includes sccache in the Nix development shell via `nix/lib/shell-common.nix`, and documents the opt-in workflow, cache-size override, and maintenance commands in `docs/nix-setup.md`.
> - Risk: sourcing `dev/sccache-env` disables Cargo incremental compilation for the current shell; developers not using sccache should not source it.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cd53d50. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->